### PR TITLE
feat: controller type selection (Xbox/PlayStation)

### DIFF
--- a/app/src/main/cpp/satellite_jni.cpp
+++ b/app/src/main/cpp/satellite_jni.cpp
@@ -43,6 +43,7 @@ static constexpr uint16_t MSG_CONTROLLER_ADD = 0x0004;
 static constexpr uint16_t MSG_CONTROLLER_REMOVE = 0x0005;
 static constexpr uint16_t MSG_CONTROLLER_ACK = 0x0006;
 static constexpr uint16_t MSG_SERVER_STATUS = 0x0007;
+static constexpr uint16_t MSG_CONTROLLER_TYPE = 0x0008;
 
 // ACK result codes
 static constexpr uint8_t ACK_OK = 0x00;
@@ -313,6 +314,16 @@ Java_com_tinkernorth_dish_SatelliteNative_controllerRemove(JNIEnv*, jobject, jin
     uint8_t payload[1] = {(uint8_t)(controllerIndex & 0xFF)};
     sendEncrypted(MSG_CONTROLLER_REMOVE, payload, 1);
     LOGI("Sent controller remove: index=%d", controllerIndex);
+}
+
+JNIEXPORT void JNICALL Java_com_tinkernorth_dish_SatelliteNative_sendControllerType(
+    JNIEnv*, jobject, jint controllerIndex, jint controllerType) {
+    // Payload: controller_index(1B) + controller_type(1B)
+    uint8_t payload[2];
+    payload[0] = (uint8_t)(controllerIndex & 0xFF);
+    payload[1] = (uint8_t)(controllerType & 0xFF);
+    sendEncrypted(MSG_CONTROLLER_TYPE, payload, 2);
+    LOGI("Sent controller type: index=%d type=%d", controllerIndex, controllerType);
 }
 
 /* ── Heartbeat start/stop ──────────────────────────────────────────────────── */

--- a/app/src/main/java/com/tinkernorth/dish/MainActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/MainActivity.kt
@@ -17,9 +17,12 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
+import android.widget.ArrayAdapter
 import android.widget.EditText
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.ProgressBar
+import android.widget.Spinner
 import android.widget.TextView
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.button.MaterialButton
@@ -53,6 +56,23 @@ enum class ControllerCardState {
     DISCONNECTING, // physical gamepad unplugged, countdown running
 }
 
