### PR TITLE
feat: allow multiple gamepads and per-slot Xbox/PS switching on satellite

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/data/network/ConnectionHub.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/network/ConnectionHub.kt
@@ -26,9 +26,16 @@ enum class ConnectionKind { SATELLITE, BLUETOOTH }
 
 enum class ConnectionLive { IDLE, CONNECTING, CONNECTED }
 
+/** Server-visible controller type. The native protocol carries the raw int. */
+const val CONTROLLER_TYPE_XBOX = 0
+const val CONTROLLER_TYPE_PLAYSTATION = 1
+
 /**
  * Snapshot of a single remembered or live connection, used by the UI to render
  * the connections list and the bind-to-connection picker on each slot.
+ *
+ * [boundSlotIds] is a list because a satellite session can host multiple
+ * controllers; for Bluetooth the hub enforces at most one entry.
  */
 data class ConnectionSummary(
     val id: String,
@@ -36,9 +43,15 @@ data class ConnectionSummary(
     val label: String,
     val detail: String,
     val live: ConnectionLive,
-    val boundSlotId: String?,
+    val boundSlotIds: List<String>,
     /** For BT only: name of the remembered [BluetoothGamepad.GamepadProfile]. */
     val btProfile: String? = null,
+    /**
+     * For SATELLITE only: per-slot controller type (Xbox / PlayStation /…).
+     * Empty for Bluetooth since BT type is fixed by the remembered host's
+     * HID profile.
+     */
+    val satelliteControllerTypes: Map<String, Int> = emptyMap(),
 )
 
 /**
@@ -47,7 +60,9 @@ data class ConnectionSummary(
  *
  * Binding a slot to a connection is a UI-level concept (which slot routes its
  * input where) — the actual wiring lives in the managers; the hub just tracks
- * the bindings so at most one slot owns any given connection.
+ * the bindings. Eviction is per-kind: Bluetooth is capped at one slot per
+ * connection (HID Device profile only supports a single host) but satellites
+ * can host as many slots as the server allows.
  */
 @Singleton
 class ConnectionHub
@@ -61,6 +76,14 @@ class ConnectionHub
         /** slotId -> connectionId of the connection currently routing that slot. */
         private val _bindings = MutableStateFlow<Map<String, String>>(emptyMap())
         val bindings: StateFlow<Map<String, String>> = _bindings.asStateFlow()
+
+        /**
+         * (connectionId, slotId) -> controller type for satellite bindings.
+         * Source of truth for the UI's per-slot Xbox/PS toggle; the actual
+         * push to the native session goes through [SatelliteConnection.setControllerType].
+         * Bluetooth's type is fixed by the remembered host so it doesn't live here.
+         */
+        private val _satTypes = MutableStateFlow<Map<Pair<String, String>, Int>>(emptyMap())
 
         private val _connections = MutableStateFlow<List<ConnectionSummary>>(emptyList())
         val connections: StateFlow<List<ConnectionSummary>> = _connections.asStateFlow()
@@ -78,7 +101,8 @@ class ConnectionHub
             satMap: Map<String, SatelliteConnection>,
             btStates: Map<String, BluetoothGamepadRegistry.SlotState>,
         ): List<ConnectionSummary> {
-            val bindingBySlot = _bindings.value
+            val bindings = _bindings.value
+            val satTypes = _satTypes.value
             val result = mutableListOf<ConnectionSummary>()
 
             // Satellites: remembered + any live not-yet-remembered (discovery hits).
@@ -93,7 +117,12 @@ class ConnectionHub
                         SatelliteState.CONNECTING -> ConnectionLive.CONNECTING
                         else -> ConnectionLive.IDLE
                     }
-                val bound = bindingBySlot.entries.firstOrNull { it.value == id }?.key
+                val bound = bindings.entries.filter { it.value == id }.map { it.key }
+                val typesForConn =
+                    bound.mapNotNull { slotId ->
+                        val key = id to slotId
+                        satTypes[key]?.let { slotId to it }
+                    }.toMap()
                 result +=
                     ConnectionSummary(
                         id = id,
@@ -101,13 +130,14 @@ class ConnectionHub
                         label = server.name.ifEmpty { server.ip },
                         detail = "${server.ip} • UDP ${server.udpPort}",
                         live = live,
-                        boundSlotId = bound,
+                        boundSlotIds = bound,
+                        satelliteControllerTypes = typesForConn,
                     )
             }
 
             // Bluetooth: one summary per remembered host; live state from registry.
             for (entry in store.rememberedBt()) {
-                val bound = bindingBySlot.entries.firstOrNull { it.value == entry.id }?.key
+                val bound = bindings.entries.filter { it.value == entry.id }.map { it.key }
                 val state = btStates[entry.id]
                 val live =
                     when {
@@ -122,7 +152,7 @@ class ConnectionHub
                         label = entry.name.ifEmpty { entry.mac },
                         detail = "${entry.profileName} • ${entry.mac}",
                         live = live,
-                        boundSlotId = bound,
+                        boundSlotIds = bound,
                         btProfile = entry.profileName,
                     )
             }
@@ -131,27 +161,57 @@ class ConnectionHub
 
         fun summary(id: String): ConnectionSummary? = _connections.value.firstOrNull { it.id == id }
 
