### PR TITLE
refactor: decompose GamepadTouchView + unify ViewBinding usage

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadConstants.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadConstants.kt
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.ui.common
+
+/**
+ * Layout, drawing and gesture-recognition tuning for [GamepadTouchView].
+ *
+ * Everything here is dimensionless: dp / fraction-of-region / multiplier, so
+ * the values can be reasoned about without thinking in pixels. Pixel-space
+ * conversion happens at the call site in `computeGamepadLayout`.
+ */
+internal object GamepadConstants {
+    // ── Safe-area envelope ────────────────────────────────────────────────
+    const val SAFE_AREA_CUSHION_DP = 6f
+
+    // ── Shoulder band (LB / RB) ──────────────────────────────────────────
+    const val SHOULDER_BAND_HEIGHT_DP = 56f
+
+    /** Inset from each side as a fraction of the safe horizontal width. */
+    const val SHOULDER_CORNER_INSET_FRACTION = 0.04f
+
+    /** Half-gap (dp) between LB and RB at the centre of the shoulder band. */
+    const val SHOULDER_CENTER_HALF_GAP_DP = 80f
+
+    // ── Trigger columns (LT / RT) ────────────────────────────────────────
+    const val TRIGGER_WIDTH_DP = 52f
+
+    /** Vertical gap between shoulder band and the content rect. */
+    const val CONTENT_GAP_DP = 6f
+
+    // ── Content rect: top / bottom row centres ───────────────────────────
+
+    /** Top-row centre Y as a fraction of the content rect's height. */
+    const val TOP_ROW_Y_FRACTION = 0.28f
+
+    /** Bottom-row centre Y as a fraction of the content rect's height. */
+    const val BOTTOM_ROW_Y_FRACTION = 0.75f
+
+    // ── D-Pad / ABXY cluster ─────────────────────────────────────────────
+    const val DPAD_INNER_PAD_DP = 12f
+
+    /** Cluster height as a fraction of the content rect's height (cap). */
+    const val CLUSTER_HEIGHT_FRACTION = 0.42f
+
+    /** Cluster centre X as a fraction-of-quarter from the content edge. */
+    const val CLUSTER_X_FRACTION_OF_QUARTER = 0.55f
+
+    /** ABXY individual button radius as a fraction of cluster size. */
+    const val ABXY_BTN_RADIUS_FRACTION = 0.18f
+
+    /** Centre-to-button spacing for ABXY (multiples of [btnRadius]). */
+    const val ABXY_BTN_SPACING_FACTOR = 1.5f
+
+    /** Drawn-icon size for ABXY (multiples of [btnRadius]). */
+    const val ABXY_BTN_DRAW_SIZE_FACTOR = 2.2f
+
+    // ── Sticks ───────────────────────────────────────────────────────────
+
+    /** Main-stick radius cap as a fraction of a content-quarter width. */
+    const val STICK_RADIUS_QW_FRACTION = 0.42f
+
+    /** Main-stick radius cap as a fraction of the content rect's height. */
+    const val STICK_RADIUS_H_FRACTION = 0.2f
+
+    /** L3/R3 secondary-stick radius as a fraction of the main stick's. */
+    const val L3_STICK_RADIUS_FRACTION = 0.7f
+
+    /** Gap (dp) between the main stick and its L3/R3 secondary. */
+    const val L3_STICK_GAP_DP = 12f
+
+    /** Main-stick centre X as a fraction-of-quarter from content edge. */
+    const val STICK_X_FRACTION_OF_QUARTER = 0.5f
+
+    /** How far the visual thumb cap travels (fraction of stick radius). */
+    const val STICK_THUMB_TRAVEL_FRACTION = 0.55f
+
+    /** Stick thumb-cap radius as a fraction of stick radius. */
+    const val STICK_THUMB_RADIUS_FRACTION = 0.55f
+
+    /** Direction-line width as a fraction of the thumb-cap radius. */
+    const val STICK_DIR_LINE_WIDTH_FRACTION = 0.35f
+
+    /** Outer ring stroke width (dp). */
+    const val STICK_RING_STROKE_DP = 2f
+
+    /** Thumb-cap ring stroke width (dp). */
+    const val STICK_THUMB_RING_STROKE_DP = 1.5f
+
+    /** Stick-label text size for single-char labels (× thumb radius). */
+    const val STICK_LABEL_SIZE_SINGLE = 0.95f
+
+    /** Stick-label text size for multi-char labels (× thumb radius). */
+    const val STICK_LABEL_SIZE_MULTI = 0.7f
+
+    /** Baseline drop for stick labels (× thumb radius). */
+    const val STICK_LABEL_BASELINE_FRACTION = 0.33f
+
+    // ── Centre cluster (Select / Start / Home) ───────────────────────────
+    const val SMALL_BTN_RADIUS_DP = 14f
+
+    /** Centre-button Y from content top, in multiples of [smallBtnRadius]. */
+    const val CENTER_BTN_TOP_OFFSET_FACTOR = 1.8f
+
+    /** Half-gap between Select and Start (dp). */
+    const val CENTER_BTN_HALF_GAP_DP = 40f
+
+    /** Drawn-icon size for centre buttons (× smallBtnRadius). */
+    const val CENTER_BTN_DRAW_SIZE_FACTOR = 2.2f
+
+    /** Vertical offset of the Home button below Select/Start, × small radius. */
+    const val HOME_VERTICAL_OFFSET_FACTOR = 2.5f
+
+    /** Home button is drawn slightly smaller than Select/Start. */
+    const val HOME_DRAW_SIZE_FACTOR = 0.8f
+
+    // ── Pill buttons (shoulders + triggers) ──────────────────────────────
+
+    /** Corner-radius as a fraction of the pill's shorter side. */
+    const val PILL_CORNER_RADIUS_FRACTION = 0.35f
+
+    /** Icon size as a fraction of the pill's shorter side. */
+    const val PILL_ICON_SIZE_FRACTION = 0.8f
+
+    // ── Touch hit-test factors ───────────────────────────────────────────
+
+    /**
+     * Pickup radius around sticks and individual ABXY buttons, as a multiple
+     * of the visual radius. >1 so a finger landing just outside the visible
+     * disc still latches onto the control.
+     */
+    const val PICKUP_RADIUS_FACTOR = 1.3f
+
+    /** Pickup radius around centre buttons (× smallBtnRadius). */
+    const val CENTER_BTN_PICKUP_FACTOR = 1.5f
+
+    // ── D-pad hat-switch bands ───────────────────────────────────────────
+
+    /** Width of one of the eight hat-switch direction bands, in degrees. */
+    const val HAT_BAND_DEG = 45.0
+
+    /** Half-width of a hat-switch band, in degrees. */
+    const val HAT_BAND_HALF_DEG = 22.5
+
+    // ── Triggers ─────────────────────────────────────────────────────────
+    const val TRIGGER_MAX = 255
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadGestureRecognizer.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadGestureRecognizer.kt
@@ -1,0 +1,396 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.ui.common
+
+import android.view.MotionEvent
+import com.tinkernorth.dish.ui.common.GamepadConstants.ABXY_BTN_SPACING_FACTOR
+import com.tinkernorth.dish.ui.common.GamepadConstants.CENTER_BTN_PICKUP_FACTOR
+import com.tinkernorth.dish.ui.common.GamepadConstants.HAT_BAND_DEG
+import com.tinkernorth.dish.ui.common.GamepadConstants.HAT_BAND_HALF_DEG
+import com.tinkernorth.dish.ui.common.GamepadConstants.HOME_VERTICAL_OFFSET_FACTOR
+import com.tinkernorth.dish.ui.common.GamepadConstants.PICKUP_RADIUS_FACTOR
+import com.tinkernorth.dish.ui.common.GamepadConstants.TRIGGER_MAX
+import kotlin.math.atan2
+import kotlin.math.hypot
+
+/**
+ * Touch handling for [GamepadTouchView]. Owns the per-pointer-id tracking and
+ * the [GamepadTouchView.GamepadState] mutation, but knows nothing about
+ * drawing — it works against a [GamepadLayout] snapshot supplied by the
+ * caller on each event.
+ *
+ * Pointer-id tracking is essential: a finger that lands on a button and then
+ * drags off must still release on UP, otherwise the button bit stays held.
+ * For sticks the displacement is also exposed via [leftStickDx]/[leftStickDy]
+ * etc. so the View can render the thumb cap at the finger's position.
+ *
+ * Threading: assumes single-threaded use from the View's touch dispatch path.
+ */
+internal class GamepadGestureRecognizer {
+    var state: GamepadTouchView.GamepadState = GamepadTouchView.GamepadState()
+        private set
+
+    var leftStickDx = 0f
+        private set
+    var leftStickDy = 0f
+        private set
+    var rightStickDx = 0f
+        private set
+    var rightStickDy = 0f
+        private set
+    var l3StickDx = 0f
+        private set
+    var l3StickDy = 0f
+        private set
+    var r3StickDx = 0f
+        private set
+    var r3StickDy = 0f
+        private set
+
+    private var leftStickPointerId = INVALID_POINTER
+    private var rightStickPointerId = INVALID_POINTER
+    private var l3StickPointerId = INVALID_POINTER
+    private var r3StickPointerId = INVALID_POINTER
+    private var ltPointerId = INVALID_POINTER
+    private var rtPointerId = INVALID_POINTER
+    private var dpadPointerId = INVALID_POINTER
+    private var abxyPointerId = INVALID_POINTER
+    private var lbPointerId = INVALID_POINTER
+    private var rbPointerId = INVALID_POINTER
+
+    /**
+     * Process a [MotionEvent] against the supplied [layout]. Mutates [state]
+     * and the per-stick displacement fields in place. The caller is
+     * responsible for invalidating the View and notifying its listener.
+     */
+    fun onTouchEvent(
+        event: MotionEvent,
+        layout: GamepadLayout,
+    ) {
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN, MotionEvent.ACTION_POINTER_DOWN -> {
+                handlePointerDown(event, event.actionIndex, layout)
+            }
+            MotionEvent.ACTION_MOVE -> {
+                for (i in 0 until event.pointerCount) {
+                    handlePointerMove(event, i, layout)
+                }
+            }
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_POINTER_UP -> {
+                handlePointerUp(event, event.actionIndex)
+            }
+            MotionEvent.ACTION_CANCEL -> reset()
+        }
+    }
+
+    /** Drop all touch state and zero the gamepad state. */
+    fun reset() {
+        state = GamepadTouchView.GamepadState()
+        leftStickDx = 0f
+        leftStickDy = 0f
+        rightStickDx = 0f
+        rightStickDy = 0f
+        l3StickDx = 0f
+        l3StickDy = 0f
+        r3StickDx = 0f
+        r3StickDy = 0f
+        leftStickPointerId = INVALID_POINTER
+        rightStickPointerId = INVALID_POINTER
+        l3StickPointerId = INVALID_POINTER
+        r3StickPointerId = INVALID_POINTER
+        ltPointerId = INVALID_POINTER
+        rtPointerId = INVALID_POINTER
+        dpadPointerId = INVALID_POINTER
+        abxyPointerId = INVALID_POINTER
+        lbPointerId = INVALID_POINTER
+        rbPointerId = INVALID_POINTER
+    }
+
+    @Suppress("CyclomaticComplexMethod", "ReturnCount", "LongMethod")
+    private fun handlePointerDown(
+        event: MotionEvent,
+        idx: Int,
+        l: GamepadLayout,
+    ) {
+        val x = event.getX(idx)
+        val y = event.getY(idx)
+        val pid = event.getPointerId(idx)
+        val pickup = PICKUP_RADIUS_FACTOR
+        val centerPickup = CENTER_BTN_PICKUP_FACTOR
+
+        // Sticks
+        if (hypot(x - l.leftStickCx, y - l.leftStickCy) < l.stickRadius * pickup) {
+            leftStickPointerId = pid
+            return
+        }
+        if (hypot(x - l.rightStickCx, y - l.rightStickCy) < l.stickRadius * pickup) {
+            rightStickPointerId = pid
+            return
+        }
+        // L3/R3 sticks (touch = button pressed + axis control)
+        if (hypot(x - l.l3StickCx, y - l.l3StickCy) < l.l3StickRadius * pickup) {
+            l3StickPointerId = pid
+            state.buttons = state.buttons or GamepadTouchView.BTN_LS
+            return
+        }
+        if (hypot(x - l.r3StickCx, y - l.r3StickCy) < l.l3StickRadius * pickup) {
+            r3StickPointerId = pid
+            state.buttons = state.buttons or GamepadTouchView.BTN_RS
+            return
+        }
+        // Triggers — binary press, tracked by pointer id so drag-off still
+        // releases cleanly on UP.
+        if (l.ltRect.contains(x, y)) {
+            ltPointerId = pid
+            state.leftTrigger = TRIGGER_MAX
+            return
+        }
+        if (l.rtRect.contains(x, y)) {
+            rtPointerId = pid
+            state.rightTrigger = TRIGGER_MAX
+            return
+        }
+        // Shoulders — pointer-id tracked so release works regardless of
+        // where the finger ends up on UP.
+        if (l.lbRect.contains(x, y)) {
+            lbPointerId = pid
+            state.buttons = state.buttons or GamepadTouchView.BTN_LB
+            return
+        }
+        if (l.rbRect.contains(x, y)) {
+            rbPointerId = pid
+            state.buttons = state.buttons or GamepadTouchView.BTN_RB
+            return
+        }
+        if (l.dpadRect.contains(x, y)) {
+            dpadPointerId = pid
+            updateDpad(x, y, l)
+            return
+        }
+        if (l.abxyRect.contains(x, y)) {
+            abxyPointerId = pid
+            updateAbxy(x, y, l)
+            return
+        }
+        // Centre buttons — not pointer-tracked; cleared in handlePointerUp's
+        // fallthrough on any unmatched UP.
+        if (hypot(x - l.selectCx, y - l.centerBtnCy) < l.smallBtnRadius * centerPickup) {
+            state.buttons = state.buttons or GamepadTouchView.BTN_SELECT
+            return
+        }
+        if (hypot(x - l.startCx, y - l.centerBtnCy) < l.smallBtnRadius * centerPickup) {
+            state.buttons = state.buttons or GamepadTouchView.BTN_START
+            return
+        }
+        val homeCy = l.centerBtnCy + l.smallBtnRadius * HOME_VERTICAL_OFFSET_FACTOR
+        if (hypot(x - l.homeCx, y - homeCy) < l.smallBtnRadius * centerPickup) {
+            state.buttons = state.buttons or GamepadTouchView.BTN_HOME
+            return
+        }
+    }
+
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    private fun handlePointerMove(
+        event: MotionEvent,
+        idx: Int,
+        l: GamepadLayout,
+    ) {
+        val x = event.getX(idx)
+        val y = event.getY(idx)
+        val pid = event.getPointerId(idx)
+
+        if (pid == leftStickPointerId) {
+            val r = computeStickAxes((x - l.leftStickCx) / l.stickRadius, (y - l.leftStickCy) / l.stickRadius)
+            leftStickDx = r.dx
+            leftStickDy = r.dy
+            state.leftX = r.axisX
+            state.leftY = r.axisY
+        }
+        if (pid == rightStickPointerId) {
+            val r = computeStickAxes((x - l.rightStickCx) / l.stickRadius, (y - l.rightStickCy) / l.stickRadius)
+            rightStickDx = r.dx
+            rightStickDy = r.dy
+            state.rightX = r.axisX
+            state.rightY = r.axisY
+        }
+        // L3 stick — same axes as L stick, plus L3 button held
+        if (pid == l3StickPointerId) {
+            val r = computeStickAxes((x - l.l3StickCx) / l.l3StickRadius, (y - l.l3StickCy) / l.l3StickRadius)
+            l3StickDx = r.dx
+            l3StickDy = r.dy
+            state.leftX = r.axisX
+            state.leftY = r.axisY
+        }
+        // R3 stick — same axes as R stick, plus R3 button held
+        if (pid == r3StickPointerId) {
+            val r = computeStickAxes((x - l.r3StickCx) / l.l3StickRadius, (y - l.r3StickCy) / l.l3StickRadius)
+            r3StickDx = r.dx
+            r3StickDy = r.dy
+            state.rightX = r.axisX
+            state.rightY = r.axisY
+        }
+        // Triggers are binary — no move-modulation. The DOWN/UP handlers
+        // set the value; MOVE is a no-op for trigger pointers.
+
+        // Live D-Pad tracking — only for the pointer that started on the d-pad.
+        if (pid == dpadPointerId) {
+            if (l.dpadRect.contains(x, y)) {
+                updateDpad(x, y, l)
+            } else {
+                state.hatSwitch = GamepadTouchView.HAT_NONE
+            }
+        }
+    }
+
+    @Suppress("ReturnCount", "LongMethod")
+    private fun handlePointerUp(
+        event: MotionEvent,
+        idx: Int,
+    ) {
+        val pid = event.getPointerId(idx)
+
+        if (pid == leftStickPointerId) {
+            leftStickPointerId = INVALID_POINTER
+            leftStickDx = 0f
+            leftStickDy = 0f
+            state.leftX = 0
+            state.leftY = 0
+            return
+        }
+        if (pid == rightStickPointerId) {
+            rightStickPointerId = INVALID_POINTER
+            rightStickDx = 0f
+            rightStickDy = 0f
+            state.rightX = 0
+            state.rightY = 0
+            return
+        }
+        if (pid == l3StickPointerId) {
+            l3StickPointerId = INVALID_POINTER
+            l3StickDx = 0f
+            l3StickDy = 0f
+            state.leftX = 0
+            state.leftY = 0
+            state.buttons = state.buttons and GamepadTouchView.BTN_LS.inv()
+            return
+        }
+        if (pid == r3StickPointerId) {
+            r3StickPointerId = INVALID_POINTER
+            r3StickDx = 0f
+            r3StickDy = 0f
+            state.rightX = 0
+            state.rightY = 0
+            state.buttons = state.buttons and GamepadTouchView.BTN_RS.inv()
+            return
+        }
+        if (pid == ltPointerId) {
+            ltPointerId = INVALID_POINTER
+            state.leftTrigger = 0
+            return
+        }
+        if (pid == rtPointerId) {
+            rtPointerId = INVALID_POINTER
+            state.rightTrigger = 0
+            return
+        }
+        // All button-region pointers clear by pointer ID, never by position —
+        // dragging the finger off the rect before release would otherwise
+        // leave the bit stuck.
+        if (pid == dpadPointerId) {
+            dpadPointerId = INVALID_POINTER
+            state.hatSwitch = GamepadTouchView.HAT_NONE
+            return
+        }
+        if (pid == abxyPointerId) {
+            abxyPointerId = INVALID_POINTER
+            state.buttons =
+                state.buttons and
+                (
+                    GamepadTouchView.BTN_A or GamepadTouchView.BTN_B or
+                        GamepadTouchView.BTN_X or GamepadTouchView.BTN_Y
+                ).inv()
+            return
+        }
+        if (pid == lbPointerId) {
+            lbPointerId = INVALID_POINTER
+            state.buttons = state.buttons and GamepadTouchView.BTN_LB.inv()
+            return
+        }
+        if (pid == rbPointerId) {
+            rbPointerId = INVALID_POINTER
+            state.buttons = state.buttons and GamepadTouchView.BTN_RB.inv()
+            return
+        }
+        // Centre / stick-click buttons aren't tracked by id — drop all of
+        // them on any unmatched up.
+        state.buttons =
+            state.buttons and
+            (
+                GamepadTouchView.BTN_SELECT or GamepadTouchView.BTN_START or
+                    GamepadTouchView.BTN_HOME or GamepadTouchView.BTN_LS or
+                    GamepadTouchView.BTN_RS
+            ).inv()
+    }
+
+    private fun updateDpad(
+        x: Float,
+        y: Float,
+        l: GamepadLayout,
+    ) {
+        val dx = x - l.dpadRect.centerX()
+        val dy = y - l.dpadRect.centerY()
+        val angle =
+            Math
+                .toDegrees(atan2(dy.toDouble(), dx.toDouble()))
+                .let { if (it < 0) it + FULL_CIRCLE_DEG else it }
+        // Eight 45° bands rotated by 22.5° so E is centred on 0°.
+        val octant = (((angle + HAT_BAND_HALF_DEG) / HAT_BAND_DEG).toInt() % HAT_OCTANTS.size)
+        state.hatSwitch = HAT_OCTANTS[octant]
+    }
+
+    private fun updateAbxy(
+        x: Float,
+        y: Float,
+        l: GamepadLayout,
+    ) {
+        val cx = l.abxyRect.centerX()
+        val cy = l.abxyRect.centerY()
+        val sp = l.btnRadius * ABXY_BTN_SPACING_FACTOR
+        val pickR = l.btnRadius * PICKUP_RADIUS_FACTOR
+        if (hypot(x - cx, y - (cy - sp)) < pickR) {
+            state.buttons = state.buttons or GamepadTouchView.BTN_Y
+        }
+        if (hypot(x - cx, y - (cy + sp)) < pickR) {
+            state.buttons = state.buttons or GamepadTouchView.BTN_A
+        }
+        if (hypot(x - (cx - sp), y - cy) < pickR) {
+            state.buttons = state.buttons or GamepadTouchView.BTN_X
+        }
+        if (hypot(x - (cx + sp), y - cy) < pickR) {
+            state.buttons = state.buttons or GamepadTouchView.BTN_B
+        }
+    }
+
+    companion object {
+        private const val INVALID_POINTER = -1
+        private const val FULL_CIRCLE_DEG = 360.0
+
+        /**
+         * Octant → hat-switch direction. Index `i` is the band centred on
+         * `i * 45°` measured from east (atan2 0° → +x). E, SE, S, SW, W, NW,
+         * N, NE — y-down so SE follows E.
+         */
+        private val HAT_OCTANTS =
+            intArrayOf(
+                GamepadTouchView.HAT_E,
+                GamepadTouchView.HAT_SE,
+                GamepadTouchView.HAT_S,
+                GamepadTouchView.HAT_SW,
+                GamepadTouchView.HAT_W,
+                GamepadTouchView.HAT_NW,
+                GamepadTouchView.HAT_N,
+                GamepadTouchView.HAT_NE,
+            )
+    }
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadLayout.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadLayout.kt
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.ui.common
+
+import android.graphics.Rect
+import android.graphics.RectF
+import com.tinkernorth.dish.ui.common.GamepadConstants.ABXY_BTN_RADIUS_FRACTION
+import com.tinkernorth.dish.ui.common.GamepadConstants.BOTTOM_ROW_Y_FRACTION
+import com.tinkernorth.dish.ui.common.GamepadConstants.CENTER_BTN_HALF_GAP_DP
+import com.tinkernorth.dish.ui.common.GamepadConstants.CENTER_BTN_TOP_OFFSET_FACTOR
+import com.tinkernorth.dish.ui.common.GamepadConstants.CLUSTER_HEIGHT_FRACTION
+import com.tinkernorth.dish.ui.common.GamepadConstants.CLUSTER_X_FRACTION_OF_QUARTER
+import com.tinkernorth.dish.ui.common.GamepadConstants.CONTENT_GAP_DP
+import com.tinkernorth.dish.ui.common.GamepadConstants.DPAD_INNER_PAD_DP
+import com.tinkernorth.dish.ui.common.GamepadConstants.L3_STICK_GAP_DP
+import com.tinkernorth.dish.ui.common.GamepadConstants.L3_STICK_RADIUS_FRACTION
+import com.tinkernorth.dish.ui.common.GamepadConstants.SAFE_AREA_CUSHION_DP
+import com.tinkernorth.dish.ui.common.GamepadConstants.SHOULDER_BAND_HEIGHT_DP
+import com.tinkernorth.dish.ui.common.GamepadConstants.SHOULDER_CENTER_HALF_GAP_DP
+import com.tinkernorth.dish.ui.common.GamepadConstants.SHOULDER_CORNER_INSET_FRACTION
+import com.tinkernorth.dish.ui.common.GamepadConstants.SMALL_BTN_RADIUS_DP
+import com.tinkernorth.dish.ui.common.GamepadConstants.STICK_RADIUS_H_FRACTION
+import com.tinkernorth.dish.ui.common.GamepadConstants.STICK_RADIUS_QW_FRACTION
+import com.tinkernorth.dish.ui.common.GamepadConstants.STICK_X_FRACTION_OF_QUARTER
+import com.tinkernorth.dish.ui.common.GamepadConstants.TOP_ROW_Y_FRACTION
+import com.tinkernorth.dish.ui.common.GamepadConstants.TRIGGER_WIDTH_DP
+import kotlin.math.min
+
+/**
+ * Pure-data snapshot of every region/centre/radius needed to draw and
+ * touch-test the on-screen gamepad. Computed once per [GamepadTouchView.onSizeChanged]
+ * by [computeGamepadLayout] and consumed by both the View (for drawing) and
+ * [GamepadGestureRecognizer] (for hit-testing).
+ */
+internal data class GamepadLayout(
+    val dpadRect: RectF,
+    val abxyRect: RectF,
+    val lbRect: RectF,
+    val rbRect: RectF,
+    val ltRect: RectF,
+    val rtRect: RectF,
+    val leftStickCx: Float,
+    val leftStickCy: Float,
+    val rightStickCx: Float,
+    val rightStickCy: Float,
+    val l3StickCx: Float,
+    val l3StickCy: Float,
+    val r3StickCx: Float,
+    val r3StickCy: Float,
+    val stickRadius: Float,
+    val l3StickRadius: Float,
+    val btnRadius: Float,
+    val smallBtnRadius: Float,
+    val selectCx: Float,
+    val startCx: Float,
+    val homeCx: Float,
+    val centerBtnCy: Float,
+)
+
+/**
+ * Compute the on-screen gamepad layout for the given view size and safe-area
+ * insets. Layout is left/right symmetric except for the stick-vs-d-pad swap
+ * between Xbox and PlayStation profiles.
+ *
+ * Layout (Xbox profile):
+ *   shoulder band:          LB | gap | RB along the top of the safe area
+ *   trigger columns:        LT (left strip) and RT (right strip), full content height
+ *   left half  (top→bot):   left stick + L3 secondary  →  d-pad
+ *   right half (top→bot):   ABXY                       →  right stick + R3 secondary
+ *   centre cluster:         Select / Start / Home, just below the shoulder band
+ *
+ * PlayStation profile swaps the d-pad with the left stick (so d-pad sits up
+ * top, left stick at the bottom-left), matching the DualShock layout.
+ */
+@Suppress("LongMethod")
+internal fun computeGamepadLayout(
+    width: Int,
+    height: Int,
+    density: Float,
+    safeInsets: Rect,
+    usePlayStation: Boolean,
+): GamepadLayout {
+    val cushion = SAFE_AREA_CUSHION_DP * density
+    val safeTop = safeInsets.top + cushion
+    val safeLeft = safeInsets.left + cushion
+    val safeRight = width - safeInsets.right - cushion
+    val safeBottom = height - safeInsets.bottom - cushion
+
+    val sbH = SHOULDER_BAND_HEIGHT_DP * density
+    val sbCornerInset = (safeRight - safeLeft) * SHOULDER_CORNER_INSET_FRACTION
+    val tW = TRIGGER_WIDTH_DP * density
+    val gap = CONTENT_GAP_DP * density
+    val centreX = (safeLeft + safeRight) / 2f
+    val sbHalfGap = SHOULDER_CENTER_HALF_GAP_DP * density
+
+    val lbRect = RectF(safeLeft + sbCornerInset, safeTop, centreX - sbHalfGap, safeTop + sbH)
+    val rbRect = RectF(centreX + sbHalfGap, safeTop, safeRight - sbCornerInset, safeTop + sbH)
+
+    val contentTop = safeTop + sbH + gap
+    val contentBottom = safeBottom
+    val ltRect = RectF(safeLeft, contentTop, safeLeft + tW, contentBottom)
+    val rtRect = RectF(safeRight - tW, contentTop, safeRight, contentBottom)
+
+    val contentLeft = ltRect.right + gap
+    val contentRight = rtRect.left - gap
+    val contentW = contentRight - contentLeft
+    val contentH = contentBottom - contentTop
+    val qw = contentW / 4f
+
+    val topRowCy = contentTop + contentH * TOP_ROW_Y_FRACTION
+    val bottomRowCy = contentTop + contentH * BOTTOM_ROW_Y_FRACTION
+
+    val pad = DPAD_INNER_PAD_DP * density
+    // Cluster size: capped both by the available half-width (left or right
+    // quarter pair, minus padding) and a fraction of content height.
+    val clusterSize = min(qw * 2f - pad * 2, contentH * CLUSTER_HEIGHT_FRACTION)
+
+    val dpadCx = contentLeft + qw * CLUSTER_X_FRACTION_OF_QUARTER
+    val dpadCy = if (usePlayStation) topRowCy else bottomRowCy
+    val dpadRect =
+        RectF(dpadCx - clusterSize / 2, dpadCy - clusterSize / 2, dpadCx + clusterSize / 2, dpadCy + clusterSize / 2)
+
+    val stickRadius = min(qw * STICK_RADIUS_QW_FRACTION, contentH * STICK_RADIUS_H_FRACTION)
+    val l3StickRadius = stickRadius * L3_STICK_RADIUS_FRACTION
+    val l3Gap = L3_STICK_GAP_DP * density
+    val leftStickCx = contentLeft + qw * STICK_X_FRACTION_OF_QUARTER
+    val leftStickCy = if (usePlayStation) bottomRowCy else topRowCy
+    val l3StickCx = leftStickCx + stickRadius + l3StickRadius + l3Gap
+    val l3StickCy = leftStickCy
+
+    // ABXY mirrors the d-pad on the right; right stick mirrors the left stick.
+    val abxyCx = contentRight - qw * CLUSTER_X_FRACTION_OF_QUARTER
+    val abxyRect =
+        RectF(abxyCx - clusterSize / 2, topRowCy - clusterSize / 2, abxyCx + clusterSize / 2, topRowCy + clusterSize / 2)
+    val btnRadius = clusterSize * ABXY_BTN_RADIUS_FRACTION
+
+    val rightStickCx = contentRight - qw * STICK_X_FRACTION_OF_QUARTER
+    val rightStickCy = bottomRowCy
+    val r3StickCx = rightStickCx - stickRadius - l3StickRadius - l3Gap
+    val r3StickCy = rightStickCy
+
+    val smallBtnRadius = SMALL_BTN_RADIUS_DP * density
+    val centerBtnCy = contentTop + smallBtnRadius * CENTER_BTN_TOP_OFFSET_FACTOR
+    val centerCx = (contentLeft + contentRight) / 2f
+    val centerHalfGap = CENTER_BTN_HALF_GAP_DP * density
+
+    return GamepadLayout(
+        dpadRect = dpadRect,
+        abxyRect = abxyRect,
+        lbRect = lbRect,
+        rbRect = rbRect,
+        ltRect = ltRect,
+        rtRect = rtRect,
+        leftStickCx = leftStickCx,
+        leftStickCy = leftStickCy,
+        rightStickCx = rightStickCx,
+        rightStickCy = rightStickCy,
+        l3StickCx = l3StickCx,
+        l3StickCy = l3StickCy,
+        r3StickCx = r3StickCx,
+        r3StickCy = r3StickCy,
+        stickRadius = stickRadius,
+        l3StickRadius = l3StickRadius,
+        btnRadius = btnRadius,
+        smallBtnRadius = smallBtnRadius,
+        selectCx = centerCx - centerHalfGap,
+        startCx = centerCx + centerHalfGap,
+        homeCx = centerCx,
+        centerBtnCy = centerBtnCy,
+    )
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadTouchView.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadTouchView.kt
@@ -17,6 +17,21 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.tinkernorth.dish.R
+import com.tinkernorth.dish.ui.common.GamepadConstants.ABXY_BTN_DRAW_SIZE_FACTOR
+import com.tinkernorth.dish.ui.common.GamepadConstants.ABXY_BTN_SPACING_FACTOR
+import com.tinkernorth.dish.ui.common.GamepadConstants.CENTER_BTN_DRAW_SIZE_FACTOR
+import com.tinkernorth.dish.ui.common.GamepadConstants.HOME_DRAW_SIZE_FACTOR
+import com.tinkernorth.dish.ui.common.GamepadConstants.HOME_VERTICAL_OFFSET_FACTOR
+import com.tinkernorth.dish.ui.common.GamepadConstants.PILL_CORNER_RADIUS_FRACTION
+import com.tinkernorth.dish.ui.common.GamepadConstants.PILL_ICON_SIZE_FRACTION
+import com.tinkernorth.dish.ui.common.GamepadConstants.STICK_DIR_LINE_WIDTH_FRACTION
+import com.tinkernorth.dish.ui.common.GamepadConstants.STICK_LABEL_BASELINE_FRACTION
+import com.tinkernorth.dish.ui.common.GamepadConstants.STICK_LABEL_SIZE_MULTI
+import com.tinkernorth.dish.ui.common.GamepadConstants.STICK_LABEL_SIZE_SINGLE
+import com.tinkernorth.dish.ui.common.GamepadConstants.STICK_RING_STROKE_DP
+import com.tinkernorth.dish.ui.common.GamepadConstants.STICK_THUMB_RADIUS_FRACTION
+import com.tinkernorth.dish.ui.common.GamepadConstants.STICK_THUMB_RING_STROKE_DP
+import com.tinkernorth.dish.ui.common.GamepadConstants.STICK_THUMB_TRAVEL_FRACTION
 import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.hypot
@@ -27,14 +42,15 @@ import kotlin.math.sin
  * Custom View rendering an on-screen gamepad with touch input.
  *
  * Layout (landscape):
- *   Left side:  D-Pad (top) + Left Stick (bottom)
+ *   Left side:  D-Pad (top) + Left Stick (bottom)   (Xbox profile; PS swaps)
  *   Center:     Select / Start buttons
  *   Right side: ABXY buttons (top) + Right Stick (bottom)
  *   Shoulders:  LB/RB at top edges, LT/RT as vertical strips on far edges
  *
- * All rendering is code-drawn (no bitmaps). Reports state via [listener].
+ * Layout, drawing tuning, and gesture handling live in
+ * [GamepadConstants] / [computeGamepadLayout] / [GamepadGestureRecognizer].
+ * This View only owns paints, drawables, and the draw + touch dispatch.
  */
-@Suppress("TooManyFunctions")
 class GamepadTouchView
     @JvmOverloads
     constructor(
@@ -63,9 +79,7 @@ class GamepadTouchView
             var rightTrigger: Int = 0,
         )
 
-        private var state = GamepadState()
-
-        // ── Button bit constants ─────────────────────────────────────────────────
+        // ── Button bit constants (public; referenced by tests + BT layout map) ──
         companion object {
             const val BTN_A = 1 shl 0
             const val BTN_B = 1 shl 1
@@ -88,8 +102,6 @@ class GamepadTouchView
             const val HAT_SW = 6
             const val HAT_W = 7
             const val HAT_NW = 8
-
-            private const val TRIGGER_MAX = 255
         }
 
         // ── Controller profile ──────────────────────────────────────────────────
@@ -98,6 +110,7 @@ class GamepadTouchView
             set(value) {
                 field = value
                 loadDrawables()
+                relayout()
                 invalidate()
             }
 
@@ -152,6 +165,12 @@ class GamepadTouchView
         private var icStart: Drawable? = null
         private var icHome: Drawable? = null
 
+        // ── Layout + gesture recognizer ─────────────────────────────────────────
+
+        private var density = 1f
+        private var layout: GamepadLayout? = null
+        private val recognizer = GamepadGestureRecognizer()
+
         init {
             loadDrawables()
             ViewCompat.setOnApplyWindowInsetsListener(this) { v, wi ->
@@ -166,7 +185,7 @@ class GamepadTouchView
                 ) {
                     safeInsets.set(ins.left, ins.top, ins.right, ins.bottom)
                     if (v.width > 0 && v.height > 0) {
-                        onSizeChanged(v.width, v.height, v.width, v.height)
+                        relayout()
                         invalidate()
                     }
                 }
@@ -218,54 +237,6 @@ class GamepadTouchView
             }
         }
 
-        // ── Layout regions (computed in onSizeChanged) ───────────────────────────
-
-        private var dp = 1f
-        private val dpadRect = RectF()
-        private val abxyRect = RectF()
-        private var leftStickCx = 0f
-        private var leftStickCy = 0f
-        private var stickRadius = 0f
-        private var rightStickCx = 0f
-        private var rightStickCy = 0f
-        private var l3StickCx = 0f
-        private var l3StickCy = 0f
-        private var r3StickCx = 0f
-        private var r3StickCy = 0f
-        private var l3StickRadius = 0f
-        private var selectCx = 0f
-        private var startCx = 0f
-        private var centerBtnCy = 0f
-        private var homeCx = 0f
-        private var btnRadius = 0f
-        private var smallBtnRadius = 0f
-        private val lbRect = RectF()
-        private val rbRect = RectF()
-        private val ltRect = RectF()
-        private val rtRect = RectF()
-
-        // ── Touch tracking ───────────────────────────────────────────────────────
-
-        private var leftStickPointerId = -1
-        private var rightStickPointerId = -1
-        private var leftStickDx = 0f
-        private var leftStickDy = 0f
-        private var rightStickDx = 0f
-        private var rightStickDy = 0f
-        private var l3StickPointerId = -1
-        private var r3StickPointerId = -1
-        private var l3StickDx = 0f
-        private var l3StickDy = 0f
-        private var r3StickDx = 0f
-        private var r3StickDy = 0f
-        private var ltPointerId = -1
-        private var rtPointerId = -1
-        private var dpadPointerId = -1
-        private var abxyPointerId = -1
-        private var lbPointerId = -1
-        private var rbPointerId = -1
-
-        @Suppress("LongMethod", "MagicNumber")
         override fun onSizeChanged(
             w: Int,
             h: Int,
@@ -273,76 +244,14 @@ class GamepadTouchView
             oldH: Int,
         ) {
             super.onSizeChanged(w, h, oldW, oldH)
-            dp = resources.displayMetrics.density
+            density = resources.displayMetrics.density
+            relayout()
+        }
 
-            // Safe-area envelope: system bars + display cutouts + small cushion so
-            // nothing abuts rounded corners / gesture zones.
-            val cushion = 6 * dp
-            val safeTop = safeInsets.top + cushion
-            val safeLeft = safeInsets.left + cushion
-            val safeRight = w - safeInsets.right - cushion
-            val safeBottom = h - safeInsets.bottom - cushion
-
-            // Shoulder band along the top, trigger columns along the sides. The
-            // inner content rect is what's left — all other controls are laid out
-            // relative to it so they never float over shoulders/triggers.
-            val sbH = 56 * dp
-            val sbCornerInset = (safeRight - safeLeft) * 0.04f
-            val tW = 52 * dp
-            val gap = 6 * dp
-
-            lbRect.set(safeLeft + sbCornerInset, safeTop, (safeLeft + safeRight) / 2f - 80 * dp, safeTop + sbH)
-            rbRect.set((safeLeft + safeRight) / 2f + 80 * dp, safeTop, safeRight - sbCornerInset, safeTop + sbH)
-
-            val contentTop = safeTop + sbH + gap
-            val contentBottom = safeBottom
-            ltRect.set(safeLeft, contentTop, safeLeft + tW, contentBottom)
-            rtRect.set(safeRight - tW, contentTop, safeRight, contentBottom)
-
-            val contentLeft = ltRect.right + gap
-            val contentRight = rtRect.left - gap
-            val contentW = contentRight - contentLeft
-            val contentH = contentBottom - contentTop
-            val qw = contentW / 4f
-
-            // Top row centre y / bottom row centre y inside the content rect.
-            val topRowCy = contentTop + contentH * 0.28f
-            val bottomRowCy = contentTop + contentH * 0.75f
-
-            val pad = 12 * dp
-            val dpadSize = min(qw * 2f - pad * 2, contentH * 0.42f)
-            val dpadCx = contentLeft + qw * 0.55f
-            // Xbox: stick top-left, d-pad bottom-left. PlayStation: swap.
-            val dpadCy = if (usePlayStation) topRowCy else bottomRowCy
-            dpadRect.set(dpadCx - dpadSize / 2, dpadCy - dpadSize / 2, dpadCx + dpadSize / 2, dpadCy + dpadSize / 2)
-
-            stickRadius = min(qw * 0.42f, contentH * 0.2f)
-            l3StickRadius = stickRadius * 0.7f
-            leftStickCx = contentLeft + qw * 0.5f
-            leftStickCy = if (usePlayStation) bottomRowCy else topRowCy
-            l3StickCx = leftStickCx + stickRadius + l3StickRadius + 12 * dp
-            l3StickCy = leftStickCy
-
-            // ABXY mirrors the d-pad on the right; right stick mirrors the left stick.
-            val abxyCx = contentRight - qw * 0.55f
-            val abxyCy = topRowCy
-            val abxySize = dpadSize
-            abxyRect.set(abxyCx - abxySize / 2, abxyCy - abxySize / 2, abxyCx + abxySize / 2, abxyCy + abxySize / 2)
-            btnRadius = abxySize * 0.18f
-
-            rightStickCx = contentRight - qw * 0.5f
-            rightStickCy = bottomRowCy
-            r3StickCx = rightStickCx - stickRadius - l3StickRadius - 12 * dp
-            r3StickCy = rightStickCy
-
-            // Centre cluster sits between the shoulder band and the top row so it
-            // never overlaps the d-pad / ABXY groups.
-            smallBtnRadius = 14 * dp
-            centerBtnCy = contentTop + smallBtnRadius * 1.8f
-            val centerCx = (contentLeft + contentRight) / 2f
-            selectCx = centerCx - 40 * dp
-            startCx = centerCx + 40 * dp
-            homeCx = centerCx
+        private fun relayout() {
+            if (width <= 0 || height <= 0) return
+            density = resources.displayMetrics.density
+            layout = computeGamepadLayout(width, height, density, safeInsets, usePlayStation)
         }
 
         // ── Drawing ──────────────────────────────────────────────────────────────
@@ -377,25 +286,30 @@ class GamepadTouchView
         override fun onDraw(canvas: Canvas) {
             super.onDraw(canvas)
             canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), paintBg)
