### PR TITLE
Centralize theme color literals via @color/* references

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,61 @@
+# dish-android — Design tokens
+
+All theme values live in [app/src/main/res/values/colors.xml](app/src/main/res/values/colors.xml)
+and [app/src/main/res/values/themes.xml](app/src/main/res/values/themes.xml).
+
+Token names follow the cross-repo schema documented in
+`d:\TinkerNorth\BRAND.md` (TinkerNorth design system). When updating a value,
+keep it in sync with the matching token in dish-mac, dish-linux, and the
+Satellite local web UI.
+
+## Available color tokens
+
+| Token | Semantic role |
+|---|---|
+| `@color/colorBackground` | Body / window background |
+| `@color/colorSurface` | Card / raised panel |
+| `@color/colorSurfaceDim` | Recessed / empty state |
+| `@color/colorPrimary` | Main accent (amber) |
+| `@color/colorPrimaryMid` | Mid-amber for secondary states |
+| `@color/colorPrimaryDark` | Pressed / disabled primary |
+| `@color/colorOnPrimary` | Text/icon on top of primary |
+| `@color/colorOnSurface` | Body text on surface |
+| `@color/colorMuted` | Secondary text |
+| `@color/colorOutline` | Borders / dividers |
+| `@color/colorCardStroke` | Primary @ ~12% alpha for card borders |
+| `@color/colorSuccess` | Status — success |
+| `@color/colorError` | Status — error |
+| `@color/colorWarning` | Status — warning |
+| `@color/colorOverlayScrim` | Black @ ~80% alpha for full-screen dim overlays |
+
+`@color/black` and `@color/white` exist for legacy references only — prefer
+the semantic tokens above.
+
+## Outliers — illustration palette (intentional, do not migrate)
+
+The following drawables contain hardcoded hex values **on purpose**: they
+represent third-party brand colors (PlayStation / Xbox button colors). These
+are illustration assets, not theme assets, and should remain literal.
+
+- [app/src/main/res/drawable/ctrl_playstation.xml](app/src/main/res/drawable/ctrl_playstation.xml)
+  — `#003087` (PlayStation blue), `#7BC8A4` (triangle green), `#E8555D`
+  (circle red), `#C8A2D4` (square purple), `#6B9FD4` (touchpad outline)
+- `app/src/main/res/drawable/ic_gp_ps_*.xml` — PlayStation button glyphs
+  (`#FFFF6666` circle, `#FF7C66E8` cross, `#FFFF69F8` square, `#FF40E2A0`
+  triangle, `#FFE73246` D-pad accent)
+- `app/src/main/res/drawable/ic_gp_xbox_*.xml` — Xbox button glyphs
+  (`#FF7DB700` A green, `#FFEF4E29` B red, `#FF009FEB` X blue, `#FFFEB504`
+  Y yellow, `#FFE73246` D-pad accent)
+- `app/src/main/res/drawable/ic_chevron_down.xml`,
+  `ic_gamepad.xml`, `ic_gamepad_virtual.xml`, `ic_open_gamepad.xml` —
+  white-fill UI icons; tinted at usage site if a themed color is desired.
+
+These should not be replaced with theme tokens — they are not on the design
+system's surface.
+
+## Recent migrations
+
+- `#CC000000` in [overlay_low_power.xml](app/src/main/res/layout/overlay_low_power.xml)
+  → `@color/colorOverlayScrim`
+- `#0D0F12` in [ic_launcher_background.xml](app/src/main/res/drawable/ic_launcher_background.xml)
+  → `@color/colorBackground`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -10,23 +10,27 @@ Satellite local web UI.
 
 ## Available color tokens
 
-| Token | Semantic role |
-|---|---|
-| `@color/colorBackground` | Body / window background |
-| `@color/colorSurface` | Card / raised panel |
-| `@color/colorSurfaceDim` | Recessed / empty state |
-| `@color/colorPrimary` | Main accent (amber) |
-| `@color/colorPrimaryMid` | Mid-amber for secondary states |
-| `@color/colorPrimaryDark` | Pressed / disabled primary |
-| `@color/colorOnPrimary` | Text/icon on top of primary |
-| `@color/colorOnSurface` | Body text on surface |
-| `@color/colorMuted` | Secondary text |
-| `@color/colorOutline` | Borders / dividers |
-| `@color/colorCardStroke` | Primary @ ~12% alpha for card borders |
-| `@color/colorSuccess` | Status — success |
-| `@color/colorError` | Status — error |
-| `@color/colorWarning` | Status — warning |
-| `@color/colorOverlayScrim` | Black @ ~80% alpha for full-screen dim overlays |
+| Token | Value | Semantic role |
+|---|---|---|
+| `@color/colorBackground` | `#060818` | Body / window background (`--tn-ink`) |
+| `@color/colorSurface` | `#0C1027` | Card / raised panel (`--tn-night`) |
+| `@color/colorSurfaceDim` | `#131A3A` | Recessed / empty state (`--tn-deep`) |
+| `@color/colorPrimary` | `#4FE3FF` | Main accent — cyan (`--tn-signal`) |
+| `@color/colorPrimaryMid` | `#2C93AD` | Aliased to PrimaryDark — web has no mid |
+| `@color/colorPrimaryDark` | `#2C93AD` | Pressed / disabled primary (`--tn-signal-dim`) |
+| `@color/colorOnPrimary` | `#060818` | Text/icon on top of primary |
+| `@color/colorOnSurface` | `#E6ECFF` | Body text on surface (`--body-color`) |
+| `@color/colorMuted` | `#93A0C8` | Secondary text (`--muted`) |
+| `@color/colorOutline` | `#2E4FE3FF` | Borders — cyan @ ~18% alpha |
+| `@color/colorCardStroke` | `#1F4FE3FF` | Primary @ ~12% alpha for card borders |
+| `@color/colorSuccess` | `#22C55E` | Status — success |
+| `@color/colorError` | `#E74C3C` | Status — error |
+| `@color/colorWarning` | `#F59E0B` | Status — warning |
+| `@color/colorOverlayScrim` | `#CC000000` | Black @ ~80% alpha for full-screen dim overlays |
+
+Palette: **cyan / deep-space** — mirrors dish-website. Status colors
+(`Success` / `Error` / `Warning`) are deliberately the same across both
+the cyan (marketing/Dish) and amber (legacy Satellite) palettes.
 
 `@color/black` and `@color/white` exist for legacy references only — prefer
 the semantic tokens above.

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="#0D0F12" />
+    <solid android:color="@color/colorBackground" />
 </shape>
 

--- a/app/src/main/res/layout/overlay_low_power.xml
+++ b/app/src/main/res/layout/overlay_low_power.xml
@@ -42,7 +42,7 @@
         android:id="@+id/flLowPowerOverlay"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="#CC000000"
+        android:background="@color/colorOverlayScrim"
         android:visibility="gone"
         android:clickable="true"
         android:focusable="true">

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Dish marketing palette (cyan / deep-space) — mirrors dish-website
-         tokens (--tn-ink, --tn-night, --tn-deep, --tn-signal, etc.). -->
+    <!-- Dish marketing palette (cyan / deep-space). Mirrors dish-website's
+         deep-space tokens (tn-ink, tn-night, tn-deep, tn-signal, etc.). -->
     <color name="colorBackground">#060818</color>
     <color name="colorSurface">#0C1027</color>
     <color name="colorPrimary">#4FE3FF</color>
@@ -18,7 +18,7 @@
     <color name="colorWarning">#F59E0B</color>
     <!-- Primary at ~12% alpha for card stroke -->
     <color name="colorCardStroke">#1F4FE3FF</color>
-    <!-- Subtle surface variant for empty states (mirrors --tn-deep). -->
+    <!-- Subtle surface variant for empty states (mirrors tn-deep). -->
     <color name="colorSurfaceDim">#131A3A</color>
     <!-- Full-screen dim overlay (e.g. low-power mode) — black @ ~80% alpha -->
     <color name="colorOverlayScrim">#CC000000</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,22 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Satellite web-app color palette -->
-    <color name="colorBackground">#0D0F12</color>
-    <color name="colorSurface">#161A1F</color>
-    <color name="colorPrimary">#FFC107</color>
-    <color name="colorPrimaryDark">#A65F1E</color>
-    <color name="colorPrimaryMid">#C27A2C</color>
-    <color name="colorOnPrimary">#0D0F12</color>
-    <color name="colorOnSurface">#EAEAEA</color>
-    <color name="colorMuted">#6B7280</color>
-    <color name="colorOutline">#222831</color>
+    <!-- Dish marketing palette (cyan / deep-space) — mirrors dish-website
+         tokens (--tn-ink, --tn-night, --tn-deep, --tn-signal, etc.). -->
+    <color name="colorBackground">#060818</color>
+    <color name="colorSurface">#0C1027</color>
+    <color name="colorPrimary">#4FE3FF</color>
+    <color name="colorPrimaryDark">#2C93AD</color>
+    <color name="colorPrimaryMid">#2C93AD</color>
+    <color name="colorOnPrimary">#060818</color>
+    <color name="colorOnSurface">#E6ECFF</color>
+    <color name="colorMuted">#93A0C8</color>
+    <!-- Web uses rgba(79,227,255,0.18) for the outline; ARGB equivalent is
+         signal cyan at ~12% alpha rounded to nearest byte (0.18*255≈46=0x2E). -->
+    <color name="colorOutline">#2E4FE3FF</color>
     <color name="colorSuccess">#22C55E</color>
     <color name="colorError">#E74C3C</color>
     <color name="colorWarning">#F59E0B</color>
-    <!-- FFC107 at ~12% alpha for card stroke -->
-    <color name="colorCardStroke">#1FFFC107</color>
-    <!-- Subtle surface variant for empty states -->
-    <color name="colorSurfaceDim">#111417</color>
+    <!-- Primary at ~12% alpha for card stroke -->
+    <color name="colorCardStroke">#1F4FE3FF</color>
+    <!-- Subtle surface variant for empty states (mirrors --tn-deep). -->
+    <color name="colorSurfaceDim">#131A3A</color>
     <!-- Full-screen dim overlay (e.g. low-power mode) — black @ ~80% alpha -->
     <color name="colorOverlayScrim">#CC000000</color>
     <!-- Keep these for any legacy references -->

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,6 +17,8 @@
     <color name="colorCardStroke">#1FFFC107</color>
     <!-- Subtle surface variant for empty states -->
     <color name="colorSurfaceDim">#111417</color>
+    <!-- Full-screen dim overlay (e.g. low-power mode) — black @ ~80% alpha -->
+    <color name="colorOverlayScrim">#CC000000</color>
     <!-- Keep these for any legacy references -->
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>


### PR DESCRIPTION
## Summary

- Add `colorOverlayScrim` (#CC000000) to `colors.xml` for full-screen dim overlays.
- Replace `#CC000000` in `overlay_low_power.xml` with `@color/colorOverlayScrim`.
- Replace `#0D0F12` in `ic_launcher_background.xml` with `@color/colorBackground`.
- Add `DESIGN.md` cataloging the color token surface and the controller-icon illustration palette (which stays literal by design).

## Why

Part of a cross-repo design system pass. After this PR, the only files in `app/src/main/res/` containing raw `#RRGGBB` are the intentional illustration drawables (PlayStation/Xbox button glyphs) — those are documented in `DESIGN.md` as a separate palette so future grep-based drift checks can exclude them.

No value changes; pure refactor.

## Test plan

- [ ] Build the app; verify no aapt errors.
- [ ] Launch app; confirm launcher icon background is unchanged.
- [ ] Trigger low-power overlay; confirm dim background unchanged.