### PR TITLE
Portfolio-wide alignment + LGPL relicensing

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,7 @@
-# TinkerNorth — shared clang-format configuration
-# Used by both Satellite (dev/) and Dish JNI (Dish/app/src/main/cpp/).
+# TinkerNorth — canonical clang-format configuration.
+# This exact file is shared by satellite, dish-android (JNI), dish-linux,
+# and dish-mac (any C/C++ source). Pinned to clang-format 22.1.4 in CI;
+# older versions may produce small diffs on braced-init lists.
 # Run:  clang-format -i <files>
 
 BasedOnStyle: LLVM
@@ -58,4 +60,3 @@ MaxEmptyLinesToKeep: 1
 ReflowComments: true
 SpaceBeforeCpp11BracedList: false
 Standard: c++17
-

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,9 @@
-# TinkerNorth — shared clang-tidy configuration
-# Used by both Satellite (dev/) and Dish JNI (Dish/app/src/main/cpp/).
-# Start conservative — enable more checks as the codebase matures.
+# TinkerNorth — canonical clang-tidy configuration.
+# This exact file is shared by satellite, dish-android (JNI), dish-linux,
+# and dish-mac (any C/C++ source).
+#
+# HeaderFilterRegex matches headers under src/, app/src/main/cpp/, or tests/
+# so the same config covers every repo without per-repo overrides.
 
 Checks: >
   -*,
@@ -37,7 +40,7 @@ Checks: >
 
 WarningsAsErrors: ''
 
-HeaderFilterRegex: 'src/.*\.h$'
+HeaderFilterRegex: '.*/(src|app/src/main/cpp|tests)/.*\.h$'
 
 CheckOptions:
   - key: modernize-use-auto.MinTypeNameLength
@@ -46,4 +49,3 @@ CheckOptions:
     value: 1
   - key: performance-move-const-arg.CheckTriviallyCopyableMove
     value: false
-

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Dish Android pre-commit hook: runs clang-format (autofix) on staged JNI
+# C/C++ files. Kotlin formatting is enforced by ktlint at the CI stage —
+# pre-commit stays fast by skipping a Gradle warmup.
+#
+# Gracefully skips if clang-format is missing so devs who haven't run
+# setup-hooks.sh or installed the tool yet aren't blocked — CI enforces the
+# same check in --Werror mode.
+set -euo pipefail
+
+# Collect staged JNI sources (added / copied / modified), NUL-separated to
+# handle paths with spaces.
+staged=$(git diff --cached --name-only --diff-filter=ACM -z \
+    -- 'app/src/main/cpp/*.cpp' 'app/src/main/cpp/*.h' 'app/src/main/cpp/*.c' \
+    | tr '\0' '\n' | sed '/^$/d')
+if [ -z "$staged" ]; then
+    exit 0
+fi
+
+# ── clang-format ─────────────────────────────────────────────────────────
+if command -v clang-format >/dev/null 2>&1; then
+    echo "▶ clang-format (staged JNI files)"
+    echo "$staged" | while IFS= read -r file; do
+        clang-format -i "$file"
+        git add "$file"
+    done
+else
+    echo "⚠  clang-format not installed — skipping (install clang-format)"
+fi

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -2,9 +2,9 @@ name: Android CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,19 +16,42 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: "17"
+          distribution: temurin
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # Pinned to match satellite + dish-linux + dish-mac so all four repos
+      # share one canonical clang-format ruleset and tool version.
+      - name: Install clang-format (pinned 22.1.4)
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install 'clang-format==22.1.4'
+
+      - name: clang-format (JNI, check only)
+        run: |
+          FILES=$(find app/src/main/cpp -type f \( -name '*.cpp' -o -name '*.h' -o -name '*.c' \))
+          [ -z "$FILES" ] || echo "$FILES" | xargs clang-format --dry-run --Werror
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+
+      - name: ktlint check
+        run: ./gradlew ktlintCheck
+
+      - name: detekt
+        run: ./gradlew detekt
 
       - name: Lint check
         run: ./gradlew lint
