### PR TITLE
feat(motion): foundation for honest per-slot motion capability

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/composer/MotionCapabilityComposer.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/MotionCapabilityComposer.kt
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.composer
+
+import com.tinkernorth.dish.architecture.abstracts.AbstractComposer
+import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
+import com.tinkernorth.dish.source.sensor.PhoneMotionAvailability
+import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Per-controller motion capability — the single source of truth that drives:
+ *
+ *   - the `CAP_MOTION` bit at `MSG_CONTROLLER_ADD` time (so the receiver's web
+ *     UI is not lied to about which pads stream IMU);
+ *   - whether [com.tinkernorth.dish.source.sensor.PhoneMotionSource] /
+ *     [com.tinkernorth.dish.source.sensor.PhysicalMotionSource] register
+ *     sensor listeners at all (gyro listeners are a measurable battery cost);
+ *   - what the on-screen motion pill renders.
+ *
+ * Three orthogonal facts, combined into [MotionCapability.effective]:
+ *
+ *   - [MotionCapability.hasGyro] — the hardware exists. Virtual slot: the
+ *     phone has a gyroscope (see [PhoneMotionAvailability]). Physical slot:
+ *     the pad has a per-device gyroscope (see
+ *     [com.tinkernorth.dish.source.sensor.PhysicalMotionProbe], cached on
+ *     [PhysicalGamepadRegistry.Device.hasGyro]).
+ *   - [MotionCapability.carriesOnConnection] — the bound connection has a
+ *     `MSG_MOTION` channel. Satellite does; Bluetooth-HID does not.
+ *   - [MotionCapability.userEnabled] — the user wants motion on for this
+ *     slot. Defaults to true; flipped by the per-slot toggle wired in a
+ *     subsequent PR (the `MotionEnabledStore`).
+ *
+ * **Why a composer:** these are pure derivations from
+ * [PhoneMotionAvailability], [PhysicalGamepadRegistry], [ConnectionHub]
+ * `bindings` + `connections`. No new lifecycle, no events — exactly the shape
+ * [AbstractComposer] exists for. Threading the same `MotionCapability` value
+ * through every consumer keeps "is motion on for this slot" un-divergeable.
+ */
+data class MotionCapability(
+    /** Hardware reports a gyroscope on the device backing this slot. */
+    val hasGyro: Boolean,
+    /** Bound connection is a satellite session (BT-HID has no `MSG_MOTION`). */
+    val carriesOnConnection: Boolean,
+    /**
+     * User has motion enabled for this slot. Stub-true until the
+     * `MotionEnabledStore` lands in the next PR; the field is here from the
+     * start so downstream call sites can already read it.
+     */
+    val userEnabled: Boolean = true,
+) {
+    /**
+     * True iff motion samples should both be captured AND would actually reach
+     * the satellite for this slot. The same boolean drives the wire `CAP_MOTION`
+     * bit (paired with [userEnabled] so that flipping the user toggle drops the
+     * advertisement) and the sensor-listener gate.
+     */
+    val effective: Boolean get() = hasGyro && carriesOnConnection && userEnabled
+
+    /**
+     * The `CAP_MOTION` (0x0004) bit the dish should advertise at
+     * `MSG_CONTROLLER_ADD` for this slot. Note that this is **not** gated on
+     * [carriesOnConnection]: the capability describes the *dish*, not the
+     * link, and we want a satellite re-connect to recover motion without a
+     * re-handshake. It IS gated on [userEnabled] because flipping the toggle
+     * is a meaningful change to what the dish will emit.
+     */
+    fun toCapBits(): Int = if (hasGyro && userEnabled) CAP_MOTION_BIT else 0
+
+    companion object {
+        /** Mirror of `satellite/src/core/types.h::CAP_MOTION`. */
+        const val CAP_MOTION_BIT: Int = 0x0004
+
+        /** Initial value before any upstream resolves — nothing is capable yet. */
+        val Off = MotionCapability(hasGyro = false, carriesOnConnection = false)
+    }
+}
+
+/**
+ * `Map<slotId, MotionCapability>` for every slot the user can currently see —
+ * the virtual touch slot (always present) plus every attached physical pad.
+ *
+ * A slot present in the map means we have a coherent capability snapshot for
+ * it. A slot absent from the map means the registry doesn't see it (e.g. a
+ * physical pad in the disconnect-grace window after a USB jiggle).
+ */
+@Singleton
+class MotionCapabilityComposer
+    @Inject
+    constructor(
+        private val phoneAvailability: PhoneMotionAvailability,
+        private val registry: PhysicalGamepadRegistry,
+        private val hub: ConnectionHub,
+        scope: CoroutineScope,
+    ) : AbstractComposer<Map<String, MotionCapability>>(scope, emptyMap()) {
+        override fun upstream(): Flow<Map<String, MotionCapability>> =
+            combine(
+                phoneAvailability.state,
+                registry.devices,
+                hub.bindings,
+                hub.connections,
+            ) { phoneHasGyro, devices, bindings, summaries ->
+                val byId = summaries.associateBy { it.id }
+                val out = HashMap<String, MotionCapability>(devices.size + 1)
+
+                // Virtual slot — always present so the touch overlay always
+                // has a capability entry to read, even when no satellite is up.
+                out[VIRTUAL_SLOT_ID] =
+                    MotionCapability(
+                        hasGyro = phoneHasGyro,
+                        carriesOnConnection = carriesMotion(VIRTUAL_SLOT_ID, bindings, byId),
+                    )
+
+                // Physical pads.
+                for ((deviceId, device) in devices) {
+                    val slotId = deviceId.toString()
+                    out[slotId] =
+                        MotionCapability(
+                            hasGyro = device.hasGyro,
+                            carriesOnConnection = carriesMotion(slotId, bindings, byId),
+                        )
+                }
+                out
+            }
+
+        /**
+         * Resolve `slotId → bound-connection-summary → kind == SATELLITE &&
+         * live`. Returns false for any unbound or non-satellite slot. The
+         * `Connected` check is deliberate: a satellite that is `Connecting` or
+         * `Unstable` can't currently sink motion, so the pill reading should
+         * reflect that, AND the registration cap bit should still claim
+         * `CAP_MOTION` (the dish is capable, the link is just temporarily
+         * down) — `toCapBits()` does not consult `carriesOnConnection`.
+         */
+        private fun carriesMotion(
+            slotId: String,
+            bindings: Map<String, String>,
+            summariesById: Map<String, ConnectionSummary>,
+        ): Boolean {
+            val cid = bindings[slotId] ?: return false
+            val summary = summariesById[cid] ?: return false
+            return summary.kind == ConnectionKind.SATELLITE &&
+                summary.live == LinkState.Connected
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistry.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistry.kt
@@ -9,6 +9,7 @@ import android.util.Log
 import android.view.InputDevice
 import android.view.MotionEvent
 import com.tinkernorth.dish.core.jni.SatelliteNative
+import com.tinkernorth.dish.source.sensor.PhysicalMotionProbe
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -46,11 +47,21 @@ class PhysicalGamepadRegistry
          *   "false disconnect") doesn't free the server-side controller index
          *   and force a re-register. `null` means the device is currently
          *   present.
+         * @property hasGyro true iff the per-device sensor API
+         *   ([android.view.InputDevice.getSensorManager], API 31+) reports a
+         *   gyroscope for this pad. Computed once at add time via
+         *   [com.tinkernorth.dish.source.sensor.PhysicalMotionProbe] and read
+         *   by [com.tinkernorth.dish.composer.MotionCapabilityComposer] to
+         *   decide the per-slot `CAP_MOTION` bit, and by
+         *   [com.tinkernorth.dish.source.sensor.PhysicalMotionSource] to
+         *   decide whether to register sensor listeners. A controller without
+         *   a gyro keeps this `false` for its whole lifetime in the registry.
          */
         data class Device(
             val id: Int,
             val name: String,
             val disconnectingTimeLeftSec: Int? = null,
+            val hasGyro: Boolean = false,
         ) {
             val isDisconnecting: Boolean get() = disconnectingTimeLeftSec != null
         }
@@ -88,7 +99,7 @@ class PhysicalGamepadRegistry
                 val dev = InputDevice.getDevice(id) ?: continue
                 if (!isGamepad(dev)) continue
                 pushDeadzones(dev)
-                next[id] = Device(id, dev.name)
+                next[id] = Device(id, dev.name, hasGyro = PhysicalMotionProbe.hasGyro(id))
             }
             _devices.value = next
         }
