### PR TITLE
feat(rumble): forward MSG_RUMBLE to phone Vibrator/VibratorManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Dish is an Android app that turns your phone into a wireless gamepad. It discove
 - **GameActivity Integration** — uses AndroidX GameActivity for the native loop while overlaying a Kotlin/View-based UI
 - **Live Telemetry** — real-time display of event rate, sample rate, send rate, axis values, and button state
 - **Gamepad Hot-Plug** — detects controller connect/disconnect events at runtime
+- **Rumble** — game-side haptic events from the satellite (`MSG_RUMBLE`) drive the phone's `VibratorManager` / `Vibrator` for an in-hand buzz; see [Rumble](#rumble) below
 
 ## Architecture
 
@@ -25,8 +26,55 @@ Kotlin UI (MainActivity)
               └── satellite_jni.cpp
                     ├── UDP socket (sendReport → sendto)
                     ├── LAN discovery (discoverServers)
-                    └── TCP pairing (pair)
+                    ├── TCP pairing (pair)
+                    └── receiveAck → RumbleBridge.dispatchRumble (return path)
 ```
+
+## Rumble
+
+Rumble flows the opposite direction to the input hot path. A game on the
+satellite host writes to the virtual controller's vibration channel, the
+satellite forwards a `MSG_RUMBLE = 0x0009` packet back over the encrypted
+UDP socket, and the dish actuates **the phone itself** via the system
+vibrator service.
+
+```
+SatelliteNative.receiveAck (Kotlin Dispatchers.IO)
+  └── satellite_jni.cpp::receiveAck
+        ├── decrypt + parse MSG_RUMBLE
+        └── env->CallStaticVoidMethod(RumbleBridge.dispatchRumble, ...)
+              └── RumbleBridge.dispatchRumble
+                    ├── API 31+ → VibratorManager.vibrate(CombinedVibration)
+                    │              (strong → vibrator id 0,
+                    │               weak   → vibrator id 1 if present)
+                    └── legacy   → Vibrator.vibrate(VibrationEffect.createOneShot)
+```
+
+The wire format is documented in
+[`satellite/README.md`](https://github.com/TinkerNorth/satellite#rumble-return-path).
+Design notes specific to dish-android:
+
+* **Phone, not pad.** All rumble is routed to the device's own vibrator(s)
+  — there is no fallback path that tries to drive a connected physical
+  gamepad's actuator. Letting the virtual on-screen pad / phone body
+  handle every rumble keeps actuation single-rooted and avoids the
+  "which device should buzz?" decision a player paired with a physical
+  pad would otherwise have to make. This is intentional, not a TODO.
+* **No dispatcher thread.** Unlike the Bluetooth bridge, rumble dispatch
+  is synchronous on the JNI caller — `receiveAck` already runs on Kotlin
+  `Dispatchers.IO`, which is JVM-attached, so we just call into Java
+  directly with no queue or `AttachCurrentThread` ceremony.
+* **Safety clamps.** Wire-format magnitudes (0..65535) map to
+  `VibrationEffect`'s 1..255 amplitude with rounding-up so any non-zero
+  request produces a perceptible buzz. Wire-format `durationMs` is
+  clamped to `[1, 1500]` to bound the worst-case stranded buzz from a
+  hung satellite.
+* **Permission.** The manifest declares
+  `<uses-permission android:name="android.permission.VIBRATE" />`; no
+  runtime prompt — VIBRATE is a normal-protection permission.
+
+The pure helpers (`rumbleMagnitudeTo255`, `rumbleSafeDurationMs`) are
+covered by `app/src/test/java/.../RumbleBridgeHelpersTest.kt`.
 
 ## Requirements
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,10 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
+    <!-- Rumble: routed to the phone's Vibrator / VibratorManager when a
+         satellite forwards game-side haptic events (MSG_RUMBLE 0x0009). -->
+    <uses-permission android:name="android.permission.VIBRATE" />
+
     <!-- Bluetooth HID gamepad -->
     <uses-permission android:name="android.permission.BLUETOOTH"
         android:maxSdkVersion="30" />

--- a/app/src/main/cpp/satellite_jni.cpp
+++ b/app/src/main/cpp/satellite_jni.cpp
@@ -64,6 +64,7 @@ static constexpr uint16_t MSG_CONTROLLER_REMOVE = 0x0005;
 static constexpr uint16_t MSG_CONTROLLER_ACK = 0x0006;
 static constexpr uint16_t MSG_SERVER_STATUS = 0x0007;
 static constexpr uint16_t MSG_CONTROLLER_TYPE = 0x0008;
+static constexpr uint16_t MSG_RUMBLE = 0x0009;
 
 #pragma pack(push, 1)
 struct XUSB_REPORT {
@@ -154,6 +155,13 @@ static std::unordered_map<int32_t, SlotBinding> g_slots;
 static JavaVM* g_jvm = nullptr;
 static jclass g_btBridgeClass = nullptr; // global ref, set once
 static jmethodID g_btDispatchMethod = nullptr;
+
+// JVM bridge for the rumble return path. Resolved once via
+// RumbleBridge.nativeInstall. Unlike the BT bridge there is no dedicated
+// dispatcher thread — receiveAck() already runs on a JVM-attached thread
+// (Kotlin Dispatchers.IO), so we can call into Java directly from there.
+static jclass g_rumbleBridgeClass = nullptr; // global ref, set once
+static jmethodID g_rumbleDispatchMethod = nullptr;
 
 /* ── BT dispatch queue ───────────────────────────────────────────────────
  *
@@ -687,8 +695,8 @@ Java_com_tinkernorth_dish_data_network_SatelliteNative_getActiveControllerCount(
 
 /* ── Receive ACK (called from a background thread) ────────────────────────── */
 
-JNIEXPORT void JNICALL
-Java_com_tinkernorth_dish_data_network_SatelliteNative_receiveAck(JNIEnv*, jobject, jint handle) {
+JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_SatelliteNative_receiveAck(
+    JNIEnv* env, jobject, jint handle) {
     auto s = getSession(handle);
     if (!s || s->udpSock < 0) return;
     uint8_t buf[128];
@@ -739,6 +747,25 @@ Java_com_tinkernorth_dish_data_network_SatelliteNative_receiveAck(JNIEnv*, jobje
             LOGI("Session %d server status: vigemAvailable=%d activeControllers=%d", handle, vigem,
                  count);
         }
+    } else if (msgType == MSG_RUMBLE && msgLen >= 8 && decLen >= 12) {
+        // Wire layout (BE16 magnitudes/duration, U8 flags + optional R/G/B):
+        //   ctrlIdx(1) strong(2) weak(2) durMs(2) flags(1) [R(1) G(1) B(1)]
+        if (g_rumbleBridgeClass == nullptr || g_rumbleDispatchMethod == nullptr) return;
+        const jint ctrlIdx = (jint)decrypted[4];
+        const jint strong = ((jint)decrypted[5] << 8) | (jint)decrypted[6];
+        const jint weakMag = ((jint)decrypted[7] << 8) | (jint)decrypted[8];
+        const jint durMs = ((jint)decrypted[9] << 8) | (jint)decrypted[10];
+        const uint8_t flags = decrypted[11];
+        const jboolean hasLightbar = (flags & 0x01) != 0 ? JNI_TRUE : JNI_FALSE;
+        jint r = 0, g = 0, b = 0;
+        if (hasLightbar && msgLen >= 11 && decLen >= 15) {
+            r = (jint)decrypted[12];
+            g = (jint)decrypted[13];
+            b = (jint)decrypted[14];
+        }
+        env->CallStaticVoidMethod(g_rumbleBridgeClass, g_rumbleDispatchMethod, handle, ctrlIdx,
+                                  strong, weakMag, durMs, hasLightbar, r, g, b);
+        if (env->ExceptionCheck()) env->ExceptionClear();
     }
 }
 
@@ -1070,10 +1097,9 @@ Java_com_tinkernorth_dish_data_network_SatelliteNative_processGamepadKeyEvent(
     // which source flag Android tagged it with. Caller (Activity dispatch)
     // is responsible for not handing us events from devices that aren't
     // gamepads in the first place.
-    bool isMappedKey =
-        (keyCode == AKEYCODE_BUTTON_L2 || keyCode == AKEYCODE_BUTTON_R2 ||
-         keyCode == AKEYCODE_BUTTON_7 || keyCode == AKEYCODE_BUTTON_8) ||
-        gamepad::keycodeToXusb(keyCode) != 0;
+    bool isMappedKey = (keyCode == AKEYCODE_BUTTON_L2 || keyCode == AKEYCODE_BUTTON_R2 ||
+                        keyCode == AKEYCODE_BUTTON_7 || keyCode == AKEYCODE_BUTTON_8) ||
+                       gamepad::keycodeToXusb(keyCode) != 0;
     if (!isMappedKey) return JNI_FALSE;
     if (action != AKEY_EVENT_ACTION_DOWN && action != AKEY_EVENT_ACTION_UP) return JNI_FALSE;
     std::lock_guard<std::mutex> lock(g_devicesMtx);
@@ -1142,6 +1168,25 @@ JNIEXPORT void JNICALL Java_com_tinkernorth_dish_data_network_BluetoothGamepadBr
     // populated by gamepadKeyFilter / gamepadMotionFilter on the UI thread.
     // Idempotent — safe if install() is ever called twice.
     startBtDispatchThread();
+}
+
+// Mirror of the BT bridge install path, but for the rumble return path. We
+// only need the class + method ids — receiveAck() is already invoked from a
+// JVM-attached thread (Kotlin Dispatchers.IO), so there's no separate
+// dispatcher thread to spawn here.
+JNIEXPORT void JNICALL
+Java_com_tinkernorth_dish_data_network_RumbleBridge_nativeInstall(JNIEnv* env, jclass bridgeCls) {
+    if (g_rumbleBridgeClass == nullptr) {
+        g_rumbleBridgeClass = (jclass)env->NewGlobalRef(bridgeCls);
+    }
+    if (g_rumbleDispatchMethod == nullptr) {
+        g_rumbleDispatchMethod =
+            env->GetStaticMethodID(g_rumbleBridgeClass, "dispatchRumble", "(IIIIIZIII)V");
+        if (g_rumbleDispatchMethod == nullptr) {
+            LOGE("RumbleBridge.dispatchRumble not found");
+            env->ExceptionClear();
+        }
+    }
 }
 
 } // extern "C"

--- a/app/src/main/java/com/tinkernorth/dish/DishApplication.kt
+++ b/app/src/main/java/com/tinkernorth/dish/DishApplication.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import com.tinkernorth.dish.data.network.BluetoothGamepadBridge
 import com.tinkernorth.dish.data.network.ConnectionForegroundObserver
 import com.tinkernorth.dish.data.network.PhysicalSlotBindingObserver
+import com.tinkernorth.dish.data.network.RumbleBridge
 import com.tinkernorth.dish.data.network.WakeStateController
 import com.tinkernorth.dish.data.repository.PhysicalGamepadRegistry
 import com.tinkernorth.dish.ui.bluetooth.BluetoothGamepadRegistry
@@ -46,5 +47,11 @@ class DishApplication : Application() {
         // physical-gamepad reports routed to a BT slot; install the registry
         // here (process-scoped) so it's ready before any input arrives.
         BluetoothGamepadBridge.install(btRegistry)
+        // Rumble flows back from the satellite (game → virtual pad → wire).
+        // RumbleBridge owns the phone's VibratorManager / Vibrator and is the
+        // single dispatch target for satellite_jni.cpp::receiveAck. Routed
+        // unconditionally to the device — no physical-controller fallback,
+        // intentionally — see RumbleBridge.kt for the design rationale.
+        RumbleBridge.install(this)
     }
 }

--- a/app/src/main/java/com/tinkernorth/dish/data/network/RumbleBridge.kt
+++ b/app/src/main/java/com/tinkernorth/dish/data/network/RumbleBridge.kt
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.data.network
+
+import android.content.Context
+import android.os.Build
+import android.os.CombinedVibration
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import androidx.annotation.RequiresApi
+
+/**
+ * Java-side dispatch target for satellite → phone rumble events.
+ *
+ * The native receive loop (see `satellite_jni.cpp::receiveAck`) calls
+ * [dispatchRumble] from the same JVM-attached thread that called into JNI
+ * (Kotlin Dispatchers.IO via [SatelliteNative.receiveAck]). That keeps the
+ * call site simple — no AttachCurrentThread, no dispatcher worker thread —
+ * and means rumble latency is bounded by the receive-loop's poll interval
+ * (currently 500 ms recv timeout, much shorter when a packet is actually
+ * available).
+ *
+ * Per the project decision, **all rumble is routed to the phone's vibrator**
+ * — there is no fallback path that tries to actuate a connected physical
+ * gamepad via [android.view.InputDevice.getVibratorManager]. Letting the
+ * virtual on-screen gamepad / phone body handle every rumble keeps the
+ * actuation single-rooted and avoids the "which device should buzz?"
+ * decision a player paired with a physical pad would otherwise have to make.
+ *
+ * The class name and `dispatchRumble` static signature are referenced by
+ * `nativeInstall` in `satellite_jni.cpp` — keep them in sync.
+ */
+object RumbleBridge {
+    init {
+        // Defensive: the .so is normally already loaded via SatelliteNative,
+        // but install() may be called before any other Kotlin entry point
+        // touches that singleton (DishApplication.onCreate runs early).
+        System.loadLibrary("satellite")
+    }
+
+    @Volatile private var vibratorManager: VibratorManager? = null
+
+    @Volatile private var vibrator: Vibrator? = null
+
+    /**
+     * Wire up the bridge once the application context is available. Called
+     * from [com.tinkernorth.dish.DishApplication.onCreate]. Also registers
+     * this class with the native layer — must run from a JVM call so the
+     * app classloader is on the stack (FindClass in JNI_OnLoad would fail).
+     *
+     * The native side caches the resolved class + method id, so re-invoking
+     * `install` is safe but redundant.
+     */
+    fun install(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            vibratorManager =
+                context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager?
+        } else {
+            // Pre-API-31 phones expose the legacy single-actuator service.
+            // Functionally identical from the user's wrist; it just can't
+            // route strong vs weak motors independently.
+            @Suppress("DEPRECATION")
+            vibrator = context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator?
+        }
+        nativeInstall()
+    }
+
+    @JvmStatic
+    private external fun nativeInstall()
+
+    /**
+     * Wire-format rumble event from the satellite. Magnitudes are 0..65535
+     * (XInput scale) and `durationMs == 0` means "stop / continuous-clear".
+     *
+     * The combined vibration is split across the device's actuators on
+     * API 31+ (`VibratorManager`) so a phone with two motors gets
+     * proportional drive on each. On older phones we collapse the two
+     * magnitudes into a single peak intensity for the legacy [Vibrator]
+     * service.
+     *
+     * `controllerIndex` is currently ignored: each WiFi connection is
+     * single-controller, so every rumble for this session targets the
+     * phone unconditionally.
+     */
+    @JvmStatic
+    fun dispatchRumble(
+        sessionHandle: Int,
+        controllerIndex: Int,
+        strongMagnitude: Int,
+        weakMagnitude: Int,
+        durationMs: Int,
+        @Suppress("UNUSED_PARAMETER") hasLightbar: Boolean,
+        @Suppress("UNUSED_PARAMETER") lightbarR: Int,
+        @Suppress("UNUSED_PARAMETER") lightbarG: Int,
+        @Suppress("UNUSED_PARAMETER") lightbarB: Int,
+    ) {
+        // Stop / no-op packet: cancel any in-flight vibration so we don't
+        // outlast the satellite-side game.
+        if (durationMs == 0 || (strongMagnitude == 0 && weakMagnitude == 0)) {
+            cancelAll()
+            return
+        }
+        // Clamp the wire-format duration to the wire-side refresh deadline
+        // so a hung satellite doesn't strand a multi-second buzz on the
+        // device. The satellite stamps `wireDurationMs = 500` by default
+        // (see `SessionService::handleRumbleFromBackend`), but a malicious
+        // or buggy server could send anything; protect the user.
+        val safeDuration = durationMs.coerceIn(1, 1500).toLong()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            dispatchApi31(strongMagnitude, weakMagnitude, safeDuration)
+        } else {
+            dispatchLegacy(strongMagnitude, weakMagnitude, safeDuration)
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun dispatchApi31(strongMagnitude: Int, weakMagnitude: Int, durationMs: Long) {
+        val mgr = vibratorManager ?: return
+        val ids = mgr.vibratorIds
+        if (ids.isEmpty()) {
+            // Phone has no haptics actuator at all. Nothing to do.
+            return
+        }
+        // Map the satellite's two-motor model onto whatever actuators this
+        // device exposes. Most phones have one general-purpose actuator;
+        // foldables / gaming phones may have two and we use them both.
+        //
+        // Magnitude is normalized to the VibrationEffect 1..255 range.
+        val combinedBuilder = CombinedVibration.startParallel()
+        val strongAmp = magnitudeTo255(strongMagnitude)
+        val weakAmp = magnitudeTo255(weakMagnitude)
+        // ids[0] gets the strong motor; ids[1] (if present) gets weak.
+        if (strongAmp > 0) {
+            combinedBuilder.addVibrator(ids[0], VibrationEffect.createOneShot(durationMs, strongAmp))
+        }
+        if (ids.size >= 2 && weakAmp > 0) {
+            combinedBuilder.addVibrator(ids[1], VibrationEffect.createOneShot(durationMs, weakAmp))
+        } else if (ids.size < 2 && weakAmp > 0 && strongAmp == 0) {
+            // Single-actuator phone where only the weak motor is non-zero —
+            // still drive that actuator, otherwise `mgr.vibrate` on an empty
+            // CombinedVibration is a silent no-op.
+            combinedBuilder.addVibrator(ids[0], VibrationEffect.createOneShot(durationMs, weakAmp))
+        }
+        // CombinedVibration.startParallel() always returns a valid combination
+        // — but combine() throws if no per-vibrator effect was added (both
+        // magnitudes zero), which we've already early-returned out of above.
+        try {
+            mgr.vibrate(combinedBuilder.combine())
+        } catch (_: IllegalStateException) {
+            // Empty combination — fine, treat as a no-op.
+        }
+    }
+
+    private fun dispatchLegacy(strongMagnitude: Int, weakMagnitude: Int, durationMs: Long) {
+        val v = vibrator ?: return
+        // Pre-API-31 has only one actuator and one magnitude. Use the peak
+        // of the two motors so the player feels the louder of the two.
+        val peak = maxOf(strongMagnitude, weakMagnitude)
+        val amp = magnitudeTo255(peak)
+        if (amp == 0) return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            v.vibrate(VibrationEffect.createOneShot(durationMs, amp))
+        } else {
+            // API < 26: no amplitude control, fixed-strength buzz of the
+            // requested duration. Almost no devices in our supported range
+            // hit this branch.
+            @Suppress("DEPRECATION")
+            v.vibrate(durationMs)
+        }
+    }
+
+    private fun cancelAll() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            vibratorManager?.cancel()
+        } else {
+            vibrator?.cancel()
+        }
+    }
+
+    /**
+     * Map a 0..65535 wire-format magnitude into VibrationEffect's 1..255
+     * amplitude range. Returns 0 only when the input is exactly 0 — even
+     * tiny non-zero magnitudes become a barely-perceptible buzz so the
+     * player gets the same on/off response they'd get from a physical pad.
+     */
+    private fun magnitudeTo255(magnitude: Int): Int = rumbleMagnitudeTo255(magnitude)
+}
+
+// ── Pure helpers (extracted for unit testing) ────────────────────────────────
+// The dispatch path inside RumbleBridge needs system services (Vibrator,
+// VibratorManager) and so can only run on a real Android device. The two
+// pure transformations below are what actually shape the user's wrist
+// experience, and they're trivially testable in isolation.
+
+/**
+ * Scale a wire-format magnitude (0..65535, XInput convention) into a
+ * VibrationEffect amplitude (0..255). Returns 0 only for exact zero;
+ * otherwise clamps into the 1..255 range so even tiny magnitudes produce
+ * a perceptible buzz.
+ */
+internal fun rumbleMagnitudeTo255(magnitude: Int): Int {
+    val clamped = magnitude.coerceIn(0, 65535)
+    if (clamped == 0) return 0
+    // 65535 → 255; 1 → 1 (rounded up).
+    val scaled = (clamped * 255 + 32767) / 65535
+    return scaled.coerceIn(1, 255)
+}
+
+/**
+ * Apply the [RumbleBridge] safety clamp to an incoming wire-format
+ * `durationMs`. The wire format is 16-bit unsigned, but a buggy or
+ * malicious satellite could strand a multi-second buzz on the device;
+ * we cap it to 1500 ms to bound the worst case at "the user's wrist
+ * survives one bad packet". Returns 0 when the input was 0 (the
+ * "stop / no-op" sentinel).
+ */
+internal fun rumbleSafeDurationMs(durationMs: Int): Int {
+    if (durationMs == 0) return 0
+    return durationMs.coerceIn(1, 1500)
+}

--- a/app/src/test/java/com/tinkernorth/dish/data/network/RumbleBridgeHelpersTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/data/network/RumbleBridgeHelpersTest.kt
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.data.network
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Coverage for the pure helpers that shape an incoming `MSG_RUMBLE` packet
+ * before the [RumbleBridge] hands it off to Android's vibrator services.
+ *
+ * The dispatch path itself touches [android.os.VibratorManager] /
+ * [android.os.Vibrator], which only exist on a real Android device, so this
+ * file deliberately stops short of the system-service boundary. The two
+ * transformations covered here are what actually shape the user's wrist
+ * experience — the rest is plumbing.
+ */
+class RumbleBridgeHelpersTest {
+
+    // ── rumbleMagnitudeTo255 ──────────────────────────────────────────────
+
+    @Test
+    fun `magnitude 0 stays 0`() {
+        assertEquals(0, rumbleMagnitudeTo255(0))
+    }
+
+    @Test
+    fun `magnitude 65535 maps to 255`() {
+        assertEquals(255, rumbleMagnitudeTo255(65535))
+    }
+
+    @Test
+    fun `magnitude midpoint maps to ~128`() {
+        // 32767 → ~128 with rounding ((32767*255 + 32767)/65535 = 128).
+        assertEquals(128, rumbleMagnitudeTo255(32767))
+        // 32768 → ~128 too (one above the exact midpoint).
+        assertEquals(128, rumbleMagnitudeTo255(32768))
+    }
+
+    @Test
+    fun `tiny magnitude rounds up to 1, not down to 0`() {
+        // The whole point of the rounding-up clamp: any non-zero wire-format
+        // magnitude must produce *some* perceptible vibration so on/off has
+        // the same feel as a physical pad.
+        assertEquals(1, rumbleMagnitudeTo255(1))
+        assertEquals(1, rumbleMagnitudeTo255(50))
+        assertEquals(1, rumbleMagnitudeTo255(127))
+        assertEquals(1, rumbleMagnitudeTo255(128)) // 128*255+32767 = 65407, /65535 = 0.99 → coerced to 1
+    }
+
+    @Test
+    fun `magnitude over 65535 is clamped to 255`() {
+        // The wire format is u16 so this never legitimately happens, but
+        // RumbleBridge sees jints from JNI and a misbehaving satellite could
+        // theoretically send anything. Defensive.
+        assertEquals(255, rumbleMagnitudeTo255(70000))
+        assertEquals(255, rumbleMagnitudeTo255(Int.MAX_VALUE))
+    }
+
+    @Test
+    fun `magnitude below 0 is treated as 0`() {
+        assertEquals(0, rumbleMagnitudeTo255(-1))
+        assertEquals(0, rumbleMagnitudeTo255(Int.MIN_VALUE))
+    }
+
+    @Test
+    fun `magnitude scaling is monotonic`() {
+        // Property: more wire-format magnitude must never produce less
+        // amplitude. Sanity check at a handful of points covering the curve.
+        val points = listOf(0, 100, 1000, 10000, 32768, 50000, 65535)
+        var prev = -1
+        for (m in points) {
+            val v = rumbleMagnitudeTo255(m)
+            assert(v >= prev) { "non-monotonic at magnitude=$m: prev=$prev got=$v" }
+            prev = v
+        }
+    }
+
+    // ── rumbleSafeDurationMs ──────────────────────────────────────────────
+
+    @Test
+    fun `duration 0 is preserved as the stop sentinel`() {
+        // 0 is the "no-op / cancel" marker for the dispatch path. It must
+        // round-trip unchanged so the stop branch still triggers.
+        assertEquals(0, rumbleSafeDurationMs(0))
+    }
+
+    @Test
+    fun `duration is clamped into the 1 to 1500 range`() {
+        assertEquals(1, rumbleSafeDurationMs(1))
+        assertEquals(500, rumbleSafeDurationMs(500))
+        assertEquals(1500, rumbleSafeDurationMs(1500))
+    }
+
+    @Test
+    fun `duration above 1500 is clamped to 1500`() {
+        // The cap protects the user from a hung satellite that strands a
+        // multi-second buzz on the device.
+        assertEquals(1500, rumbleSafeDurationMs(2000))
+        assertEquals(1500, rumbleSafeDurationMs(65535))
+        assertEquals(1500, rumbleSafeDurationMs(Int.MAX_VALUE))
+    }
+
+    @Test
+    fun `negative duration is clamped to 1`() {
+        // The wire format is u16 so this can't happen in practice, but JNI
+        // hands us jints; defensive against a misbehaving satellite.
+        assertEquals(1, rumbleSafeDurationMs(-1))
+    }
+}


### PR DESCRIPTION
## Summary
- New `RumbleBridge.kt` owns the phone's `VibratorManager` (API 31+) / `Vibrator` (legacy) and is the dispatch target for the satellite's reverse-direction rumble message (`MSG_RUMBLE = 0x0009`).
- Native `receiveAck` parses the payload and JNI-calls into `RumbleBridge.dispatchRumble` synchronously — no dispatcher thread needed because `receiveAck` already runs on `Dispatchers.IO`.
- All rumble routed to the **phone**, not to a connected physical pad. Single-rooted actuation by design — see `RumbleBridge.kt` header for rationale.

## Wire format
Documented in [`satellite/README.md#rumble-return-path`](https://github.com/TinkerNorth/satellite#rumble-return-path) (paired PR adds the producer side):