+            val l = layout ?: return
+            val s = recognizer.state
 
-            drawDpad(canvas)
-            drawAbxy(canvas)
-            drawStick(canvas, leftStickCx, leftStickCy, leftStickDx, leftStickDy, stickRadius, "L")
-            drawStick(canvas, rightStickCx, rightStickCy, rightStickDx, rightStickDy, stickRadius, "R")
-            drawStick(canvas, l3StickCx, l3StickCy, l3StickDx, l3StickDy, l3StickRadius, "L3")
-            drawStick(canvas, r3StickCx, r3StickCy, r3StickDx, r3StickDy, l3StickRadius, "R3")
-            drawCenterButtons(canvas)
-            drawShoulders(canvas)
-            drawTriggers(canvas)
+            drawDpad(canvas, l, s)
+            drawAbxy(canvas, l, s)
+            drawStick(canvas, l.leftStickCx, l.leftStickCy, recognizer.leftStickDx, recognizer.leftStickDy, l.stickRadius, "L")
+            drawStick(canvas, l.rightStickCx, l.rightStickCy, recognizer.rightStickDx, recognizer.rightStickDy, l.stickRadius, "R")
+            drawStick(canvas, l.l3StickCx, l.l3StickCy, recognizer.l3StickDx, recognizer.l3StickDy, l.l3StickRadius, "L3")
+            drawStick(canvas, l.r3StickCx, l.r3StickCy, recognizer.r3StickDx, recognizer.r3StickDy, l.l3StickRadius, "R3")
+            drawCenterButtons(canvas, l, s)
+            drawShoulders(canvas, l, s)
+            drawTriggers(canvas, l, s)
         }
 
