### PR TITLE
fix(connections): unstick "Connecting" UI and surface unreachable servers cleanly

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/data/network/ConnectionHub.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/network/ConnectionHub.kt
@@ -6,10 +6,14 @@ package com.tinkernorth.dish.data.network
 import com.tinkernorth.dish.ui.bluetooth.BluetoothGamepad
 import com.tinkernorth.dish.ui.bluetooth.BluetoothGamepadRegistry
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -89,11 +93,29 @@ class ConnectionHub
         private val _connections = MutableStateFlow<List<ConnectionSummary>>(emptyList())
         val connections: StateFlow<List<ConnectionSummary>> = _connections.asStateFlow()
 
+        @OptIn(ExperimentalCoroutinesApi::class)
+        private val flatSatConnections: Flow<Map<String, SatelliteConnection>> =
+            satellite.connections
+                .flatMapLatest { satMap ->
+                    // The outer Map<String, SatelliteConnection> only re-emits when
+                    // a session is added/removed — *not* when an existing session's
+                    // state flips IDLE → CONNECTING → CONNECTED. Without flattening
+                    // into each session's `state` flow, the connections-list UI would
+                    // show stale "Connecting…" until the screen is reopened.
+                    if (satMap.isEmpty()) {
+                        flowOf(satMap)
+                    } else {
+                        combine(satMap.values.map { it.state }) { satMap }
+                    }
+                }
+
         init {
             combine(
-                satellite.connections,
+                flatSatConnections,
                 bt.states,
-            ) { satMap, btStates -> buildSummaries(satMap, btStates) }
+                _bindings,
+                _satTypes,
+            ) { satMap, btStates, _, _ -> buildSummaries(satMap, btStates) }
                 .onEach { _connections.value = it }
                 .launchIn(scope)
         }

--- a/app/src/main/java/com/tinkernorth/dish/data/network/SatelliteConnectionManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/network/SatelliteConnectionManager.kt
@@ -111,22 +111,48 @@ class SatelliteConnectionManager
                 }
             conn.updateServer(server)
             conn.markConnecting()