```
ctrlIdx(u8)  strong(u16 BE)  weak(u16 BE)  durMs(u16 BE)  flags(u8)
[R, G, B] (u8×3 if flags bit 0 set)
```

Mandatory section is 8 bytes; optional DS4 lightbar tail brings it to 11.

## Behaviour
- Magnitudes 0..65535 → `VibrationEffect` 1..255 with rounding-up so any non-zero request produces a perceptible buzz; zero stays zero.
- Wire-format `durationMs` clamped to `[1, 1500]` to bound the worst-case stranded buzz from a hung satellite. `0` is preserved as the stop/no-op sentinel.
- On dual-actuator phones (API 31+) strong → vibrator id 0, weak → id 1; on single-actuator phones the peak of the two is used.
- Manifest declares `android.permission.VIBRATE` (normal-protection, no runtime prompt).

## Test plan
- [ ] `./gradlew testDebugUnitTest` — new `RumbleBridgeHelpersTest` (10 cases) covers magnitude scaling, monotonicity, duration clamps, stop sentinel
- [ ] `./gradlew assembleDebug` — confirms native + Kotlin compile against current toolchain
- [ ] Manual: pair with a satellite running this PR's companion server-side change; in any game that calls `XInputSetState`, verify the phone vibrates
- [ ] Manual: kill satellite mid-rumble, verify buzz stops within 1.5 s (the safety clamp)

## Related
Pairs with the satellite-side server change (TinkerNorth/satellite). Sibling dish PRs: dish-linux, dish-windows, dish-mac (all open in parallel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)