-        private fun drawDpad(c: Canvas) {
-            val cx = dpadRect.centerX()
-            val cy = dpadRect.centerY()
-            val size = dpadRect.width()
-            val hat = state.hatSwitch
+        private fun drawDpad(
+            c: Canvas,
+            l: GamepadLayout,
+            s: GamepadState,
+        ) {
+            val cx = l.dpadRect.centerX()
+            val cy = l.dpadRect.centerY()
+            val size = l.dpadRect.width()
             val active =
-                when (hat) {
+                when (s.hatSwitch) {
                     HAT_N, HAT_NE, HAT_NW -> icDpadUp
                     HAT_S, HAT_SE, HAT_SW -> icDpadDown
                     HAT_W -> icDpadLeft
@@ -406,15 +320,19 @@ class GamepadTouchView
             if (active != null) drawDrawable(c, active, cx, cy, size)
         }
 
-        private fun drawAbxy(c: Canvas) {
-            val cx = abxyRect.centerX()
-            val cy = abxyRect.centerY()
-            val sp = btnRadius * 1.5f
-            val sz = btnRadius * 2.2f
-            drawIcon(c, icBtnY, cx, cy - sp, sz, state.buttons and BTN_Y != 0)
-            drawIcon(c, icBtnA, cx, cy + sp, sz, state.buttons and BTN_A != 0)
-            drawIcon(c, icBtnX, cx - sp, cy, sz, state.buttons and BTN_X != 0)
-            drawIcon(c, icBtnB, cx + sp, cy, sz, state.buttons and BTN_B != 0)
+        private fun drawAbxy(
+            c: Canvas,
+            l: GamepadLayout,
+            s: GamepadState,
+        ) {
+            val cx = l.abxyRect.centerX()
+            val cy = l.abxyRect.centerY()
+            val sp = l.btnRadius * ABXY_BTN_SPACING_FACTOR
+            val sz = l.btnRadius * ABXY_BTN_DRAW_SIZE_FACTOR
+            drawIcon(c, icBtnY, cx, cy - sp, sz, s.buttons and BTN_Y != 0)
+            drawIcon(c, icBtnA, cx, cy + sp, sz, s.buttons and BTN_A != 0)
+            drawIcon(c, icBtnX, cx - sp, cy, sz, s.buttons and BTN_X != 0)
+            drawIcon(c, icBtnB, cx + sp, cy, sz, s.buttons and BTN_B != 0)
         }
 
         private fun drawIcon(
@@ -432,7 +350,6 @@ class GamepadTouchView
             }
         }
 
-        @Suppress("MagicNumber")
         private fun drawStick(
             c: Canvas,
             cx: Float,
@@ -443,36 +360,41 @@ class GamepadTouchView
             label: String,
         ) {
             // Top-down view: outer base ring, a direction line from center to the
-            // displaced thumb cap, then the thumb cap with its label. No side-view
-            // stem, so the stick no longer appears to always point down.
+            // displaced thumb cap, then the thumb cap with its label.
             c.drawCircle(cx, cy, radius, paintStickBg)
-            paintStickRing.strokeWidth = 2f * dp
+            paintStickRing.strokeWidth = STICK_RING_STROKE_DP * density
             c.drawCircle(cx, cy, radius, paintStickRing)
 
-            val travel = radius * 0.55f
+            val travel = radius * STICK_THUMB_TRAVEL_FRACTION
             val thumbCx = cx + dx * travel
             val thumbCy = cy + dy * travel
-            val thumbR = radius * 0.55f
+            val thumbR = radius * STICK_THUMB_RADIUS_FRACTION
 
-            if (dx != 0f || dy != 0f) {
-                paintStickDir.strokeWidth = thumbR * 0.35f
+            val active = (dx != 0f || dy != 0f)
+            if (active) {
+                paintStickDir.strokeWidth = thumbR * STICK_DIR_LINE_WIDTH_FRACTION
                 c.drawLine(cx, cy, thumbCx, thumbCy, paintStickDir)
             }
 
-            val active = (dx != 0f || dy != 0f)
             c.drawCircle(thumbCx, thumbCy, thumbR, if (active) paintStickThumbActive else paintStickThumb)
-            paintStickRing.strokeWidth = 1.5f * dp
+            paintStickRing.strokeWidth = STICK_THUMB_RING_STROKE_DP * density
             c.drawCircle(thumbCx, thumbCy, thumbR, paintStickRing)
 
-            paintStickLabel.textSize = thumbR * (if (label.length > 1) 0.7f else 0.95f)
-            c.drawText(label, thumbCx, thumbCy + thumbR * 0.33f, paintStickLabel)
+            paintStickLabel.textSize =
+                thumbR * (if (label.length > 1) STICK_LABEL_SIZE_MULTI else STICK_LABEL_SIZE_SINGLE)
+            c.drawText(label, thumbCx, thumbCy + thumbR * STICK_LABEL_BASELINE_FRACTION, paintStickLabel)
         }
 
-        private fun drawCenterButtons(c: Canvas) {
-            val sz = smallBtnRadius * 2.2f
-            drawIcon(c, icSelect, selectCx, centerBtnCy, sz, state.buttons and BTN_SELECT != 0)
-            drawIcon(c, icStart, startCx, centerBtnCy, sz, state.buttons and BTN_START != 0)
-            drawIcon(c, icHome, homeCx, centerBtnCy + smallBtnRadius * 2.5f, sz * 0.8f, state.buttons and BTN_HOME != 0)
+        private fun drawCenterButtons(
+            c: Canvas,
+            l: GamepadLayout,
+            s: GamepadState,
+        ) {
+            val sz = l.smallBtnRadius * CENTER_BTN_DRAW_SIZE_FACTOR
+            drawIcon(c, icSelect, l.selectCx, l.centerBtnCy, sz, s.buttons and BTN_SELECT != 0)
+            drawIcon(c, icStart, l.startCx, l.centerBtnCy, sz, s.buttons and BTN_START != 0)
+            val homeCy = l.centerBtnCy + l.smallBtnRadius * HOME_VERTICAL_OFFSET_FACTOR
+            drawIcon(c, icHome, l.homeCx, homeCy, sz * HOME_DRAW_SIZE_FACTOR, s.buttons and BTN_HOME != 0)
         }
 
         private fun drawPillButton(
@@ -481,10 +403,10 @@ class GamepadTouchView
             d: Drawable?,
             pressed: Boolean,
         ) {
-            val r = min(rect.width(), rect.height()) * 0.35f
+            val r = min(rect.width(), rect.height()) * PILL_CORNER_RADIUS_FRACTION
             c.drawRoundRect(rect, r, r, if (pressed) paintPillPressed else paintPillBg)
             if (d != null) {
-                val iconSize = (min(rect.width(), rect.height()) * 0.8f).toInt()
+                val iconSize = (min(rect.width(), rect.height()) * PILL_ICON_SIZE_FRACTION).toInt()
                 val half = iconSize / 2
                 val cx = rect.centerX().toInt()
                 val cy = rect.centerY().toInt()
@@ -493,318 +415,33 @@ class GamepadTouchView
             }
         }
 
-        private fun drawShoulders(c: Canvas) {
-            drawPillButton(c, lbRect, icLB, state.buttons and BTN_LB != 0)
-            drawPillButton(c, rbRect, icRB, state.buttons and BTN_RB != 0)
+        private fun drawShoulders(
+            c: Canvas,
+            l: GamepadLayout,
+            s: GamepadState,
+        ) {
+            drawPillButton(c, l.lbRect, icLB, s.buttons and BTN_LB != 0)
+            drawPillButton(c, l.rbRect, icRB, s.buttons and BTN_RB != 0)
         }
 
-        private fun drawTriggers(c: Canvas) {
-            drawPillButton(c, ltRect, icLT, state.leftTrigger > 0)
-            drawPillButton(c, rtRect, icRT, state.rightTrigger > 0)
+        private fun drawTriggers(
+            c: Canvas,
+            l: GamepadLayout,
+            s: GamepadState,
+        ) {
+            drawPillButton(c, l.ltRect, icLT, s.leftTrigger > 0)
+            drawPillButton(c, l.rtRect, icRT, s.rightTrigger > 0)
         }
 
         // ── Touch handling ───────────────────────────────────────────────────────
 
         @SuppressLint("ClickableViewAccessibility")
         override fun onTouchEvent(event: MotionEvent): Boolean {
-            when (event.actionMasked) {
-                MotionEvent.ACTION_DOWN, MotionEvent.ACTION_POINTER_DOWN -> {
-                    val idx = event.actionIndex
-                    handlePointerDown(event, idx)
-                }
-                MotionEvent.ACTION_MOVE -> {
-                    for (i in 0 until event.pointerCount) {
-                        handlePointerMove(event, i)
-                    }
-                }
-                MotionEvent.ACTION_UP, MotionEvent.ACTION_POINTER_UP -> {
-                    val idx = event.actionIndex
-                    handlePointerUp(event, idx)
-                }
-                MotionEvent.ACTION_CANCEL -> {
-                    resetAll()
-                }
-            }
+            val l = layout ?: return false
+            recognizer.onTouchEvent(event, l)
             invalidate()
-            listener?.onGamepadStateChanged(state)
+            listener?.onGamepadStateChanged(recognizer.state)
             return true
-        }
-
-        @Suppress("CyclomaticComplexity", "MagicNumber", "ReturnCount")
-        private fun handlePointerDown(
-            event: MotionEvent,
-            idx: Int,
-        ) {
-            val x = event.getX(idx)
-            val y = event.getY(idx)
-            val pid = event.getPointerId(idx)
-
-            // Sticks
-            if (hypot(x - leftStickCx, y - leftStickCy) < stickRadius * 1.3f) {
-                leftStickPointerId = pid
-                return
-            }
-            if (hypot(x - rightStickCx, y - rightStickCy) < stickRadius * 1.3f) {
-                rightStickPointerId = pid
-                return
-            }
-
-            // L3/R3 sticks (touch = button pressed + axis control)
-            if (hypot(x - l3StickCx, y - l3StickCy) < l3StickRadius * 1.3f) {
-                l3StickPointerId = pid
-                state.buttons = state.buttons or BTN_LS
-                return
-            }
-            if (hypot(x - r3StickCx, y - r3StickCy) < l3StickRadius * 1.3f) {
-                r3StickPointerId = pid
-                state.buttons = state.buttons or BTN_RS
-                return
-            }
-
-            // Triggers — binary press, tracked by pointer id so drag-off still
-            // releases cleanly on UP.
-            if (ltRect.contains(x, y)) {
-                ltPointerId = pid
-                state.leftTrigger = TRIGGER_MAX
-                return
-            }
-            if (rtRect.contains(x, y)) {
-                rtPointerId = pid
-                state.rightTrigger = TRIGGER_MAX
-                return
-            }
-
-            // Shoulders — pointer-id tracked so release works regardless of
-            // where the finger ends up on UP.
-            if (lbRect.contains(x, y)) {
-                lbPointerId = pid
-                state.buttons = state.buttons or BTN_LB
-                return
-            }
-            if (rbRect.contains(x, y)) {
-                rbPointerId = pid
-                state.buttons = state.buttons or BTN_RB
-                return
-            }
-
-            // D-Pad
-            if (dpadRect.contains(x, y)) {
-                dpadPointerId = pid
-                updateDpad(x, y)
-                return
-            }
-
-            // ABXY
-            if (abxyRect.contains(x, y)) {
-                abxyPointerId = pid
-                updateAbxy(x, y)
-                return
-            }
-
-            // Center buttons
-            if (hypot(x - selectCx, y - centerBtnCy) < smallBtnRadius * 1.5f) {
-                state.buttons = state.buttons or BTN_SELECT
-                return
-            }
-            if (hypot(x - startCx, y - centerBtnCy) < smallBtnRadius * 1.5f) {
-                state.buttons = state.buttons or BTN_START
-                return
-            }
-            if (hypot(x - homeCx, y - (centerBtnCy + smallBtnRadius * 2.5f)) < smallBtnRadius * 1.5f) {
-                state.buttons = state.buttons or BTN_HOME
-                return
-            }
-        }
-
-        @Suppress("MagicNumber")
-        private fun handlePointerMove(
-            event: MotionEvent,
-            idx: Int,
-        ) {
-            val x = event.getX(idx)
-            val y = event.getY(idx)
-            val pid = event.getPointerId(idx)
-
-            if (pid == leftStickPointerId) {
-                val r = computeStickAxes((x - leftStickCx) / stickRadius, (y - leftStickCy) / stickRadius)
-                leftStickDx = r.dx
-                leftStickDy = r.dy
-                state.leftX = r.axisX
-                state.leftY = r.axisY
-            }
-            if (pid == rightStickPointerId) {
-                val r = computeStickAxes((x - rightStickCx) / stickRadius, (y - rightStickCy) / stickRadius)
-                rightStickDx = r.dx
-                rightStickDy = r.dy
-                state.rightX = r.axisX
-                state.rightY = r.axisY
-            }
-            // L3 stick — same axes as L stick, plus L3 button held
-            if (pid == l3StickPointerId) {
-                val r = computeStickAxes((x - l3StickCx) / l3StickRadius, (y - l3StickCy) / l3StickRadius)
-                l3StickDx = r.dx
-                l3StickDy = r.dy
-                state.leftX = r.axisX
-                state.leftY = r.axisY
-            }
-            // R3 stick — same axes as R stick, plus R3 button held
-            if (pid == r3StickPointerId) {
-                val r = computeStickAxes((x - r3StickCx) / l3StickRadius, (y - r3StickCy) / l3StickRadius)
-                r3StickDx = r.dx
-                r3StickDy = r.dy
-                state.rightX = r.axisX
-                state.rightY = r.axisY
-            }
-            // Triggers are binary — no move-modulation. The DOWN/UP handlers
-            // set the value; MOVE is a no-op for trigger pointers.
-
-            // Live D-Pad tracking — only for the pointer that started on the d-pad
-            if (pid == dpadPointerId) {
-                if (dpadRect.contains(x, y)) {
-                    updateDpad(x, y)
-                } else {
-                    state.hatSwitch = HAT_NONE
-                }
-            }
-        }
-
-        @Suppress("MagicNumber", "ReturnCount")
-        private fun handlePointerUp(
-            event: MotionEvent,
-            idx: Int,
-        ) {
-            val pid = event.getPointerId(idx)
-
-            if (pid == leftStickPointerId) {
-                leftStickPointerId = -1
-                leftStickDx = 0f
-                leftStickDy = 0f
-                state.leftX = 0
-                state.leftY = 0
-                return
-            }
-            if (pid == rightStickPointerId) {
-                rightStickPointerId = -1
-                rightStickDx = 0f
-                rightStickDy = 0f
-                state.rightX = 0
-                state.rightY = 0
-                return
-            }
-            if (pid == l3StickPointerId) {
-                l3StickPointerId = -1
-                l3StickDx = 0f
-                l3StickDy = 0f
-                state.leftX = 0
-                state.leftY = 0
-                state.buttons = state.buttons and BTN_LS.inv()
-                return
-            }
-            if (pid == r3StickPointerId) {
-                r3StickPointerId = -1
-                r3StickDx = 0f
-                r3StickDy = 0f
-                state.rightX = 0
-                state.rightY = 0
-                state.buttons = state.buttons and BTN_RS.inv()
-                return
-            }
-            if (pid == ltPointerId) {
-                ltPointerId = -1
-                state.leftTrigger = 0
-                return
-            }
-            if (pid == rtPointerId) {
-                rtPointerId = -1
-                state.rightTrigger = 0
-                return
-            }
-
-            // All button-region pointers clear by pointer ID, never by
-            // position — otherwise dragging the finger off the rect before
-            // release leaves the bit stuck.
-            if (pid == dpadPointerId) {
-                dpadPointerId = -1
-                state.hatSwitch = HAT_NONE
-                return
-            }
-            if (pid == abxyPointerId) {
-                abxyPointerId = -1
-                state.buttons = state.buttons and (BTN_A or BTN_B or BTN_X or BTN_Y).inv()
-                return
-            }
-            if (pid == lbPointerId) {
-                lbPointerId = -1
-                state.buttons = state.buttons and BTN_LB.inv()
-                return
-            }
-            if (pid == rbPointerId) {
-                rbPointerId = -1
-                state.buttons = state.buttons and BTN_RB.inv()
-                return
-            }
-            // Center / stick-click buttons: the pointer isn't tracked by id so
-            // just drop all of them on any unmatched up — same as before.
-            state.buttons = state.buttons and (BTN_SELECT or BTN_START or BTN_HOME or BTN_LS or BTN_RS).inv()
-        }
-
-        private fun resetAll() {
-            state = GamepadState()
-            leftStickPointerId = -1
-            rightStickPointerId = -1
-            leftStickDx = 0f
-            leftStickDy = 0f
-            rightStickDx = 0f
-            rightStickDy = 0f
-            ltPointerId = -1
-            rtPointerId = -1
-            l3StickPointerId = -1
-            r3StickPointerId = -1
-            l3StickDx = 0f
-            l3StickDy = 0f
-            r3StickDx = 0f
-            r3StickDy = 0f
-            dpadPointerId = -1
-            abxyPointerId = -1
-            lbPointerId = -1
-            rbPointerId = -1
-        }
-
-        @Suppress("MagicNumber")
-        private fun updateDpad(
-            x: Float,
-            y: Float,
-        ) {
-            val cx = dpadRect.centerX()
-            val cy = dpadRect.centerY()
-            val dx = x - cx
-            val dy = y - cy
-            val angle = Math.toDegrees(atan2(dy.toDouble(), dx.toDouble())).let { if (it < 0) it + 360 else it }
-            state.hatSwitch =
-                when {
-                    angle < 22.5 || angle >= 337.5 -> HAT_E
-                    angle < 67.5 -> HAT_SE
-                    angle < 112.5 -> HAT_S
-                    angle < 157.5 -> HAT_SW
-                    angle < 202.5 -> HAT_W
-                    angle < 247.5 -> HAT_NW
-                    angle < 292.5 -> HAT_N
-                    else -> HAT_NE
-                }
-        }
-
-        @Suppress("MagicNumber")
-        private fun updateAbxy(
-            x: Float,
-            y: Float,
-        ) {
-            val cx = abxyRect.centerX()
-            val cy = abxyRect.centerY()
-            val sp = btnRadius * 1.5f
-            if (hypot(x - cx, y - (cy - sp)) < btnRadius * 1.3f) state.buttons = state.buttons or BTN_Y
-            if (hypot(x - cx, y - (cy + sp)) < btnRadius * 1.3f) state.buttons = state.buttons or BTN_A
-            if (hypot(x - (cx - sp), y - cy) < btnRadius * 1.3f) state.buttons = state.buttons or BTN_X
-            if (hypot(x - (cx + sp), y - cy) < btnRadius * 1.3f) state.buttons = state.buttons or BTN_B
         }
     }
 

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
@@ -11,10 +11,8 @@ import android.content.pm.PackageManager
 import android.graphics.drawable.GradientDrawable
 import android.os.Build
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.widget.EditText
-import android.widget.TextView
+import android.view.ViewGroup
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
@@ -32,6 +30,8 @@ import com.tinkernorth.dish.data.network.ConnectionSummary
 import com.tinkernorth.dish.data.network.WifiConnection
 import com.tinkernorth.dish.data.network.WifiConnectionManager
 import com.tinkernorth.dish.databinding.ActivityConnectionsBinding
+import com.tinkernorth.dish.databinding.DialogPairingBinding
+import com.tinkernorth.dish.databinding.RowConnectionBinding
 import com.tinkernorth.dish.ui.bluetooth.BluetoothGamepad
 import com.tinkernorth.dish.ui.bluetooth.BluetoothGamepadRegistry
 import dagger.hilt.android.AndroidEntryPoint
@@ -140,68 +140,63 @@ class ConnectionsActivity : AppCompatActivity() {
     }
 
     private fun wifiRow(c: ConnectionSummary): View {
-        val v = inflateRow(c.label, c.detail, statusText(c))
-        val btn = v.findViewById<com.google.android.material.button.MaterialButton>(R.id.btnRowAction)
-        val btnSecondary = v.findViewById<com.google.android.material.button.MaterialButton>(R.id.btnRowSecondary)
+        val rb = inflateRow(binding.llWifiList, c.label, c.detail, statusText(c))
         when (c.live) {
             ConnectionLive.CONNECTED -> {
-                btn.text = "Disconnect"
-                btn.setOnClickListener { wifi.disconnect(c.id) }
+                rb.btnRowAction.text = "Disconnect"
+                rb.btnRowAction.setOnClickListener { wifi.disconnect(c.id) }
             }
             ConnectionLive.CONNECTING -> {
-                btn.text = "Connecting…"
-                btn.isEnabled = false
+                rb.btnRowAction.text = "Connecting…"
+                rb.btnRowAction.isEnabled = false
             }
             ConnectionLive.IDLE -> {
-                btn.text = "Connect"
-                btn.setOnClickListener {
+                rb.btnRowAction.text = "Connect"
+                rb.btnRowAction.setOnClickListener {
                     val remembered = wifi.remembered().firstOrNull { it.id == c.id } ?: return@setOnClickListener
                     wifi.connect(remembered.toDiscovered())
                 }
             }
         }
-        btnSecondary.visibility = View.VISIBLE
-        btnSecondary.text = "Forget"
-        btnSecondary.setOnClickListener { wifi.forget(c.id) }
-        return v
+        rb.btnRowSecondary.visibility = View.VISIBLE
+        rb.btnRowSecondary.text = "Forget"
+        rb.btnRowSecondary.setOnClickListener { wifi.forget(c.id) }
+        return rb.root
     }
 
     private fun discoveredWifiRow(s: com.tinkernorth.dish.data.model.DiscoveredServer): View {
-        val v = inflateRow(s.name.ifEmpty { s.ip }, "${s.ip} • UDP ${s.udpPort}", "Discovered")
-        val btn = v.findViewById<com.google.android.material.button.MaterialButton>(R.id.btnRowAction)
-        btn.text = "Connect"
-        btn.setOnClickListener { wifi.connect(s) }
-        return v
+        val rb = inflateRow(binding.llWifiList, s.name.ifEmpty { s.ip }, "${s.ip} • UDP ${s.udpPort}", "Discovered")
+        rb.btnRowAction.text = "Connect"
+        rb.btnRowAction.setOnClickListener { wifi.connect(s) }
+        return rb.root
     }
 
     private fun btRow(c: ConnectionSummary): View {
-        val v = inflateRow(c.label, c.detail, statusText(c))
-        val btn = v.findViewById<com.google.android.material.button.MaterialButton>(R.id.btnRowAction)
-        val btnSecondary = v.findViewById<com.google.android.material.button.MaterialButton>(R.id.btnRowSecondary)
+        val rb = inflateRow(binding.llBtList, c.label, c.detail, statusText(c))
         when (c.live) {
             ConnectionLive.CONNECTED -> {
-                btn.text = "Disconnect"
-                btn.setOnClickListener { btRegistry.stop(c.id) }
+                rb.btnRowAction.text = "Disconnect"
+                rb.btnRowAction.setOnClickListener { btRegistry.stop(c.id) }
             }
             ConnectionLive.CONNECTING -> {
-                btn.text = "Waiting…"
-                btn.isEnabled = false
+                rb.btnRowAction.text = "Waiting…"
+                rb.btnRowAction.isEnabled = false
             }
             ConnectionLive.IDLE -> {
-                btn.text = "Reconnect"
-                btn.setOnClickListener {
+                rb.btnRowAction.text = "Reconnect"
+                rb.btnRowAction.setOnClickListener {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) btRegistry.tryAutoReconnect(c.id)
                 }
             }
         }
-        btnSecondary.visibility = View.VISIBLE
-        btnSecondary.text = "Forget"
-        btnSecondary.setOnClickListener {
+        rb.btnRowSecondary.visibility = View.VISIBLE
+        rb.btnRowSecondary.text = "Forget"
+        rb.btnRowSecondary.setOnClickListener {
             btRegistry.stop(c.id)
             store.forgetBt(c.id)
             render(hub.connections.value)
         }
-        return v
+        return rb.root
     }
 
     private fun statusText(c: ConnectionSummary): String =
@@ -212,24 +207,24 @@ class ConnectionsActivity : AppCompatActivity() {
         }
 
     private fun inflateRow(
+        parent: ViewGroup,
         title: String,
         detail: String,
         status: String,
-    ): View {
-        val v = LayoutInflater.from(this).inflate(R.layout.row_connection, binding.llWifiList, false)
-        v.findViewById<TextView>(R.id.tvRowTitle).text = title
-        v.findViewById<TextView>(R.id.tvRowDetail).text = detail
-        v.findViewById<TextView>(R.id.tvRowStatus).text = status
-        val dot = v.findViewById<View>(R.id.dotRow)
-        dot.background = GradientDrawable().apply { shape = GradientDrawable.OVAL }
+    ): RowConnectionBinding {
+        val rb = RowConnectionBinding.inflate(layoutInflater, parent, false)
+        rb.tvRowTitle.text = title
+        rb.tvRowDetail.text = detail
+        rb.tvRowStatus.text = status
+        rb.dotRow.background = GradientDrawable().apply { shape = GradientDrawable.OVAL }
         val color =
-            when {
-                status == "Connected" -> R.color.colorSuccess
-                status == "Connecting" -> R.color.colorPrimary
+            when (status) {
+                "Connected" -> R.color.colorSuccess
+                "Connecting" -> R.color.colorPrimary
                 else -> R.color.colorMuted
             }
-        (dot.background as GradientDrawable).setColor(getColor(color))
-        return v
+        (rb.dotRow.background as GradientDrawable).setColor(getColor(color))
+        return rb
     }
 
     // ── Bluetooth add flow ────────────────────────────────────────────────
@@ -281,12 +276,14 @@ class ConnectionsActivity : AppCompatActivity() {
         ip: String,
         pairPort: Int,
     ) {
-        val v = layoutInflater.inflate(R.layout.dialog_pairing, null)
-        val etPin = v.findViewById<EditText>(R.id.et_pin)
+        val db = DialogPairingBinding.inflate(layoutInflater)
         MaterialAlertDialogBuilder(this)
-            .setView(v)
+            .setView(db.root)
             .setPositiveButton("Connect") { _, _ ->
-                val pin = etPin.text.toString().ifEmpty { "0000" }
+                val pin =
+                    db.etPin.text
+                        .toString()
+                        .ifEmpty { "0000" }
                 val server =
                     com.tinkernorth.dish.data.model.DiscoveredServer(
                         name = "",

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
@@ -24,6 +24,7 @@ import com.tinkernorth.dish.data.network.ConnectionKind
 import com.tinkernorth.dish.data.network.ConnectionLive
 import com.tinkernorth.dish.data.network.WifiConnectionManager
 import com.tinkernorth.dish.databinding.ActivityMainBinding
+import com.tinkernorth.dish.databinding.OverlayLowPowerBinding
 import com.tinkernorth.dish.ui.bluetooth.BluetoothGamepadRegistry
 import com.tinkernorth.dish.ui.bluetooth.xusbToHid
 import com.tinkernorth.dish.ui.connections.ConnectionsActivity
@@ -40,6 +41,7 @@ class MainActivity :
     InputManager.InputDeviceListener,
     SlotActionListener {
     private lateinit var binding: ActivityMainBinding
+    private lateinit var lowPowerBinding: OverlayLowPowerBinding
     private val viewModel: MainViewModel by viewModels()
     private lateinit var controllerAdapter: ControllerAdapter
     private lateinit var inputManager: InputManager
@@ -59,6 +61,10 @@ class MainActivity :
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        // Low-power overlay is a <merge> include in activity_main.xml, so its
+        // IDs aren't surfaced on ActivityMainBinding — bind() pulls them off
+        // the already-inflated tree.
+        lowPowerBinding = OverlayLowPowerBinding.bind(binding.root)
         inputManager = getSystemService(Context.INPUT_SERVICE) as InputManager
         controllerAdapter = ControllerAdapter(this)
         setupUI()
@@ -143,11 +149,11 @@ class MainActivity :
         lowPowerManager = LowPowerManager(window)
         lowPowerManager.views =
             LowPowerManager.Views(
-                llCountdownBanner = findViewById(R.id.llCountdownBanner),
-                tvCountdownSeconds = findViewById(R.id.tvCountdownSeconds),
-                flLowPowerOverlay = findViewById(R.id.flLowPowerOverlay),
-                tvLowPowerTime = findViewById(R.id.tvLowPowerTime),
-                tvLowPowerStatus = findViewById(R.id.tvLowPowerStatus),
+                llCountdownBanner = lowPowerBinding.llCountdownBanner,
+                tvCountdownSeconds = lowPowerBinding.tvCountdownSeconds,
+                flLowPowerOverlay = lowPowerBinding.flLowPowerOverlay,
+                tvLowPowerTime = lowPowerBinding.tvLowPowerTime,
+                tvLowPowerStatus = lowPowerBinding.tvLowPowerStatus,
             )
         lowPowerManager.activeControllerCount = {
             viewModel.uiState.value.connections


### PR DESCRIPTION
## Summary
- Split `GamepadTouchView` (862-line god-class with `TooManyFunctions` + 10× `MagicNumber` suppressions) into a thin View plus three focused helpers: `GamepadConstants`, `GamepadLayout` / `computeGamepadLayout`, and `GamepadGestureRecognizer`. Public API (`BTN_*`, `HAT_*`, `GamepadState`, `Listener`) preserved — existing tests and `GamepadOverlayActivity` compile unchanged.
- Unify `findViewById` vs generated-binding inconsistency in `MainActivity` (5 `findViewById` calls → `OverlayLowPowerBinding.bind(binding.root)` for the `<merge>`-rooted include) and `ConnectionsActivity` (`inflateRow` now returns `RowConnectionBinding`; pairing dialog uses `DialogPairingBinding`).
- D-pad octant math is now arithmetic on `HAT_BAND_DEG` instead of eight hand-tuned thresholds.

## Test plan
- [x] `./gradlew compileDebugKotlin` passes
- [x] `./gradlew testDebugUnitTest` — all 15 unit-test files pass (covers `BluetoothGamepadRegistry`, `BluetoothHidSession*`, `GamepadButtonLayouts`, `GamepadInputProcessor`, `MainViewModel`, `ConnectionHub`, `WifiConnection`, `VirtualStickMath`, etc.)
- [x] `./gradlew ktlintCheck detekt` clean
- [x] `./gradlew lintDebug` clean
- [ ] Smoke-test on device: tap-and-hold the four sticks (L/R/L3/R3), drag-off-then-release every button (ABXY, LB/RB, LT/RT, dpad, Select/Start/Home), and verify the d-pad direction follows the finger across all eight octants
- [ ] Verify the low-power countdown banner + dim overlay still appear and dismiss correctly in `MainActivity`
- [ ] Verify the WiFi/BT row layouts and the pairing dialog render identically in `ConnectionsActivity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)