-            scope.launch { pairAndConnect(conn, server) }
+            scope.launch {
+                // If we already have a pair-derived shared key for this server,
+                // skip the pairing handshake entirely. This shaves a network
+                // round-trip off every auto-reconnect and — more importantly —
+                // means a server that's silently moved networks fails fast in
+                // openSession with a clean "unreachable" error, instead of
+                // bouncing the user back to a pin dialog they can never satisfy
+                // (the dialog would re-pair against the dead IP).
+                if (store.satelliteSharedKey(id) != null) {
+                    openSession(conn, server)
+                } else {
+                    pairAndConnect(conn, server)
+                }
+            }
         }
 
         private suspend fun pairAndConnect(
             conn: SatelliteConnection,
             server: DiscoveredServer,
         ) {
+            val raw = runCatching { discoveryRepo.pair(server.ip, server.pairPort, deviceId, deviceName, "") }
+            val rawText = raw.getOrNull()
+            if (raw.isFailure || rawText.isNullOrBlank()) {
+                // Empty/exception from native pair() means we couldn't reach the
+                // server at all (DNS/connect failure on the LAN). This is the
+                // network-move case — surface it clearly instead of routing the
+                // user through a pin dialog that will fail against the dead IP.
+                conn.markDisconnected()
+                _events.emit(ConnectionEvent.Error(SERVER_UNREACHABLE_MSG))
+                return
+            }
             val pair =
-                runCatching {
-                    json.decodeFromString(
-                        PairResponse.serializer(),
-                        discoveryRepo.pair(server.ip, server.pairPort, deviceId, deviceName, ""),
-                    )
-                }.getOrElse { PairResponse(error = "Malformed pair response") }
-
+                runCatching { json.decodeFromString(PairResponse.serializer(), rawText) }
+                    .getOrNull()
+            if (pair == null) {
+                conn.markDisconnected()
+                _events.emit(ConnectionEvent.Error(SERVER_UNREACHABLE_MSG))
+                return
+            }
             if (!pair.ok || pair.sharedKey == null) {
+                // Server reachable but refused the empty PIN — first-time pair
+                // or credentials rotated server-side. Prompt for a PIN.
                 conn.markDisconnected()
                 _events.emit(ConnectionEvent.PairingRequired(server))
                 return
@@ -146,13 +172,21 @@ class SatelliteConnectionManager
                 }
             conn.markConnecting()
             scope.launch {
+                val raw = runCatching { discoveryRepo.pair(server.ip, server.pairPort, deviceId, deviceName, pin) }
+                val rawText = raw.getOrNull()
+                if (raw.isFailure || rawText.isNullOrBlank()) {
+                    conn.markDisconnected()
+                    _events.emit(ConnectionEvent.Error(SERVER_UNREACHABLE_MSG))
+                    return@launch
+                }
                 val pair =
-                    runCatching {
-                        json.decodeFromString(
-                            PairResponse.serializer(),
-                            discoveryRepo.pair(server.ip, server.pairPort, deviceId, deviceName, pin),
-                        )
-                    }.getOrElse { PairResponse(error = "Malformed pair response") }
+                    runCatching { json.decodeFromString(PairResponse.serializer(), rawText) }
+                        .getOrNull()
+                if (pair == null) {
+                    conn.markDisconnected()
+                    _events.emit(ConnectionEvent.Error(SERVER_UNREACHABLE_MSG))
+                    return@launch
+                }
                 if (!pair.ok || pair.sharedKey == null) {
                     conn.markDisconnected()
                     _events.emit(ConnectionEvent.Error(pair.error ?: "Pairing failed"))
@@ -174,13 +208,21 @@ class SatelliteConnectionManager
                 return@withContext
             }
             val key = hexToBytes(keyHex)
+            val rawConn = runCatching { discoveryRepo.connect(server.ip, server.httpPort, deviceId) }
+            val rawConnText = rawConn.getOrNull()
+            if (rawConn.isFailure || rawConnText.isNullOrBlank()) {
+                conn.markDisconnected()
+                _events.emit(ConnectionEvent.Error(SERVER_UNREACHABLE_MSG))
+                return@withContext
+            }
             val resp =
-                runCatching {
-                    json.decodeFromString(
-                        ConnectResponse.serializer(),
-                        discoveryRepo.connect(server.ip, server.httpPort, deviceId),
-                    )
-                }.getOrElse { ConnectResponse(error = "Malformed connect response") }
+                runCatching { json.decodeFromString(ConnectResponse.serializer(), rawConnText) }
+                    .getOrNull()
+            if (resp == null) {
+                conn.markDisconnected()
+                _events.emit(ConnectionEvent.Error(SERVER_UNREACHABLE_MSG))
+                return@withContext
+            }
             val connId = resp.connectionId
             val tokenHex = resp.token
             if (connId == null || tokenHex == null) {
@@ -267,5 +309,7 @@ class SatelliteConnectionManager
             private const val DISC_TIMEOUT_MS = 4000
             private const val LEGACY_PREFS = "satellite"
             private const val LEGACY_KEY_SHARED = "sharedKey"
+            internal const val SERVER_UNREACHABLE_MSG =
+                "Server unreachable — has it moved networks? Forget and re-add."
         }
     }

--- a/app/src/test/java/com/tinkernorth/dish/data/network/ConnectionHubTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/data/network/ConnectionHubTest.kt
@@ -415,6 +415,99 @@ class ConnectionHubTest {
         verify(exactly = 0) { bt.tryAutoReconnect("bt:B") }
     }
 
+    /**
+     * Regression: previously the hub combined only on the outer
+     * `Map<String, SatelliteConnection>` identity, so a session flipping
+     * CONNECTING → CONNECTED inside the same map left the connections list
+     * stuck on "Connecting…" until the screen was reopened.
+     */
+    @Test
+    fun `connections re-emits when an inner SatelliteConnection state transitions`() {
+        every { store.remembered() } returns
+            listOf(
+                RememberedSatellite(
+                    id = "satellite:1.1.1.1:9876",
+                    name = "Pc",
+                    ip = "1.1.1.1",
+                    udpPort = 9876,
+                    pairPort = 9878,
+                    httpPort = 9877,
+                ),
+            )
+        val state = MutableStateFlow(SatelliteState.CONNECTING)
+        val conn =
+            mockk<SatelliteConnection>(relaxed = true) {
+                every { id } returns "satellite:1.1.1.1:9876"
+                every { this@mockk.state } returns state
+                every { server } returns
+                    MutableStateFlow(
+                        com.tinkernorth.dish.data.model
+                            .DiscoveredServer(name = "Pc", ip = "1.1.1.1", udpPort = 9876, pairPort = 9878, httpPort = 9877),
+                    )
+                every { slots } returns MutableStateFlow(emptyMap())
+            }
+        satConnsFlow.value = mapOf("satellite:1.1.1.1:9876" to conn)
+        val hub = buildHub()
+
+        // First snapshot: still CONNECTING.
+        assertEquals(
+            ConnectionLive.CONNECTING,
+            hub.connections.value
+                .first { it.id == "satellite:1.1.1.1:9876" }
+                .live,
+        )
+
+        // Inner state flips to CONNECTED — hub must re-emit even though the
+        // outer satellite.connections map is unchanged.
+        state.value = SatelliteState.CONNECTED
+        scope.testScheduler.runCurrent()
+
+        assertEquals(
+            ConnectionLive.CONNECTED,
+            hub.connections.value
+                .first { it.id == "satellite:1.1.1.1:9876" }
+                .live,
+        )
+    }
+
+    @Test
+    fun `connections re-emits when an inner SatelliteConnection drops back to IDLE`() {
+        every { store.remembered() } returns
+            listOf(
+                RememberedSatellite(
+                    id = "satellite:1.1.1.1:9876",
+                    name = "Pc",
+                    ip = "1.1.1.1",
+                    udpPort = 9876,
+                    pairPort = 9878,
+                    httpPort = 9877,
+                ),
+            )
+        val state = MutableStateFlow(SatelliteState.CONNECTED)
+        val conn =
+            mockk<SatelliteConnection>(relaxed = true) {
+                every { id } returns "satellite:1.1.1.1:9876"
+                every { this@mockk.state } returns state
+                every { server } returns
+                    MutableStateFlow(
+                        com.tinkernorth.dish.data.model
+                            .DiscoveredServer(name = "Pc", ip = "1.1.1.1", udpPort = 9876, pairPort = 9878, httpPort = 9877),
+                    )
+                every { slots } returns MutableStateFlow(emptyMap())
+            }
+        satConnsFlow.value = mapOf("satellite:1.1.1.1:9876" to conn)
+        val hub = buildHub()
+        state.value = SatelliteState.IDLE
+        scope.testScheduler.runCurrent()
+
+        assertEquals(
+            ConnectionLive.IDLE,
+            hub.connections.value
+                .first { it.id == "satellite:1.1.1.1:9876" }
+                .live,
+        )
+    }
+
     @Test
     fun `autoReconnectAll skips bt when a remembered host is already registered`() {
         every { store.rememberedBt() } returns

--- a/app/src/test/java/com/tinkernorth/dish/data/network/SatelliteConnectionManagerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/data/network/SatelliteConnectionManagerTest.kt
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.data.network
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.tinkernorth.dish.data.model.DiscoveredServer
+import com.tinkernorth.dish.data.repository.ControllerRepository
+import com.tinkernorth.dish.data.repository.DiscoveryRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Failure-path tests for [SatelliteConnectionManager]. Locks in two changes:
+ *   1. "Server unreachable" (network move / wrong LAN) is distinguished from
+ *      "needs PIN" so the UI doesn't trap users in a pin dialog they can't
+ *      satisfy against a dead IP.
+ *   2. Auto-reconnect skips the pair handshake when a shared key is already
+ *      saved, so a moved server fails fast in openSession instead of bouncing
+ *      through pair → PairingRequired.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SatelliteConnectionManagerTest {
+    private lateinit var context: Context
+    private lateinit var discoveryRepo: DiscoveryRepository
+    private lateinit var controllerRepo: ControllerRepository
+    private lateinit var store: ConnectionStore
+    private lateinit var prefs: SharedPreferences
+    private lateinit var prefsEditor: SharedPreferences.Editor
+
+    private val scope = TestScope(StandardTestDispatcher())
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val server =
+        DiscoveredServer(
+            name = "Pc",
+            ip = "10.0.0.5",
+            udpPort = 9876,
+            pairPort = 9878,
+            httpPort = 9877,
+        )
+    private val serverId = SatelliteConnection.idFor(server)
+
+    @Before
+    fun setUp() {
+        context = mockk(relaxed = true)
+        discoveryRepo = mockk(relaxed = true)
+        controllerRepo = mockk(relaxed = true)
+        store = mockk(relaxed = true)
+        prefs = mockk(relaxed = true)
+        prefsEditor = mockk(relaxed = true)
+        every { context.getSharedPreferences(any(), any()) } returns prefs
+        every { prefs.getString("deviceId", null) } returns "test-device-id"
+        every { prefs.edit() } returns prefsEditor
+        every { prefsEditor.putString(any(), any()) } returns prefsEditor
+        every { prefsEditor.remove(any()) } returns prefsEditor
+        every { store.remembered() } returns emptyList()
+        every { store.satelliteSharedKey(any()) } returns null
+    }
+
+    private fun manager(): SatelliteConnectionManager =
+        SatelliteConnectionManager(
+            context = context,
+            scope = scope,
+            discoveryRepo = discoveryRepo,
+            controllerRepo = controllerRepo,
+            store = store,
+            json = json,
+        )
+
+    private fun runMgrTest(block: suspend (SatelliteConnectionManager, MutableList<ConnectionEvent>) -> Unit) =
+        runTest(scope.testScheduler) {
+            val mgr = manager()
+            val events = mutableListOf<ConnectionEvent>()
+            val collector = scope.launch { mgr.events.collect { events += it } }
+            block(mgr, events)
+            scope.testScheduler.advanceUntilIdle()
+            collector.cancel()
+        }
+
+    @Test
+    fun `pair returning empty string surfaces server-unreachable error not PairingRequired`() =
+        runMgrTest { mgr, events ->
+            // Native pair() returns empty when the server can't be reached on the LAN.
+            // Without this distinction, the previous code misclassified it as
+            // "needs pairing" and trapped the user in a pin dialog that re-pinged
+            // the dead IP forever.
+            coEvery { discoveryRepo.pair(any(), any(), any(), any(), any()) } returns ""
+
+            mgr.connect(server)
+            scope.testScheduler.advanceUntilIdle()
+
+            assertTrue(
+                "expected unreachable Error, got: $events",
+                events.any { it is ConnectionEvent.Error && it.message.contains("unreachable", ignoreCase = true) },
+            )
+            assertTrue(events.none { it is ConnectionEvent.PairingRequired })
+            assertEquals(SatelliteState.IDLE, mgr.get(serverId)?.state?.value)
+        }
+
+    @Test
+    fun `pair throwing exception surfaces server-unreachable error`() =
+        runMgrTest { mgr, events ->
+            coEvery { discoveryRepo.pair(any(), any(), any(), any(), any()) } throws
+                RuntimeException("ECONNREFUSED")
+
+            mgr.connect(server)
+            scope.testScheduler.advanceUntilIdle()
+
+            assertTrue(events.any { it is ConnectionEvent.Error && it.message.contains("unreachable", ignoreCase = true) })
+        }
+
+    @Test
+    fun `pair returning ok=false with reachable server emits PairingRequired`() =
+        runMgrTest { mgr, events ->
+            // Server reachable but rejected the empty PIN — first-time pair or
+            // server's credentials rotated. Legitimate pin-dialog case.
+            coEvery { discoveryRepo.pair(any(), any(), any(), any(), any()) } returns
+                """{"ok":false,"error":"PIN required"}"""
+
+            mgr.connect(server)
+            scope.testScheduler.advanceUntilIdle()
+
+            assertTrue("expected PairingRequired, got: $events", events.any { it is ConnectionEvent.PairingRequired })
+        }
+
+    @Test
+    fun `pairWithPin returning empty string surfaces unreachable error rather than retrying`() =
+        runMgrTest { mgr, events ->
+            coEvery { discoveryRepo.pair(any(), any(), any(), any(), "1234") } returns ""
+
+            mgr.pairWithPin(server, "1234")
+            scope.testScheduler.advanceUntilIdle()
+
+            assertTrue(events.any { it is ConnectionEvent.Error && it.message.contains("unreachable", ignoreCase = true) })
+        }
+
+    @Test
+    fun `pairWithPin returning ok=false surfaces server's error message`() =
+        runMgrTest { mgr, events ->
+            coEvery { discoveryRepo.pair(any(), any(), any(), any(), "0000") } returns
+                """{"ok":false,"error":"Invalid PIN"}"""
+
+            mgr.pairWithPin(server, "0000")
+            scope.testScheduler.advanceUntilIdle()
+
+            assertTrue(events.any { it is ConnectionEvent.Error && it.message.contains("Invalid PIN") })
+        }
+
+    @Test
+    fun `connect skips pair when a shared key is already stored`() =
+        runMgrTest { mgr, _ ->
+            // 64 hex chars (32 bytes) is the contract openSession enforces.
+            every { store.satelliteSharedKey(serverId) } returns "aa".repeat(32)
+            // Force connect HTTP to fail so we don't try to spin up a real
+            // session — we just want to assert that pair() was never called.
+            coEvery { discoveryRepo.connect(any(), any(), any()) } returns ""
+
+            mgr.connect(server)
+            scope.testScheduler.advanceUntilIdle()
+
+            coVerify(exactly = 0) { discoveryRepo.pair(any(), any(), any(), any(), any()) }
+        }
+
+    // Note: openSession's HTTP-unreachable path (saved key, but http connect
+    // returns empty) is exercised in production but not asserted here — that
+    // body runs under withContext(Dispatchers.IO), which the TestScope's
+    // scheduler doesn't drive. The "connect skips pair when a shared key is
+    // already stored" test above proves the saved-key branch is taken; the
+    // "pair returning empty string surfaces server-unreachable error" test
+    // proves the unreachable-handling shape. Together they cover the bug-2
+    // path without a flaky cross-dispatcher assertion.
+
+    @Test
+    fun `disconnect on unknown id is a no-op`() {
+        val mgr = manager()
+        mgr.disconnect("satellite:does-not-exist:0")
+    }
+
+    @Test
+    fun `forget removes the connection from the live map`() =
+        runMgrTest { mgr, _ ->
+            // Seed by failing to pair (state IDLE but entry present).
+            coEvery { discoveryRepo.pair(any(), any(), any(), any(), any()) } returns ""
+            mgr.connect(server)
+            scope.testScheduler.advanceUntilIdle()
+            assertTrue(mgr.connections.value.containsKey(serverId))
+
+            mgr.forget(serverId)
+
+            assertNull(mgr.connections.value[serverId])
+        }
+
+    @Test
+    fun `connect is idempotent while a session is already in CONNECTING`() =
+        runMgrTest { mgr, _ ->
+            // Block pair forever so the session stays in CONNECTING for the test.
+            coEvery { discoveryRepo.pair(any(), any(), any(), any(), any()) } coAnswers {
+                awaitCancellation()
+            }
+
+            mgr.connect(server)
+            scope.testScheduler.runCurrent()
+            mgr.connect(server)
+            scope.testScheduler.runCurrent()
+
+            // The guard in connect() must not have re-launched a second pair
+            // for an already in-flight session.
+            coVerify(exactly = 1) { discoveryRepo.pair(any(), any(), any(), any(), any()) }
+        }
+}


### PR DESCRIPTION
## Summary
- **Stuck "Connecting" UI**: `ConnectionHub` only re-emitted on outer-map identity changes, so a session flipping `CONNECTING → CONNECTED` inside the same map never refreshed the connections list. Hub now `flatMapLatest`s into each `SatelliteConnection.state` and also combines `_bindings`/`_satTypes` so the summary stream covers every input that affects what the UI shows.
- **Network-move pin trap**: `pair()` / `httpConnect()` returning empty (LAN unreachable, server moved networks) was treated identically to `{ok:false}` (auth needed), which dropped the user into a pin dialog that re-pinged a dead IP forever. Failure paths now distinguish unreachable (clear toast: *"Server unreachable — has it moved networks? Forget and re-add."*) from a real auth challenge (still shows the pin dialog).
- **Auto-reconnect skips pair when a shared key is saved** — shaves a round-trip and means a moved server fails fast in `openSession` rather than bouncing through `pair → PairingRequired`.
- **Architecture review**: `SatelliteConnectionManager`, `ConnectionHub`, and `BluetoothGamepadRegistry` are already `@Singleton`s injected via Hilt and live outside any Activity lifecycle; `ConnectionsActivity` already uses the same `repeatOnLifecycle(STARTED) { … .collect { } }` pattern as `MainActivity`. The reported bug was purely flow plumbing inside the hub, not a binding-paradigm issue.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest` (78 → 87 tests, all green)
- [x] `./gradlew :app:ktlintCheck :app:detekt`
- New tests:
  - `ConnectionHubTest`: regression for inner-state-flow propagation (CONNECTING→CONNECTED and CONNECTED→IDLE).
  - `SatelliteConnectionManagerTest`: empty pair → unreachable Error; pair throw → unreachable Error; reachable + ok=false → PairingRequired; pin path mirrored; saved key skips pair; idempotent connect during CONNECTING; forget removes from live map; disconnect on unknown id is a no-op.
- [ ] Manual: enter pin on a fresh server — UI flips to Connected without reopening the screen.
- [ ] Manual: move server to a different LAN, open Connections — toast surfaces "unreachable" rather than pin prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)