-        /** Bind [slotId] to [connectionId]. Evicts any prior binding on either side. */
+        /**
+         * Bind [slotId] to [connectionId]. Eviction depends on the connection
+         * kind: Bluetooth releases any prior slot on the same host (single-host
+         * HID Device profile constraint), but satellites accept multiple slots
+         * side-by-side. If the slot was previously bound elsewhere, that prior
+         * binding is detached first regardless of kind.
+         */
         fun bind(
             slotId: String,
             connectionId: String,
         ) {
             val current = _bindings.value.toMutableMap()
-            // Another slot already holds this connection? Release it and
-            // tell the native session so the server sees a clean
-            // CONTROLLER_REMOVE before the new slot's CONTROLLER_ADD.
-            val priorSlot = current.entries.firstOrNull { it.value == connectionId }?.key
-            if (priorSlot != null && priorSlot != slotId) {
-                current.remove(priorSlot)
-                satellite.get(connectionId)?.detachSlot()
+
+            // Slot was previously bound to a different connection: release it
+            // there before claiming the new one. Without this the old satellite
+            // session would keep treating this slot as its owner and reports
+            // for it would still be addressed to the old controller index.
+            val priorConnId = current[slotId]
+            if (priorConnId != null && priorConnId != connectionId) {
+                satellite.get(priorConnId)?.detachSlot(slotId)
+                _satTypes.value = _satTypes.value - (priorConnId to slotId)
             }
+
+            // Bluetooth-only: another slot already holds this connection?
+            // Release it and tell the native session so the server sees a
+            // clean CONTROLLER_REMOVE before the new slot's CONTROLLER_ADD.
+            // Satellites are multi-slot so we leave existing bindings alone.
+            val isBt = store.rememberedBt().any { it.id == connectionId }
+            if (isBt) {
+                val priorSlot = current.entries.firstOrNull { it.value == connectionId && it.key != slotId }?.key
+                if (priorSlot != null) {
+                    current.remove(priorSlot)
+                    satellite.get(connectionId)?.detachSlot(priorSlot)
+                }
+            }
+
             current[slotId] = connectionId
             _bindings.value = current
-            // Re-emit connections so boundSlotId refreshes.
+
+            // Stash a default type for new satellite bindings so the UI's
+            // per-slot toggle has something to render before the user picks.
+            val type = _satTypes.value[connectionId to slotId] ?: CONTROLLER_TYPE_XBOX
+            if (!isBt) {
+                _satTypes.value = _satTypes.value + ((connectionId to slotId) to type)
+            }
+
+            // Re-emit connections so boundSlotIds refreshes.
             _connections.value = buildSummaries(satellite.connections.value, bt.states.value)
             // For satellite: attach the controller slot on the server side.
             satellite.get(connectionId)?.let { conn ->
-                scope.launch { conn.attachSlot(slotId, controllerType = 0) }
+                scope.launch { conn.attachSlot(slotId, controllerType = type) }
             }
         }
 
@@ -159,7 +219,29 @@ class ConnectionHub
             val current = _bindings.value.toMutableMap()
             val connId = current.remove(slotId) ?: return
             _bindings.value = current
-            satellite.get(connId)?.detachSlot()
+            satellite.get(connId)?.detachSlot(slotId)
+            _satTypes.value = _satTypes.value - (connId to slotId)
+            _connections.value = buildSummaries(satellite.connections.value, bt.states.value)
+        }
+
+        /**
+         * Change the controller type (Xbox/PS/…) for a satellite-bound slot.
+         * Pushes the change to the native session if it's live; otherwise
+         * stashes the new value so it's used at the next registration.
+         * No-op for Bluetooth bindings since BT type is fixed by the
+         * remembered host's HID profile.
+         */
+        fun setSatelliteControllerType(
+            connectionId: String,
+            slotId: String,
+            type: Int,
+        ) {
+            val key = connectionId to slotId
+            if (_satTypes.value[key] == type) return
+            _satTypes.value = _satTypes.value + (key to type)
+            satellite.get(connectionId)?.let { conn ->
+                scope.launch { conn.setControllerType(slotId, type) }
+            }
             _connections.value = buildSummaries(satellite.connections.value, bt.states.value)
         }
 

--- a/app/src/main/java/com/tinkernorth/dish/data/network/SatelliteConnection.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/network/SatelliteConnection.kt
@@ -12,17 +12,27 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 /**
  * A single live or potential session to one Satellite server (the host PC the
  * device routes input to over LAN).
  *
+ * Multi-slot: a satellite session can host more than one controller. Each
+ * attached slot is allocated a server-visible [SlotBinding.controllerIndex]
+ * (0..N) so per-slot reports, type changes and removals can be addressed
+ * independently. Bluetooth's single-host constraint is enforced one layer up
+ * in [ConnectionHub.bind].
+ *
  * The [id] is stable across app restarts (derived from server IP+port) so the
- * hub can persist a list of remembered connections and reclaim the same slot
- * binding after a relaunch. [handle] is the native session handle returned by
+ * hub can persist a list of remembered connections and reclaim slot bindings
+ * after a relaunch. [handle] is the native session handle returned by
  * [ControllerRepository.openSocket] and is only valid while [state] is
  * [SatelliteState.CONNECTED]; once the session is torn down it is reset to -1
  * and a fresh handle is allocated on reconnect.
@@ -58,15 +68,32 @@ class SatelliteConnection(
     /** Native socket handle for the live session, or -1 when idle. */
     val handle: Int get() = live?.handle ?: -1
 
-    /** Which slot id (if any) currently routes its input to this connection. */
-    private val _boundSlotId = MutableStateFlow<String?>(null)
-    val boundSlotId: StateFlow<String?> = _boundSlotId.asStateFlow()
+    /**
+     * State of a single slot bound to this connection. [controllerIndex] is the
+     * server-visible 0..N index used in `addController`/`sendReport` etc.
+     * [registered] flips true once `addController` has been ACKed and the type
+     * has been pushed; reports for this slot are dropped until then so we don't
+     * silently feed packets the server will reject as "unknown controller".
+     */
+    data class SlotBinding(
+        val controllerIndex: Int,
+        val controllerType: Int,
+        val registered: Boolean,
+    )
+
+    private val _slots = MutableStateFlow<Map<String, SlotBinding>>(emptyMap())
+    val slots: StateFlow<Map<String, SlotBinding>> = _slots.asStateFlow()
 
     private var ackJob: Job? = null
     private var aliveJob: Job? = null
 
