### PR TITLE
chore: bump build toolchain to latest stable (Gradle 9.5 / AGP 9.2 / Kotlin 2.3.21)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,8 +1,7 @@
 plugins {
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ktlint)
     alias(libs.plugins.detekt)
@@ -45,7 +44,8 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
@@ -55,17 +55,14 @@ android {
             signingConfig = signingConfigs.findByName("release")
         }
     }
-    kotlin {
-        jvmToolchain(11)
-    }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
         compilerOptions {
-            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
         }
     }
     buildFeatures {
@@ -83,16 +80,6 @@ android {
             version = "3.22.1"
         }
     }
-    lint {
-        // NonNullableMutableLiveDataDetector crashes under the K2 analysis API
-        // (IncompatibleClassChangeError) with the current AGP/Kotlin pairing.
-        // The detector's own crash message suggests disabling it as the workaround.
-        disable += "NullSafeMutableLiveData"
-    }
-}
-
-kotlin {
-    jvmToolchain(11)
 }
 
 dependencies {
@@ -107,7 +94,7 @@ dependencies {
     implementation(libs.androidx.games.activity)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testImplementation(libs.turbine)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.serialization) apply false
-    alias(libs.plugins.kotlin.kapt) apply false
+    alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.ktlint) apply false
     alias(libs.plugins.detekt) apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,3 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 kotlin.code.style=official
 
 android.useAndroidX=true
-android.enableJetifier=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,24 +1,25 @@
 [versions]
-activity = "1.10.0"
-agp = "8.7.2"
-kotlin = "2.0.21"
-serialization = "1.7.3"
-hilt = "2.51.1"
-coreKtx = "1.13.1"
+activity = "1.13.0"
+agp = "9.2.0"
+kotlin = "2.3.21"
+ksp = "2.3.7"
+serialization = "1.9.0"
+hilt = "2.59.2"
+coreKtx = "1.18.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
-espressoCore = "3.6.1"
+espressoCore = "3.7.0"
 appcompat = "1.7.1"
 material = "1.12.0"
-coroutines = "1.8.1"
+coroutines = "1.10.2"
 lifecycle = "2.10.0"
-gamesActivity = "4.4.0"
+gamesActivity = "4.4.1"
 ktlint = "14.2.0"
 detekt = "1.23.8"
-dependency-check = "10.0.4"
-mockk = "1.13.12"
-turbine = "1.1.0"
-kotlinx-coroutines-test = "1.8.1"
+dependency-check = "12.1.0"
+mockk = "1.14.3"
+turbine = "1.2.0"
+kotlinx-coroutines-test = "1.10.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -42,11 +43,9 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dependency-check = { id = "org.owasp.dependencycheck", version.ref = "dependency-check" }
-

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionSha256Sum=553c78f50dafcd54d65b9a444649057857469edf836431389695608536d6b746
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

Brings the entire build toolchain to current latest stable (May 2026), removes existing workarounds, and tightens the release build hardening.

### Toolchain
| | Before | After |
|---|---|---|
| Gradle | 8.10.2 | **9.5.0** |
| AGP | 8.7.2 | **9.2.0** (built-in Kotlin) |
| Kotlin | 2.0.21 | **2.3.21** |
| JVM toolchain / source-target | 11 | **17** (required by AGP 9) |
| Hilt | 2.51.1 | **2.59.2** |
| Annotation processor | kapt | **KSP 2.3.7** |
| OWASP dep-check | 10.0.4 | **12.1.0** |

### Library bumps
- coroutines 1.8.1 → 1.10.2
- activity 1.10.0 → 1.13.0
- core-ktx 1.13.1 → 1.18.0
- games-activity 4.4.0 → 4.4.1
- kotlinx-serialization-json 1.7.3 → 1.9.0
- mockk 1.13.12 → 1.14.3
- turbine 1.1.0 → 1.2.0
- espresso-core 3.6.1 → 3.7.0

(Held: `material 1.12.0` — no newer stable; `appcompat 1.7.1` — no newer stable; `lifecycle 2.10.0` — already current; `detekt 1.23.8` — last 1.x stable, 2.x is alpha; `ktlint plugin 14.2.0` — already current.)

### Release hardening
- Enable `isMinifyEnabled = true` and `isShrinkResources = true` on the release build type. R8 + lintVital pass.

### Workarounds removed
- Drop `NullSafeMutableLiveData` lint disable (K2/AGP crash fixed upstream).
- Drop deprecated `android.enableJetifier=true` from `gradle.properties`.
- Drop redundant top-level `kotlin { jvmToolchain }` block — AGP 9 has built-in Kotlin support, `kotlin-android` plugin removed.
- `kapt` plugin removed entirely; Hilt now wired through KSP.

### Device support (unchanged)
`minSdk = 24` (Android 7.0+), `targetSdk = 36`, `compileSdk = 36`. NDK ABIs: `arm64-v8a`, `x86_64`.

## Test plan
- [x] `./gradlew assembleDebug` — green
- [x] `./gradlew testDebugUnitTest` — green
- [x] `./gradlew assembleRelease` — green (R8 minify + resource shrink + lintVital)
- [ ] CI green on push
- [ ] Smoke test: install debug APK, exercise gamepad overlay + Bluetooth pairing flows
- [ ] Confirm `dependencyCheckAggregate` still completes on the new dep-check 12.x (NVD feed format change between 10.x and 12.x)
- [ ] Confirm Android Studio sync on a fresh checkout (built-in-Kotlin migration is the riskiest IDE-side change)

## Notes for reviewers
- OWASP dependency-check upstream repo was archived 2025-09-27. 12.1.0 is the last release from the original maintainer. Worth a follow-up issue to evaluate alternatives (e.g. the renew/maintained fork) before that becomes a security gap.
- A handful of pre-existing Kotlin compiler warnings surfaced under 2.3 (annotation target `param-property` migration in `ConnectionStore`/`WifiConnectionManager`, redundant safe call in `GamepadOverlayActivity`). Not addressed here — left for a focused cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)