@@ -98,7 +109,9 @@ class PhysicalGamepadRegistry
             if (!isGamepad(dev)) return
             pushDeadzones(dev)
             cancelDisconnect(deviceId)
-            _devices.value = _devices.value + (deviceId to Device(deviceId, dev.name))
+            _devices.value =
+                _devices.value +
+                    (deviceId to Device(deviceId, dev.name, hasGyro = PhysicalMotionProbe.hasGyro(deviceId)))
         }
 
         override fun onInputDeviceRemoved(deviceId: Int) {
@@ -121,7 +134,12 @@ class PhysicalGamepadRegistry
             cancelDisconnect(deviceId)
             val current = _devices.value[deviceId]
             if (current == null || current.name != dev.name || current.isDisconnecting) {
-                _devices.value = _devices.value + (deviceId to Device(deviceId, dev.name))
+                // Re-probe in case capabilities changed (rare in practice, but
+                // a USB pad swapping firmware between detach/attach cycles can
+                // change its sensor exposure — and the probe is cheap).
+                _devices.value =
+                    _devices.value +
+                        (deviceId to Device(deviceId, dev.name, hasGyro = PhysicalMotionProbe.hasGyro(deviceId)))
             }
         }
 

--- a/app/src/main/java/com/tinkernorth/dish/source/sensor/PhoneMotionAvailability.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/sensor/PhoneMotionAvailability.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.sensor
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorManager
+import com.tinkernorth.dish.architecture.abstracts.AbstractStateSource
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Process-scoped fact: does the phone itself have a usable gyroscope?
+ *
+ * The activity-scoped [PhoneMotionSource] already exposes this as its
+ * `isAvailable` property, but the satellite registration path and the
+ * [com.tinkernorth.dish.composer.MotionCapabilityComposer] need the same fact
+ * *without* an overlay being on screen — capability negotiation at controller
+ * add time happens long before the overlay activity is constructed.
+ *
+ * Implemented as an [AbstractStateSource]`<Boolean>` so it composes through the
+ * existing `state` flow plumbing. The value is computed once at injection time
+ * because Android device hardware does not change at runtime; the source still
+ * extends the base class purely so consumers can `.state.collect { … }`
+ * uniformly with the other availability flows.
+ */
+@Singleton
+class PhoneMotionAvailability
+    @Inject
+    constructor(
+        @ApplicationContext context: Context,
+    ) : AbstractStateSource<Boolean>(initialState = false) {
+        init {
+            val sm = context.getSystemService(Context.SENSOR_SERVICE) as? SensorManager
+            val hasGyro = sm?.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null
+            setState(hasGyro)
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalMotionProbe.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalMotionProbe.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.sensor
+
+import android.hardware.Sensor
+import android.os.Build
+import android.view.InputDevice
+
+/**
+ * One-shot capability probe: does this physical gamepad expose a gyroscope
+ * through Android's per-device sensor API?
+ *
+ * Pulled out of [PhysicalMotionSource] so the same probe can populate
+ * [com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry.Device.hasGyro]
+ * once at device-add time. That fact is then read by
+ * [com.tinkernorth.dish.composer.MotionCapabilityComposer] to decide whether
+ * to advertise `CAP_MOTION` for a slot, and by [PhysicalMotionSource] to
+ * decide whether to register sensor listeners — without each call site re-doing
+ * the API-31 / null-sensor dance.
+ *
+ * The probe is API-gated: [InputDevice.getSensorManager] is API 31+. Below
+ * that, per-device sensors are not exposed by the platform and a pad's IMU is
+ * unreachable from the app regardless of hardware.
+ *
+ * **Testability:** the pure decision (given an SDK level and an
+ * `InputDevice`, does it have a gyro?) is exposed as [evaluate], so unit
+ * tests don't have to stub `Build.VERSION.SDK_INT` via reflection.
+ * [hasGyro] is the wrapper that resolves both inputs from the live OS.
+ */
+object PhysicalMotionProbe {
+    /**
+     * Returns true iff the device with [deviceId] is currently attached and
+     * its per-device [android.hardware.SensorManager] reports a
+     * [Sensor.TYPE_GYROSCOPE] sensor. Returns false on API < 31, on an
+     * unknown device id, or on a pad with no IMU surface — all of which are
+     * legitimate "not motion-capable" outcomes, not errors.
+     */
+    fun hasGyro(deviceId: Int): Boolean = evaluate(Build.VERSION.SDK_INT, InputDevice.getDevice(deviceId))
+
+    /**
+     * Pure variant: returns true iff [sdkInt] is API 31+ and [device] has a
+     * gyroscope on its per-device [android.hardware.SensorManager]. The
+     * [InputDevice] is still queried (not a pure data class), but the SDK
+     * gate is parameterised so unit tests can drive every branch from a JVM
+     * without reflection on the system constants.
+     */
+    fun evaluate(
+        sdkInt: Int,
+        device: InputDevice?,
+    ): Boolean {
+        if (sdkInt < Build.VERSION_CODES.S) return false
+        if (device == null) return false
+        return device.sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/composer/MotionCapabilityComposerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/MotionCapabilityComposerTest.kt
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.composer
+
+import com.tinkernorth.dish.architecture.testing.composerTest
+import com.tinkernorth.dish.architecture.testing.probe
+import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
+import com.tinkernorth.dish.source.sensor.PhoneMotionAvailability
+import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [MotionCapabilityComposer] — the per-slot
+ * `MotionCapability` map that drives the `CAP_MOTION` bit at registration
+ * time, the sensor-listener gating, and the on-screen pill.
+ *
+ * Headline regressions pinned here:
+ *
+ *  - The virtual slot is *always present in the map* (key
+ *    [VIRTUAL_SLOT_ID]), regardless of whether any physical pad is attached
+ *    or any satellite is up. This is the bit the overlay reads at construct
+ *    time; if it weren't there, the pill would flicker UNAVAILABLE until the
+ *    first hub emission.
+ *  - `hasGyro` for a physical slot comes from
+ *    [PhysicalGamepadRegistry.Device.hasGyro] verbatim — not re-probed by
+ *    the composer (the probe is at device-add time, not on the hot
+ *    capability-flow path).
+ *  - `carriesOnConnection` is `kind == SATELLITE && live == Connected`,
+ *    nothing else. Bluetooth-HID, Connecting, Unstable all resolve to false.
+ *  - `toCapBits()` does *not* gate on `carriesOnConnection` — a satellite
+ *    re-connect must not require a re-handshake to recover motion.
+ */
+class MotionCapabilityComposerTest {
+    private fun summary(
+        id: String,
+        kind: ConnectionKind = ConnectionKind.SATELLITE,
+        live: LinkState = LinkState.Connected,
+    ) = ConnectionSummary(
+        id = id,
+        kind = kind,
+        label = id,
+        detail = "",
+        live = live,
+        boundSlotIds = emptyList(),
+    )
+
+    private fun device(
+        id: Int,
+        hasGyro: Boolean,
+    ) = PhysicalGamepadRegistry.Device(id, "Pad-$id", hasGyro = hasGyro)
+
+    /** Build a composer with mockable upstreams. */
+    private fun composerFor(
+        phoneAvailable: MutableStateFlow<Boolean>,
+        devices: MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>,
+        bindings: MutableStateFlow<Map<String, String>>,
+        connections: MutableStateFlow<List<ConnectionSummary>>,
+        scope: CoroutineScope,
+    ): MotionCapabilityComposer {
+        val availability: PhoneMotionAvailability =
+            mockk { every { state } returns phoneAvailable }
+        val registry: PhysicalGamepadRegistry =
+            mockk { every { this@mockk.devices } returns devices }
+        val hub: ConnectionHub =
+            mockk {
+                every { this@mockk.bindings } returns bindings
+                every { this@mockk.connections } returns connections
+            }
+        return MotionCapabilityComposer(availability, registry, hub, scope)
+    }
+
+    // ── Pure data-class invariants ──────────────────────────────────────
+
+    @Test
+    fun `effective requires every axis true`() {
+        // All-true is the only effective state. The three booleans are
+        // orthogonal — exhaustively check the false-leaning cases.
+        assertTrue(
+            MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = true).effective,
+        )
+        assertFalse(
+            MotionCapability(hasGyro = false, carriesOnConnection = true, userEnabled = true).effective,
+        )
+        assertFalse(
+            MotionCapability(hasGyro = true, carriesOnConnection = false, userEnabled = true).effective,
+        )
+        assertFalse(
+            MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = false).effective,
+        )
+    }
+
+    @Test
+    fun `toCapBits returns CAP_MOTION when the dish CAN emit motion`() {
+        // The CAP bit describes the dish's *capability*, not the live link.
+        // A connected, gyro-equipped, user-enabled slot ⇒ CAP_MOTION.
+        val cap = MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = true)
+        assertEquals(MotionCapability.CAP_MOTION_BIT, cap.toCapBits())
+    }
+
+    @Test
+    fun `toCapBits ignores carriesOnConnection — link-down is not a capability change`() {
+        // A satellite that is momentarily Connecting / Unstable must not flip
+        // the cap bit — otherwise every reconnect would force an unregister /
+        // re-register round trip. The cap bit only depends on hasGyro AND
+        // userEnabled.
+        val cap = MotionCapability(hasGyro = true, carriesOnConnection = false, userEnabled = true)
+        assertEquals(MotionCapability.CAP_MOTION_BIT, cap.toCapBits())
+    }
+
+    @Test
+    fun `toCapBits is zero when the user has disabled motion`() {
+        // Flipping the user toggle off is a real capability change — the
+        // dish stops emitting motion, so it should stop advertising CAP_MOTION.
+        val cap = MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = false)
+        assertEquals(0, cap.toCapBits())
+    }
+
+    @Test
+    fun `toCapBits is zero on hardware without a gyro — even if the user enabled it`() {
+        // No gyro means no motion, period; never lie to the receiver.
+        val cap = MotionCapability(hasGyro = false, carriesOnConnection = true, userEnabled = true)
+        assertEquals(0, cap.toCapBits())
+    }
+
+    // ── Composer derivation ──────────────────────────────────────────────
+
+    @Test
+    fun `virtual slot is always present in the map`() =
+        composerTest {
+            // No physical pads, no satellite — the touch overlay still has a
+            // capability entry to read at construct time. This is the pill's
+            // first-paint contract.
+            val phoneAvail = MutableStateFlow(false)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow<Map<String, String>>(emptyMap())
+            val conns = MutableStateFlow<List<ConnectionSummary>>(emptyList())
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+
+            val virtual = probe.latest[VIRTUAL_SLOT_ID]
+            assertEquals(
+                MotionCapability(hasGyro = false, carriesOnConnection = false, userEnabled = true),
+                virtual,
+            )
+        }
+
+    @Test
+    fun `virtual slot hasGyro mirrors PhoneMotionAvailability`() =
+        composerTest {
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow<Map<String, String>>(emptyMap())
+            val conns = MutableStateFlow<List<ConnectionSummary>>(emptyList())
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertEquals(true, probe.latest[VIRTUAL_SLOT_ID]?.hasGyro)
+
+            // Flip the source's value — the composer must re-derive.
+            phoneAvail.value = false
+            testScheduler.runCurrent()
+            assertEquals(false, probe.latest[VIRTUAL_SLOT_ID]?.hasGyro)
+        }
+
+    @Test
+    fun `virtual slot carriesOnConnection is true when bound to a Connected satellite`() =
+        composerTest {
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "sat-A"))
+            val conns = MutableStateFlow(listOf(summary("sat-A")))
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertTrue(probe.latest[VIRTUAL_SLOT_ID]?.carriesOnConnection == true)
+        }
+
+    @Test
+    fun `virtual slot carriesOnConnection is false on a Bluetooth-HID binding`() =
+        composerTest {
+            // BT-HID has no MSG_MOTION channel, so the pill must read
+            // NOT_FORWARDED. The composer's carriesOnConnection is the truth
+            // table's gate.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "bt-A"))
+            val conns = MutableStateFlow(listOf(summary("bt-A", kind = ConnectionKind.BLUETOOTH)))
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertFalse(probe.latest[VIRTUAL_SLOT_ID]?.carriesOnConnection == true)
+        }
+
+    @Test
+    fun `virtual slot carriesOnConnection is false while still Connecting`() =
+        composerTest {
+            // A satellite that hasn't reached Connected yet can't sink
+            // motion. The cap bit doesn't gate on this; the pill does.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "sat-A"))
+            val conns = MutableStateFlow(listOf(summary("sat-A", live = LinkState.Connecting)))
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertFalse(probe.latest[VIRTUAL_SLOT_ID]?.carriesOnConnection == true)
+        }
+
+    @Test
+    fun `physical slot uses Device hasGyro verbatim — no re-probe`() =
+        composerTest {
+            // The composer never calls PhysicalMotionProbe itself; the truth
+            // is whatever the registry recorded at add time. This pin
+            // catches a regression where someone "helpfully" re-probes on
+            // every emission and slows the hot capability-flow path.
+            val phoneAvail = MutableStateFlow(false)
+            val devices =
+                MutableStateFlow(
+                    mapOf(
+                        9 to device(9, hasGyro = true),
+                        11 to device(11, hasGyro = false),
+                    ),
+                )
+            val bindings = MutableStateFlow<Map<String, String>>(emptyMap())
+            val conns = MutableStateFlow<List<ConnectionSummary>>(emptyList())
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertEquals(true, probe.latest["9"]?.hasGyro)
+            assertEquals(false, probe.latest["11"]?.hasGyro)
+        }
+
+    @Test
+    fun `physical slot drops from the map when the device leaves the registry`() =
+        composerTest {
+            // The registry's disconnect grace removes Devices from its flow
+            // when the grace expires. The composer must drop the slot too,
+            // not stash a stale "still capable" entry.
+            val phoneAvail = MutableStateFlow(false)
+            val devices = MutableStateFlow(mapOf(9 to device(9, hasGyro = true)))
+            val bindings = MutableStateFlow<Map<String, String>>(emptyMap())
+            val conns = MutableStateFlow<List<ConnectionSummary>>(emptyList())
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertEquals(true, probe.latest["9"]?.hasGyro)
+
+            devices.value = emptyMap()
+            testScheduler.runCurrent()
+            assertNull(probe.latest["9"])
+        }
+
+    @Test
+    fun `the map re-emits when the routing flips kind from satellite to bluetooth`() =
+        composerTest {
+            // Mid-game the user changes a slot from satellite to BT-HID. The
+            // capability for that slot must flip carriesOnConnection from
+            // true → false on the next emission.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow(mapOf(9 to device(9, hasGyro = true)))
+            val bindings = MutableStateFlow(mapOf("9" to "sat-A"))
+            val conns = MutableStateFlow(listOf(summary("sat-A")))
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertTrue(probe.latest["9"]?.carriesOnConnection == true)
+
+            bindings.value = mapOf("9" to "bt-A")
+            conns.value = listOf(summary("bt-A", kind = ConnectionKind.BLUETOOTH))
+            testScheduler.runCurrent()
+            assertFalse(probe.latest["9"]?.carriesOnConnection == true)
+        }
+}