-    @Volatile private var controllerAdded = false
-    private var pendingControllerType: Int = DEFAULT_CONTROLLER_TYPE
+    /**
+     * Serializes [registerController] runs. The native ACK channel
+     * (`getLastControllerAck`) is per-handle, not per-controller-index, so two
+     * concurrent registrations would race on `resetControllerAck` and steal
+     * each other's ACKs.
+     */
+    private val registrationMutex = Mutex()
     private var onRegistrationFailed: (() -> Unit)? = null
 
     fun updateServer(server: DiscoveredServer) {
@@ -94,9 +121,9 @@ class SatelliteConnection(
      * rebind. Calls from IDLE are likewise rejected — the pair/auth path must
      * go through [markConnecting].
      *
-     * If a slot was bound before the session was online (common right after an
-     * app relaunch/auto-reconnect) the server-side `addController` handshake
-     * is run now so subsequent [sendReport] packets are accepted.
+     * Any slots attached before the session was online (common right after an
+     * app relaunch/auto-reconnect) get their `addController` handshake run now,
+     * sequentially, so subsequent [sendReport] packets are accepted.
      */
     internal fun markConnected(
         handle: Int,
@@ -129,8 +156,11 @@ class SatelliteConnection(
                     }
                 }
             }
-        if (_boundSlotId.value != null && !controllerAdded) {
-            scope.launch { registerController(pendingControllerType) }
+        val pending = _slots.value.filterValues { !it.registered }.keys.toList()
+        if (pending.isNotEmpty()) {
+            scope.launch {
+                for (slotId in pending) registerController(slotId)
+            }
         }
     }
 
@@ -138,6 +168,9 @@ class SatelliteConnection(
      * Tear the session down. Idempotent: a second call from IDLE is a no-op
      * so callers (alive-poll, manager.disconnect, forget, foreground kicks)
      * can invoke it freely without needing to check state first.
+     *
+     * Slot attachments are preserved (only the `registered` flag is cleared)
+     * so the next [markConnected] re-registers them automatically.
      */
     internal fun markDisconnected() {
         val snap = live
@@ -154,59 +187,110 @@ class SatelliteConnection(
             controllerRepo.stopHeartbeat(snap.handle)
             controllerRepo.closeSocket(snap.handle)
         }
-        controllerAdded = false
+        _slots.update { map -> map.mapValues { (_, v) -> v.copy(registered = false) } }
         onRegistrationFailed = null
         _state.value = SatelliteState.IDLE
     }
 
     /**
-     * Record this slot as the owner of this connection. If the native session
-     * is already live the server is notified immediately; otherwise the
-     * registration is deferred to [markConnected].
+     * Record [slotId] as bound to this connection at [controllerType]. If the
+     * slot is already attached this is a no-op (use [setControllerType] to
+     * change the type of an attached slot). When the native session is live
+     * the server is notified immediately; otherwise the registration is
+     * deferred to [markConnected].
      */
     suspend fun attachSlot(
         slotId: String,
         controllerType: Int,
-    ) = withContext(Dispatchers.IO) {
-        _boundSlotId.value = slotId
-        pendingControllerType = controllerType
-        if (_state.value == SatelliteState.CONNECTED && handle >= 0 && !controllerAdded) {
-            registerController(controllerType)
+    ) {
+        val updated =
+            _slots.updateAndGet { map ->
+                if (map.containsKey(slotId)) return@updateAndGet map
+                val index = lowestFreeIndex(map.values.map { it.controllerIndex })
+                map + (slotId to SlotBinding(index, controllerType, registered = false))
+            }
+        // No-op if this slot was already present.
+        val info = updated[slotId] ?: return
+        if (info.registered) return
+        if (_state.value == SatelliteState.CONNECTED && handle >= 0) {
+            registerController(slotId)
         }
     }
 
-    private suspend fun registerController(controllerType: Int) =
-        withContext(Dispatchers.IO) {
-            if (handle < 0) return@withContext
-            controllerRepo.resetControllerAck(handle)
-            controllerRepo.addController(handle, DEFAULT_CTRL_INDEX, DEFAULT_CAPABILITIES)
-            var ack = -1
-            repeat(ACK_WAIT_ATTEMPTS) {
-                ack = controllerRepo.getLastControllerAck(handle)
-                if (ack != -1) return@repeat
-                delay(ACK_WAIT_INTERVAL_MS)
+    /**
+     * Update the controller type for an already-attached [slotId] (Xbox/PS
+     * etc.). If the slot is registered with the server, the change is pushed
+     * immediately; otherwise it sticks in [SlotBinding.controllerType] and is
+     * sent at registration time.
+     */
+    suspend fun setControllerType(
+        slotId: String,
+        controllerType: Int,
+    ) {
+        var info: SlotBinding? = null
+        _slots.update { map ->
+            val cur = map[slotId] ?: return@update map
+            if (cur.controllerType == controllerType) {
+                info = null
+                return@update map
             }
-            if (ack != -1) {
-                controllerRepo.sendControllerType(handle, DEFAULT_CTRL_INDEX, controllerType)
-                controllerAdded = true
-            } else {
-                // Server never ACKed addController; don't silently feed reports
-                // into a connection it will reject. Surface so the user sees
-                // "couldn't register controller" instead of an inert UI.
-                onRegistrationFailed?.invoke()
+            val next = cur.copy(controllerType = controllerType)
+            info = next
+            map + (slotId to next)
+        }
+        val snap = info ?: return
+        if (snap.registered && handle >= 0) {
+            withContext(Dispatchers.IO) {
+                controllerRepo.sendControllerType(handle, snap.controllerIndex, controllerType)
+            }
+        }
+    }
+
+    private suspend fun registerController(slotId: String) =
+        registrationMutex.withLock {
+            withContext(Dispatchers.IO) {
+                val info = _slots.value[slotId] ?: return@withContext
+                if (info.registered) return@withContext
+                if (handle < 0) return@withContext
+                controllerRepo.resetControllerAck(handle)
+                controllerRepo.addController(handle, info.controllerIndex, DEFAULT_CAPABILITIES)
+                var ack = -1
+                repeat(ACK_WAIT_ATTEMPTS) {
+                    ack = controllerRepo.getLastControllerAck(handle)
+                    if (ack != -1) return@repeat
+                    delay(ACK_WAIT_INTERVAL_MS)
+                }
+                if (ack != -1) {
+                    controllerRepo.sendControllerType(handle, info.controllerIndex, info.controllerType)
+                    _slots.update { map ->
+                        val cur = map[slotId] ?: return@update map
+                        map + (slotId to cur.copy(registered = true))
+                    }
+                } else {
+                    // Server never ACKed addController; don't silently feed
+                    // reports into a connection it will reject. Surface so the
+                    // user sees "couldn't register controller" instead of an
+                    // inert UI.
+                    onRegistrationFailed?.invoke()
+                }
             }
         }
 
-    fun detachSlot() {
-        if (_boundSlotId.value == null) return
-        _boundSlotId.value = null
-        if (handle >= 0 && controllerAdded) {
-            controllerRepo.removeController(handle, DEFAULT_CTRL_INDEX)
+    fun detachSlot(slotId: String) {
+        var removed: SlotBinding? = null
+        _slots.update { map ->
+            val cur = map[slotId] ?: return@update map
+            removed = cur
+            map - slotId
         }
-        controllerAdded = false
+        val info = removed ?: return
+        if (handle >= 0 && info.registered) {
+            controllerRepo.removeController(handle, info.controllerIndex)
+        }
     }
 
     fun sendReport(
+        slotId: String,
         buttons: Int,
         lt: Int,
         rt: Int,
@@ -216,23 +300,29 @@ class SatelliteConnection(
         ry: Int,
     ) {
         val snap = live ?: return
-        // Gate on controllerAdded so reports during the registerController()
-        // ACK window (up to 2s after markConnected) aren't silently dropped
+        val info = _slots.value[slotId] ?: return
+        // Gate on registered so reports during the registerController() ACK
+        // window (up to 2s after markConnected) aren't silently dropped
         // server-side as "unknown controller". Slot-bind → connect ordering
         // makes this window unavoidable on auto-reconnect.
-        if (!controllerAdded) return
-        controllerRepo.sendReport(snap.handle, DEFAULT_CTRL_INDEX, buttons, lt, rt, lx, ly, rx, ry)
+        if (!info.registered) return
+        controllerRepo.sendReport(snap.handle, info.controllerIndex, buttons, lt, rt, lx, ly, rx, ry)
     }
 
     companion object {
         private const val ALIVE_POLL_MS = 1000L
         private const val ACK_WAIT_ATTEMPTS = 20
         private const val ACK_WAIT_INTERVAL_MS = 100L
-        private const val DEFAULT_CTRL_INDEX = 0
         private const val DEFAULT_CAPABILITIES = 0x0003
-        private const val DEFAULT_CONTROLLER_TYPE = 0
 
         fun idFor(server: DiscoveredServer): String = "satellite:${server.ip}:${server.udpPort}"
+
+        private fun lowestFreeIndex(taken: List<Int>): Int {
+            val set = taken.toHashSet()
+            var i = 0
+            while (i in set) i++
+            return i
+        }
     }
 }
 

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
@@ -14,6 +14,8 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.tinkernorth.dish.R
+import com.tinkernorth.dish.data.network.CONTROLLER_TYPE_PLAYSTATION
+import com.tinkernorth.dish.data.network.CONTROLLER_TYPE_XBOX
 import com.tinkernorth.dish.data.network.ConnectionKind
 import com.tinkernorth.dish.data.network.ConnectionLive
 import com.tinkernorth.dish.data.network.ConnectionSummary
@@ -30,6 +32,13 @@ interface SlotActionListener {
     fun onUnbind(slotId: String)
 
     fun onOpenGamepad()
+
+    /** User picked a new controller type (Xbox/PS) for a satellite-bound slot. */
+    fun onChangeDeviceType(
+        slotId: String,
+        connectionId: String,
+        type: Int,
+    )
 }
 
 class ControllerAdapter(
@@ -126,7 +135,14 @@ class ControllerAdapter(
         ) {
             val ctx = parent.context
             val bound = slot.boundConnectionId == c.id
-            val ownedByOther = c.boundSlotId != null && c.boundSlotId != slot.id
+            // Bluetooth is single-host: another slot already bound to this BT
+            // connection blocks this slot from claiming it. Satellites accept
+            // multiple slots side-by-side so we never disable for sat.
+            val ownedByOther =
+                when (c.kind) {
+                    ConnectionKind.BLUETOOTH -> c.boundSlotIds.any { it != slot.id }
+                    ConnectionKind.SATELLITE -> false
+                }
             val row =
                 LinearLayout(ctx).apply {
                     orientation = LinearLayout.VERTICAL
@@ -189,8 +205,100 @@ class ControllerAdapter(
                     typeface = Typeface.MONOSPACE
                 },
             )
+            // Per-slot Xbox/PS toggle for the satellite this slot is bound to.
+            // Bluetooth's controller type is fixed by the remembered host so
+            // we don't render a switcher there.
+            if (bound && c.kind == ConnectionKind.SATELLITE) {
+                row.addView(buildTypeToggle(ctx, dp, slot, c))
+            }
             parent.addView(row)
         }
+
+        private fun buildTypeToggle(
+            ctx: android.content.Context,
+            dp: Float,
+            slot: ControllerSlot,
+            c: ConnectionSummary,
+        ): View {
+            val current = c.satelliteControllerTypes[slot.id] ?: CONTROLLER_TYPE_XBOX
+            val container =
+                LinearLayout(ctx).apply {
+                    orientation = LinearLayout.HORIZONTAL
+                    layoutParams =
+                        LinearLayout.LayoutParams(
+                            LinearLayout.LayoutParams.MATCH_PARENT,
+                            LinearLayout.LayoutParams.WRAP_CONTENT,
+                        ).apply { topMargin = (8 * dp).toInt() }
+                }
+            container.addView(
+                TextView(ctx).apply {
+                    text = "Type"
+                    setTextColor(ctx.getColor(R.color.colorMuted))
+                    textSize = 11f
+                    typeface = Typeface.MONOSPACE
+                    layoutParams =
+                        LinearLayout.LayoutParams(
+                            LinearLayout.LayoutParams.WRAP_CONTENT,
+                            LinearLayout.LayoutParams.WRAP_CONTENT,
+                        ).apply {
+                            gravity = android.view.Gravity.CENTER_VERTICAL
+                            marginEnd = (10 * dp).toInt()
+                        }
+                },
+            )
+            container.addView(
+                typeChip(
+                    ctx,
+                    dp,
+                    label = "Xbox",
+                    selected = current == CONTROLLER_TYPE_XBOX,
+                ) { listener.onChangeDeviceType(slot.id, c.id, CONTROLLER_TYPE_XBOX) },
+            )
+            container.addView(
+                typeChip(
+                    ctx,
+                    dp,
+                    label = "PlayStation",
+                    selected = current == CONTROLLER_TYPE_PLAYSTATION,
+                ) { listener.onChangeDeviceType(slot.id, c.id, CONTROLLER_TYPE_PLAYSTATION) },
+            )
+            return container
+        }
+
+        private fun typeChip(
+            ctx: android.content.Context,
+            dp: Float,
+            label: String,
+            selected: Boolean,
+            onClick: () -> Unit,
+        ): TextView =
+            TextView(ctx).apply {
+                text = label
+                textSize = 12f
+                setTextColor(
+                    ctx.getColor(if (selected) R.color.colorOnPrimary else R.color.colorOnSurface),
+                )
+                val padH = (10 * dp).toInt()
+                val padV = (4 * dp).toInt()
+                setPadding(padH, padV, padH, padV)
+                background =
+                    GradientDrawable().apply {
+                        setColor(
+                            ctx.getColor(
+                                if (selected) R.color.colorPrimary else R.color.colorBackground,
+                            ),
+                        )
+                        cornerRadius = 4 * dp
+                        setStroke((1 * dp).toInt(), ctx.getColor(R.color.colorOutline))
+                    }
+                layoutParams =
+                    LinearLayout.LayoutParams(
+                        LinearLayout.LayoutParams.WRAP_CONTENT,
+                        LinearLayout.LayoutParams.WRAP_CONTENT,
+                    ).apply { marginEnd = (6 * dp).toInt() }
+                isClickable = !selected
+                if (!selected) setOnClickListener { onClick() }
+            }
 
         private fun slotStatusText(s: ControllerSlot) =
             when {

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
@@ -111,6 +111,7 @@ class GamepadOverlayActivity :
                 // wButtons with the d-pad folded back into the low nibble.
                 val wButtons = hidToXusb(state.buttons, state.hatSwitch)
                 satellite.get(connectionId)?.sendReport(
+                    VIRTUAL_SLOT_ID,
                     wButtons,
                     state.leftTrigger,
                     state.rightTrigger,

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
@@ -144,7 +144,7 @@ class MainActivity :
         if (summary.live != ConnectionLive.CONNECTED) return
         when (summary.kind) {
             ConnectionKind.SATELLITE ->
-                satellite.get(cid)?.sendReport(wButtons, bLT, bRT, sLX, sLY, sRX, sRY)
+                satellite.get(cid)?.sendReport(slot.id, wButtons, bLT, bRT, sLX, sLY, sRX, sRY)
             ConnectionKind.BLUETOOTH -> {
                 // Physical controllers emit an XUSB-layout wButtons; the BT HID
                 // descriptor expects a different bit layout plus a hat-switch
@@ -246,6 +246,12 @@ class MainActivity :
 
     override fun onUnbind(slotId: String) = viewModel.unbindSlot(slotId)
 
+    override fun onChangeDeviceType(
+        slotId: String,
+        connectionId: String,
+        type: Int,
+    ) = viewModel.setSatelliteControllerType(connectionId, slotId, type)
+
     override fun onOpenGamepad() {
         val v = viewModel.uiState.value.virtualSlot
         val cid =
@@ -254,10 +260,17 @@ class MainActivity :
                 return
             }
         val summary = v.boundStatus
+        // BT carries its profile in summary.btProfile; satellites carry a per-slot
+        // controller type the user can flip from the dashboard. Either signals
+        // "use PS layout" to the overlay.
+        val usePs =
+            summary?.btProfile == "PlayStation" ||
+                summary?.satelliteControllerTypes?.get(VIRTUAL_SLOT_ID) ==
+                com.tinkernorth.dish.data.network.CONTROLLER_TYPE_PLAYSTATION
         val intent =
             Intent(this, GamepadOverlayActivity::class.java).apply {
                 putExtra(GamepadOverlayActivity.EXTRA_CONNECTION_ID, cid)
-                putExtra(GamepadOverlayActivity.EXTRA_USE_PS_LAYOUT, summary?.btProfile == "PlayStation")
+                putExtra(GamepadOverlayActivity.EXTRA_USE_PS_LAYOUT, usePs)
             }
         startActivity(intent)
     }

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
@@ -82,6 +82,19 @@ class MainViewModel
             hub.unbind(slotId)
         }
 
+        /**
+         * Switch the controller type (Xbox/PS) for a slot bound to a satellite.
+         * No-op for Bluetooth bindings — BT type is fixed by the remembered
+         * host's HID profile.
+         */
+        fun setSatelliteControllerType(
+            connectionId: String,
+            slotId: String,
+            type: Int,
+        ) {
+            hub.setSatelliteControllerType(connectionId, slotId, type)
+        }
+
         // ── Physical controller lifecycle ─────────────────────────────────────
 
         fun onControllerConnected(

--- a/app/src/test/java/com/tinkernorth/dish/data/network/ConnectionHubTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/data/network/ConnectionHubTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -84,6 +85,7 @@ class ConnectionHubTest {
         assertEquals(ConnectionKind.SATELLITE, summaries[0].kind)
         assertEquals(ConnectionLive.IDLE, summaries[0].live)
         assertEquals("satellite:10.0.0.1:9876", summaries[0].id)
+        assertTrue(summaries[0].boundSlotIds.isEmpty())
     }
 
     @Test
@@ -128,15 +130,17 @@ class ConnectionHubTest {
 
         assertEquals(mapOf("slot-A" to "s:1"), hub.bindings.value)
         assertEquals(
-            "slot-A",
+            listOf("slot-A"),
             hub.connections.value
                 .first()
-                .boundSlotId,
+                .boundSlotIds,
         )
     }
 
     @Test
-    fun `bind evicts a prior slot holding the same connection`() {
+    fun `binding two slots to the same satellite keeps both attached`() {
+        val satConn = mockk<SatelliteConnection>(relaxed = true)
+        every { satellite.get("s:1") } returns satConn
         every { store.remembered() } returns
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
@@ -146,11 +150,53 @@ class ConnectionHubTest {
         hub.bind("slot-A", "s:1")
         hub.bind("slot-B", "s:1")
 
-        assertEquals(mapOf("slot-B" to "s:1"), hub.bindings.value)
+        assertEquals(
+            mapOf("slot-A" to "s:1", "slot-B" to "s:1"),
+            hub.bindings.value,
+        )
+        // Both slots show as bound on the satellite summary; nothing was detached.
+        val summary = hub.connections.value.first { it.id == "s:1" }
+        assertEquals(setOf("slot-A", "slot-B"), summary.boundSlotIds.toSet())
+        verify(exactly = 0) { satConn.detachSlot(any()) }
     }
 
     @Test
-    fun `unbind removes the binding and detaches the satellite slot`() {
+    fun `bind evicts the prior slot for a bluetooth host`() {
+        every { store.rememberedBt() } returns
+            listOf(
+                RememberedBt(id = "bt:X", name = "Xbox", mac = "X", profileName = "XBOX"),
+            )
+        val hub = buildHub()
+
+        hub.bind("slot-A", "bt:X")
+        hub.bind("slot-B", "bt:X")
+
+        // BT is single-host: the earlier slot is released so the new one owns it.
+        assertEquals(mapOf("slot-B" to "bt:X"), hub.bindings.value)
+    }
+
+    @Test
+    fun `binding a slot to a new satellite detaches it from the prior one`() {
+        val sat1 = mockk<SatelliteConnection>(relaxed = true)
+        val sat2 = mockk<SatelliteConnection>(relaxed = true)
+        every { satellite.get("s:1") } returns sat1
+        every { satellite.get("s:2") } returns sat2
+        every { store.remembered() } returns
+            listOf(
+                RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
+                RememberedSatellite(id = "s:2", name = "B", ip = "2", udpPort = 4, pairPort = 5, httpPort = 6),
+            )
+        val hub = buildHub()
+
+        hub.bind("slot-A", "s:1")
+        hub.bind("slot-A", "s:2")
+
+        assertEquals(mapOf("slot-A" to "s:2"), hub.bindings.value)
+        verify { sat1.detachSlot("slot-A") }
+    }
+
+    @Test
+    fun `unbind removes the binding and detaches the satellite slot by id`() {
         val satConn = mockk<SatelliteConnection>(relaxed = true)
         every { satellite.get("s:1") } returns satConn
         every { store.remembered() } returns
@@ -163,7 +209,39 @@ class ConnectionHubTest {
         hub.unbind("slot-A")
 
         assertNull(hub.bindings.value["slot-A"])
-        verify { satConn.detachSlot() }
+        verify { satConn.detachSlot("slot-A") }
+    }
+
+    @Test
+    fun `bind seeds a default Xbox controller type for new satellite slots`() {
+        every { store.remembered() } returns
+            listOf(
+                RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
+            )
+        val hub = buildHub()
+
+        hub.bind("slot-A", "s:1")
+
+        val summary = hub.connections.value.first { it.id == "s:1" }
+        assertEquals(CONTROLLER_TYPE_XBOX, summary.satelliteControllerTypes["slot-A"])
+    }
+
+    @Test
+    fun `setSatelliteControllerType updates the summary and pushes to the connection`() {
+        val satConn = mockk<SatelliteConnection>(relaxed = true)
+        every { satellite.get("s:1") } returns satConn
+        every { store.remembered() } returns
+            listOf(
+                RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
+            )
+        val hub = buildHub()
+
+        hub.bind("slot-A", "s:1")
+        hub.setSatelliteControllerType("s:1", "slot-A", CONTROLLER_TYPE_PLAYSTATION)
+        scope.testScheduler.runCurrent()
+
+        val summary = hub.connections.value.first { it.id == "s:1" }
+        assertEquals(CONTROLLER_TYPE_PLAYSTATION, summary.satelliteControllerTypes["slot-A"])
     }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/data/network/SatelliteConnectionTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/data/network/SatelliteConnectionTest.kt
@@ -18,12 +18,13 @@ import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
 /**
- * Unit tests for [SatelliteConnection] state transitions and gating of
- * [SatelliteConnection.sendReport] on connection state.
+ * Unit tests for [SatelliteConnection] state transitions, multi-slot binding
+ * and gating of [SatelliteConnection.sendReport] on connection state.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class SatelliteConnectionTest {
@@ -64,10 +65,11 @@ class SatelliteConnectionTest {
     }
 
     @Test
-    fun `initial state is IDLE with no handle or connectionId`() {
+    fun `initial state is IDLE with no handle, connectionId or slots`() {
         assertEquals(SatelliteState.IDLE, conn.state.value)
         assertEquals(-1, conn.handle)
         assertNull(conn.connectionId)
+        assertTrue(conn.slots.value.isEmpty())
     }
 
     @Test
@@ -94,27 +96,33 @@ class SatelliteConnectionTest {
         }
 
     @Test
-    fun `markDisconnected tears down heartbeat and clears handle`() {
-        every { repo.resetControllerAck(any()) } just Runs
-        every { repo.startHeartbeat(any()) } just Runs
-        every { repo.stopHeartbeat(any()) } just Runs
-        every { repo.closeSocket(any()) } just Runs
-        every { repo.isConnectionAlive(any()) } returns true
+    fun `markDisconnected tears down heartbeat, clears handle and unregisters slots`() =
+        runTest {
+            every { repo.resetControllerAck(any()) } just Runs
+            every { repo.startHeartbeat(any()) } just Runs
+            every { repo.stopHeartbeat(any()) } just Runs
+            every { repo.closeSocket(any()) } just Runs
+            every { repo.isConnectionAlive(any()) } returns true
+            every { repo.getLastControllerAck(any()) } returns 1
 
-        conn.markConnecting()
-        conn.markConnected(handle = 3, connectionId = "c") {}
-        conn.markDisconnected()
+            conn.markConnecting()
+            conn.markConnected(handle = 3, connectionId = "c") {}
+            conn.attachSlot(slotId = "slot-1", controllerType = 0)
+            conn.markDisconnected()
 
-        assertEquals(SatelliteState.IDLE, conn.state.value)
-        assertEquals(-1, conn.handle)
-        assertNull(conn.connectionId)
-        verify { repo.stopHeartbeat(3) }
-        verify { repo.closeSocket(3) }
-    }
+            assertEquals(SatelliteState.IDLE, conn.state.value)
+            assertEquals(-1, conn.handle)
+            assertNull(conn.connectionId)
+            verify { repo.stopHeartbeat(3) }
+            verify { repo.closeSocket(3) }
+            // Slot is preserved across disconnect (so reconnect re-registers it)
+            // but its registered flag is cleared.
+            assertEquals(false, conn.slots.value["slot-1"]?.registered)
+        }
 
     @Test
     fun `sendReport is a no-op when state is IDLE`() {
-        conn.sendReport(buttons = 1, lt = 0, rt = 0, lx = 0, ly = 0, rx = 0, ry = 0)
+        conn.sendReport(slotId = "slot-1", buttons = 1, lt = 0, rt = 0, lx = 0, ly = 0, rx = 0, ry = 0)
         verify(exactly = 0) { repo.sendReport(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
@@ -127,13 +135,32 @@ class SatelliteConnectionTest {
             every { repo.getLastControllerAck(any()) } returns 1
             conn.markConnecting()
             conn.markConnected(handle = 9, connectionId = "c") {}
-            // Registration sets controllerAdded=true; sendReport gates on it
-            // so reports during the addController ACK window don't leak.
+            // attachSlot triggers registerController which sets registered=true;
+            // sendReport gates on it so reports during the addController ACK
+            // window don't leak.
             conn.attachSlot(slotId = "slot-1", controllerType = 0)
 
-            conn.sendReport(buttons = 0x42, lt = 10, rt = 20, lx = 30, ly = -40, rx = 50, ry = -60)
+            conn.sendReport(slotId = "slot-1", buttons = 0x42, lt = 10, rt = 20, lx = 30, ly = -40, rx = 50, ry = -60)
 
             verify { repo.sendReport(9, 0, 0x42, 10, 20, 30, -40, 50, -60) }
+        }
+
+    @Test
+    fun `sendReport for an unknown slot is dropped`() =
+        runTest {
+            every { repo.resetControllerAck(any()) } just Runs
+            every { repo.startHeartbeat(any()) } just Runs
+            every { repo.isConnectionAlive(any()) } returns false
+            every { repo.getLastControllerAck(any()) } returns 1
+            conn.markConnecting()
+            conn.markConnected(handle = 9, connectionId = "c") {}
+            conn.attachSlot(slotId = "slot-1", controllerType = 0)
+
+            conn.sendReport(slotId = "ghost", buttons = 1, lt = 0, rt = 0, lx = 0, ly = 0, rx = 0, ry = 0)
+
+            verify(exactly = 0) {
+                repo.sendReport(any(), any(), any(), any(), any(), any(), any(), any(), any())
+            }
         }
 
     @Test
@@ -143,8 +170,8 @@ class SatelliteConnectionTest {
         every { repo.isConnectionAlive(any()) } returns true
         conn.markConnecting()
         conn.markConnected(handle = 9, connectionId = "c") {}
-        // No attachSlot → no registerController → controllerAdded stays false.
-        conn.sendReport(buttons = 0x42, lt = 0, rt = 0, lx = 0, ly = 0, rx = 0, ry = 0)
+        // No attachSlot → no registerController → registered stays false.
+        conn.sendReport(slotId = "slot-1", buttons = 0x42, lt = 0, rt = 0, lx = 0, ly = 0, rx = 0, ry = 0)
 
         verify(exactly = 0) {
             repo.sendReport(any(), any(), any(), any(), any(), any(), any(), any(), any())
@@ -152,9 +179,8 @@ class SatelliteConnectionTest {
     }
 
     @Test
-    fun `detachSlot without prior attach is a no-op`() {
-        conn.detachSlot()
-        assertNull(conn.boundSlotId.value)
+    fun `detachSlot for an unknown slot is a no-op`() {
+        conn.detachSlot("ghost")
         verify(exactly = 0) { repo.removeController(any(), any()) }
     }
 
@@ -162,7 +188,8 @@ class SatelliteConnectionTest {
     fun `attachSlot records the binding even when not connected`() =
         runTest {
             conn.attachSlot(slotId = "slot-1", controllerType = 0)
-            assertEquals("slot-1", conn.boundSlotId.value)
+            assertEquals(0, conn.slots.value["slot-1"]?.controllerIndex)
+            assertEquals(false, conn.slots.value["slot-1"]?.registered)
             // Server-side registration is deferred until markConnected runs.
             coVerify(exactly = 0) { repo.addController(any(), any(), any()) }
         }
@@ -181,21 +208,148 @@ class SatelliteConnectionTest {
 
             coVerify { repo.addController(8, 0, any()) }
             verify { repo.sendControllerType(8, 0, 0) }
+            assertEquals(true, conn.slots.value["slot-1"]?.registered)
         }
 
     @Test
-    fun `markConnected preserves a slot binding recorded before connect`() =
+    fun `markConnected preserves slot bindings recorded before connect`() =
         runTest {
             every { repo.resetControllerAck(any()) } just Runs
             every { repo.startHeartbeat(any()) } just Runs
             every { repo.isConnectionAlive(any()) } returns false
+            every { repo.getLastControllerAck(any()) } returns 1
 
             conn.attachSlot(slotId = "slot-1", controllerType = 0)
-            assertEquals("slot-1", conn.boundSlotId.value)
+            assertTrue(conn.slots.value.containsKey("slot-1"))
             conn.markConnecting()
             conn.markConnected(handle = 5, connectionId = "c") {}
 
-            assertEquals("slot-1", conn.boundSlotId.value)
+            // Slot survives the IDLE → CONNECTED transition; registration is
+            // dispatched via scope.launch into the connection's scope, not the
+            // runTest scope, so we don't assert the addController call here —
+            // see "attachSlot when already connected" for the registration
+            // contract.
+            assertTrue(conn.slots.value.containsKey("slot-1"))
+        }
+
+    // ── Multi-slot ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `attaching a second slot allocates a fresh controller index`() =
+        runTest {
+            every { repo.resetControllerAck(any()) } just Runs
+            every { repo.startHeartbeat(any()) } just Runs
+            every { repo.isConnectionAlive(any()) } returns false
+            every { repo.getLastControllerAck(any()) } returns 1
+
+            conn.markConnecting()
+            conn.markConnected(handle = 4, connectionId = "c") {}
+            conn.attachSlot("slot-A", controllerType = 0)
+            conn.attachSlot("slot-B", controllerType = 0)
+
+            assertEquals(0, conn.slots.value["slot-A"]?.controllerIndex)
+            assertEquals(1, conn.slots.value["slot-B"]?.controllerIndex)
+            coVerify { repo.addController(4, 0, any()) }
+            coVerify { repo.addController(4, 1, any()) }
+        }
+
+    @Test
+    fun `sendReport routes to the attached slot's controller index`() =
+        runTest {
+            every { repo.resetControllerAck(any()) } just Runs
+            every { repo.startHeartbeat(any()) } just Runs
+            every { repo.isConnectionAlive(any()) } returns false
+            every { repo.getLastControllerAck(any()) } returns 1
+
+            conn.markConnecting()
+            conn.markConnected(handle = 11, connectionId = "c") {}
+            conn.attachSlot("slot-A", controllerType = 0)
+            conn.attachSlot("slot-B", controllerType = 0)
+
+            conn.sendReport("slot-B", buttons = 1, lt = 0, rt = 0, lx = 0, ly = 0, rx = 0, ry = 0)
+
+            verify { repo.sendReport(11, 1, 1, 0, 0, 0, 0, 0, 0) }
+        }
+
+    @Test
+    fun `detaching one slot frees its index for the next attach`() =
+        runTest {
+            every { repo.resetControllerAck(any()) } just Runs
+            every { repo.startHeartbeat(any()) } just Runs
+            every { repo.isConnectionAlive(any()) } returns false
+            every { repo.getLastControllerAck(any()) } returns 1
+            every { repo.removeController(any(), any()) } just Runs
+
+            conn.markConnecting()
+            conn.markConnected(handle = 2, connectionId = "c") {}
+            conn.attachSlot("slot-A", controllerType = 0)
+            conn.attachSlot("slot-B", controllerType = 0)
+
+            conn.detachSlot("slot-A")
+            verify { repo.removeController(2, 0) }
+            assertNull(conn.slots.value["slot-A"])
+
+            conn.attachSlot("slot-C", controllerType = 0)
+            // index 0 freed by the detach is reclaimed before allocating a new one.
+            assertEquals(0, conn.slots.value["slot-C"]?.controllerIndex)
+        }
+
+    @Test
+    fun `setControllerType pushes to the server when slot is registered`() =
+        runTest {
+            every { repo.resetControllerAck(any()) } just Runs
+            every { repo.startHeartbeat(any()) } just Runs
+            every { repo.isConnectionAlive(any()) } returns false
+            every { repo.getLastControllerAck(any()) } returns 1
+
+            conn.markConnecting()
+            conn.markConnected(handle = 6, connectionId = "c") {}
+            conn.attachSlot("slot-A", controllerType = 0)
+            // Initial register pushed type=0; the change pushes type=1.
+            conn.setControllerType("slot-A", controllerType = 1)
+
+            verify { repo.sendControllerType(6, 0, 0) }
+            verify { repo.sendControllerType(6, 0, 1) }
+            assertEquals(1, conn.slots.value["slot-A"]?.controllerType)
+        }
+
+    @Test
+    fun `setControllerType for an unregistered slot only updates local state`() =
+        runTest {
+            // Not connected, so attachSlot stashes locally without registering.
+            conn.attachSlot("slot-A", controllerType = 0)
+            conn.setControllerType("slot-A", controllerType = 1)
+
+            assertEquals(1, conn.slots.value["slot-A"]?.controllerType)
+            verify(exactly = 0) { repo.sendControllerType(any(), any(), any()) }
+        }
+
+    @Test
+    fun `setControllerType for an unknown slot is a no-op`() =
+        runTest {
+            conn.setControllerType("ghost", controllerType = 1)
+            verify(exactly = 0) { repo.sendControllerType(any(), any(), any()) }
+            assertTrue(conn.slots.value.isEmpty())
+        }
+
+    @Test
+    fun `attachSlot for an already-attached slot does not re-register`() =
+        runTest {
+            every { repo.resetControllerAck(any()) } just Runs
+            every { repo.startHeartbeat(any()) } just Runs
+            every { repo.isConnectionAlive(any()) } returns false
+            every { repo.getLastControllerAck(any()) } returns 1
+
+            conn.markConnecting()
+            conn.markConnected(handle = 1, connectionId = "c") {}
+            conn.attachSlot("slot-A", controllerType = 0)
+            conn.attachSlot("slot-A", controllerType = 1)
+
+            // Only the first registration runs; setControllerType is the path
+            // for changing type on an attached slot.
+            coVerify(exactly = 1) { repo.addController(1, 0, any()) }
+            // Type stays at the initial value because attachSlot is idempotent.
+            assertEquals(0, conn.slots.value["slot-A"]?.controllerType)
         }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
@@ -121,6 +121,12 @@ class MainViewModelTest {
     }
 
     @Test
+    fun `setSatelliteControllerType delegates to hub`() {
+        vm.setSatelliteControllerType(connectionId = "s:1", slotId = "slot-X", type = 1)
+        verify { hub.setSatelliteControllerType("s:1", "slot-X", 1) }
+    }
+
+    @Test
     fun `hub bindings are reflected as boundConnectionId on slots`() =
         runTest(dispatcher) {
             val summary =
@@ -130,7 +136,7 @@ class MainViewModelTest {
                     label = "PC",
                     detail = "1.1.1.1",
                     live = ConnectionLive.CONNECTED,
-                    boundSlotId = VIRTUAL_SLOT_ID,
+                    boundSlotIds = listOf(VIRTUAL_SLOT_ID),
                 )
             connectionsFlow.value = listOf(summary)
             bindingsFlow.value = mapOf(VIRTUAL_SLOT_ID to "s:1")


### PR DESCRIPTION
## Summary

- **Multiple gamepads on one satellite.** Binding a second slot to a satellite no longer evicts the first — each slot gets its own server-visible controller index (0, 1, 2…). Bluetooth single-host constraint is unchanged.
- **Per-slot Xbox/PS switching on satellite.** An inline Xbox/PlayStation chip toggle appears on any satellite row the slot is bound to. Switching on a live session pushes the new type to the server immediately; pre-connect changes are stashed and applied at registration time.
- **sendReport now routes by slotId.** Physical and virtual slot reports are addressed to the correct controller index; the old hardcoded index 0 is gone.

### Architecture changes
- `SatelliteConnection`: `_boundSlotId: String?` → `_slots: Map<slotId, SlotBinding(controllerIndex, controllerType, registered)>`. Registration serialized with a `Mutex` to avoid ACK races when multiple slots register on the same session.
- `ConnectionHub`: `ConnectionSummary.boundSlotId` → `boundSlotIds: List<String>` + new `satelliteControllerTypes: Map<String, Int>`. `bind()` conditionally evicts (BT) or extends (satellite). New `setSatelliteControllerType()`.
- `ControllerAdapter`: drops `ownedByOther` disable for satellite; adds `onChangeDeviceType` to `SlotActionListener`.

## Test plan
- [ ] Physical gamepad bound to satellite — reports route correctly, Xbox/PS toggle visible and switches layout
- [ ] Virtual gamepad bound to same satellite alongside physical — both appear on server, each routes independently
- [ ] Unbinding one slot leaves the other connected
- [ ] Switch from Xbox → PlayStation on live satellite session — server reflects the change
- [ ] Bluetooth path unchanged — still single-host, no type toggle shown
- [ ] App restart with remembered satellite + remembered slot bindings — reconnects and registers slots as before
- [ ] All unit tests pass (`./gradlew :app:testDebugUnitTest`)

> Per-slot controller type does not currently persist across app restarts. Let me know if you want that wired into `RememberedSatellite`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)