### PR TITLE
refactor: rename wifi → satellite throughout codebase

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/data/network/ConnectionForegroundObserver.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/network/ConnectionForegroundObserver.kt
@@ -9,15 +9,15 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Process-scoped observer that re-establishes both Bluetooth and WiFi links
- * when the app returns to the foreground.
+ * Process-scoped observer that re-establishes both Bluetooth and satellite
+ * links when the app returns to the foreground.
  *
  * The original reconnect bug was caused by holding a stale HID registration
  * across backgrounding: the OS-level Bluetooth link was still live, but the
  * app's proxy binding had been severed, so reports silently went nowhere.
- * WiFi has a symmetric hazard — a dropped native socket/handle stays torn
- * down until someone explicitly reconnects. Binding this observer to
- * [androidx.lifecycle.ProcessLifecycleOwner] guarantees we always kick
+ * The satellite path has a symmetric hazard — a dropped native socket/handle
+ * stays torn down until someone explicitly reconnects. Binding this observer
+ * to [androidx.lifecycle.ProcessLifecycleOwner] guarantees we always kick
  * [ConnectionHub.autoReconnectAll] on every return to foreground, which in
  * turn rebuilds any session whose remembered target isn't currently live.
  * Safe to no-op when everything is already healthy — the hub's reconnect

--- a/app/src/main/java/com/tinkernorth/dish/data/network/ConnectionHub.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/network/ConnectionHub.kt
@@ -22,7 +22,7 @@ import javax.inject.Singleton
  * hosts and exposes them as separate [ConnectionSummary] entries so the user
  * can switch between them.
  */
-enum class ConnectionKind { WIFI, BLUETOOTH }
+enum class ConnectionKind { SATELLITE, BLUETOOTH }
 
 enum class ConnectionLive { IDLE, CONNECTING, CONNECTED }
 