+/** Supported controller visual types (must match satellite types.h values). */
+enum class ControllerType(
+    val wireValue: Int,
+    val label: String,
+    val drawableRes: Int,
+) {
+    XBOX(0, "Xbox", R.drawable.ctrl_xbox),
+    PLAYSTATION(1, "PlayStation", R.drawable.ctrl_playstation),
+    ;
+
+    companion object {
+        val labels = entries.map { it.label }
+
+        fun fromIndex(index: Int) = entries.getOrElse(index) { XBOX }
+    }
+}
+
 /** Mutable state for one physical controller. */
 data class ControllerEntry(
     val androidDeviceId: Int,
@@ -60,6 +80,7 @@ data class ControllerEntry(
     var controllerIndex: Int = -1,
     var cardState: ControllerCardState = ControllerCardState.NEED_SERVER,
     var vigemActive: Boolean = false,
+    var controllerType: ControllerType = ControllerType.XBOX,
     var countdownTimer: CountDownTimer? = null,
     var countdownSeconds: Int = 10,
     // UI references (set when card is built)
@@ -337,9 +358,12 @@ class MainActivity :
         controllers[androidDeviceId] = entry
         refreshDashboard()
 
-        // If server is connected, send controller-add right away
+        // If server is connected, send controller-add right away;
+        // otherwise auto-start discovery so servers appear immediately
         if (serverConnected) {
             sendControllerAdd(entry)
+        } else if (entry.cardState == ControllerCardState.NEED_SERVER) {
+            startDiscoveryForController(entry)
         }
     }
 
@@ -411,6 +435,11 @@ class MainActivity :
             if (ackResult != -1 && (ackResult and 0xFF) == 0x00) {
                 entry.vigemActive = true
                 entry.cardState = ControllerCardState.ACTIVE
+                // Send the current controller type to the server
+                SatelliteNative.sendControllerType(
+                    entry.controllerIndex,
+                    entry.controllerType.wireValue,
+                )
             } else {
                 entry.cardState = ControllerCardState.ACTIVE // show status even on error
             }
@@ -726,10 +755,11 @@ class MainActivity :
         // State-specific content
         when (entry.cardState) {
             ControllerCardState.NEED_SERVER -> {
-                addLabel(container, "Ready to connect", R.color.colorMuted)
+                addLabel(container, "No servers found", R.color.colorMuted)
+                addControllerTypeSelector(container, entry, dp)
                 val btn =
                     MaterialButton(this).apply {
-                        text = "Connect to Server"
+                        text = "Scan for Servers"
                         setOnClickListener { startDiscoveryForController(entry) }
                         val lp =
                             LinearLayout.LayoutParams(
@@ -781,6 +811,7 @@ class MainActivity :
                 val statusText = if (entry.vigemActive) "Streaming" else "Connected (no ViGEm)"
                 val statusColor = if (entry.vigemActive) R.color.colorSuccess else R.color.colorWarning
                 addLabel(container, statusText, statusColor)
+                addControllerTypeSelector(container, entry, dp)
             }
             ControllerCardState.DISCONNECTING -> {
                 addLabel(
@@ -825,6 +856,83 @@ class MainActivity :
                 layoutParams = lp
             }
         parent.addView(tv)
+    }
+
+    @Suppress("LongMethod")
+    private fun addControllerTypeSelector(
+        container: LinearLayout,
+        entry: ControllerEntry,
+        dp: Float,
+    ) {
+        val row =
+            LinearLayout(this).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
+                val lp =
+                    LinearLayout.LayoutParams(
+                        LinearLayout.LayoutParams.MATCH_PARENT,
+                        LinearLayout.LayoutParams.WRAP_CONTENT,
+                    )
+                lp.topMargin = (8 * dp).toInt()
+                layoutParams = lp
+            }
+
+        val icon =
+            ImageView(this).apply {
+                setImageResource(entry.controllerType.drawableRes)
+                val size = (40 * dp).toInt()
+                layoutParams =
+                    LinearLayout.LayoutParams(size, size).apply {
+                        marginEnd = (10 * dp).toInt()
+                    }
+                scaleType = ImageView.ScaleType.FIT_CENTER
+                contentDescription = entry.controllerType.label
+            }
+
+        val spinner =
+            Spinner(this).apply {
+                adapter =
+                    ArrayAdapter(
+                        this@MainActivity,
+                        android.R.layout.simple_spinner_item,
+                        ControllerType.labels,
+                    ).also {
+                        it.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+                    }
+                setSelection(entry.controllerType.ordinal, false)
+                onItemSelectedListener =
+                    object : android.widget.AdapterView.OnItemSelectedListener {
+                        override fun onItemSelected(
+                            parent: android.widget.AdapterView<*>?,
+                            view: View?,
+                            position: Int,
+                            id: Long,
+                        ) {
+                            val newType = ControllerType.fromIndex(position)
+                            if (newType != entry.controllerType) {
+                                entry.controllerType = newType
+                                icon.setImageResource(newType.drawableRes)
+                                icon.contentDescription = newType.label
+                                // If active, send type change to server
+                                if (entry.vigemActive) {
+                                    SatelliteNative.sendControllerType(
+                                        entry.controllerIndex,
+                                        newType.wireValue,
+                                    )
+                                }
+                            }
+                        }
+
+                        override fun onNothingSelected(parent: android.widget.AdapterView<*>?) {
+                            // Required by interface — no action needed
+                        }
+                    }
+                layoutParams = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
+            }
+
+        row.addView(icon)
+        row.addView(spinner)
+        container.addView(row)
     }
 
     private fun stateColor(state: ControllerCardState): Int =

--- a/app/src/main/java/com/tinkernorth/dish/SatelliteNative.kt
+++ b/app/src/main/java/com/tinkernorth/dish/SatelliteNative.kt
@@ -58,6 +58,12 @@ object SatelliteNative {
     /** Send 0x0005 Controller Remove message. */
     external fun controllerRemove(controllerIndex: Int)
 
+    /** Send 0x0008 Controller Type message. */
+    external fun sendControllerType(
+        controllerIndex: Int,
+        controllerType: Int,
+    )
+
     // ── Heartbeat ───────────────────────────────────────────────────────────
 
     /** Start the heartbeat sender thread (sends 0x0002 every 2s). */

--- a/app/src/main/res/drawable/ctrl_playstation.xml
+++ b/app/src/main/res/drawable/ctrl_playstation.xml
@@ -1,0 +1,31 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="64dp"
+    android:height="64dp"
+    android:viewportWidth="64"
+    android:viewportHeight="64">
+    <path
+        android:pathData="M8,32 C8,23.16 15.16,16 24,16 L40,16 C48.84,16 56,23.16 56,32 L56,32 C56,40.84 48.84,48 40,48 L24,48 C15.16,48 8,40.84 8,32 Z"
+        android:fillColor="#003087"/>
+    <path
+        android:pathData="M24,28 m-5,0 a5,5 0 1,1 10,0 a5,5 0 1,1 -10,0"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.9"/>
+    <path
+        android:pathData="M40,20 L42,24 L38,24 Z"
+        android:fillColor="#7BC8A4"
+        android:fillAlpha="0.9"/>
+    <path
+        android:pathData="M44,28 m-2,0 a2,2 0 1,1 4,0 a2,2 0 1,1 -4,0"
+        android:fillColor="#E8555D"
+        android:fillAlpha="0.9"/>
+    <path
+        android:pathData="M38,26 L42,26 L42,30 L38,30 Z"
+        android:fillColor="#C8A2D4"
+        android:fillAlpha="0.9"/>
+    <path
+        android:pathData="M38,32 L42,32"
+        android:strokeColor="#6B9FD4"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:fillAlpha="0.9"/>
+</vector>

--- a/app/src/main/res/drawable/ctrl_xbox.xml
+++ b/app/src/main/res/drawable/ctrl_xbox.xml
@@ -1,0 +1,29 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="64dp"
+    android:height="64dp"
+    android:viewportWidth="64"
+    android:viewportHeight="64">
+    <path
+        android:pathData="M8,32 C8,23.16 15.16,16 24,16 L40,16 C48.84,16 56,23.16 56,32 L56,32 C56,40.84 48.84,48 40,48 L24,48 C15.16,48 8,40.84 8,32 Z"
+        android:fillColor="#107C10"/>
+    <path
+        android:pathData="M24,28 m-5,0 a5,5 0 1,1 10,0 a5,5 0 1,1 -10,0"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.9"/>
+    <path
+        android:pathData="M40,28 m-2,0 a2,2 0 1,1 4,0 a2,2 0 1,1 -4,0"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.9"/>
+    <path
+        android:pathData="M44,24 m-2,0 a2,2 0 1,1 4,0 a2,2 0 1,1 -4,0"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.9"/>
+    <path
+        android:pathData="M36,24 m-2,0 a2,2 0 1,1 4,0 a2,2 0 1,1 -4,0"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.9"/>
+    <path
+        android:pathData="M40,20 m-2,0 a2,2 0 1,1 4,0 a2,2 0 1,1 -4,0"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.9"/>
+</vector>


### PR DESCRIPTION
- Add ControllerType enum with Xbox and PlayStation options
- Controller type selector (Spinner + icon) in NEED_SERVER and ACTIVE card states
- Send MSG_CONTROLLER_TYPE (0x0008) to server on type change and after successful controller add
- Auto-start server discovery when controller is plugged in
- Add vector drawable icons for Xbox and PlayStation controllers
- All linting clean: ktlintFormat, detekt, lint