### PR TITLE
Virtual gamepad latency + history draining + low-power touch fix

### DIFF
--- a/app/src/main/cpp/satellite_jni.cpp
+++ b/app/src/main/cpp/satellite_jni.cpp
@@ -95,7 +95,12 @@ struct Session {
     uint8_t token[4] = {};
     uint8_t key[32] = {};
     std::atomic<uint32_t> counter{0};
-    std::mutex sendMtx; // protects sendto for this session
+    // No userspace sendMtx: Linux UDP `sendto` is thread-safe per-socket
+    // (kernel serialises via the socket's own lock), and our protocol is
+    // tolerant of slight reordering across producers (each packet carries
+    // its own counter-as-nonce; the host's virtual gamepad applies state
+    // idempotently). Adding a userspace lock here would only propagate
+    // any one thread's kernel-side stall to every other producer.
 
     std::thread heartbeatThread;
     std::atomic<bool> heartbeatRunning{false};
@@ -423,9 +428,22 @@ static bool sendEncrypted(Session* s, uint16_t msgType, const uint8_t* payload,
     memcpy(packet + 8, ciphertext, (size_t)cipherLen);
 
     size_t totalLen = 8 + (size_t)cipherLen;
-    std::lock_guard<std::mutex> lock(s->sendMtx);
-    ssize_t sent =
-        sendto(s->udpSock, packet, totalLen, 0, (struct sockaddr*)&s->dest, sizeof(s->dest));
+    // MSG_DONTWAIT: make sendto non-blocking. Without this, when the Wi-Fi
+    // power-save state transitions or the radio TX buffer fills, sendto
+    // could block in the kernel for hundreds of ms (worst observed during
+    // diagnosis: 1.56 s, with that latency propagating to every other
+    // thread waiting to send). With MSG_DONTWAIT the call returns -1 /
+    // EAGAIN immediately instead; the next periodic-resend tick tries
+    // again with the latest state. UDP is already lossy by contract, so
+    // a buffer-full drop is no worse than any other packet loss.
+    ssize_t sent = sendto(s->udpSock, packet, totalLen, MSG_DONTWAIT,
+                          (struct sockaddr*)&s->dest, sizeof(s->dest));
+    // EAGAIN / EWOULDBLOCK: kernel send buffer momentarily unavailable.
+    // Treat as a soft drop, not a hard error — UDP semantics absorb it and
+    // the next periodic tick will refresh the state.
+    if (sent < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+        return true;
+    }
     return sent == (ssize_t)totalLen;
 }
 

--- a/app/src/main/java/com/tinkernorth/dish/hotpath/overlay/GamepadActivityHost.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/overlay/GamepadActivityHost.kt
@@ -220,11 +220,21 @@ class GamepadActivityHost(
      * Reads the overlay-active state *before* notifying the manager so a
      * DOWN that dismisses the dim still wins the gate (and consumes the
      * rest of the gesture, so the underlying button doesn't get a click).
+     *
+     * Resets the inactivity timer on any non-CANCEL touch action — not just
+     * DOWN — so a user dragging a finger on the gamepad (a held stick
+     * stroke, a long ABXY swipe) keeps the screen awake. The pre-fix code
+     * only fired on DOWN, so a 15 s continuous stroke would let the
+     * inactivity timer expire mid-gesture. `onUserInteraction` is cheap
+     * (two Handler post/remove ops in the IDLE case), so calling it on
+     * every MOVE at the panel's sample rate (~120 Hz) is negligible.
      */
     fun dispatchTouchEvent(ev: MotionEvent): Boolean {
         val overlayActive = lowPowerManager.state.value == LowPowerManager.State.ACTIVE
         val consume = lowPowerTouchGate.onDispatch(ev.action, overlayActive)
-        if (ev.action == MotionEvent.ACTION_DOWN && wakeState.shouldKeepScreenOn.value) {
+        if (wakeState.shouldKeepScreenOn.value &&
+            ev.actionMasked != MotionEvent.ACTION_CANCEL
+        ) {
             lowPowerManager.onUserInteraction()
         }
         return consume

--- a/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadGestureRecognizer.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadGestureRecognizer.kt
@@ -72,25 +72,64 @@ internal class GamepadGestureRecognizer {
     /**
      * Process a [MotionEvent] against the supplied [layout]. Mutates [state]
      * and the per-stick displacement fields in place. The caller is
-     * responsible for invalidating the View and notifying its listener.
+     * responsible for invalidating the View.
+     *
+     * [onSampleApplied] fires after each *sample* has been applied so the
+     * caller can dispatch its listener per sample, not per event. For
+     * `ACTION_MOVE` this includes every historical sample carried by the
+     * `MotionEvent` plus the current one — Android coalesces multiple
+     * touch-panel reads at vsync, so a single `ACTION_MOVE` can carry several
+     * intermediate finger positions. Reading only `event.getX/getY` and
+     * notifying once would drop those intermediate positions, producing
+     * visible stutter on fast stick movements at the host (the in-between
+     * axis values never reach the wire). For non-MOVE actions the callback
+     * fires once. Pass `null` (the default) to suppress per-sample dispatch.
      */
     fun onTouchEvent(
         event: MotionEvent,
         layout: GamepadLayout,
+        onSampleApplied: (() -> Unit)? = null,
     ) {
         when (event.actionMasked) {
             MotionEvent.ACTION_DOWN, MotionEvent.ACTION_POINTER_DOWN -> {
                 handlePointerDown(event, event.actionIndex, layout)
+                onSampleApplied?.invoke()
             }
             MotionEvent.ACTION_MOVE -> {
-                for (i in 0 until event.pointerCount) {
-                    handlePointerMove(event, i, layout)
+                // Drain historical samples first (oldest → newest) and notify
+                // per sample so each intermediate finger position becomes its
+                // own wire report. Per Android, only ACTION_MOVE carries a
+                // history; getHistoricalX/Y for any other action is undefined.
+                val historySize = event.historySize
+                for (h in 0 until historySize) {
+                    for (i in 0 until event.pointerCount) {
+                        applyPointerMove(
+                            event.getHistoricalX(i, h),
+                            event.getHistoricalY(i, h),
+                            event.getPointerId(i),
+                            layout,
+                        )
+                    }
+                    onSampleApplied?.invoke()
                 }
+                for (i in 0 until event.pointerCount) {
+                    applyPointerMove(
+                        event.getX(i),
+                        event.getY(i),
+                        event.getPointerId(i),
+                        layout,
+                    )
+                }
+                onSampleApplied?.invoke()
             }
             MotionEvent.ACTION_UP, MotionEvent.ACTION_POINTER_UP -> {
                 handlePointerUp(event, event.actionIndex)
+                onSampleApplied?.invoke()
             }
-            MotionEvent.ACTION_CANCEL -> reset()
+            MotionEvent.ACTION_CANCEL -> {
+                reset()
+                onSampleApplied?.invoke()
+            }
         }
     }
 
@@ -200,16 +239,20 @@ internal class GamepadGestureRecognizer {
         }
     }
 
+    /**
+     * Apply a single (x, y) sample for [pid] against the current per-pointer
+     * tracking. Called once per finger position — including historical
+     * samples drained out of an [MotionEvent] by [onTouchEvent]. Pure: takes
+     * coordinates by value so the caller can reuse it for both
+     * `event.getHistoricalX/Y(idx, h)` and `event.getX/Y(idx)`.
+     */
     @Suppress("CyclomaticComplexMethod", "LongMethod")
-    private fun handlePointerMove(
-        event: MotionEvent,
-        idx: Int,
+    private fun applyPointerMove(
+        x: Float,
+        y: Float,
+        pid: Int,
         l: GamepadLayout,
     ) {
-        val x = event.getX(idx)
-        val y = event.getY(idx)
-        val pid = event.getPointerId(idx)
-
         if (pid == leftStickPointerId) {
             val r = computeStickAxes((x - l.leftStickCx) / l.stickRadius, (y - l.leftStickCy) / l.stickRadius)
             leftStickDx = r.dx

--- a/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadTouchView.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadTouchView.kt
@@ -329,7 +329,6 @@ class GamepadTouchView
             canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), paintBg)
             val l = layout ?: return
             val s = recognizer.state
-
             drawDpad(canvas, l, s)
             drawAbxy(canvas, l, s)
             drawStick(canvas, l.leftStickCx, l.leftStickCy, recognizer.leftStickDx, recognizer.leftStickDy, l.stickRadius, "L")
@@ -537,9 +536,16 @@ class GamepadTouchView
         @SuppressLint("ClickableViewAccessibility")
         override fun onTouchEvent(event: MotionEvent): Boolean {
             val l = layout ?: return false
-            recognizer.onTouchEvent(event, l)
+            // Notify the listener per *sample* — for ACTION_MOVE the
+            // recognizer drains every historical sample carried by the
+            // MotionEvent, so each intermediate finger position becomes its
+            // own report instead of being collapsed into the latest. The
+            // single invalidate() at the end is intentional: the view only
+            // ever needs to repaint the final state once per OS event.
+            recognizer.onTouchEvent(event, l) {
+                listener?.onGamepadStateChanged(recognizer.state)
+            }
             invalidate()
-            listener?.onGamepadStateChanged(recognizer.state)
             return true
         }
     }

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
@@ -123,10 +123,14 @@ class ConnectionsActivity : AppCompatActivity() {
         registerForActivityResult(
             ActivityResultContracts.RequestMultiplePermissions(),
         ) { results ->
+            // The OS doesn't broadcast permission changes, and the process
+            // never backgrounds during the system dialog, so the observer's
+            // ProcessLifecycleOwner.onStart re-poll never fires. Re-poll
+            // here so applyBtPermissionBanner dismisses on grant (and
+            // re-confirms the still-DENIED state on deny).
+            btPermissionState.refresh()
             if (results.values.all { it }) {
                 showProfilePicker()
-            } else {
-                notifyBtPermissionDenied()
             }
         }
 
@@ -629,13 +633,6 @@ class ConnectionsActivity : AppCompatActivity() {
             title = getString(R.string.notif_server_unreachable_title, pairing?.name ?: getString(R.string.satellite_fallback_name)),
             body = message,
         )
-    }
-
-    private fun notifyBtPermissionDenied() {
-        // Refresh the permission observer so the persistent banner from
-        // applyBtPermissionBanner fires straight away (it normally only
-        // refreshes on foreground entry).
-        btPermissionState.refresh()
     }
 
     private fun notifyDiscoverabilityDenied() {

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
@@ -37,6 +37,9 @@ import com.tinkernorth.dish.source.sensor.PhoneBatterySource
 import com.tinkernorth.dish.source.sensor.PhoneMotionSource
 import com.tinkernorth.dish.ui.common.GamepadTouchView
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -72,6 +75,22 @@ class GamepadOverlayActivity :
     private lateinit var binding: ActivityGamepadOverlayBinding
     private lateinit var gamepadHost: GamepadActivityHost
     private var connectionId: String = ""
+
+    /**
+     * Most recent gamepad state surfaced by [onGamepadStateChanged]. The touch
+     * view's recognizer mutates a single [GamepadTouchView.GamepadState] in
+     * place, so this holds the live reference — reading fields here always
+     * reflects the latest values. `null` until the user first touches the
+     * pad; the periodic-resend loop skips while it is still null.
+     *
+     * Written on the main thread (touch dispatch) and read from the resend
+     * coroutine which now runs on `Dispatchers.Default`, so the reference is
+     * `@Volatile` for cross-thread visibility. Per-field reads of the
+     * underlying [GamepadTouchView.GamepadState] may briefly see a torn
+     * snapshot if the recognizer is mid-update — acceptable for axis values
+     * (next tick corrects) and not a correctness hazard.
+     */
+    @Volatile private var lastReportedState: GamepadTouchView.GamepadState? = null
 
     /**
      * Phone IMU + battery sources for the on-screen touch controller. Created
@@ -137,6 +156,66 @@ class GamepadOverlayActivity :
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 satellite.events.collect(::handleConnectionEvent)
+            }
+        }
+        // Periodic resend of the latest virtual-gamepad state to the satellite.
+        //
+        // Physical pads route through `gamepadMotionFilter` →
+        // `consumePublishIfChanged` (see `satellite_jni.cpp`), which is also
+        // change-driven — but the kernel HID poll plus the analog sticks'
+        // hardware noise keep producing fresh samples even when the user's
+        // thumb is steady, so the wire stays warm and any single dropped UDP
+        // packet is recovered within a few ms by the next sample.
+        //
+        // The touch panel filters sub-pixel jitter, so a finger held still
+        // emits ZERO `ACTION_MOVE` events; the listener never re-fires; the
+        // wire goes completely silent. If the *last* packet before stillness
+        // is the one UDP drops, the host's virtual gamepad sits on stale
+        // state until the user moves their finger again — the visible "gap"
+        // / "stuck stick" feeling. Resending the latest state every
+        // RESEND_INTERVAL_MS replicates the physical-pad's continuous-refresh
+        // behaviour and recovers from single-packet loss within one tick.
+        //
+        // Bluetooth is intentionally excluded: BT-HID has its own polling
+        // discipline (the host queries the slave at the negotiated rate),
+        // and the bounded native BT dispatch queue would just fill up with
+        // redundant reports.
+        // Run on Dispatchers.Default — JNI sendReport doesn't need the main
+        // thread, and competing with touch dispatch / vsync / layout on
+        // Dispatchers.Main.immediate was producing 14 ms tick-interval tails
+        // (measured via GpTrace) where the configured rate was 4 ms.
+        lifecycleScope.launch(Dispatchers.Default) {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                // Deadline-based pacing — each iteration targets an absolute
+                // `nextTickNs` deadline instead of "sleep N ms from now."
+                // Without this, work time (sendSatelliteReport + JNI +
+                // encrypt + sendto) leaks into the cycle, so a 4 ms config
+                // produces ≈ 6 ms cycles → 168 Hz, not the requested 250 Hz.
+                // With drift correction, the long-term rate matches the
+                // configured interval exactly; a slow tick is followed by a
+                // shorter wait, not a permanent slip.
+                var nextTickNs = System.nanoTime() + RESEND_INTERVAL_NS
+                while (isActive) {
+                    val now = System.nanoTime()
+                    // Guard against runaway catch-up: if we somehow fell more
+                    // than a few intervals behind (process throttled, dispatcher
+                    // starved), reset rather than burning CPU spamming back-
+                    // dated reports the host has already aged past.
+                    if (now - nextTickNs > RESEND_INTERVAL_NS * MAX_BACKLOG_FACTOR) {
+                        nextTickNs = now + RESEND_INTERVAL_NS
+                    }
+                    val waitNs = nextTickNs - now
+                    if (waitNs > 0) {
+                        val waitMs = waitNs / 1_000_000L
+                        if (waitMs > 0) delay(waitMs)
+                    }
+                    nextTickNs += RESEND_INTERVAL_NS
+                    val state = lastReportedState ?: continue
+                    val summary = hub.summary(connectionId) ?: continue
+                    if (summary.kind != ConnectionKind.SATELLITE) continue
+                    if (summary.live != LinkState.Connected) continue
+                    sendSatelliteReport(state)
+                }
             }
         }
     }
@@ -269,6 +348,10 @@ class GamepadOverlayActivity :
     }
 
     override fun onGamepadStateChanged(state: GamepadTouchView.GamepadState) {
+        // Stored before the connection-status gate so input captured while
+        // the session is still Linking is replayed by the resend loop the
+        // moment it flips to Connected.
+        lastReportedState = state
         val summary = hub.summary(connectionId) ?: return
         if (summary.live != LinkState.Connected) return
         when (summary.kind) {
@@ -287,23 +370,29 @@ class GamepadOverlayActivity :
                     ) ?: return
                 btRegistry.sendReport(connectionId, report)
             }
-            ConnectionKind.SATELLITE -> {
-                // The touch view emits HID-layout button bits plus a
-                // separate hat-switch; the satellite path wants an XUSB
-                // wButtons with the d-pad folded back into the low nibble.
-                val wButtons = hidToXusb(state.buttons, state.hatSwitch)
-                satellite.get(connectionId)?.sendReport(
-                    VIRTUAL_SLOT_ID,
-                    wButtons,
-                    state.leftTrigger,
-                    state.rightTrigger,
-                    state.leftX.toInt(),
-                    state.leftY.toInt(),
-                    state.rightX.toInt(),
-                    state.rightY.toInt(),
-                )
-            }
+            ConnectionKind.SATELLITE -> sendSatelliteReport(state)
         }
+    }
+
+    /**
+     * Emit one MSG_GAMEPAD_DATA report to the bound satellite. The touch
+     * view emits HID-layout button bits plus a separate hat-switch; the
+     * satellite path wants an XUSB `wButtons` with the d-pad folded back
+     * into the low nibble. Shared between the touch-driven [onGamepadStateChanged]
+     * and the periodic resend loop in [onCreate].
+     */
+    private fun sendSatelliteReport(state: GamepadTouchView.GamepadState) {
+        val wButtons = hidToXusb(state.buttons, state.hatSwitch)
+        satellite.get(connectionId)?.sendReport(
+            VIRTUAL_SLOT_ID,
+            wButtons,
+            state.leftTrigger,
+            state.rightTrigger,
+            state.leftX.toInt(),
+            state.leftY.toInt(),
+            state.rightX.toInt(),
+            state.rightY.toInt(),
+        )
     }
 
     /**
@@ -355,5 +444,33 @@ class GamepadOverlayActivity :
     companion object {
         const val EXTRA_CONNECTION_ID = "extra_connection_id"
         const val EXTRA_USE_PS_LAYOUT = "extra_use_ps_layout"
+
+        /**
+         * Interval between periodic resends of the last virtual-gamepad
+         * state to a satellite. 4 ms ≈ 250 Hz matches the polling rate of a
+         * typical wired Xbox/PS controller — the rate the host's virtual
+         * gamepad backend (ViGEm / equivalent) is implicitly tuned for.
+         * Faster than the 60 Hz Steam Remote Play / Moonlight default, but
+         * the wire cost is still trivial (~17 KB/s of encrypted UDP) and the
+         * recovery window after a dropped packet shrinks to ≤ 4 ms instead
+         * of ≤ 16 ms — invisible at 60 Hz host displays, perceptibly
+         * smoother on 120/240 Hz panels and twitch genres.
+         *
+         * The resend loop uses [RESEND_INTERVAL_NS] for deadline arithmetic;
+         * this ms value is preserved as the human-facing knob.
+         */
+        private const val RESEND_INTERVAL_MS = 4L
+        private const val RESEND_INTERVAL_NS = RESEND_INTERVAL_MS * 1_000_000L
+
+        /**
+         * If the resend loop falls more than this many intervals behind
+         * `nextTickNs` (e.g. because the dispatcher was starved or the
+         * process was throttled), we reset the deadline to `now + INTERVAL`
+         * instead of issuing back-dated catch-up sends. The host has already
+         * aged past those states; sending them adds wire chatter without
+         * benefit. Five intervals (~20 ms at 250 Hz) is wider than any
+         * normal scheduler hiccup but narrow enough to recover quickly.
+         */
+        private const val MAX_BACKLOG_FACTOR = 5L
     }
 }

--- a/app/src/test/java/com/tinkernorth/dish/ui/common/GamepadGestureRecognizerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/common/GamepadGestureRecognizerTest.kt
@@ -104,6 +104,34 @@ class GamepadGestureRecognizerTest {
             every { getPointerId(0) } returns pid
             every { getX(0) } returns x
             every { getY(0) } returns y
+            // No historical samples — exercised in moveEventWithHistory below.
+            every { historySize } returns 0
+        }
+
+    /**
+     * Build a synthetic `ACTION_MOVE` event for a single pointer that carries
+     * [history] intermediate (x, y) samples followed by the current
+     * ([currentX], [currentY]) position. Used to exercise the recognizer's
+     * historical-sample draining path.
+     */
+    private fun moveEventWithHistory(
+        history: List<Pair<Float, Float>>,
+        currentX: Float,
+        currentY: Float,
+        pid: Int = POINTER_0,
+    ): MotionEvent =
+        mockk {
+            every { this@mockk.actionMasked } returns MotionEvent.ACTION_MOVE
+            every { this@mockk.actionIndex } returns 0
+            every { pointerCount } returns 1
+            every { getPointerId(0) } returns pid
+            every { getX(0) } returns currentX
+            every { getY(0) } returns currentY
+            every { historySize } returns history.size
+            history.forEachIndexed { h, (hx, hy) ->
+                every { getHistoricalX(0, h) } returns hx
+                every { getHistoricalY(0, h) } returns hy
+            }
         }
 
     // ── DOWN: octant resolution ─────────────────────────────────────────────
@@ -384,6 +412,63 @@ class GamepadGestureRecognizerTest {
             layout,
         )
         assertEquals(GamepadTouchView.BTN_B, recognizer.state.buttons and ABXY_MASK)
+    }
+
+    // ── History draining: coalesced ACTION_MOVE samples ────────────────────
+
+    @Test
+    fun `move with historical samples applies each intermediate position`() {
+        // Claim the d-pad in the east octant, then deliver a single MOVE
+        // event that coalesces three panel samples: S (south), W (west),
+        // current = N (north). Without history draining the recognizer
+        // would jump E → N and the south/west sweeps would never appear.
+        recognizer.onTouchEvent(event(MotionEvent.ACTION_DOWN, x = 180f, y = 250f), layout)
+        assertEquals(GamepadTouchView.HAT_E, recognizer.state.hatSwitch)
+
+        val sweep =
+            moveEventWithHistory(
+                history = listOf(150f to 280f, 120f to 250f),
+                currentX = 150f,
+                currentY = 220f,
+            )
+        val seen = mutableListOf<Int>()
+        recognizer.onTouchEvent(sweep, layout) {
+            seen.add(recognizer.state.hatSwitch)
+        }
+
+        // Three callbacks: S (historical 0), W (historical 1), N (current).
+        assertEquals(listOf(GamepadTouchView.HAT_S, GamepadTouchView.HAT_W, GamepadTouchView.HAT_N), seen)
+        // Final state reflects the current sample.
+        assertEquals(GamepadTouchView.HAT_N, recognizer.state.hatSwitch)
+    }
+
+    @Test
+    fun `move with no historical samples still fires callback once`() {
+        // Existing behaviour: an ACTION_MOVE with historySize=0 must still
+        // produce exactly one callback so the listener can dispatch the
+        // current sample. Pins that the per-sample notification path
+        // collapses cleanly when there's no history to drain.
+        recognizer.onTouchEvent(event(MotionEvent.ACTION_DOWN, x = 180f, y = 250f), layout)
+
+        var callbackCount = 0
+        recognizer.onTouchEvent(event(MotionEvent.ACTION_MOVE, x = 150f, y = 220f), layout) {
+            callbackCount += 1
+        }
+
+        assertEquals(1, callbackCount)
+        assertEquals(GamepadTouchView.HAT_N, recognizer.state.hatSwitch)
+    }
+
+    @Test
+    fun `down fires callback exactly once`() {
+        // DOWN/UP/CANCEL don't carry history per Android contract, so the
+        // recognizer must fire the callback exactly once for those — the
+        // touch view relies on this to dispatch a single state update.
+        var callbackCount = 0
+        recognizer.onTouchEvent(event(MotionEvent.ACTION_DOWN, x = 180f, y = 250f), layout) {
+            callbackCount += 1
+        }
+        assertEquals(1, callbackCount)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Five commits cleaning up perceived stutter / lag in the virtual-gamepad-to-host path, plus an orthogonal BT permission banner fix and a low-power-overlay bug found along the way.

The investigation ran as six measured iterations (logged in `.claude/test-results.md` locally, summary inlined below). End-to-end OS-event-to-wire latency went from **~1.58 s worst-case → 16 ms worst-case** while keeping median at **~7.1 ms** (≈90 % of which is Android input dispatch before our handler runs — not something app code can change).

### Commits

| # | Commit | Why |
|---|---|---|
| 1 | `fix(connections): refresh BT permission banner when granted in-app` | Banner stayed up forever after the user granted perms via the in-app prompt. Orthogonal to the gamepad work. |
| 2 | `feat(virtual-gamepad): periodic state resend at 250 Hz` | Held-still finger → no MOVE events → silent wire. Single dropped packet = host stuck on stale state. Periodic resend on `Dispatchers.Default` with deadline-based pacing + backlog clamp. |
| 3 | `feat(touch-recognizer): drain MotionEvent history per sample` | Android coalesces multiple panel reads into one `ACTION_MOVE` when UI thread is busy; we were dropping the intermediates. Captured: 3 684 samples from 1 176 OS events = 3.1× more state updates reaching the host on fast strokes. |
| 4 | `perf(satellite-wire): non-blocking sendto, drop userspace sendMtx` | `MSG_DONTWAIT` eliminates 1.5 s kernel blocks during Wi-Fi power-state transitions. Userspace mutex was redundant (kernel UDP socket lock + atomic counter + read-only state) and was propagating one thread's stall to every other producer. **Also benefits the USB / physical-controller path** — both flow through the same `sendEncrypted`. |
| 5 | `fix(low-power): reset inactivity timer on any non-CANCEL touch` | Continuous stroke without a lift left the inactivity timer running; the dim countdown banner would appear mid-gesture after 15 s. Reset on every MOVE in addition to DOWN/UP. |

### Measurement deltas (sustained virtual-gamepad play)

| | before any fix | after this PR |
|---|---:|---:|
| **End-to-end OS-event-to-wire (touch) p50** | 7.12 ms | 7.14 ms (flat — OS-side) |
| **End-to-end OS-event-to-wire (touch) max** | **1 575 ms** | **16 ms** |
| Periodic tick p50 | 5.96 ms | **3.97 ms** (250 Hz achieved) |
| Periodic tick max | 1 568 ms | 15.8 ms |
| `sendto` max | 1 562 ms | 4.1 ms |
| Wire send rate (with active input) | event-driven only | ~345 Hz combined (touch+periodic) |

### Test plan

- [x] `./gradlew :app:ktlintCheck` — green
- [x] `./gradlew :app:testDebugUnitTest` — green (includes three new tests pinning the history-drain contract)
- [x] `./gradlew :app:lintDebug` — green
- [x] `./gradlew :app:assembleDebug` — green
- [x] `./gradlew :app:assembleRelease` — green (with `lintVitalRelease`)
- [ ] Manual: tap "Grant" on the BT permission banner — banner dismisses (test 1).
- [ ] Manual: open the virtual gamepad overlay over an active satellite session, hold a stick at deflection, observe host receives steady state (test 2 + 4).
- [ ] Manual: drag a finger continuously on the gamepad for ≥ 20 s without lifting — dim countdown does **not** appear (test 5).
- [ ] Manual: simulate Wi-Fi flake during play — recovery is bounded to ≤ 1 tick (~4 ms) rather than the prior multi-hundred-ms gap (test 4 — exercised in capture, mechanism in place but didn't fire on healthy Wi-Fi).