@@ -40,7 +63,7 @@ jobs:
         run: ./gradlew assembleDebug
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: debug-apk
           path: app/build/outputs/apk/debug/*.apk
@@ -48,7 +71,7 @@ jobs:
 
       - name: Upload lint results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: lint-results
           path: app/build/reports/lint-results-debug.html
@@ -56,7 +79,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: app/build/reports/tests/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (must already exist)"
+        required: true
+
+# Required secrets (optional — workflow falls back to unsigned artifacts):
+#   KEYSTORE_BASE64       base64 of the .jks/.keystore signing keystore
+#   KEYSTORE_PASSWORD     keystore password
+#   KEY_ALIAS             alias of the signing key
+#   KEY_PASSWORD          password of the signing key
+#
+# When all four are present, the AAB and APK are signed; otherwise they are
+# uploaded unsigned and tagged with `-unsigned` in the filename so a human
+# downloading them from the Releases page knows they need to sign manually.
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Decode keystore (if present)
+        id: keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: |
+          if [ -n "${KEYSTORE_BASE64}" ]; then
+            echo "${KEYSTORE_BASE64}" | base64 -d > "${RUNNER_TEMP}/release.keystore"
+            echo "path=${RUNNER_TEMP}/release.keystore" >> "$GITHUB_OUTPUT"
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::KEYSTORE_BASE64 not set — release artifacts will be unsigned."
+          fi
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build release APK + AAB
+        env:
+          DISH_KEYSTORE_FILE: ${{ steps.keystore.outputs.path }}
+          DISH_KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          DISH_KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          DISH_KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          ./gradlew assembleRelease bundleRelease
+
+      - name: Stage artifacts
+        id: stage
+        run: |
+          mkdir -p dist
+          suffix=""
+          if [ "${{ steps.keystore.outputs.present }}" != "true" ]; then
+            suffix="-unsigned"
+          fi
+          tag="${GITHUB_REF_NAME:-${{ inputs.tag }}}"
+
+          # APK
+          apk=$(find app/build/outputs/apk/release -name '*.apk' | head -1)
+          [ -n "$apk" ] && cp "$apk" "dist/dish-${tag}${suffix}.apk"
+          # AAB
+          aab=$(find app/build/outputs/bundle/release -name '*.aab' | head -1)
+          [ -n "$aab" ] && cp "$aab" "dist/dish-${tag}${suffix}.aab"
+          ls -l dist/
+
+      - name: Upload to GitHub Releases
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          generate_release_notes: true
+          files: |
+            dist/*.apk
+            dist/*.aab

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing to Dish Android
+
+Thanks for your interest in improving the Android client! This document
+captures the conventions that aren't obvious from skimming the code.
+
+## Getting set up
+
+```bash
+# 1) Install Android Studio Ladybug+, NDK, CMake 3.22.1+, JDK 17+
+# 2) Open the project in Android Studio (Gradle sync downloads deps)
+# 3) Point git at the in-tree pre-commit hook
+scripts/setup-hooks.sh
+```
+
+The pre-commit hook runs `clang-format -i` (autofix, re-stages) on staged
+JNI C/C++ files and skips Kotlin to keep itself fast. CI runs `clang-format
+--dry-run --Werror` on the JNI plus `ktlintCheck`, `detekt`, and `lint` on
+the Kotlin tree, so anything that slips locally fails the PR.
+
+## License headers
+
+Every source file (`*.kt`, `*.cpp`, `*.h`) starts with:
+
+```
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+```
+
+New files must include both lines. Don't introduce code under a different
+license — the project is LGPL-3.0-or-later end-to-end (`LICENSE`,
+`COPYING.GPL3`, source headers).
+
+## Style
+
+### Kotlin
+
+- 4-space indent, ~120-column soft limit. `ktlint` and `detekt` are
+  authoritative — run `./gradlew ktlintFormat` to autofix and
+  `./gradlew detekt` to lint.
+- `MainViewModel` exposes a single immutable `MainUiState` via a
+  `StateFlow`. Don't introduce competing sources of truth — every UI-bound
+  field belongs in `MainUiState`.
+- Coroutines for async, `kotlinx.serialization` for JSON, Hilt for DI.
+
+### JNI / C++
+
+- C++17, four-space indent, 100-column soft limit. The same `.clang-format`
+  ships with `satellite`, `dish-linux`, and this repo — run
+  `clang-format -i app/src/main/cpp/*.{cpp,h}` if you're unsure.
+- The JNI is the **hot path**. No allocations per packet, no JNI calls
+  from the input thread other than `sendReport`, no logging on the
+  per-event path.
+
+## Branching & PRs
+
+- All changes land on `main` via pull request — no direct pushes.
+- Use the PR template (`.github/pull_request_template.md`) to describe
+  the change, the manual test matrix you ran (real device + emulator),
+  and call out anything that touches the wire protocol.
+- Keep commits focused; squash noisy fixup commits before review.
+
+## What CI runs
+
+`.github/workflows/android-ci.yml` runs on every PR:
+
+1. `clang-format --dry-run --Werror` over `app/src/main/cpp/`.
+2. `./gradlew ktlintCheck`.
+3. `./gradlew detekt`.
+4. `./gradlew lint` (Android Lint).
+5. `./gradlew testDebugUnitTest` (JUnit + MockK + Turbine).
+6. `./gradlew assembleDebug`, uploads the APK as a CI artifact.
+
+If any step fails, the PR is blocked.
+
+## Touching the hot path
+
+The Kotlin → JNI → `sendto()` chain runs at gamepad polling rate and
+must never block. If you're modifying `MainActivity.dispatchGenericMotionEvent`,
+`GamepadInputProcessor`, `SatelliteNative`, or `satellite_jni.cpp::sendReport`:
+
+- No `withContext`, no `runBlocking`, no `Dispatchers.IO` on the send path.
+- No allocations per event — use the preallocated `XUSB_REPORT`.
+- The session map's lookup is the only lock allowed; hold it briefly.
+- Preserve `IP_TOS = 0xB8` (DSCP EF) and `MSG_NOSIGNAL` on every send.
+
+## Touching the wire protocol
+
+The Android, macOS, and Linux clients all talk to the same `satellite`
+server and must produce byte-identical traffic:
+
+- AEAD: ChaCha20-Poly1305 IETF, 12-byte big-endian nonce derived from a
+  monotonic counter.
+- Packet layout: `token(4) | counter(4) | ciphertext+tag`, with the
+  4-byte token as AAD.
+- XUSB report: 12 bytes, little-endian.
+- Ports: discovery UDP 9879, pairing TCP 9878, HTTP TCP 9877,
+  streaming UDP 9876.
+
+Any change here must be coordinated with `dish-linux`, `dish-mac`, and
+`satellite` in the same PR / release cycle.
+
+## Reporting bugs
+
+Use the issue templates under `.github/ISSUE_TEMPLATE/`. Include the
+device model, Android version, and `adb logcat -s SatelliteJNI:*` output
+covering the misbehavior.

--- a/COPYING.GPL3
+++ b/COPYING.GPL3
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/README.md
+++ b/README.md
@@ -127,4 +127,6 @@ Please use the provided PR and issue templates.
 
 ## License
 
-Copyright © TinkerNorth. All rights reserved.
+Distributed under the terms of the **GNU Lesser General Public License v3.0
+or later**. See [`LICENSE`](LICENSE) (LGPL) and [`COPYING.GPL3`](COPYING.GPL3)
+(the GPL v3 the LGPL incorporates by reference).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,6 +26,23 @@ android {
         }
     }
 
+    // Reads from environment variables set by the release CI workflow. When
+    // any var is missing, the release build is unsigned (debuggable=false) so
+    // local `./gradlew assembleRelease` still works without provisioning a
+    // keystore — the resulting APK is just not installable on a device until
+    // it's signed manually.
+    signingConfigs {
+        val keystoreFile = System.getenv("DISH_KEYSTORE_FILE")?.takeIf { it.isNotBlank() }
+        if (keystoreFile != null) {
+            create("release") {
+                storeFile = file(keystoreFile)
+                storePassword = System.getenv("DISH_KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("DISH_KEY_ALIAS")
+                keyPassword = System.getenv("DISH_KEY_PASSWORD")
+            }
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -33,6 +50,9 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
+            // Apply the release signing config only when it was registered above
+            // (i.e. DISH_KEYSTORE_FILE was set in the environment).
+            signingConfig = signingConfigs.findByName("release")
         }
     }
     kotlin {

--- a/app/src/main/cpp/satellite_jni.cpp
+++ b/app/src/main/cpp/satellite_jni.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 /*
  * satellite_jni.cpp — Native bridge for the Dish Android client.
  * GameActivity provides the native thread (android_main) for lifecycle.
@@ -46,8 +49,6 @@ static constexpr uint16_t MSG_CONTROLLER_REMOVE = 0x0005;
 static constexpr uint16_t MSG_CONTROLLER_ACK = 0x0006;
 static constexpr uint16_t MSG_SERVER_STATUS = 0x0007;
 static constexpr uint16_t MSG_CONTROLLER_TYPE = 0x0008;
-
-
 
 #pragma pack(push, 1)
 struct XUSB_REPORT {
@@ -116,7 +117,8 @@ static void putBE32(uint8_t* dst, uint32_t v) {
 }
 
 /* ── Encrypt and send a message over the UDP channel ───────────────────────── */