@@ -42,7 +42,7 @@ data class ConnectionSummary(
 )
 
 /**
- * Single place every slot talks to. Aggregates [WifiConnectionManager] and
+ * Single place every slot talks to. Aggregates [SatelliteConnectionManager] and
  * [BluetoothGamepadRegistry] into one stream of [ConnectionSummary] entries.
  *
  * Binding a slot to a connection is a UI-level concept (which slot routes its
@@ -53,7 +53,7 @@ data class ConnectionSummary(
 class ConnectionHub
     @Inject
     constructor(
-        private val wifi: WifiConnectionManager,
+        private val satellite: SatelliteConnectionManager,
         private val bt: BluetoothGamepadRegistry,
         private val store: ConnectionStore,
         private val scope: CoroutineScope,
@@ -67,37 +67,37 @@ class ConnectionHub
 
         init {
             combine(
-                wifi.connections,
+                satellite.connections,
                 bt.states,
-            ) { wifiMap, btStates -> buildSummaries(wifiMap, btStates) }
+            ) { satMap, btStates -> buildSummaries(satMap, btStates) }
                 .onEach { _connections.value = it }
                 .launchIn(scope)
         }
 
         private fun buildSummaries(
-            wifiMap: Map<String, WifiConnection>,
+            satMap: Map<String, SatelliteConnection>,
             btStates: Map<String, BluetoothGamepadRegistry.SlotState>,
         ): List<ConnectionSummary> {
             val bindingBySlot = _bindings.value
             val result = mutableListOf<ConnectionSummary>()
 
-            // WiFi: remembered + any live not-yet-remembered (discovery hits).
+            // Satellites: remembered + any live not-yet-remembered (discovery hits).
             val remembered = store.remembered().associateBy { it.id }
-            val wifiIds = (remembered.keys + wifiMap.keys).toSet()
-            for (id in wifiIds) {
-                val conn = wifiMap[id]
+            val satIds = (remembered.keys + satMap.keys).toSet()
+            for (id in satIds) {
+                val conn = satMap[id]
                 val server = conn?.server?.value ?: remembered[id]?.toDiscovered() ?: continue
                 val live =
                     when (conn?.state?.value) {
-                        WifiState.CONNECTED -> ConnectionLive.CONNECTED
-                        WifiState.CONNECTING -> ConnectionLive.CONNECTING
+                        SatelliteState.CONNECTED -> ConnectionLive.CONNECTED
+                        SatelliteState.CONNECTING -> ConnectionLive.CONNECTING
                         else -> ConnectionLive.IDLE
                     }
                 val bound = bindingBySlot.entries.firstOrNull { it.value == id }?.key
                 result +=
                     ConnectionSummary(
                         id = id,
-                        kind = ConnectionKind.WIFI,
+                        kind = ConnectionKind.SATELLITE,
                         label = server.name.ifEmpty { server.ip },
                         detail = "${server.ip} • UDP ${server.udpPort}",
                         live = live,
@@ -143,14 +143,14 @@ class ConnectionHub
             val priorSlot = current.entries.firstOrNull { it.value == connectionId }?.key
             if (priorSlot != null && priorSlot != slotId) {
                 current.remove(priorSlot)
-                wifi.get(connectionId)?.detachSlot()
+                satellite.get(connectionId)?.detachSlot()
             }
             current[slotId] = connectionId
             _bindings.value = current
             // Re-emit connections so boundSlotId refreshes.
-            _connections.value = buildSummaries(wifi.connections.value, bt.states.value)
-            // For WiFi: attach the controller slot on the server side.
-            wifi.get(connectionId)?.let { conn ->
+            _connections.value = buildSummaries(satellite.connections.value, bt.states.value)
+            // For satellite: attach the controller slot on the server side.
+            satellite.get(connectionId)?.let { conn ->
                 scope.launch { conn.attachSlot(slotId, controllerType = 0) }
             }
         }
@@ -159,15 +159,15 @@ class ConnectionHub
             val current = _bindings.value.toMutableMap()
             val connId = current.remove(slotId) ?: return
             _bindings.value = current
-            wifi.get(connId)?.detachSlot()
-            _connections.value = buildSummaries(wifi.connections.value, bt.states.value)
+            satellite.get(connId)?.detachSlot()
+            _connections.value = buildSummaries(satellite.connections.value, bt.states.value)
         }
 
         fun boundConnection(slotId: String): ConnectionSummary? =
             _bindings.value[slotId]?.let { id -> _connections.value.firstOrNull { it.id == id } }
 
         /**
-         * Kick off a reconnect for every remembered WiFi server that isn't live
+         * Kick off a reconnect for every remembered satellite that isn't live
          * yet, plus the first remembered Bluetooth host (Android's HID Device
          * profile only supports one active host per app).
          *
@@ -176,9 +176,9 @@ class ConnectionHub
          */
         fun autoReconnectAll() {
             for (remembered in store.remembered()) {
-                val existing = wifi.get(remembered.id)
-                if (existing?.state?.value != WifiState.CONNECTED) {
-                    wifi.connect(remembered.toDiscovered())
+                val existing = satellite.get(remembered.id)
+                if (existing?.state?.value != SatelliteState.CONNECTED) {
+                    satellite.connect(remembered.toDiscovered())
                 }
             }
             val btHosts = store.rememberedBt()

--- a/app/src/main/java/com/tinkernorth/dish/data/network/ConnectionStore.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/network/ConnectionStore.kt
@@ -14,8 +14,8 @@ import javax.inject.Singleton
 
 /**
  * Persistent registry of remembered connections. Stores just enough to
- * auto-reconnect on next launch: server address/ports for WiFi, MAC+profile
- * for Bluetooth HID hosts.
+ * auto-reconnect on next launch: server address/ports for satellites,
+ * MAC+profile for Bluetooth HID hosts.
  */
 @Singleton
 class ConnectionStore
@@ -28,21 +28,21 @@ class ConnectionStore
             context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         }
 
-        // ── WiFi ──────────────────────────────────────────────────────────────
+        // ── Satellites ────────────────────────────────────────────────────────
 
-        fun remembered(): List<RememberedWifi> {
-            val raw = prefs.getString(KEY_WIFI, null) ?: return emptyList()
+        fun remembered(): List<RememberedSatellite> {
+            val raw = prefs.getString(KEY_SATELLITES, null) ?: return emptyList()
             return runCatching {
-                json.decodeFromString(ListSerializer(RememberedWifi.serializer()), raw)
+                json.decodeFromString(ListSerializer(RememberedSatellite.serializer()), raw)
             }.getOrDefault(emptyList())
         }
 
-        fun rememberWifi(server: DiscoveredServer) {
+        fun rememberSatellite(server: DiscoveredServer) {
             val list = remembered().toMutableList()
-            val id = WifiConnection.idFor(server)
+            val id = SatelliteConnection.idFor(server)
             list.removeAll { it.id == id }
             list +=
-                RememberedWifi(
+                RememberedSatellite(
                     id = id,
                     name = server.name,
                     ip = server.ip,
@@ -50,38 +50,38 @@ class ConnectionStore
                     pairPort = server.pairPort,
                     httpPort = server.httpPort,
                 )
-            persistWifi(list)
+            persistSatellites(list)
         }
 
-        fun forgetWifi(id: String) {
+        fun forgetSatellite(id: String) {
             val list = remembered().filterNot { it.id == id }
-            persistWifi(list)
-            prefs.edit().remove(wifiKeyPref(id)).apply()
+            persistSatellites(list)
+            prefs.edit().remove(satelliteKeyPref(id)).apply()
         }
 
-        private fun persistWifi(list: List<RememberedWifi>) {
-            val raw = json.encodeToString(ListSerializer(RememberedWifi.serializer()), list)
-            prefs.edit().putString(KEY_WIFI, raw).apply()
+        private fun persistSatellites(list: List<RememberedSatellite>) {
+            val raw = json.encodeToString(ListSerializer(RememberedSatellite.serializer()), list)
+            prefs.edit().putString(KEY_SATELLITES, raw).apply()
         }
 
         /**
          * Return the pair-derived shared key for [id], or null if we've never
-         * paired with that server. Keys are stored per-server so pairing with a
-         * second server can't clobber the first server's credential, which was a
-         * latent bug in the pre-per-server-key build. Legacy migration from that
-         * build lives in [WifiConnectionManager] since the legacy slot sits in a
-         * different prefs file.
+         * paired with that satellite. Keys are stored per-satellite so pairing
+         * with a second satellite can't clobber the first satellite's
+         * credential, which was a latent bug in the pre-per-server-key build.
+         * Legacy migration from that build lives in [SatelliteConnectionManager]
+         * since the legacy slot sits in a different prefs file.
          */
-        fun wifiSharedKey(id: String): String? = prefs.getString(wifiKeyPref(id), null)
+        fun satelliteSharedKey(id: String): String? = prefs.getString(satelliteKeyPref(id), null)
 
-        fun setWifiSharedKey(
+        fun setSatelliteSharedKey(
             id: String,
             keyHex: String,
         ) {
-            prefs.edit().putString(wifiKeyPref(id), keyHex).apply()
+            prefs.edit().putString(satelliteKeyPref(id), keyHex).apply()
         }
 
-        private fun wifiKeyPref(id: String): String = "$KEY_WIFI_SHARED_PREFIX$id"
+        private fun satelliteKeyPref(id: String): String = "$KEY_SATELLITE_SHARED_PREFIX$id"
 
         // ── Bluetooth ─────────────────────────────────────────────────────────
 
@@ -111,14 +111,14 @@ class ConnectionStore
 
         companion object {
             private const val PREFS_NAME = "connection_store"
-            private const val KEY_WIFI = "wifi_list"
+            private const val KEY_SATELLITES = "satellite_list"
             private const val KEY_BT = "bt_list"
-            private const val KEY_WIFI_SHARED_PREFIX = "wifi_shared_key:"
+            private const val KEY_SATELLITE_SHARED_PREFIX = "satellite_shared_key:"
         }
     }
 
 @Serializable
-data class RememberedWifi(
+data class RememberedSatellite(
     val id: String,
     val name: String,
     val ip: String,

--- a/app/src/main/java/com/tinkernorth/dish/data/network/SatelliteConnection.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/network/SatelliteConnection.kt
@@ -17,16 +17,17 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
- * A single live or potential WiFi session to one Satellite server.
+ * A single live or potential session to one Satellite server (the host PC the
+ * device routes input to over LAN).
  *
  * The [id] is stable across app restarts (derived from server IP+port) so the
  * hub can persist a list of remembered connections and reclaim the same slot
  * binding after a relaunch. [handle] is the native session handle returned by
  * [ControllerRepository.openSocket] and is only valid while [state] is
- * [WifiState.CONNECTED]; once the session is torn down it is reset to -1 and
- * a fresh handle is allocated on reconnect.
+ * [SatelliteState.CONNECTED]; once the session is torn down it is reset to -1
+ * and a fresh handle is allocated on reconnect.
  */
-class WifiConnection(
+class SatelliteConnection(
     val id: String,
     server: DiscoveredServer,
     private val scope: CoroutineScope,
@@ -35,8 +36,8 @@ class WifiConnection(
     private val _server = MutableStateFlow(server)
     val server: StateFlow<DiscoveredServer> = _server.asStateFlow()
 
-    private val _state = MutableStateFlow(WifiState.IDLE)
-    val state: StateFlow<WifiState> = _state.asStateFlow()
+    private val _state = MutableStateFlow(SatelliteState.IDLE)
+    val state: StateFlow<SatelliteState> = _state.asStateFlow()
 
     /**
      * Immutable tuple of the live-session handle + connection id. Held in a
@@ -78,8 +79,8 @@ class WifiConnection(
      * session's state back to CONNECTING without an intervening disconnect.
      */
     internal fun markConnecting() {
-        if (_state.value == WifiState.CONNECTED) return
-        _state.value = WifiState.CONNECTING
+        if (_state.value == SatelliteState.CONNECTED) return
+        _state.value = SatelliteState.CONNECTING
     }
 
     /**
@@ -103,12 +104,12 @@ class WifiConnection(
         onRegistrationFailed: (() -> Unit)? = null,
         onDead: () -> Unit,
     ) {
-        if (_state.value != WifiState.CONNECTING) return
+        if (_state.value != SatelliteState.CONNECTING) return
         // Publish the (handle, connectionId) pair before flipping state so
         // any concurrent sendReport that observes CONNECTED cannot see a
         // null/-1 tuple.
         live = Live(handle, connectionId)
-        _state.value = WifiState.CONNECTED
+        _state.value = SatelliteState.CONNECTED
         this.onRegistrationFailed = onRegistrationFailed
         controllerRepo.resetControllerAck(handle)
         ackJob =
@@ -140,7 +141,7 @@ class WifiConnection(
      */
     internal fun markDisconnected() {
         val snap = live
-        if (_state.value == WifiState.IDLE && snap == null) return
+        if (_state.value == SatelliteState.IDLE && snap == null) return
         aliveJob?.cancel()
         aliveJob = null
         ackJob?.cancel()
@@ -155,7 +156,7 @@ class WifiConnection(
         }
         controllerAdded = false
         onRegistrationFailed = null
-        _state.value = WifiState.IDLE
+        _state.value = SatelliteState.IDLE
     }
 
     /**
@@ -169,7 +170,7 @@ class WifiConnection(
     ) = withContext(Dispatchers.IO) {
         _boundSlotId.value = slotId
         pendingControllerType = controllerType
-        if (_state.value == WifiState.CONNECTED && handle >= 0 && !controllerAdded) {
+        if (_state.value == SatelliteState.CONNECTED && handle >= 0 && !controllerAdded) {
             registerController(controllerType)
         }
     }
@@ -231,8 +232,8 @@ class WifiConnection(
         private const val DEFAULT_CAPABILITIES = 0x0003
         private const val DEFAULT_CONTROLLER_TYPE = 0
 
-        fun idFor(server: DiscoveredServer): String = "wifi:${server.ip}:${server.udpPort}"
+        fun idFor(server: DiscoveredServer): String = "satellite:${server.ip}:${server.udpPort}"
     }
 }
 
-enum class WifiState { IDLE, CONNECTING, CONNECTED }
+enum class SatelliteState { IDLE, CONNECTING, CONNECTED }

--- a/app/src/main/java/com/tinkernorth/dish/data/network/SatelliteConnectionManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/network/SatelliteConnectionManager.kt
@@ -35,13 +35,14 @@ sealed class ConnectionEvent {
 }
 
 /**
- * Owns the pool of live + remembered WiFi sessions. Each session runs its own
- * native handle, heartbeat and ACK loop so multiple servers can be active in
- * parallel. Slots bind to a specific connection via the hub and their input is
- * routed through the bound connection's [WifiConnection.sendReport].
+ * Owns the pool of live + remembered satellite sessions. Each session runs its
+ * own native handle, heartbeat and ACK loop so multiple satellites can be
+ * active in parallel. Slots bind to a specific connection via the hub and
+ * their input is routed through the bound connection's
+ * [SatelliteConnection.sendReport].
  */
 @Singleton
-class WifiConnectionManager
+class SatelliteConnectionManager
     @Inject
     constructor(
         @ApplicationContext private val context: Context,
@@ -51,8 +52,8 @@ class WifiConnectionManager
         private val store: ConnectionStore,
         private val json: Json,
     ) {
-        private val _connections = MutableStateFlow<Map<String, WifiConnection>>(emptyMap())
-        val connections: StateFlow<Map<String, WifiConnection>> = _connections.asStateFlow()
+        private val _connections = MutableStateFlow<Map<String, SatelliteConnection>>(emptyMap())
+        val connections: StateFlow<Map<String, SatelliteConnection>> = _connections.asStateFlow()
 
         private val _discoveredServers = MutableStateFlow<List<DiscoveredServer>>(emptyList())
         val discoveredServers: StateFlow<List<DiscoveredServer>> = _discoveredServers.asStateFlow()
@@ -66,9 +67,9 @@ class WifiConnectionManager
         private val deviceId by lazy { getOrCreateDeviceId() }
         private val deviceName by lazy { android.os.Build.MODEL ?: "Android" }
 
-        fun get(id: String): WifiConnection? = _connections.value[id]
+        fun get(id: String): SatelliteConnection? = _connections.value[id]
 
-        fun remembered(): List<RememberedWifi> = store.remembered()
+        fun remembered(): List<RememberedSatellite> = store.remembered()
 
         // ── Discovery ─────────────────────────────────────────────────────────
 
@@ -79,14 +80,14 @@ class WifiConnectionManager
                 val servers = discoveryRepo.discoverServers(DISC_PORT, DISC_TIMEOUT_MS)
                 _discoveredServers.value = servers
                 _isScanning.value = false
-                if (servers.isEmpty()) _events.emit(ConnectionEvent.Error("No servers found — check your network"))
+                if (servers.isEmpty()) _events.emit(ConnectionEvent.Error("No satellites found — check your network"))
             }
         }
 
         // ── Connect / Disconnect ──────────────────────────────────────────────
 
         fun connect(server: DiscoveredServer) {
-            val id = WifiConnection.idFor(server)
+            val id = SatelliteConnection.idFor(server)
             val existing = _connections.value[id]
             // Idempotent on live / in-flight sessions: the foreground observer
             // and MainActivity both kick auto-reconnect on every return, so
@@ -95,17 +96,17 @@ class WifiConnectionManager
             // server.
             if (existing != null) {
                 when (existing.state.value) {
-                    WifiState.CONNECTED,
-                    WifiState.CONNECTING,
+                    SatelliteState.CONNECTED,
+                    SatelliteState.CONNECTING,
                     -> {
                         existing.updateServer(server)
                         return
                     }
-                    WifiState.IDLE -> Unit
+                    SatelliteState.IDLE -> Unit
                 }
             }
             val conn =
-                existing ?: WifiConnection(id, server, scope, controllerRepo).also {
+                existing ?: SatelliteConnection(id, server, scope, controllerRepo).also {
                     _connections.value = _connections.value + (id to it)
                 }
             conn.updateServer(server)
@@ -114,7 +115,7 @@ class WifiConnectionManager
         }
 
         private suspend fun pairAndConnect(
-            conn: WifiConnection,
+            conn: SatelliteConnection,
             server: DiscoveredServer,
         ) {
             val pair =
@@ -130,7 +131,7 @@ class WifiConnectionManager
                 _events.emit(ConnectionEvent.PairingRequired(server))
                 return
             }
-            store.setWifiSharedKey(WifiConnection.idFor(server), pair.sharedKey)
+            store.setSatelliteSharedKey(SatelliteConnection.idFor(server), pair.sharedKey)
             openSession(conn, server)
         }
 
@@ -138,9 +139,9 @@ class WifiConnectionManager
             server: DiscoveredServer,
             pin: String,
         ) {
-            val id = WifiConnection.idFor(server)
+            val id = SatelliteConnection.idFor(server)
             val conn =
-                _connections.value[id] ?: WifiConnection(id, server, scope, controllerRepo).also {
+                _connections.value[id] ?: SatelliteConnection(id, server, scope, controllerRepo).also {
                     _connections.value = _connections.value + (id to it)
                 }
             conn.markConnecting()
@@ -157,13 +158,13 @@ class WifiConnectionManager
                     _events.emit(ConnectionEvent.Error(pair.error ?: "Pairing failed"))
                     return@launch
                 }
-                store.setWifiSharedKey(WifiConnection.idFor(server), pair.sharedKey)
+                store.setSatelliteSharedKey(SatelliteConnection.idFor(server), pair.sharedKey)
                 openSession(conn, server)
             }
         }
 
         private suspend fun openSession(
-            conn: WifiConnection,
+            conn: SatelliteConnection,
             server: DiscoveredServer,
         ) = withContext(Dispatchers.IO) {
             val keyHex = sharedKeyFor(server) ?: ""
@@ -198,7 +199,7 @@ class WifiConnectionManager
                 return@withContext
             }
             controllerRepo.setConnectionParams(handle, token, key)
-            store.rememberWifi(server)
+            store.rememberSatellite(server)
             conn.markConnected(
                 handle,
                 connId,
@@ -229,7 +230,7 @@ class WifiConnectionManager
 
         fun forget(id: String) {
             disconnect(id)
-            store.forgetWifi(id)
+            store.forgetSatellite(id)
             _connections.value = _connections.value - id
         }
 
@@ -252,11 +253,11 @@ class WifiConnectionManager
          * no other server can inherit it later. Returns null if no key is known.
          */
         private fun sharedKeyFor(server: DiscoveredServer): String? {
-            val id = WifiConnection.idFor(server)
-            store.wifiSharedKey(id)?.let { return it }
+            val id = SatelliteConnection.idFor(server)
+            store.satelliteSharedKey(id)?.let { return it }
             val legacyPrefs = context.getSharedPreferences(LEGACY_PREFS, Context.MODE_PRIVATE)
             val legacy = legacyPrefs.getString(LEGACY_KEY_SHARED, null) ?: return null
-            store.setWifiSharedKey(id, legacy)
+            store.setSatelliteSharedKey(id, legacy)
             legacyPrefs.edit().remove(LEGACY_KEY_SHARED).apply()
             return legacy
         }

--- a/app/src/main/java/com/tinkernorth/dish/data/network/SatelliteNative.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/network/SatelliteNative.kt
@@ -16,7 +16,7 @@ object SatelliteNative {
 
     // ── UDP Session (handle-based) ──────────────────────────────────────────
     // openSocket returns a positive session handle, or -1 on failure. All other
-    // session-scoped calls take that handle so multiple WiFi servers can run
+    // session-scoped calls take that handle so multiple satellites can run
     // side-by-side with independent sockets, tokens, counters and heartbeat
     // threads.
 

--- a/app/src/main/java/com/tinkernorth/dish/ui/bluetooth/GamepadButtonLayouts.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/bluetooth/GamepadButtonLayouts.kt
@@ -8,7 +8,7 @@ package com.tinkernorth.dish.ui.bluetooth
  *
  *   - **XUSB** (`wButtons`): the XInput-compatible layout produced by the
  *     physical-controller path ([com.tinkernorth.dish.ui.main.GamepadInputProcessor])
- *     and consumed by the Wi-Fi path (see `XUSB_REPORT` in satellite_jni.cpp).
+ *     and consumed by the satellite path (see `XUSB_REPORT` in satellite_jni.cpp).
  *   - **HID**: the 14-button + 4-bit hat-switch layout used by the on-screen
  *     gamepad ([com.tinkernorth.dish.ui.common.GamepadTouchView]) and the
  *     Bluetooth HID descriptor ([buildHidDescriptor] / [buildHidReport]).
@@ -87,7 +87,7 @@ fun xusbToHid(wButtons: Int): Pair<Int, Int> {
 
 /**
  * Inverse of [xusbToHid]: translate the HID `(buttons, hat)` pair emitted by
- * `GamepadTouchView` into an XUSB `wButtons` value the Wi-Fi path can hand
+ * `GamepadTouchView` into an XUSB `wButtons` value the satellite path can hand
  * verbatim to `SatelliteNative.sendReport`.
  */
 fun hidToXusb(

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
@@ -27,8 +27,8 @@ import com.tinkernorth.dish.data.network.ConnectionHub
 import com.tinkernorth.dish.data.network.ConnectionKind
 import com.tinkernorth.dish.data.network.ConnectionLive
 import com.tinkernorth.dish.data.network.ConnectionSummary
-import com.tinkernorth.dish.data.network.WifiConnection
-import com.tinkernorth.dish.data.network.WifiConnectionManager
+import com.tinkernorth.dish.data.network.SatelliteConnection
+import com.tinkernorth.dish.data.network.SatelliteConnectionManager
 import com.tinkernorth.dish.databinding.ActivityConnectionsBinding
 import com.tinkernorth.dish.databinding.DialogPairingBinding
 import com.tinkernorth.dish.databinding.RowConnectionBinding
@@ -39,14 +39,14 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
- * Dedicated screen for managing the pool of WiFi servers and Bluetooth hosts.
+ * Dedicated screen for managing the pool of satellites and Bluetooth hosts.
  * Two sections, both living on top of [ConnectionHub]:
- *   - WiFi: scan → pair (if needed) → connect; remembered entries auto-reconnect
+ *   - Satellites: scan → pair (if needed) → connect; remembered entries auto-reconnect
  *   - Bluetooth: pick profile → register HID → pair from the target host
  */
 @AndroidEntryPoint
 class ConnectionsActivity : AppCompatActivity() {
-    @Inject lateinit var wifi: WifiConnectionManager
+    @Inject lateinit var satellite: SatelliteConnectionManager
 
     @Inject lateinit var btRegistry: BluetoothGamepadRegistry
 
@@ -83,7 +83,7 @@ class ConnectionsActivity : AppCompatActivity() {
         setSupportActionBar(binding.toolbar)
         binding.toolbar.setNavigationOnClickListener { finish() }
 
-        binding.btnWifiScan.setOnClickListener { wifi.startDiscovery() }
+        binding.btnSatelliteScan.setOnClickListener { satellite.startDiscovery() }
         binding.btnBtAdd.setOnClickListener { requestBtPermissions() }
 
         lifecycleScope.launch {
@@ -93,20 +93,20 @@ class ConnectionsActivity : AppCompatActivity() {
         }
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                wifi.discoveredServers.collect { render(hub.connections.value) }
+                satellite.discoveredServers.collect { render(hub.connections.value) }
             }
         }
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                wifi.isScanning.collect { scanning ->
-                    binding.btnWifiScan.isEnabled = !scanning
-                    binding.btnWifiScan.text = if (scanning) "Scanning…" else "Scan"
+                satellite.isScanning.collect { scanning ->
+                    binding.btnSatelliteScan.isEnabled = !scanning
+                    binding.btnSatelliteScan.text = if (scanning) "Scanning…" else "Scan"
                 }
             }
         }
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                wifi.events.collect { ev ->
+                satellite.events.collect { ev ->
                     when (ev) {
                         is ConnectionEvent.Error -> Toast.makeText(this@ConnectionsActivity, ev.message, Toast.LENGTH_SHORT).show()
                         is ConnectionEvent.PairingRequired -> showPairingDialog(ev.server.ip, ev.server.pairPort)
@@ -116,20 +116,20 @@ class ConnectionsActivity : AppCompatActivity() {
         }
     }
 
-    // ── WiFi rendering ────────────────────────────────────────────────────
+    // ── Satellite rendering ───────────────────────────────────────────────
 
     private fun render(conns: List<ConnectionSummary>) {
-        val wifiConns = conns.filter { it.kind == ConnectionKind.WIFI }
-        val discovered = wifi.discoveredServers.value
-        val knownIds = wifiConns.map { it.id }.toSet()
-        val list = binding.llWifiList
+        val satConns = conns.filter { it.kind == ConnectionKind.SATELLITE }
+        val discovered = satellite.discoveredServers.value
+        val knownIds = satConns.map { it.id }.toSet()
+        val list = binding.llSatelliteList
         list.removeAllViews()
-        wifiConns.forEach { list.addView(wifiRow(it)) }
+        satConns.forEach { list.addView(satelliteRow(it)) }
         for (s in discovered) {
-            val id = WifiConnection.idFor(s)
-            if (id !in knownIds) list.addView(discoveredWifiRow(s))
+            val id = SatelliteConnection.idFor(s)
+            if (id !in knownIds) list.addView(discoveredSatelliteRow(s))
         }
-        binding.tvWifiEmpty.visibility =
+        binding.tvSatelliteEmpty.visibility =
             if (list.childCount == 0) View.VISIBLE else View.GONE
 
         val btConns = conns.filter { it.kind == ConnectionKind.BLUETOOTH }
@@ -139,12 +139,12 @@ class ConnectionsActivity : AppCompatActivity() {
             if (btConns.isEmpty()) View.VISIBLE else View.GONE
     }
 
-    private fun wifiRow(c: ConnectionSummary): View {
-        val rb = inflateRow(binding.llWifiList, c.label, c.detail, statusText(c))
+    private fun satelliteRow(c: ConnectionSummary): View {
+        val rb = inflateRow(binding.llSatelliteList, c.label, c.detail, statusText(c))
         when (c.live) {
             ConnectionLive.CONNECTED -> {
                 rb.btnRowAction.text = "Disconnect"
-                rb.btnRowAction.setOnClickListener { wifi.disconnect(c.id) }
+                rb.btnRowAction.setOnClickListener { satellite.disconnect(c.id) }
             }
             ConnectionLive.CONNECTING -> {
                 rb.btnRowAction.text = "Connecting…"
@@ -153,21 +153,21 @@ class ConnectionsActivity : AppCompatActivity() {
             ConnectionLive.IDLE -> {
                 rb.btnRowAction.text = "Connect"
                 rb.btnRowAction.setOnClickListener {
-                    val remembered = wifi.remembered().firstOrNull { it.id == c.id } ?: return@setOnClickListener
-                    wifi.connect(remembered.toDiscovered())
+                    val remembered = satellite.remembered().firstOrNull { it.id == c.id } ?: return@setOnClickListener
+                    satellite.connect(remembered.toDiscovered())
                 }
             }
         }
         rb.btnRowSecondary.visibility = View.VISIBLE
         rb.btnRowSecondary.text = "Forget"
-        rb.btnRowSecondary.setOnClickListener { wifi.forget(c.id) }
+        rb.btnRowSecondary.setOnClickListener { satellite.forget(c.id) }
         return rb.root
     }
 
-    private fun discoveredWifiRow(s: com.tinkernorth.dish.data.model.DiscoveredServer): View {
-        val rb = inflateRow(binding.llWifiList, s.name.ifEmpty { s.ip }, "${s.ip} • UDP ${s.udpPort}", "Discovered")
+    private fun discoveredSatelliteRow(s: com.tinkernorth.dish.data.model.DiscoveredServer): View {
+        val rb = inflateRow(binding.llSatelliteList, s.name.ifEmpty { s.ip }, "${s.ip} • UDP ${s.udpPort}", "Discovered")
         rb.btnRowAction.text = "Connect"
-        rb.btnRowAction.setOnClickListener { wifi.connect(s) }
+        rb.btnRowAction.setOnClickListener { satellite.connect(s) }
         return rb.root
     }
 
@@ -290,7 +290,7 @@ class ConnectionsActivity : AppCompatActivity() {
                         ip = ip,
                         pairPort = pairPort,
                     )
-                wifi.pairWithPin(server, pin)
+                satellite.pairWithPin(server, pin)
             }.setNegativeButton("Cancel", null)
             .show()
     }

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
@@ -155,7 +155,7 @@ class ControllerAdapter(
                 }
             val prefix =
                 when (c.kind) {
-                    ConnectionKind.WIFI -> "📡 "
+                    ConnectionKind.SATELLITE -> "📡 "
                     ConnectionKind.BLUETOOTH -> "🔗 "
                 }
             val statusSuffix =

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
@@ -17,7 +17,7 @@ import com.tinkernorth.dish.R
 import com.tinkernorth.dish.data.network.ConnectionHub
 import com.tinkernorth.dish.data.network.ConnectionKind
 import com.tinkernorth.dish.data.network.ConnectionLive
-import com.tinkernorth.dish.data.network.WifiConnectionManager
+import com.tinkernorth.dish.data.network.SatelliteConnectionManager
 import com.tinkernorth.dish.databinding.ActivityGamepadOverlayBinding
 import com.tinkernorth.dish.ui.bluetooth.BluetoothGamepadRegistry
 import com.tinkernorth.dish.ui.bluetooth.hidToXusb
@@ -31,9 +31,9 @@ import javax.inject.Inject
  *
  * Bound to a single connection id passed via [EXTRA_CONNECTION_ID]; reports
  * are routed to that connection through either the [BluetoothGamepadRegistry]
- * or the matching [com.tinkernorth.dish.data.network.WifiConnection] in the
- * [WifiConnectionManager]. Both owners outlive the host activity so the same
- * session is reused on re-entry.
+ * or the matching [com.tinkernorth.dish.data.network.SatelliteConnection] in
+ * the [SatelliteConnectionManager]. Both owners outlive the host activity so
+ * the same session is reused on re-entry.
  */
 @AndroidEntryPoint
 class GamepadOverlayActivity :
@@ -41,7 +41,7 @@ class GamepadOverlayActivity :
     GamepadTouchView.Listener {
     @Inject lateinit var btRegistry: BluetoothGamepadRegistry
 
-    @Inject lateinit var wifi: WifiConnectionManager
+    @Inject lateinit var satellite: SatelliteConnectionManager
 
     @Inject lateinit var hub: ConnectionHub
 
@@ -105,12 +105,12 @@ class GamepadOverlayActivity :
                     ) ?: return
                 btRegistry.sendReport(connectionId, report)
             }
-            ConnectionKind.WIFI -> {
+            ConnectionKind.SATELLITE -> {
                 // The touch view emits HID-layout button bits plus a
-                // separate hat-switch; the Wi-Fi path wants an XUSB
+                // separate hat-switch; the satellite path wants an XUSB
                 // wButtons with the d-pad folded back into the low nibble.
                 val wButtons = hidToXusb(state.buttons, state.hatSwitch)
-                wifi.get(connectionId)?.sendReport(
+                satellite.get(connectionId)?.sendReport(
                     wButtons,
                     state.leftTrigger,
                     state.rightTrigger,

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
@@ -23,7 +23,7 @@ import com.tinkernorth.dish.R
 import com.tinkernorth.dish.data.network.ConnectionHub
 import com.tinkernorth.dish.data.network.ConnectionKind
 import com.tinkernorth.dish.data.network.ConnectionLive
-import com.tinkernorth.dish.data.network.WifiConnectionManager
+import com.tinkernorth.dish.data.network.SatelliteConnectionManager
 import com.tinkernorth.dish.databinding.ActivityMainBinding
 import com.tinkernorth.dish.databinding.OverlayLowPowerBinding
 import com.tinkernorth.dish.ui.bluetooth.BluetoothGamepadRegistry
@@ -48,7 +48,7 @@ class MainActivity :
 
     @Inject lateinit var btRegistry: BluetoothGamepadRegistry
 
-    @Inject lateinit var wifi: WifiConnectionManager
+    @Inject lateinit var satellite: SatelliteConnectionManager
 
     @Inject lateinit var hub: ConnectionHub
 
@@ -143,8 +143,8 @@ class MainActivity :
         val summary = slot.boundStatus ?: return
         if (summary.live != ConnectionLive.CONNECTED) return
         when (summary.kind) {
-            ConnectionKind.WIFI ->
-                wifi.get(cid)?.sendReport(wButtons, bLT, bRT, sLX, sLY, sRX, sRY)
+            ConnectionKind.SATELLITE ->
+                satellite.get(cid)?.sendReport(wButtons, bLT, bRT, sLX, sLY, sRX, sRY)
             ConnectionKind.BLUETOOTH -> {
                 // Physical controllers emit an XUSB-layout wButtons; the BT HID
                 // descriptor expects a different bit layout plus a hat-switch

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tinkernorth.dish.data.network.ConnectionEvent
 import com.tinkernorth.dish.data.network.ConnectionHub
-import com.tinkernorth.dish.data.network.WifiConnectionManager
+import com.tinkernorth.dish.data.network.SatelliteConnectionManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,15 +23,15 @@ import javax.inject.Inject
 
 /**
  * Dashboard view-model. The heavy lifting (connection sessions, persistence,
- * heartbeat) lives in [WifiConnectionManager] and [ConnectionHub] — this just
- * adapts their state for rendering and relays bind/unbind actions from slot
- * rows.
+ * heartbeat) lives in [SatelliteConnectionManager] and [ConnectionHub] — this
+ * just adapts their state for rendering and relays bind/unbind actions from
+ * slot rows.
  */
 @HiltViewModel
 class MainViewModel
     @Inject
     constructor(
-        val wifi: WifiConnectionManager,
+        val satellite: SatelliteConnectionManager,
         val hub: ConnectionHub,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(MainUiState())
@@ -54,13 +54,13 @@ class MainViewModel
                 prev.copy(slots = newSlots, connections = conns)
             }.onEach { _uiState.value = it }.launchIn(viewModelScope)
 
-            wifi.events
+            satellite.events
                 .onEach { event ->
                     when (event) {
                         is ConnectionEvent.PairingRequired ->
                             _events.emit(
                                 MainEvent.ShowPairingDialog(
-                                    com.tinkernorth.dish.data.network.WifiConnection
+                                    com.tinkernorth.dish.data.network.SatelliteConnection
                                         .idFor(event.server),
                                 ),
                             )

--- a/app/src/main/res/layout/activity_connections.xml
+++ b/app/src/main/res/layout/activity_connections.xml
@@ -28,7 +28,7 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <!-- ── WiFi section ── -->
+            <!-- ── Satellite section ── -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -39,14 +39,14 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:text="WIFI SERVERS"
+                    android:text="SATELLITES"
                     android:textColor="@color/colorPrimary"
                     android:textSize="11sp"
                     android:fontFamily="monospace"
                     android:letterSpacing="0.12" />
 
                 <com.google.android.material.button.MaterialButton
-                    android:id="@+id/btnWifiScan"
+                    android:id="@+id/btnSatelliteScan"
                     style="@style/Widget.Dish.Button.Outlined"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -55,17 +55,17 @@
             </LinearLayout>
 
             <LinearLayout
-                android:id="@+id/llWifiList"
+                android:id="@+id/llSatelliteList"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
                 android:paddingTop="8dp" />
 
             <TextView
-                android:id="@+id/tvWifiEmpty"
+                android:id="@+id/tvSatelliteEmpty"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Tap Scan to find servers on your network"
+                android:text="Tap Scan to find satellites on your network"
                 android:textColor="@color/colorMuted"
                 android:textSize="12sp"
                 android:paddingVertical="12dp"

--- a/app/src/test/java/com/tinkernorth/dish/data/network/ConnectionForegroundObserverTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/data/network/ConnectionForegroundObserverTest.kt
@@ -12,8 +12,8 @@ import org.junit.Test
 
 /**
  * The observer is the process-wide answer to the original bug: when the app
- * returns to the foreground, any stale BT/WiFi session needs to be rebuilt
- * so input keeps flowing. We drive the observer directly against a
+ * returns to the foreground, any stale BT/satellite session needs to be
+ * rebuilt so input keeps flowing. We drive the observer directly against a
  * [LifecycleRegistry] via [LifecycleRegistry.createUnsafe] so the test is
  * not tied to a Looper.
  */

--- a/app/src/test/java/com/tinkernorth/dish/data/network/ConnectionHubTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/data/network/ConnectionHubTest.kt
@@ -19,26 +19,26 @@ import org.junit.Test
 
 /**
  * Unit tests for [ConnectionHub] binding semantics. Upstream flows from
- * [WifiConnectionManager] and [BluetoothGamepadRegistry] are driven with
+ * [SatelliteConnectionManager] and [BluetoothGamepadRegistry] are driven with
  * [MutableStateFlow] stubs so the hub's `buildSummaries` logic can be exercised
  * without spinning real sockets or Bluetooth stacks.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class ConnectionHubTest {
-    private lateinit var wifi: WifiConnectionManager
+    private lateinit var satellite: SatelliteConnectionManager
     private lateinit var bt: BluetoothGamepadRegistry
     private lateinit var store: ConnectionStore
     private lateinit var scope: TestScope
 
-    private val wifiConnsFlow = MutableStateFlow<Map<String, WifiConnection>>(emptyMap())
+    private val satConnsFlow = MutableStateFlow<Map<String, SatelliteConnection>>(emptyMap())
     private val btStatesFlow = MutableStateFlow<Map<String, BluetoothGamepadRegistry.SlotState>>(emptyMap())
 
     @Before
     fun setUp() {
-        wifi = mockk(relaxed = true)
+        satellite = mockk(relaxed = true)
         bt = mockk(relaxed = true)
         store = mockk(relaxed = true)
-        every { wifi.connections } returns wifiConnsFlow
+        every { satellite.connections } returns satConnsFlow
         every { bt.states } returns btStatesFlow
         every { store.remembered() } returns emptyList()
         every { store.rememberedBt() } returns emptyList()
@@ -51,7 +51,7 @@ class ConnectionHubTest {
      * store-mocking must happen before this call.
      */
     private fun buildHub(): ConnectionHub {
-        val hub = ConnectionHub(wifi, bt, store, scope)
+        val hub = ConnectionHub(satellite, bt, store, scope)
         scope.testScheduler.runCurrent()
         return hub
     }
@@ -65,11 +65,11 @@ class ConnectionHubTest {
         }
 
     @Test
-    fun `remembered wifi entries appear as IDLE summaries`() {
+    fun `remembered satellite entries appear as IDLE summaries`() {
         every { store.remembered() } returns
             listOf(
-                RememberedWifi(
-                    id = "wifi:10.0.0.1:9876",
+                RememberedSatellite(
+                    id = "satellite:10.0.0.1:9876",
                     name = "A",
                     ip = "10.0.0.1",
                     udpPort = 9876,
@@ -81,9 +81,9 @@ class ConnectionHubTest {
 
         val summaries = hub.connections.value
         assertEquals(1, summaries.size)
-        assertEquals(ConnectionKind.WIFI, summaries[0].kind)
+        assertEquals(ConnectionKind.SATELLITE, summaries[0].kind)
         assertEquals(ConnectionLive.IDLE, summaries[0].live)
-        assertEquals("wifi:10.0.0.1:9876", summaries[0].id)
+        assertEquals("satellite:10.0.0.1:9876", summaries[0].id)
     }
 
     @Test
@@ -120,13 +120,13 @@ class ConnectionHubTest {
     fun `bind sets slot to connection and binding is reflected in summary`() {
         every { store.remembered() } returns
             listOf(
-                RememberedWifi(id = "w:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
+                RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
             )
         val hub = buildHub()
 
-        hub.bind(slotId = "slot-A", connectionId = "w:1")
+        hub.bind(slotId = "slot-A", connectionId = "s:1")
 
-        assertEquals(mapOf("slot-A" to "w:1"), hub.bindings.value)
+        assertEquals(mapOf("slot-A" to "s:1"), hub.bindings.value)
         assertEquals(
             "slot-A",
             hub.connections.value
@@ -139,62 +139,62 @@ class ConnectionHubTest {
     fun `bind evicts a prior slot holding the same connection`() {
         every { store.remembered() } returns
             listOf(
-                RememberedWifi(id = "w:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
+                RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
             )
         val hub = buildHub()
 
-        hub.bind("slot-A", "w:1")
-        hub.bind("slot-B", "w:1")
+        hub.bind("slot-A", "s:1")
+        hub.bind("slot-B", "s:1")
 
-        assertEquals(mapOf("slot-B" to "w:1"), hub.bindings.value)
+        assertEquals(mapOf("slot-B" to "s:1"), hub.bindings.value)
     }
 
     @Test
-    fun `unbind removes the binding and detaches the wifi slot`() {
-        val wifiConn = mockk<WifiConnection>(relaxed = true)
-        every { wifi.get("w:1") } returns wifiConn
+    fun `unbind removes the binding and detaches the satellite slot`() {
+        val satConn = mockk<SatelliteConnection>(relaxed = true)
+        every { satellite.get("s:1") } returns satConn
         every { store.remembered() } returns
             listOf(
-                RememberedWifi(id = "w:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
+                RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
             )
         val hub = buildHub()
 
-        hub.bind("slot-A", "w:1")
+        hub.bind("slot-A", "s:1")
         hub.unbind("slot-A")
 
         assertNull(hub.bindings.value["slot-A"])
-        verify { wifiConn.detachSlot() }
+        verify { satConn.detachSlot() }
     }
 
     @Test
     fun `summary returns the entry matching id or null`() {
         every { store.remembered() } returns
             listOf(
-                RememberedWifi(id = "w:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
+                RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
             )
         val hub = buildHub()
 
-        assertEquals("w:1", hub.summary("w:1")?.id)
+        assertEquals("s:1", hub.summary("s:1")?.id)
         assertNull(hub.summary("missing"))
     }
 
     @Test
-    fun `autoReconnectAll connects each remembered wifi that is not live`() {
-        val live = RememberedWifi(id = "w:live", name = "L", ip = "1.1.1.1", udpPort = 1, pairPort = 2, httpPort = 3)
-        val idle = RememberedWifi(id = "w:idle", name = "I", ip = "2.2.2.2", udpPort = 4, pairPort = 5, httpPort = 6)
+    fun `autoReconnectAll connects each remembered satellite that is not live`() {
+        val live = RememberedSatellite(id = "s:live", name = "L", ip = "1.1.1.1", udpPort = 1, pairPort = 2, httpPort = 3)
+        val idle = RememberedSatellite(id = "s:idle", name = "I", ip = "2.2.2.2", udpPort = 4, pairPort = 5, httpPort = 6)
         every { store.remembered() } returns listOf(live, idle)
         val liveConn =
-            mockk<WifiConnection>(relaxed = true) {
-                every { state } returns MutableStateFlow(WifiState.CONNECTED)
+            mockk<SatelliteConnection>(relaxed = true) {
+                every { state } returns MutableStateFlow(SatelliteState.CONNECTED)
             }
-        every { wifi.get("w:live") } returns liveConn
-        every { wifi.get("w:idle") } returns null
+        every { satellite.get("s:live") } returns liveConn
+        every { satellite.get("s:idle") } returns null
         val hub = buildHub()
 
         hub.autoReconnectAll()
 
-        verify(exactly = 0) { wifi.connect(match { it.ip == "1.1.1.1" }) }
-        verify { wifi.connect(match { it.ip == "2.2.2.2" }) }
+        verify(exactly = 0) { satellite.connect(match { it.ip == "1.1.1.1" }) }
+        verify { satellite.connect(match { it.ip == "2.2.2.2" }) }
     }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/data/network/SatelliteConnectionTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/data/network/SatelliteConnectionTest.kt
@@ -22,11 +22,11 @@ import org.junit.Before
 import org.junit.Test
 
 /**
- * Unit tests for [WifiConnection] state transitions and gating of
- * [WifiConnection.sendReport] on connection state.
+ * Unit tests for [SatelliteConnection] state transitions and gating of
+ * [SatelliteConnection.sendReport] on connection state.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class WifiConnectionTest {
+class SatelliteConnectionTest {
     private val server =
         DiscoveredServer(
             name = "Pc",
@@ -37,15 +37,15 @@ class WifiConnectionTest {
         )
     private lateinit var repo: ControllerRepository
     private lateinit var scope: TestScope
-    private lateinit var conn: WifiConnection
+    private lateinit var conn: SatelliteConnection
 
     @Before
     fun setUp() {
         repo = mockk(relaxed = true)
         scope = TestScope(StandardTestDispatcher())
         conn =
-            WifiConnection(
-                id = WifiConnection.idFor(server),
+            SatelliteConnection(
+                id = SatelliteConnection.idFor(server),
                 server = server,
                 scope = scope,
                 controllerRepo = repo,
@@ -60,12 +60,12 @@ class WifiConnectionTest {
 
     @Test
     fun `idFor derives stable id from ip and udp port`() {
-        assertEquals("wifi:10.0.0.5:9876", WifiConnection.idFor(server))
+        assertEquals("satellite:10.0.0.5:9876", SatelliteConnection.idFor(server))
     }
 
     @Test
     fun `initial state is IDLE with no handle or connectionId`() {
-        assertEquals(WifiState.IDLE, conn.state.value)
+        assertEquals(SatelliteState.IDLE, conn.state.value)
         assertEquals(-1, conn.handle)
         assertNull(conn.connectionId)
     }
@@ -73,7 +73,7 @@ class WifiConnectionTest {
     @Test
     fun `markConnecting advances state to CONNECTING`() {
         conn.markConnecting()
-        assertEquals(WifiState.CONNECTING, conn.state.value)
+        assertEquals(SatelliteState.CONNECTING, conn.state.value)
     }
 
     @Test
@@ -86,7 +86,7 @@ class WifiConnectionTest {
             conn.markConnecting()
             conn.markConnected(handle = 7, connectionId = "conn-abc") {}
 
-            assertEquals(WifiState.CONNECTED, conn.state.value)
+            assertEquals(SatelliteState.CONNECTED, conn.state.value)
             assertEquals(7, conn.handle)
             assertEquals("conn-abc", conn.connectionId)
             verify { repo.resetControllerAck(7) }
@@ -105,7 +105,7 @@ class WifiConnectionTest {
         conn.markConnected(handle = 3, connectionId = "c") {}
         conn.markDisconnected()
 
-        assertEquals(WifiState.IDLE, conn.state.value)
+        assertEquals(SatelliteState.IDLE, conn.state.value)
         assertEquals(-1, conn.handle)
         assertNull(conn.connectionId)
         verify { repo.stopHeartbeat(3) }
@@ -211,7 +211,7 @@ class WifiConnectionTest {
     fun `markConnected from IDLE is rejected and leaves state IDLE`() {
         conn.markConnected(handle = 11, connectionId = "c") {}
 
-        assertEquals(WifiState.IDLE, conn.state.value)
+        assertEquals(SatelliteState.IDLE, conn.state.value)
         assertEquals(-1, conn.handle)
         assertNull(conn.connectionId)
         verify(exactly = 0) { repo.resetControllerAck(any()) }
@@ -230,7 +230,7 @@ class WifiConnectionTest {
         // so we don't leak the first session's native handle.
         conn.markConnected(handle = 2, connectionId = "second") {}
 
-        assertEquals(WifiState.CONNECTED, conn.state.value)
+        assertEquals(SatelliteState.CONNECTED, conn.state.value)
         assertEquals(1, conn.handle)
         assertEquals("first", conn.connectionId)
         verify(exactly = 1) { repo.resetControllerAck(any()) }
@@ -247,7 +247,7 @@ class WifiConnectionTest {
         conn.markConnected(handle = 4, connectionId = "c") {}
         conn.markConnecting()
 
-        assertEquals(WifiState.CONNECTED, conn.state.value)
+        assertEquals(SatelliteState.CONNECTED, conn.state.value)
         assertEquals(4, conn.handle)
     }
 
@@ -255,7 +255,7 @@ class WifiConnectionTest {
     fun `markDisconnected from IDLE is a no-op and touches no native handles`() {
         conn.markDisconnected()
 
-        assertEquals(WifiState.IDLE, conn.state.value)
+        assertEquals(SatelliteState.IDLE, conn.state.value)
         verify(exactly = 0) { repo.stopHeartbeat(any()) }
         verify(exactly = 0) { repo.closeSocket(any()) }
     }

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
@@ -8,7 +8,7 @@ import com.tinkernorth.dish.data.network.ConnectionHub
 import com.tinkernorth.dish.data.network.ConnectionKind
 import com.tinkernorth.dish.data.network.ConnectionLive
 import com.tinkernorth.dish.data.network.ConnectionSummary
-import com.tinkernorth.dish.data.network.WifiConnectionManager
+import com.tinkernorth.dish.data.network.SatelliteConnectionManager
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -29,30 +29,30 @@ import org.junit.Before
 import org.junit.Test
 
 /**
- * Unit tests for [MainViewModel]. The hub and wifi manager are stubbed so the
- * VM is exercised in isolation; only the slot lifecycle + bind/unbind
+ * Unit tests for [MainViewModel]. The hub and satellite manager are stubbed
+ * so the VM is exercised in isolation; only the slot lifecycle + bind/unbind
  * forwarding is under test here.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainViewModelTest {
     private val dispatcher: TestDispatcher = StandardTestDispatcher()
     private lateinit var hub: ConnectionHub
-    private lateinit var wifi: WifiConnectionManager
+    private lateinit var satellite: SatelliteConnectionManager
     private lateinit var vm: MainViewModel
 
     private val connectionsFlow = MutableStateFlow<List<ConnectionSummary>>(emptyList())
     private val bindingsFlow = MutableStateFlow<Map<String, String>>(emptyMap())
-    private val wifiEvents = MutableSharedFlow<ConnectionEvent>(extraBufferCapacity = 8)
+    private val satelliteEvents = MutableSharedFlow<ConnectionEvent>(extraBufferCapacity = 8)
 
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
         hub = mockk(relaxed = true)
-        wifi = mockk(relaxed = true)
+        satellite = mockk(relaxed = true)
         every { hub.connections } returns connectionsFlow
         every { hub.bindings } returns bindingsFlow
-        every { wifi.events } returns wifiEvents
-        vm = MainViewModel(wifi, hub)
+        every { satellite.events } returns satelliteEvents
+        vm = MainViewModel(satellite, hub)
     }
 
     @After
@@ -110,8 +110,8 @@ class MainViewModelTest {
 
     @Test
     fun `bindSlot delegates to hub`() {
-        vm.bindSlot(slotId = "slot-X", connectionId = "w:1")
-        verify { hub.bind("slot-X", "w:1") }
+        vm.bindSlot(slotId = "slot-X", connectionId = "s:1")
+        verify { hub.bind("slot-X", "s:1") }
     }
 
     @Test
@@ -125,21 +125,21 @@ class MainViewModelTest {
         runTest(dispatcher) {
             val summary =
                 ConnectionSummary(
-                    id = "w:1",
-                    kind = ConnectionKind.WIFI,
+                    id = "s:1",
+                    kind = ConnectionKind.SATELLITE,
                     label = "PC",
                     detail = "1.1.1.1",
                     live = ConnectionLive.CONNECTED,
                     boundSlotId = VIRTUAL_SLOT_ID,
                 )
             connectionsFlow.value = listOf(summary)
-            bindingsFlow.value = mapOf(VIRTUAL_SLOT_ID to "w:1")
+            bindingsFlow.value = mapOf(VIRTUAL_SLOT_ID to "s:1")
             dispatcher.scheduler.runCurrent()
 
             val virtual =
                 vm.uiState.value.slots
                     .first { it.id == VIRTUAL_SLOT_ID }
-            assertEquals("w:1", virtual.boundConnectionId)
+            assertEquals("s:1", virtual.boundConnectionId)
             assertEquals(summary, virtual.boundStatus)
         }
 


### PR DESCRIPTION
## Summary

- Renames all `wifi`/`WiFi`/`Wi-Fi` terminology in code, class names, method names, SharedPreferences keys, and user-facing UI copy to `satellite` — reflecting that the app connects to a host PC running a satellite server, not a WiFi access point
- `WifiConnection` → `SatelliteConnection`, `WifiConnectionManager` → `SatelliteConnectionManager` (git mv to preserve history)
- `ConnectionKind.WIFI` → `ConnectionKind.SATELLITE`; `RememberedWifi` → `RememberedSatellite`; prefs key `wifi_list` → `satellite_list`
- Layout: `"WIFI SERVERS"` → `"SATELLITES"`; empty-state hint updated; view IDs `btnWifiScan`/`llWifiList`/`tvWifiEmpty` → `btnSatelliteScan`/`llSatelliteList`/`tvSatelliteEmpty`
- All unit tests updated to use new names and `"satellite:ip:port"` ID format

Android system permission names (`ACCESS_WIFI_STATE`, `CHANGE_WIFI_MULTICAST_STATE`) are unchanged — those are fixed OS API strings.

Build and all 34 unit tests pass.

## Test plan

- [ ] `./gradlew testDebugUnitTest` — all 34 tests green
- [ ] `./gradlew assembleDebug` — clean build
- [ ] Launch app → Connections screen shows "SATELLITES" header and "Tap Scan to find satellites on your network" empty state
- [ ] Scan finds a satellite server and it appears in the list; connect/disconnect works
- [ ] Previously remembered connections: note that stored prefs key changed (`wifi_list` → `satellite_list`), so existing remembered entries will not migrate — acceptable for pre-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)