--- a/app/src/test/java/com/tinkernorth/dish/source/sensor/PhoneMotionAvailabilityTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/sensor/PhoneMotionAvailabilityTest.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.sensor
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorManager
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [PhoneMotionAvailability] — the process-scoped "does the
+ * phone itself have a gyro?" fact. The value is decided once at injection
+ * time (Android device hardware does not change at runtime), so the tests
+ * just pin: gyro present ⇒ true, gyro absent ⇒ false, SENSOR_SERVICE absent
+ * ⇒ false. The state flow exposing those values is the same shape every
+ * [com.tinkernorth.dish.architecture.abstracts.AbstractStateSource] subclass
+ * uses; the base class is covered by `StateSourceProbeSampleTest`.
+ */
+class PhoneMotionAvailabilityTest {
+    private fun contextWithSensor(sensor: Sensor?): Context {
+        val sm =
+            mockk<SensorManager> {
+                every { getDefaultSensor(Sensor.TYPE_GYROSCOPE) } returns sensor
+            }
+        return mockk { every { getSystemService(Context.SENSOR_SERVICE) } returns sm }
+    }
+
+    @Test
+    fun `phone with a gyroscope is motion-available`() {
+        val src = PhoneMotionAvailability(contextWithSensor(mockk()))
+        assertTrue(src.state.value)
+    }
+
+    @Test
+    fun `phone without a gyroscope is not motion-available`() {
+        // Tablets, very cheap phones, some kiosk hardware — the touch
+        // overlay should show "Motion: not available", and the satellite
+        // CAP_MOTION advertisement must not lie.
+        val src = PhoneMotionAvailability(contextWithSensor(sensor = null))
+        assertFalse(src.state.value)
+    }
+
+    @Test
+    fun `null SENSOR_SERVICE falls through to not-available, does not throw`() {
+        // Robolectric- or stub-flavoured Contexts can return null for system
+        // services; the source defends so the app never NPEs at startup.
+        val ctx =
+            mockk<Context> {
+                every { getSystemService(Context.SENSOR_SERVICE) } returns null
+            }
+        val src = PhoneMotionAvailability(ctx)
+        assertFalse(src.state.value)
+    }
+
+    @Test
+    fun `state flow exposes the same boolean as state value`() {
+        // The composer subscribes via .state.collect — assert the StateFlow's
+        // current value matches what the property reports.
+        val src = PhoneMotionAvailability(contextWithSensor(mockk()))
+        assertEquals(src.state.value, src.state.value)
+        assertTrue(src.state.value)
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/source/sensor/PhysicalMotionProbeTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/sensor/PhysicalMotionProbeTest.kt
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.sensor
+
+import android.hardware.Sensor
+import android.hardware.SensorManager
+import android.os.Build
+import android.view.InputDevice
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [PhysicalMotionProbe.evaluate] — the pure decision exercised
+ * directly. The thin `hasGyro(deviceId)` wrapper is just `evaluate(SDK_INT,
+ * InputDevice.getDevice(id))`, so pinning the four cases here covers both.
+ *
+ * `Build.VERSION_CODES.S` is referenced as the threshold; the test makes both
+ * sides of that threshold explicit so a future API bump that nudges the
+ * constant is still caught.
+ */
+class PhysicalMotionProbeTest {
+    private val gyro: Sensor = mockk(relaxed = true)
+
+    private fun deviceWithGyro(): InputDevice {
+        val sm =
+            mockk<SensorManager> {
+                every { getDefaultSensor(Sensor.TYPE_GYROSCOPE) } returns gyro
+            }
+        return mockk { every { sensorManager } returns sm }
+    }
+
+    private fun deviceWithoutGyro(): InputDevice {
+        val sm =
+            mockk<SensorManager> {
+                every { getDefaultSensor(Sensor.TYPE_GYROSCOPE) } returns null
+            }
+        return mockk { every { sensorManager } returns sm }
+    }
+
+    @Test
+    fun `returns false on API below 31 — per-device sensor API does not exist`() {
+        // Even a pad with a real IMU can't be reached pre-API 31, so the
+        // probe must say no. Use SDK_INT - 1 (one below S) explicitly.
+        assertFalse(PhysicalMotionProbe.evaluate(sdkInt = 30, device = deviceWithGyro()))
+    }
+
+    @Test
+    fun `returns false when the InputDevice is null`() {
+        // A device that was unplugged between the InputManager callback and
+        // the probe call must resolve to "no gyro" without throwing.
+        assertFalse(PhysicalMotionProbe.evaluate(sdkInt = Build.VERSION_CODES.S, device = null))
+    }
+
+    @Test
+    fun `returns false when the pad has no gyroscope sensor`() {
+        // A cheap Bluetooth pad on API 31+ — the per-device SensorManager
+        // exists but reports no TYPE_GYROSCOPE.
+        assertFalse(
+            PhysicalMotionProbe.evaluate(
+                sdkInt = Build.VERSION_CODES.S,
+                device = deviceWithoutGyro(),
+            ),
+        )
+    }
+
+    @Test
+    fun `returns true when API 31+ and the pad reports a gyroscope`() {
+        // The success path — DualSense or similar with an IMU.
+        assertTrue(
+            PhysicalMotionProbe.evaluate(
+                sdkInt = Build.VERSION_CODES.S,
+                device = deviceWithGyro(),
+            ),
+        )
+    }
+
+    @Test
+    fun `is stable across higher SDK levels — does not regress past API 31`() {
+        // Future API bumps must not silently turn the gate back off; pin a
+        // higher SDK level too so a typo in the threshold check is caught.
+        assertTrue(
+            PhysicalMotionProbe.evaluate(
+                sdkInt = Build.VERSION_CODES.S + 5,
+                device = deviceWithGyro(),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Foundation PR for fixing the gyro/IMU flow. Pure plumbing — **no
behaviour changes** in this PR; the wiring lands in follow-up PRs so
the abstractions can be reviewed cleanly.

Introduces four new things that the rest of the motion-fix series
depends on:

- **`PhoneMotionAvailability`** — process-scoped `AbstractStateSource<Boolean>`
  that answers "does this phone have a gyroscope?" so the satellite
  registration path and the capability composer can read the fact
  without an overlay being on screen.
- **`PhysicalMotionProbe`** — pure-function gyro probe for a physical
  pad, split into `evaluate(sdkInt, device)` + a thin Android wrapper
  so the four decision branches (API < 31, null device, no gyro
  sensor, has gyro) are unit-testable from a JVM without reflecting
  on `Build.VERSION`.
- **`PhysicalGamepadRegistry.Device.hasGyro`** — populated at
  device-add / device-changed time via `PhysicalMotionProbe`. The hot
  capability flow reads this cached value rather than re-probing per
  emission.
- **`MotionCapabilityComposer`** — `Map<slotId, MotionCapability>`
  derived from `PhoneMotionAvailability` + `PhysicalGamepadRegistry
  .devices` + hub bindings/connections. Always emits an entry for
  `VIRTUAL_SLOT_ID` so the touch overlay's motion pill has a value
  to read at construct time. `MotionCapability` carries `hasGyro` /
  `carriesOnConnection` / `userEnabled` with `effective` and
  `toCapBits()` helpers.

  Critically: `toCapBits()` does **not** gate on `carriesOnConnection`
  — a satellite reconnect must not force a re-handshake to recover
  motion. `userEnabled` defaults to true until the per-slot toggle
  store lands in PR2.

## What this is *not* doing

- Not wiring `MotionCapabilityComposer` into
  `SatelliteConnection.registerController` yet (replaces the
  hardcoded `DEFAULT_CAPABILITIES = ANALOG | RUMBLE | CAP_MOTION`) —
  that's PR3.
- Not gating `PhoneMotionSource.start` on `effective` — also PR3.
- Not adding the user-facing motion toggle — PR2.

Splitting these keeps each PR readable.

## Test plan

22 new unit tests across three test classes (all passing locally; full
617-test suite green):

- `PhysicalMotionProbeTest` (5) — API-gate branches, null device, no
  gyro, has gyro, stability across future SDKs.
- `PhoneMotionAvailabilityTest` (4) — gyro present/absent, null
  `SENSOR_SERVICE` defence, `StateFlow` parity.
- `MotionCapabilityComposerTest` (13) — the `effective` truth table,
  every `toCapBits()` branch (incl. the "link-down is not a
  capability change" invariant), virtual-slot-always-present,
  hasGyro mirroring availability, BT-HID kind gate, Connecting live
  gate, Device.hasGyro-verbatim (no re-probe), slot drop on
  registry departure, kind-flip mid-session re-emission.

- [x] `./gradlew :app:compileDebugKotlin` — passes
- [x] `./gradlew :app:testDebugUnitTest` — 617/617 pass