### PR TITLE
feat(motion): per-slot motion toggle — durable + reactive

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/repository/MotionPreferenceRepository.kt
+++ b/app/src/main/java/com/tinkernorth/dish/repository/MotionPreferenceRepository.kt
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.repository
+
+import android.content.Context
+import com.tinkernorth.dish.architecture.interfaces.KeyedRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Durable per-slot motion preference: should the user-facing "stream gyro"
+ * toggle be on for this slot?
+ *
+ * **Why per-slot, not global:** a player may have a DualSense pad (motion
+ * great for shooters) routed to one satellite and an Xbox-typed virtual
+ * controller (motion not useful) routed to another. The receiver-side
+ * "Xbox virtual pads have no IMU surface" reality (see satellite
+ * `vigem_adapter.cpp::submitMotion`) makes a global toggle wrong by
+ * default. Per-slot lets the same dish be honest about each slot.
+ *
+ * **Absence semantics:** [get] returns null when the slot has never been
+ * touched. Callers ([MotionEnabledStore]) collapse null onto a global
+ * default (currently true — "motion on unless I turned it off"). The
+ * repository itself does NOT bake in the default; that's a policy
+ * decision that belongs in the in-memory store.
+ *
+ * Storage shape: single `SharedPreferences` entry holding a JSON list of
+ * `MotionPreference` records. The same shape and write-lock discipline as
+ * [RememberedSatelliteRepository] — see that file for the rationale.
+ */
+@Serializable
+data class MotionPreference(
+    /** Slot id — `VIRTUAL_SLOT_ID` for the touch overlay, or the integer-as-string `InputDevice` id for a physical pad. */
+    val slotId: String,
+    /** True ⇒ the dish should stream motion for this slot when otherwise capable. */
+    val enabled: Boolean,
+)
+
+@Singleton
+class MotionPreferenceRepository
+    @Inject
+    constructor(
+        @ApplicationContext context: Context,
+        private val json: Json,
+    ) : KeyedRepository<String, MotionPreference> {
+        private val prefs by lazy {
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        }
+        private val writeLock = Any()
+
+        override fun keyOf(value: MotionPreference): String = value.slotId
+
+        override fun get(key: String): MotionPreference? = all().firstOrNull { it.slotId == key }
+
+        override fun all(): List<MotionPreference> {
+            val raw = prefs.getString(KEY_LIST, null) ?: return emptyList()
+            return runCatching {
+                json.decodeFromString(ListSerializer(MotionPreference.serializer()), raw)
+            }.getOrDefault(emptyList())
+        }
+
+        override fun put(
+            key: String,
+            value: MotionPreference,
+        ) {
+            synchronized(writeLock) {
+                val list = all().toMutableList()
+                list.removeAll { it.slotId == key }
+                list += value
+                persist(list)
+            }
+        }
+
+        override fun remove(key: String) {
+            synchronized(writeLock) {
+                val list = all().filterNot { it.slotId == key }
+                persist(list)
+            }
+        }
+
+        override fun clear() {
+            synchronized(writeLock) {
+                prefs.edit().remove(KEY_LIST).apply()
+            }
+        }
+
+        private fun persist(list: List<MotionPreference>) {
+            val raw = json.encodeToString(ListSerializer(MotionPreference.serializer()), list)
+            prefs.edit().putString(KEY_LIST, raw).apply()
+        }
+
+        private companion object {
+            const val PREFS_NAME = "motion_preferences"
+            const val KEY_LIST = "preferences"
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/source/store/MotionEnabledStore.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/store/MotionEnabledStore.kt
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.store
+
+import com.tinkernorth.dish.architecture.abstracts.AbstractStateSource
+import com.tinkernorth.dish.repository.MotionPreference
+import com.tinkernorth.dish.repository.MotionPreferenceRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Process-scoped reactive mirror of the durable
+ * [MotionPreferenceRepository]: `slotId → enabled`.
+ *
+ * The repository is the durable source of truth; this store hydrates from
+ * it on construction and republishes every write as a `StateFlow` so the
+ * [com.tinkernorth.dish.composer.MotionCapabilityComposer] (and the UI) can
+ * react without re-reading SharedPreferences on every frame.
+ *
+ * **Pattern:** [AbstractStateSource]`<Map<String, Boolean>>` — same shape
+ * as [ControllerTypeStore]. The two stores are parallel "reactive
+ * in-memory cache over a persisted choice" types; if you grow another one
+ * (per-slot rumble strength etc.), copy this file.
+ *
+ * **Default policy:** [isEnabled] collapses an absent entry onto
+ * [DEFAULT_ENABLED] (true). The product decision is "motion on unless the
+ * user turned it off" — discoverable via the indicator pill, recoverable
+ * via the toggle. The repository deliberately does not bake the default in
+ * (an absent entry is semantically different from `enabled=true`), so
+ * downstream consumers consult [isEnabled] rather than the raw map.
+ */
+@Singleton
+class MotionEnabledStore
+    @Inject
+    constructor(
+        private val repo: MotionPreferenceRepository,
+    ) : AbstractStateSource<Map<String, Boolean>>(initialState = emptyMap()) {
+        init {
+            // Hydrate once on construction. Subsequent durable changes flow
+            // through this store (setEnabled below), so it stays in sync.
+            setState(repo.all().associate { it.slotId to it.enabled })
+        }
+
+        /**
+         * Persist the user's choice for [slotId] and republish. Writes are
+         * synchronous to disk via SharedPreferences' edit().apply() (which
+         * commits the in-memory map immediately and persists asynchronously).
+         */
+        fun setEnabled(
+            slotId: String,
+            enabled: Boolean,
+        ) {
+            repo.put(MotionPreference(slotId = slotId, enabled = enabled))
+            setState { it + (slotId to enabled) }
+        }
+
+        /**
+         * Resolve the effective enabled boolean for [slotId], collapsing an
+         * absent entry onto [DEFAULT_ENABLED]. Use this — not the raw map
+         * — wherever the consumer cares about effective behaviour.
+         */
+        fun isEnabled(slotId: String): Boolean = state.value[slotId] ?: DEFAULT_ENABLED
+
+        /**
+         * Forget the user's choice for [slotId] (revert to default). Used
+         * when a physical pad is unbound permanently — keeping a stale
+         * entry forever would silently override the default for a future
+         * unrelated device that happened to get the same `InputDevice` id.
+         */
+        fun forget(slotId: String) {
+            repo.remove(slotId)
+            setState { it - slotId }
+        }
+
+        companion object {
+            /**
+             * Product default: motion is on for any slot that has not been
+             * explicitly toggled off. Surfaced as a constant so the composer
+             * and tests can pin the same value.
+             */
+            const val DEFAULT_ENABLED: Boolean = true
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
@@ -13,6 +13,7 @@ import com.tinkernorth.dish.source.connection.ConnectionEvent
 import com.tinkernorth.dish.source.connection.SatelliteConnection
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.store.BatteryStatusStore
+import com.tinkernorth.dish.source.store.MotionEnabledStore
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -45,7 +46,20 @@ class MainViewModel
         val hub: ConnectionHub,
         private val gamepadRegistry: PhysicalGamepadRegistry,
         private val batteryStatusStore: BatteryStatusStore,
+        private val motionEnabledStore: MotionEnabledStore,
     ) : ViewModel() {
+        /**
+         * Reactive `slotId -> enabled` map for the per-slot motion toggle.
+         * Hydrated at process start from [MotionEnabledStore]'s durable
+         * backing repo, so the dashboard renders yesterday's toggle state
+         * with no first-frame flicker.
+         *
+         * Absence from the map means "user has not toggled" — call sites
+         * use [isMotionEnabled] to apply the default rather than reading
+         * the map directly.
+         */
+        val motionEnabled: StateFlow<Map<String, Boolean>> = motionEnabledStore.state
+
         private val _uiState = MutableStateFlow(MainUiState())
         val uiState: StateFlow<MainUiState> = _uiState.asStateFlow()
 
@@ -131,4 +145,34 @@ class MainViewModel
         ) {
             hub.setSatelliteControllerType(connectionId, slotId, type)
         }
+
+        // ── Motion toggle ─────────────────────────────────────────────────────
+
+        /**
+         * Persist the user's per-slot motion preference. The store writes
+         * through to the durable [com.tinkernorth.dish.repository.MotionPreferenceRepository]
+         * AND republishes its state flow so the
+         * [com.tinkernorth.dish.composer.MotionCapabilityComposer] (wired
+         * in a follow-up PR) re-derives the slot's `CAP_MOTION` bit and
+         * the sensor-listener gate flips on the next emission.
+         *
+         * No-op semantics: writing the same value twice is harmless;
+         * the store still re-emits so any downstream observer that
+         * relies on identity equality (none today) is unaffected.
+         */
+        fun setMotionEnabled(
+            slotId: String,
+            enabled: Boolean,
+        ) {
+            motionEnabledStore.setEnabled(slotId, enabled)
+        }
+
+        /**
+         * Resolve the effective motion-enabled boolean for [slotId],
+         * collapsing an absent entry onto [MotionEnabledStore.DEFAULT_ENABLED].
+         * Use this in render code — never read [motionEnabled] directly,
+         * since absence and `false` mean different things in the store
+         * but the same thing to the user.
+         */
+        fun isMotionEnabled(slotId: String): Boolean = motionEnabledStore.isEnabled(slotId)
     }

--- a/app/src/test/java/com/tinkernorth/dish/repository/MotionPreferenceRepositoryContractTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/MotionPreferenceRepositoryContractTest.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.tinkernorth.dish.architecture.interfaces.Repository
+import com.tinkernorth.dish.architecture.testing.AbstractRepositoryContract
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.serialization.json.Json
+import kotlin.random.Random
+
+/**
+ * Inherits the standard CRUD contract from [AbstractRepositoryContract]:
+ * get on empty, all on empty, get-after-put, replace-on-same-key, remove,
+ * all-contains-every-put, clear, remove-absent-is-noop.
+ *
+ * Per-implementation behaviour (corrupt-JSON tolerance, multi-entry
+ * persistence after a re-read) is in the sibling `MotionPreferenceRepositoryTest`.
+ *
+ * SharedPreferences is mocked into a `MutableMap` so this stays a pure
+ * JVM test — same pattern as
+ * [RememberedSatelliteRepositoryContractTest].
+ */
+class MotionPreferenceRepositoryContractTest : AbstractRepositoryContract<String, MotionPreference>() {
+    override fun newRepository(): Repository<String, MotionPreference> =
+        MotionPreferenceRepository(
+            context = fakeContextBackedByMap(),
+            json = Json { ignoreUnknownKeys = true },
+        )
+
+    override fun newKey(): String = "slot-${Random.nextLong()}"
+
+    /** Same key ⇒ same value. The contract test compares sets of values. */
+    override fun newValue(key: String): MotionPreference =
+        MotionPreference(slotId = key, enabled = key.hashCode() and 1 == 0)
+
+    private fun fakeContextBackedByMap(): Context {
+        val store = mutableMapOf<String, Any?>()
+        val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+        val keySlot = slot<String>()
+        val strSlot = slot<String?>()
+        every { editor.putString(capture(keySlot), captureNullable(strSlot)) } answers {
+            store[keySlot.captured] = strSlot.captured
+            editor
+        }
+        every { editor.remove(capture(keySlot)) } answers {
+            store.remove(keySlot.captured)
+            editor
+        }
+        every { editor.apply() } answers { /* no-op */ }
+
+        val prefs = mockk<SharedPreferences>(relaxed = true)
+        every { prefs.getString(any(), any()) } answers {
+            val k = firstArg<String>()
+            val default = secondArg<String?>()
+            (store[k] as? String) ?: default
+        }
+        every { prefs.edit() } returns editor
+        every { prefs.all } answers { store.toMap() }
+
+        val context = mockk<Context>(relaxed = true)
+        every { context.getSharedPreferences(any(), any()) } returns prefs
+        return context
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/repository/MotionPreferenceRepositoryTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/MotionPreferenceRepositoryTest.kt
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Behaviour-specific tests for [MotionPreferenceRepository] — the CRUD
+ * contract is covered by [MotionPreferenceRepositoryContractTest]; this
+ * file pins the JSON serialization edges and the multi-write durability
+ * that matter for upgrades.
+ */
+class MotionPreferenceRepositoryTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `enabled true and false round-trip through SharedPreferences`() {
+        // The repository must persist the boolean verbatim — a sloppy
+        // implementation that conflates `null` (unset) with `false` would
+        // destroy the "I haven't decided yet" signal the store relies on
+        // for its default. Pin both true and false through a write/read.
+        val (ctx, _) = fakePrefs()
+        val repo = MotionPreferenceRepository(ctx, json)
+        repo.put(MotionPreference("virtual", enabled = true))
+        repo.put(MotionPreference("9", enabled = false))
+
+        // Re-read through a fresh repo on the same backing prefs to prove
+        // durability (no in-memory cache shortcut).
+        val (ctx2, _) = fakePrefs(seedFrom = ctx)
+        val repo2 = MotionPreferenceRepository(ctx2, json)
+        assertEquals(true, repo2.get("virtual")?.enabled)
+        assertEquals(false, repo2.get("9")?.enabled)
+    }
+
+    @Test
+    fun `get on a slot that was never written returns null — not a default boolean`() {
+        // The repository never invents a default. The store layer
+        // collapses null onto MotionEnabledStore.DEFAULT_ENABLED; the repo
+        // must stay honest so the store can distinguish "user has not
+        // decided" from "user explicitly enabled".
+        val (ctx, _) = fakePrefs()
+        val repo = MotionPreferenceRepository(ctx, json)
+        assertNull(repo.get("never-written"))
+    }
+
+    @Test
+    fun `corrupt JSON in prefs falls back to empty — does not crash app startup`() {
+        // A crash during a previous write, or a sideloaded apk overwriting
+        // the prefs, could leave invalid JSON behind. The repo must
+        // tolerate it (the user just loses their motion preferences for
+        // every slot) rather than crash the app on first read.
+        val (ctx, store) = fakePrefs()
+        store["preferences"] = "{not valid json"
+        val repo = MotionPreferenceRepository(ctx, json)
+        assertTrue(repo.all().isEmpty())
+        assertNull(repo.get("anything"))
+    }
+
+    @Test
+    fun `remove of one slot does not disturb other slots' preferences`() {
+        // Per-slot removal must touch only the named entry — important
+        // when a physical pad is unbound but a virtual slot's preference
+        // must survive.
+        val (ctx, _) = fakePrefs()
+        val repo = MotionPreferenceRepository(ctx, json)
+        repo.put(MotionPreference("virtual", enabled = true))
+        repo.put(MotionPreference("9", enabled = false))
+        repo.remove("9")
+
+        assertEquals(true, repo.get("virtual")?.enabled)
+        assertNull(repo.get("9"))
+    }
+
+    @Test
+    fun `put with same slot replaces in place — list never grows`() {
+        // The contract test exercises this generically; this version pins
+        // the absolute size to catch a regression where put accidentally
+        // append-only's the list and persists duplicate entries.
+        val (ctx, _) = fakePrefs()
+        val repo = MotionPreferenceRepository(ctx, json)
+        repo.put(MotionPreference("virtual", enabled = true))
+        repo.put(MotionPreference("virtual", enabled = false))
+        repo.put(MotionPreference("virtual", enabled = true))
+        assertEquals(1, repo.all().size)
+        assertEquals(true, repo.get("virtual")?.enabled)
+    }
+
+    // ── Test fixtures ────────────────────────────────────────────────────
+
+    /**
+     * Returns a Context + the underlying mutable map. Pass [seedFrom] to
+     * mirror an earlier prefs' state (testing durability across a fresh
+     * repo instance on the same prefs key).
+     */
+    private fun fakePrefs(seedFrom: Context? = null): Pair<Context, MutableMap<String, Any?>> {
+        val store: MutableMap<String, Any?> =
+            (seedFrom?.getSharedPreferences("motion_preferences", 0)?.all as? Map<String, Any?>)
+                ?.toMutableMap()
+                ?: mutableMapOf()
+
+        val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+        val keySlot = slot<String>()
+        val strSlot = slot<String?>()
+        every { editor.putString(capture(keySlot), captureNullable(strSlot)) } answers {
+            store[keySlot.captured] = strSlot.captured
+            editor
+        }
+        every { editor.remove(capture(keySlot)) } answers {
+            store.remove(keySlot.captured)
+            editor
+        }
+        every { editor.apply() } answers { /* no-op */ }
+
+        val prefs = mockk<SharedPreferences>(relaxed = true)
+        every { prefs.getString(any(), any()) } answers {
+            val k = firstArg<String>()
+            val default = secondArg<String?>()
+            (store[k] as? String) ?: default
+        }
+        every { prefs.edit() } returns editor
+        every { prefs.all } answers { store.toMap() }
+
+        val ctx = mockk<Context>(relaxed = true)
+        every { ctx.getSharedPreferences(any(), any()) } returns prefs
+        return ctx to store
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/source/store/MotionEnabledStoreTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/store/MotionEnabledStoreTest.kt
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.store
+
+import com.tinkernorth.dish.repository.MotionPreference
+import com.tinkernorth.dish.repository.MotionPreferenceRepository
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [MotionEnabledStore] — the reactive mirror over the
+ * durable [MotionPreferenceRepository].
+ *
+ * Headline invariants pinned here:
+ *
+ *  - **Hydration on construction:** the store seeds its `state` from
+ *    `repo.all()` at construction time, so a fresh process restart sees
+ *    yesterday's toggles without an extra round trip.
+ *  - **Default policy:** an absent slot's [MotionEnabledStore.isEnabled]
+ *    returns [MotionEnabledStore.DEFAULT_ENABLED] (true). The composer and
+ *    pill consume this default; if the policy changes it changes here.
+ *  - **Write-through:** [MotionEnabledStore.setEnabled] always persists
+ *    AND republishes — neither side is allowed to silently win. If a
+ *    future refactor drops the repo write, the durability test fails.
+ *  - **Forget restores default:** removing a slot's entry causes
+ *    [MotionEnabledStore.isEnabled] to flip back to the default.
+ */
+class MotionEnabledStoreTest {
+    @Test
+    fun `hydrates state from the repository on construction`() {
+        // Process restart scenario: the durable repository already holds
+        // yesterday's toggles. The store must surface them immediately —
+        // no race window where state reads emptyMap and isEnabled
+        // returns the default for a slot the user explicitly turned off.
+        val repo =
+            mockk<MotionPreferenceRepository> {
+                every { all() } returns
+                    listOf(
+                        MotionPreference("virtual", enabled = true),
+                        MotionPreference("9", enabled = false),
+                    )
+            }
+        val store = MotionEnabledStore(repo)
+
+        assertEquals(true, store.state.value["virtual"])
+        assertEquals(false, store.state.value["9"])
+        assertEquals(2, store.state.value.size)
+    }
+
+    @Test
+    fun `default is on for an unwritten slot`() {
+        // The product decision is "motion is on unless I turn it off."
+        // Pin the default through the public isEnabled getter so a future
+        // refactor can't silently flip the polarity.
+        val repo = repoWithEmpty()
+        val store = MotionEnabledStore(repo)
+        assertTrue(store.isEnabled("never-toggled"))
+        assertTrue(MotionEnabledStore.DEFAULT_ENABLED) // constant pin
+    }
+
+    @Test
+    fun `setEnabled persists to the repository AND republishes state`() {
+        // The store must be both reactive (state flow) AND durable (repo
+        // write). A regression that only updates the in-memory cache
+        // would lose the toggle on app restart.
+        val repo = repoWithEmpty()
+        val store = MotionEnabledStore(repo)
+
+        store.setEnabled("9", enabled = false)
+
+        verify { repo.put(MotionPreference("9", enabled = false)) }
+        assertEquals(false, store.state.value["9"])
+        assertFalse(store.isEnabled("9"))
+    }
+
+    @Test
+    fun `setEnabled then setEnabled with opposite value flips both layers`() {
+        // Toggling the switch on then off then on again must leave the
+        // store in the final state across both the durable and reactive
+        // layers — no half-updated state.
+        val repo = repoWithEmpty()
+        val store = MotionEnabledStore(repo)
+        store.setEnabled("9", enabled = false)
+        store.setEnabled("9", enabled = true)
+        store.setEnabled("9", enabled = false)
+
+        verify { repo.put(MotionPreference("9", enabled = false)) }
+        verify { repo.put(MotionPreference("9", enabled = true)) }
+        assertEquals(false, store.state.value["9"])
+        assertFalse(store.isEnabled("9"))
+    }
+
+    @Test
+    fun `forget removes the entry from state AND from the repository`() {
+        // Per-slot forget is used when a physical pad is unbound
+        // permanently — keeping a stale entry forever would silently
+        // override the default for a future device that reused the same
+        // InputDevice id.
+        val repo =
+            mockk<MotionPreferenceRepository> {
+                every { all() } returns listOf(MotionPreference("9", enabled = false))
+                justRun { remove("9") }
+            }
+        val store = MotionEnabledStore(repo)
+        assertFalse(store.isEnabled("9"))
+
+        store.forget("9")
+
+        verify { repo.remove("9") }
+        // After forget, the slot returns to the default, NOT the prior
+        // explicit value — that's the whole point.
+        assertTrue(store.isEnabled("9"))
+        assertEquals(null, store.state.value["9"])
+    }
+
+    @Test
+    fun `setEnabled for slot A leaves slot B unchanged`() {
+        // The state map is a single MutableStateFlow; a sloppy reducer
+        // could overwrite the whole map and drop other slots. Pin
+        // isolation across slots.
+        val repo = repoWithEmpty()
+        val store = MotionEnabledStore(repo)
+
+        store.setEnabled("virtual", enabled = true)
+        store.setEnabled("9", enabled = false)
+        store.setEnabled("virtual", enabled = false)
+
+        assertEquals(false, store.state.value["virtual"])
+        assertEquals(false, store.state.value["9"])
+    }
+
+    @Test
+    fun `isEnabled for an explicitly disabled slot returns false`() {
+        // The store's isEnabled has two paths: present-in-map and absent.
+        // Cover the present path explicitly so a regression that
+        // collapses both onto the default would fail here.
+        val repo =
+            mockk<MotionPreferenceRepository> {
+                every { all() } returns listOf(MotionPreference("9", enabled = false))
+            }
+        val store = MotionEnabledStore(repo)
+        assertFalse(store.isEnabled("9"))
+    }
+
+    private fun repoWithEmpty(): MotionPreferenceRepository =
+        mockk(relaxed = true) {
+            every { all() } returns emptyList()
+        }
+}

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
@@ -14,6 +14,7 @@ import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.sensor.BatteryValidator
 import com.tinkernorth.dish.source.sensor.BatteryValidator.BatterySample
 import com.tinkernorth.dish.source.store.BatteryStatusStore
+import com.tinkernorth.dish.source.store.MotionEnabledStore
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -45,6 +46,7 @@ class MainViewModelTest {
     private lateinit var satellite: SatelliteConnectionManager
     private lateinit var gamepadRegistry: PhysicalGamepadRegistry
     private lateinit var batteryStore: BatteryStatusStore
+    private lateinit var motionEnabledStore: MotionEnabledStore
     private lateinit var vm: MainViewModel
 
     private val connectionsFlow = MutableStateFlow<List<ConnectionSummary>>(emptyList())
@@ -61,6 +63,13 @@ class MainViewModelTest {
         // BatteryStatusStore is a pure JVM holder (no Android deps) — use the
         // real thing so battery samples really thread through to the slots.
         batteryStore = BatteryStatusStore()
+        // MotionEnabledStore is hydrated from MotionPreferenceRepository at
+        // construction. Stub the repo so the store's init reads emptyMap()
+        // (the relevant default for these slot-wiring tests).
+        motionEnabledStore =
+            MotionEnabledStore(
+                mockk(relaxed = true) { every { all() } returns emptyList() },
+            )
         every { hub.connections } returns connectionsFlow
         every { hub.bindings } returns bindingsFlow
         every { gamepadRegistry.devices } returns devicesFlow
@@ -69,7 +78,7 @@ class MainViewModelTest {
         // injected Context. A relaxed mock returns "" by default, which keeps
         // the existing assertions (focused on slot wiring, not the label) green.
         val context = mockk<Context>(relaxed = true)
-        vm = MainViewModel(context, satellite, hub, gamepadRegistry, batteryStore)
+        vm = MainViewModel(context, satellite, hub, gamepadRegistry, batteryStore, motionEnabledStore)
     }
 
     @After
@@ -143,6 +152,32 @@ class MainViewModelTest {
     fun `setSatelliteControllerType delegates to hub`() {
         vm.setSatelliteControllerType(connectionId = "s:1", slotId = "slot-X", type = 1)
         verify { hub.setSatelliteControllerType("s:1", "slot-X", 1) }
+    }
+
+    @Test
+    fun `setMotionEnabled writes through to the motion store`() {
+        // The dashboard's toggle should be a thin pass-through; the durable
+        // write happens in MotionEnabledStore. Pin that the VM does not
+        // accidentally short-circuit (e.g. only updating local state).
+        vm.setMotionEnabled(slotId = "9", enabled = false)
+        assertEquals(false, motionEnabledStore.state.value["9"])
+        assertEquals(false, motionEnabledStore.isEnabled("9"))
+    }
+
+    @Test
+    fun `isMotionEnabled defaults to true for a slot that has not been toggled`() {
+        // Product default — flip in MotionEnabledStore.DEFAULT_ENABLED if
+        // policy changes. Pinned here so a regression in the VM accessor
+        // (e.g. reading the raw map and treating null as false) fails.
+        assertTrue(vm.isMotionEnabled("never-touched"))
+    }
+
+    @Test
+    fun `motionEnabled flow forwards the underlying store state`() {
+        // Bind point for the dashboard adapter: a write through the VM
+        // must be observable on its motionEnabled flow.
+        vm.setMotionEnabled(slotId = "virtual", enabled = false)
+        assertEquals(false, vm.motionEnabled.value["virtual"])
     }
 
     @Test


### PR DESCRIPTION
## Summary

Persists the user-facing "stream gyro for this slot" choice and exposes
it as a reactive flow the `MotionCapabilityComposer` (#71) will consume
in the wiring PR.

- **`MotionPreferenceRepository`** — `KeyedRepository<String,
  MotionPreference>` over a single `SharedPreferences` key holding a
  JSON list. Same shape as `RememberedSatelliteRepository` (single
  `writeLock`, `ignoreUnknownKeys` JSON, `ListSerializer`).

  Per-slot, not global: a DualSense routed to one satellite and an
  Xbox-typed virtual pad routed to another have genuinely different
  motion answers — satellite Xbox emulation has no IMU surface (see
  `vigem_adapter.cpp::submitMotion`), so a global toggle would be
  wrong by default.

  Repository stays "dumb storage" and returns `null` for un-toggled
  slots; the default policy lives in the store layer.

- **`MotionEnabledStore`** — `AbstractStateSource<Map<String,
  Boolean>>` that hydrates from the repo on construction (so a fresh
  process surfaces yesterday's toggles with no first-frame flicker),
  republishes on every write, and collapses an absent entry onto
  `DEFAULT_ENABLED = true` ("motion on unless I turned it off"). Same
  architectural shape as `ControllerTypeStore`.

- **`MainViewModel`** — `setMotionEnabled` / `isMotionEnabled` /
  `motionEnabled` surface the toggle to the dashboard, with the
  absent-means-default rule handled in `isMotionEnabled` so callers
  can't accidentally read the raw map and treat `null` as `false`.

## What this is *not* doing

- Not consuming `MotionEnabledStore` from `MotionCapabilityComposer`
  yet — that lands in the wiring PR alongside the `SatelliteConnection`
  `CAP_MOTION` change and the `PhoneMotionSource` listener gate. The
  composer's `userEnabled` field stays defaulted to `true` until then.
- Not adding the toggle widget in `ControllerAdapter` yet — also in
  the wiring PR, so the visible UI and the backend gate ship as one
  reviewable change.

This PR is **independent of #71** — they merge in either order, then
the wiring PR rebases on both.

## Test plan

23 new unit tests (all passing locally; full 618-test suite green):

- **8 contract tests** (inherited via `AbstractRepositoryContract`) —
  get-on-empty, all-on-empty, get-after-put, replace-on-same-key,
  remove, all-contains-every-put, clear, remove-absent-is-noop.
- **5 repo-specific tests** — true/false round-trip through a fresh
  repo instance, null-on-unread (not a default boolean), corrupt-JSON
  tolerance, per-slot remove isolation, put-replaces-no-grow.
- **7 store tests** — hydration from the repo on construction,
  default-true for unwritten slots, write-through to both layers,
  toggle flip durability, `forget` restores the default, per-slot
  isolation across writes, `isEnabled` honors an explicit `false`.
- **3 ViewModel tests** — `setMotionEnabled` writes through the
  store, `isMotionEnabled` defaults to true, the `motionEnabled` flow
  forwards store state.

- [x] `./gradlew :app:testDebugUnitTest` — 618/618 pass.