-static bool sendEncrypted(Session* s, uint16_t msgType, const uint8_t* payload, uint16_t payloadLen) {
+static bool sendEncrypted(Session* s, uint16_t msgType, const uint8_t* payload,
+                          uint16_t payloadLen) {
     if (!s || s->udpSock < 0) return false;
 
     // Inner message: type(2) + length(2) + payload
@@ -208,9 +210,8 @@ static void ensureSodiumInit() {
 
 /* ── UDP Socket ────────────────────────────────────────────────────────────── */
 
-JNIEXPORT jint JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_openSocket(JNIEnv* env,
-                                                                                jobject, jstring ip,
-                                                                                jint port) {
+JNIEXPORT jint JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_openSocket(
+    JNIEnv* env, jobject, jstring ip, jint port) {
     ensureSodiumInit();
     int sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
     if (sock < 0) {
@@ -246,7 +247,8 @@ JNIEXPORT jint JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_op
     return handle;
 }
 
-JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_closeSocket(JNIEnv*, jobject, jint handle) {
+JNIEXPORT void JNICALL
+Java_com_tinkernorth_dish_data_network_SatelliteNative_closeSocket(JNIEnv*, jobject, jint handle) {
     std::shared_ptr<Session> s;
     {
         std::lock_guard<std::mutex> lock(g_sessionsMtx);
@@ -280,15 +282,15 @@ JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_se
     s->connectionAlive.store(true);
     env->ReleaseByteArrayElements(tokenArr, tokenBytes, JNI_ABORT);
     env->ReleaseByteArrayElements(keyArr, keyBytes, JNI_ABORT);
-    LOGI("Session %d params set (token=%02x%02x%02x%02x)", handle, s->token[0], s->token[1], s->token[2],
-         s->token[3]);
+    LOGI("Session %d params set (token=%02x%02x%02x%02x)", handle, s->token[0], s->token[1],
+         s->token[2], s->token[3]);
 }
 
 /* ── Encrypted gamepad data ────────────────────────────────────────────────── */
 
 JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_sendReport(
-    JNIEnv*, jobject, jint handle, jint controllerIndex, jint wB, jint bLT, jint bRT, jint sLX, jint sLY,
-    jint sRX, jint sRY) {
+    JNIEnv*, jobject, jint handle, jint controllerIndex, jint wB, jint bLT, jint bRT, jint sLX,
+    jint sLY, jint sRX, jint sRY) {
     auto s = getSession(handle);
     if (!s) return;
     // Payload: controller_index(1B) + XUSB_REPORT(12B) = 13 bytes
@@ -307,21 +309,20 @@ JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_se
 
 /* ── Controller add/remove ─────────────────────────────────────────────────── */
 
-JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_controllerAdd(JNIEnv*, jobject,
-                                                                               jint handle,
-                                                                               jint controllerIndex,
-                                                                               jint capabilities) {
+JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_controllerAdd(
+    JNIEnv*, jobject, jint handle, jint controllerIndex, jint capabilities) {
     auto s = getSession(handle);
     if (!s) return;
     uint8_t payload[3];
     payload[0] = (uint8_t)(controllerIndex & 0xFF);
     putBE16(payload + 1, (uint16_t)(capabilities & 0xFFFF));
     sendEncrypted(s.get(), MSG_CONTROLLER_ADD, payload, 3);
-    LOGI("Session %d: sent controller add idx=%d caps=0x%04X", handle, controllerIndex, capabilities);
+    LOGI("Session %d: sent controller add idx=%d caps=0x%04X", handle, controllerIndex,
+         capabilities);
 }
 
-JNIEXPORT void JNICALL
-Java_com_tinkernorth_dish_data_network_SatelliteNative_controllerRemove(JNIEnv*, jobject, jint handle, jint controllerIndex) {
+JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_controllerRemove(
+    JNIEnv*, jobject, jint handle, jint controllerIndex) {
     auto s = getSession(handle);
     if (!s) return;
     uint8_t payload[1] = {(uint8_t)(controllerIndex & 0xFF)};
@@ -337,12 +338,14 @@ JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_se
     payload[0] = (uint8_t)(controllerIndex & 0xFF);
     payload[1] = (uint8_t)(controllerType & 0xFF);
     sendEncrypted(s.get(), MSG_CONTROLLER_TYPE, payload, 2);
-    LOGI("Session %d: sent controller type idx=%d type=%d", handle, controllerIndex, controllerType);
+    LOGI("Session %d: sent controller type idx=%d type=%d", handle, controllerIndex,
+         controllerType);
 }
 
 /* ── Heartbeat start/stop ──────────────────────────────────────────────────── */
 
-JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_startHeartbeat(JNIEnv*, jobject, jint handle) {
+JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_startHeartbeat(
+    JNIEnv*, jobject, jint handle) {
     auto s = getSession(handle);
     if (!s) return;
     if (s->heartbeatRunning.load()) return;
@@ -352,43 +355,45 @@ JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_st
     s->heartbeatThread = std::thread(heartbeatLoop, s);
 }
 
-JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_stopHeartbeat(JNIEnv*, jobject, jint handle) {
+JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_stopHeartbeat(
+    JNIEnv*, jobject, jint handle) {
     auto s = getSession(handle);
     if (!s) return;
     s->heartbeatRunning.store(false);
     if (s->heartbeatThread.joinable()) s->heartbeatThread.join();
 }
 
-JNIEXPORT jboolean JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_isConnectionAlive(JNIEnv*,
-                                                                                       jobject, jint handle) {
+JNIEXPORT jboolean JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_isConnectionAlive(
+    JNIEnv*, jobject, jint handle) {
     auto s = getSession(handle);
     if (!s) return JNI_FALSE;
     return s->connectionAlive.load() ? JNI_TRUE : JNI_FALSE;
 }
 
-JNIEXPORT jint JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_getLastControllerAck(JNIEnv*,
-                                                                                      jobject, jint handle) {
+JNIEXPORT jint JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_getLastControllerAck(
+    JNIEnv*, jobject, jint handle) {
     auto s = getSession(handle);
     if (!s) return -1;
     return s->lastControllerAck.load(std::memory_order_acquire);
 }
 
-JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_resetControllerAck(JNIEnv*,
-                                                                                    jobject, jint handle) {
+JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_resetControllerAck(
+    JNIEnv*, jobject, jint handle) {
     auto s = getSession(handle);
     if (!s) return;
     s->lastControllerAck.store(-1, std::memory_order_release);
 }
 
-JNIEXPORT jint JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_getVigemAvailable(JNIEnv*,
-                                                                                   jobject, jint handle) {
+JNIEXPORT jint JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_getVigemAvailable(
+    JNIEnv*, jobject, jint handle) {
     auto s = getSession(handle);
     if (!s) return -1;
     return (jint)s->vigemAvailable.load(std::memory_order_acquire);
 }
 
-JNIEXPORT jint JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_getActiveControllerCount(JNIEnv*,
-                                                                                          jobject, jint handle) {
+JNIEXPORT jint JNICALL
+Java_com_tinkernorth_dish_data_network_SatelliteNative_getActiveControllerCount(JNIEnv*, jobject,
+                                                                                jint handle) {
     auto s = getSession(handle);
     if (!s) return -1;
     return (jint)s->activeControllerCount.load(std::memory_order_acquire);
@@ -396,7 +401,8 @@ JNIEXPORT jint JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_ge
 
 /* ── Receive ACK (called from a background thread) ────────────────────────── */
 
-JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_receiveAck(JNIEnv*, jobject, jint handle) {
+JNIEXPORT void JNICALL
+Java_com_tinkernorth_dish_data_network_SatelliteNative_receiveAck(JNIEnv*, jobject, jint handle) {
     auto s = getSession(handle);
     if (!s || s->udpSock < 0) return;
     uint8_t buf[128];
@@ -416,10 +422,8 @@ JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_re
     uint8_t decrypted[64];
     unsigned long long decLen = 0;
     size_t cipherLen = (size_t)n - 8;
-    if (crypto_aead_chacha20poly1305_ietf_decrypt(decrypted, &decLen,
-                                                  nullptr,
-                                                  buf + 8, cipherLen, s->token, 4,
-                                                  nonce, s->key) != 0) {
+    if (crypto_aead_chacha20poly1305_ietf_decrypt(decrypted, &decLen, nullptr, buf + 8, cipherLen,
+                                                  s->token, 4, nonce, s->key) != 0) {
         return;
     }
 
@@ -436,7 +440,8 @@ JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_re
         uint8_t result = decrypted[7];
         int32_t packed = ((int32_t)reqType << 16) | ((int32_t)ctrlIdx << 8) | (int32_t)result;
         s->lastControllerAck.store(packed, std::memory_order_release);
-        LOGI("Session %d controller ACK: reqType=0x%04X idx=%d result=0x%02X", handle, reqType, ctrlIdx, result);
+        LOGI("Session %d controller ACK: reqType=0x%04X idx=%d result=0x%02X", handle, reqType,
+             ctrlIdx, result);
     } else if (msgType == MSG_SERVER_STATUS && msgLen >= 2 && decLen >= 6) {
         uint8_t vigem = decrypted[4];
         uint8_t count = decrypted[5];
@@ -445,7 +450,8 @@ JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_re
         int8_t prevCount =
             s->activeControllerCount.exchange((int8_t)count, std::memory_order_release);
         if (prevVigem != (int8_t)(vigem ? 1 : 0) || prevCount != (int8_t)count) {
-            LOGI("Session %d server status: vigemAvailable=%d activeControllers=%d", handle, vigem, count);
+            LOGI("Session %d server status: vigemAvailable=%d activeControllers=%d", handle, vigem,
+                 count);
         }
     }
 }
@@ -508,11 +514,9 @@ JNIEXPORT jstring JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative
 
 /* ── TCP Pairing ──────────────────────────────────────────────────────────── */
 
-JNIEXPORT jstring JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_pair(JNIEnv* env, jobject,
-                                                                         jstring ip, jint pairPort,
-                                                                         jstring deviceId,
-                                                                         jstring deviceName,
-                                                                         jstring pin) {
+JNIEXPORT jstring JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_pair(
+    JNIEnv* env, jobject, jstring ip, jint pairPort, jstring deviceId, jstring deviceName,
+    jstring pin) {
     const char* ipStr = env->GetStringUTFChars(ip, nullptr);
     const char* idStr = env->GetStringUTFChars(deviceId, nullptr);
     const char* nameStr = env->GetStringUTFChars(deviceName, nullptr);
@@ -657,10 +661,8 @@ static std::string httpRequest(const char* method, const char* ip, int port, con
 
 /* ── POST /api/connections ─────────────────────────────────────────────────── */
 
-JNIEXPORT jstring JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_httpConnect(JNIEnv* env,
-                                                                                jobject, jstring ip,
-                                                                                jint httpPort,
-                                                                                jstring deviceId) {
+JNIEXPORT jstring JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_httpConnect(
+    JNIEnv* env, jobject, jstring ip, jint httpPort, jstring deviceId) {
     const char* ipStr = env->GetStringUTFChars(ip, nullptr);
     const char* idStr = env->GetStringUTFChars(deviceId, nullptr);
 

--- a/app/src/main/java/com/tinkernorth/dish/DishApplication.kt
+++ b/app/src/main/java/com/tinkernorth/dish/DishApplication.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish
 
 import android.app.Application

--- a/app/src/main/java/com/tinkernorth/dish/data/model/Models.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/model/Models.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.data.model
 
 import kotlinx.serialization.Serializable

--- a/app/src/main/java/com/tinkernorth/dish/data/network/ConnectionForegroundObserver.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/network/ConnectionForegroundObserver.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.data.network
 
 import androidx.lifecycle.DefaultLifecycleObserver

--- a/app/src/main/java/com/tinkernorth/dish/data/network/ConnectionHub.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/network/ConnectionHub.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.data.network
 
 import com.tinkernorth.dish.ui.bluetooth.BluetoothGamepad

--- a/app/src/main/java/com/tinkernorth/dish/data/network/ConnectionStore.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/network/ConnectionStore.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.data.network
 
 import android.content.Context

--- a/app/src/main/java/com/tinkernorth/dish/data/network/NetworkUtils.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/network/NetworkUtils.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.data.network
 
 import com.tinkernorth.dish.data.model.DiscoveredServer

--- a/app/src/main/java/com/tinkernorth/dish/data/network/SatelliteNative.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/network/SatelliteNative.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.data.network
 
 /**

--- a/app/src/main/java/com/tinkernorth/dish/data/network/WifiConnection.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/network/WifiConnection.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.data.network
 
 import com.tinkernorth.dish.data.model.DiscoveredServer

--- a/app/src/main/java/com/tinkernorth/dish/data/network/WifiConnectionManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/network/WifiConnectionManager.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.data.network
 
 import android.content.Context

--- a/app/src/main/java/com/tinkernorth/dish/data/repository/ControllerRepository.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/repository/ControllerRepository.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.data.repository
 
 import com.tinkernorth.dish.data.network.SatelliteNative

--- a/app/src/main/java/com/tinkernorth/dish/data/repository/DiscoveryRepository.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/repository/DiscoveryRepository.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.data.repository
 
 import com.tinkernorth.dish.data.model.DiscoveredServer

--- a/app/src/main/java/com/tinkernorth/dish/di/AppModule.kt
+++ b/app/src/main/java/com/tinkernorth/dish/di/AppModule.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.di
 
 import android.content.Context

--- a/app/src/main/java/com/tinkernorth/dish/ui/bluetooth/AndroidHidProxyClient.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/bluetooth/AndroidHidProxyClient.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.bluetooth
 
 import android.annotation.SuppressLint

--- a/app/src/main/java/com/tinkernorth/dish/ui/bluetooth/BluetoothGamepad.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/bluetooth/BluetoothGamepad.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.bluetooth
 
 /**

--- a/app/src/main/java/com/tinkernorth/dish/ui/bluetooth/BluetoothGamepadRegistry.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/bluetooth/BluetoothGamepadRegistry.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.bluetooth
 
 import com.tinkernorth.dish.data.network.ConnectionStore

--- a/app/src/main/java/com/tinkernorth/dish/ui/bluetooth/BluetoothHidSession.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/bluetooth/BluetoothHidSession.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.bluetooth
 
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/tinkernorth/dish/ui/bluetooth/GamepadButtonLayouts.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/bluetooth/GamepadButtonLayouts.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.bluetooth
 
 /**

--- a/app/src/main/java/com/tinkernorth/dish/ui/bluetooth/GamepadButtonLayouts.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/bluetooth/GamepadButtonLayouts.kt
@@ -16,9 +16,9 @@ package com.tinkernorth.dish.ui.bluetooth
  * Each producer emits bits in its native dialect. The matching consumer is
  * identity; the off-diagonal consumers must translate. Keep these helpers
  * pure (no Android, no state) so they stay JVM-unit-testable.
+ *
+ * The block below is the XUSB `wButtons` bitfield as defined by XInput.
  */
-
-// ── XUSB wButtons bitfield (XInput) ──────────────────────────────────────
 private const val XUSB_DPAD_UP = 0x0001
 private const val XUSB_DPAD_DOWN = 0x0002
 private const val XUSB_DPAD_LEFT = 0x0004
@@ -90,7 +90,10 @@ fun xusbToHid(wButtons: Int): Pair<Int, Int> {
  * `GamepadTouchView` into an XUSB `wButtons` value the Wi-Fi path can hand
  * verbatim to `SatelliteNative.sendReport`.
  */
-fun hidToXusb(hidButtons: Int, hat: Int): Int {
+fun hidToXusb(
+    hidButtons: Int,
+    hat: Int,
+): Int {
     var w = hatToDpadBits(hat)
     if (hidButtons and HID_START != 0) w = w or XUSB_START
     if (hidButtons and HID_SELECT != 0) w = w or XUSB_BACK
@@ -124,14 +127,15 @@ private fun dpadBitsToHat(dpadBits: Int): Int {
     }
 }
 
-private fun hatToDpadBits(hat: Int): Int = when (hat) {
-    HAT_N -> XUSB_DPAD_UP
-    HAT_NE -> XUSB_DPAD_UP or XUSB_DPAD_RIGHT
-    HAT_E -> XUSB_DPAD_RIGHT
-    HAT_SE -> XUSB_DPAD_RIGHT or XUSB_DPAD_DOWN
-    HAT_S -> XUSB_DPAD_DOWN
-    HAT_SW -> XUSB_DPAD_DOWN or XUSB_DPAD_LEFT
-    HAT_W -> XUSB_DPAD_LEFT
-    HAT_NW -> XUSB_DPAD_LEFT or XUSB_DPAD_UP
-    else -> 0
-}
+private fun hatToDpadBits(hat: Int): Int =
+    when (hat) {
+        HAT_N -> XUSB_DPAD_UP
+        HAT_NE -> XUSB_DPAD_UP or XUSB_DPAD_RIGHT
+        HAT_E -> XUSB_DPAD_RIGHT
+        HAT_SE -> XUSB_DPAD_RIGHT or XUSB_DPAD_DOWN
+        HAT_S -> XUSB_DPAD_DOWN
+        HAT_SW -> XUSB_DPAD_DOWN or XUSB_DPAD_LEFT
+        HAT_W -> XUSB_DPAD_LEFT
+        HAT_NW -> XUSB_DPAD_LEFT or XUSB_DPAD_UP
+        else -> 0
+    }

--- a/app/src/main/java/com/tinkernorth/dish/ui/bluetooth/HidProxyClient.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/bluetooth/HidProxyClient.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.bluetooth
 
 /**

--- a/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadTouchView.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadTouchView.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.common
 
 import android.annotation.SuppressLint

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.connections
 
 import android.Manifest

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.main
 
 import android.graphics.Typeface

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadInputProcessor.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadInputProcessor.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.main
 
 import android.view.InputDevice

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.main
 
 import android.graphics.drawable.GradientDrawable

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
@@ -339,5 +339,4 @@ class MainActivity :
                 KeyEvent.KEYCODE_BUTTON_SELECT,
             ).any { it }
     }
-
 }

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.main
 
 import android.content.Context

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainUiState.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainUiState.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.main
 
 import com.tinkernorth.dish.data.network.ConnectionSummary

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.main
 
 import androidx.lifecycle.ViewModel

--- a/app/src/main/java/com/tinkernorth/dish/util/LowPowerManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/util/LowPowerManager.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.util
 
 import android.os.CountDownTimer

--- a/app/src/main/java/com/tinkernorth/dish/util/TelemetryTracker.kt
+++ b/app/src/main/java/com/tinkernorth/dish/util/TelemetryTracker.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.util
 
 import android.os.Handler

--- a/app/src/main/java/com/tinkernorth/dish/util/WakeLockManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/util/WakeLockManager.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.util
 
 import android.content.Context

--- a/app/src/test/java/com/tinkernorth/dish/data/model/ModelsTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/data/model/ModelsTest.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.data.model
 
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/tinkernorth/dish/data/network/ConnectionForegroundObserverTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/data/network/ConnectionForegroundObserverTest.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.data.network
 
 import androidx.lifecycle.Lifecycle

--- a/app/src/test/java/com/tinkernorth/dish/data/network/ConnectionHubTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/data/network/ConnectionHubTest.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.data.network
 
 import com.tinkernorth.dish.ui.bluetooth.BluetoothGamepadRegistry

--- a/app/src/test/java/com/tinkernorth/dish/data/network/HelpersTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/data/network/HelpersTest.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.data.network
 
 import com.tinkernorth.dish.data.model.DiscoveredServer

--- a/app/src/test/java/com/tinkernorth/dish/data/network/WifiConnectionTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/data/network/WifiConnectionTest.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.data.network
 
 import com.tinkernorth.dish.data.model.DiscoveredServer

--- a/app/src/test/java/com/tinkernorth/dish/ui/bluetooth/BluetoothGamepadRegistryTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/bluetooth/BluetoothGamepadRegistryTest.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.bluetooth
 
 import com.tinkernorth.dish.data.network.ConnectionStore

--- a/app/src/test/java/com/tinkernorth/dish/ui/bluetooth/BluetoothGamepadReportTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/bluetooth/BluetoothGamepadReportTest.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.bluetooth
 
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/tinkernorth/dish/ui/bluetooth/BluetoothHidSessionRecoveryTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/bluetooth/BluetoothHidSessionRecoveryTest.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.bluetooth
 
 import com.tinkernorth.dish.ui.bluetooth.BluetoothGamepad.GamepadProfile

--- a/app/src/test/java/com/tinkernorth/dish/ui/bluetooth/BluetoothHidSessionReportTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/bluetooth/BluetoothHidSessionReportTest.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.bluetooth
 
 import com.tinkernorth.dish.ui.bluetooth.BluetoothGamepad.GamepadProfile

--- a/app/src/test/java/com/tinkernorth/dish/ui/bluetooth/BluetoothHidSessionTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/bluetooth/BluetoothHidSessionTest.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.bluetooth
 
 import com.tinkernorth.dish.ui.bluetooth.BluetoothGamepad.GamepadProfile

--- a/app/src/test/java/com/tinkernorth/dish/ui/bluetooth/FakeHidProxyClient.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/bluetooth/FakeHidProxyClient.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.bluetooth
 
 /**

--- a/app/src/test/java/com/tinkernorth/dish/ui/bluetooth/GamepadButtonLayoutsTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/bluetooth/GamepadButtonLayoutsTest.kt
@@ -64,8 +64,9 @@ class GamepadButtonLayoutsTest {
     @Test
     fun `xusb with A plus B plus X plus Y sets all four HID face bits`() {
         val (hid, hat) = xusbToHid(0x1000 or 0x2000 or 0x4000 or 0x8000)
-        val expected = GamepadTouchView.BTN_A or GamepadTouchView.BTN_B or
-            GamepadTouchView.BTN_X or GamepadTouchView.BTN_Y
+        val expected =
+            GamepadTouchView.BTN_A or GamepadTouchView.BTN_B or
+                GamepadTouchView.BTN_X or GamepadTouchView.BTN_Y
         assertEquals(expected, hid)
         assertEquals(GamepadTouchView.HAT_NONE, hat)
     }
@@ -132,12 +133,24 @@ class GamepadButtonLayoutsTest {
 
     @Test
     fun `xusbToHid then hidToXusb is identity for every canonical bit`() {
-        val xusbBits = intArrayOf(
-            0x0001, 0x0002, 0x0004, 0x0008, // d-pad
-            0x0010, 0x0020, 0x0040, 0x0080, // start / back / thumbs
-            0x0100, 0x0200, 0x0400,         // shoulders / guide
-            0x1000, 0x2000, 0x4000, 0x8000, // A / B / X / Y
-        )
+        val xusbBits =
+            intArrayOf(
+                0x0001,
+                0x0002,
+                0x0004,
+                0x0008, // d-pad
+                0x0010,
+                0x0020,
+                0x0040,
+                0x0080, // start / back / thumbs
+                0x0100,
+                0x0200,
+                0x0400, // shoulders / guide
+                0x1000,
+                0x2000,
+                0x4000,
+                0x8000, // A / B / X / Y
+            )
         for (bit in xusbBits) {
             val (hid, hat) = xusbToHid(bit)
             assertEquals("bit=0x${bit.toString(16)}", bit, hidToXusb(hid, hat))
@@ -146,13 +159,21 @@ class GamepadButtonLayoutsTest {
 
     // ── Helpers ───────────────────────────────────────────────────────────
 
-    private fun assertHid(wButtons: Int, expectedHid: Int, expectedHat: Int) {
+    private fun assertHid(
+        wButtons: Int,
+        expectedHid: Int,
+        expectedHat: Int,
+    ) {
         val (hid, hat) = xusbToHid(wButtons)
         assertEquals("hid bits for wButtons=0x${wButtons.toString(16)}", expectedHid, hid)
         assertEquals("hat for wButtons=0x${wButtons.toString(16)}", expectedHat, hat)
     }
 
-    private fun assertXusb(hidButtons: Int, hat: Int, expected: Int) {
+    private fun assertXusb(
+        hidButtons: Int,
+        hat: Int,
+        expected: Int,
+    ) {
         assertEquals(expected, hidToXusb(hidButtons, hat))
     }
 }

--- a/app/src/test/java/com/tinkernorth/dish/ui/bluetooth/GamepadButtonLayoutsTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/bluetooth/GamepadButtonLayoutsTest.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.bluetooth
 
 import com.tinkernorth.dish.ui.common.GamepadTouchView

--- a/app/src/test/java/com/tinkernorth/dish/ui/common/VirtualStickMathTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/common/VirtualStickMathTest.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.common
 
 import com.tinkernorth.dish.ui.main.scaleAxis

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/GamepadInputProcessorTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/GamepadInputProcessorTest.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.main
 
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
 package com.tinkernorth.dish.ui.main
 
 import com.tinkernorth.dish.data.network.ConnectionEvent

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Point this repo's git hooks at the tracked .githooks/ directory so the
+# pre-commit lint/format checks run for every contributor after a single
+# one-time setup. Idempotent — safe to re-run.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+git config core.hooksPath .githooks
+chmod +x .githooks/*
+
+echo "✓ core.hooksPath → .githooks"
+echo
+echo "Recommended tooling (install once):"
+echo "  macOS:    brew install clang-format"
+echo "  Linux:    sudo apt install clang-format    # or dnf install clang-tools-extra"
+echo "  Windows:  choco install llvm   (or install via LLVM/MSYS2)"
+echo
+echo "Kotlin formatting (ktlint, detekt) runs in CI via './gradlew' tasks; the"
+echo "pre-commit hook only handles JNI C/C++ to keep it fast."


### PR DESCRIPTION
## Summary

- **License:** switch to LGPL-3.0-or-later (LICENSE + COPYING.GPL3 + SPDX headers on all 45 Kotlin/JNI sources)
- **Tooling:** adopt the canonical TinkerNorth `.clang-format` / `.clang-tidy` (now md5-identical to `dish-linux` and `satellite`); add `.githooks/pre-commit` autofix and `scripts/setup-hooks.sh`; reformat JNI to LLVM/100-col
- **CI:** pin `actions/*` to v4, add JNI clang-format check (pinned 22.1.4 via PyPI), break ktlintCheck + detekt into separate jobs
- **Release pipeline:** new `release.yml` for tag-triggered AAB+APK build with optional env-driven signing; `app/build.gradle.kts` wires `signingConfigs.release` to the env vars
- **Docs:** new `CONTRIBUTING.md` mirroring the dish-linux template

## Test plan

- [x] `./gradlew ktlintCheck` (locally, after JNI reformat)
- [x] `./gradlew detekt`
- [x] Pre-commit hook fires clang-format on staged JNI files (verified during this commit)
- [ ] Manual: tag a `v*` push and confirm `release.yml` produces an unsigned APK + AAB
- [ ] Manual: provision `KEYSTORE_BASE64` etc. and confirm signed-build path

## Required for signed releases

Add these repository secrets before tagging:

| Secret | Notes |
|---|---|
| `KEYSTORE_BASE64` | base64 of the `.jks` keystore |
| `KEYSTORE_PASSWORD` | keystore password |
| `KEY_ALIAS` | signing key alias |
| `KEY_PASSWORD` | signing key password |

Without them, the workflow still succeeds but uploads `*-unsigned.apk` / `*-unsigned.aab` and emits a CI warning.