### PR TITLE
feat(motion): wire MotionCapabilityComposer through cap bit + listener gates

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/composer/MotionCapabilityComposer.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/MotionCapabilityComposer.kt
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.composer
+
+import com.tinkernorth.dish.architecture.abstracts.AbstractComposer
+import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
+import com.tinkernorth.dish.source.sensor.PhoneMotionAvailability
+import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Per-controller motion capability — the single source of truth that drives:
+ *
+ *   - the `CAP_MOTION` bit at `MSG_CONTROLLER_ADD` time (so the receiver's web
+ *     UI is not lied to about which pads stream IMU);
+ *   - whether [com.tinkernorth.dish.source.sensor.PhoneMotionSource] /
+ *     [com.tinkernorth.dish.source.sensor.PhysicalMotionSource] register
+ *     sensor listeners at all (gyro listeners are a measurable battery cost);
+ *   - what the on-screen motion pill renders.
+ *
+ * Three orthogonal facts, combined into [MotionCapability.effective]:
+ *
+ *   - [MotionCapability.hasGyro] — the hardware exists. Virtual slot: the
+ *     phone has a gyroscope (see [PhoneMotionAvailability]). Physical slot:
+ *     the pad has a per-device gyroscope (see
+ *     [com.tinkernorth.dish.source.sensor.PhysicalMotionProbe], cached on
+ *     [PhysicalGamepadRegistry.Device.hasGyro]).
+ *   - [MotionCapability.carriesOnConnection] — the bound connection has a
+ *     `MSG_MOTION` channel. Satellite does; Bluetooth-HID does not.
+ *   - [MotionCapability.userEnabled] — the user wants motion on for this
+ *     slot. Defaults to true; flipped by the per-slot toggle wired in a
+ *     subsequent PR (the `MotionEnabledStore`).
+ *
+ * **Why a composer:** these are pure derivations from
+ * [PhoneMotionAvailability], [PhysicalGamepadRegistry], [ConnectionHub]
+ * `bindings` + `connections`. No new lifecycle, no events — exactly the shape
+ * [AbstractComposer] exists for. Threading the same `MotionCapability` value
+ * through every consumer keeps "is motion on for this slot" un-divergeable.
+ */
+data class MotionCapability(
+    /** Hardware reports a gyroscope on the device backing this slot. */
+    val hasGyro: Boolean,
+    /** Bound connection is a satellite session (BT-HID has no `MSG_MOTION`). */
+    val carriesOnConnection: Boolean,
+    /**
+     * User has motion enabled for this slot. Stub-true until the
+     * `MotionEnabledStore` lands in the next PR; the field is here from the
+     * start so downstream call sites can already read it.
+     */
+    val userEnabled: Boolean = true,
+) {
+    /**
+     * True iff motion samples should both be captured AND would actually reach
+     * the satellite for this slot. The same boolean drives the wire `CAP_MOTION`
+     * bit (paired with [userEnabled] so that flipping the user toggle drops the
+     * advertisement) and the sensor-listener gate.
+     */
+    val effective: Boolean get() = hasGyro && carriesOnConnection && userEnabled
+
+    /**
+     * The `CAP_MOTION` (0x0004) bit the dish should advertise at
+     * `MSG_CONTROLLER_ADD` for this slot. Note that this is **not** gated on
+     * [carriesOnConnection]: the capability describes the *dish*, not the
+     * link, and we want a satellite re-connect to recover motion without a
+     * re-handshake. It IS gated on [userEnabled] because flipping the toggle
+     * is a meaningful change to what the dish will emit.
+     */
+    fun toCapBits(): Int = if (hasGyro && userEnabled) CAP_MOTION_BIT else 0
+
+    companion object {
+        /** Mirror of `satellite/src/core/types.h::CAP_MOTION`. */
+        const val CAP_MOTION_BIT: Int = 0x0004
+
+        /** Initial value before any upstream resolves — nothing is capable yet. */
+        val Off = MotionCapability(hasGyro = false, carriesOnConnection = false)
+    }
+}
+
+/**
+ * `Map<slotId, MotionCapability>` for every slot the user can currently see —
+ * the virtual touch slot (always present) plus every attached physical pad.
+ *
+ * A slot present in the map means we have a coherent capability snapshot for
+ * it. A slot absent from the map means the registry doesn't see it (e.g. a
+ * physical pad in the disconnect-grace window after a USB jiggle).
+ */
+@Singleton
+class MotionCapabilityComposer
+    @Inject
+    constructor(
+        private val phoneAvailability: PhoneMotionAvailability,
+        private val registry: PhysicalGamepadRegistry,
+        private val hub: ConnectionHub,
+        scope: CoroutineScope,
+    ) : AbstractComposer<Map<String, MotionCapability>>(scope, emptyMap()) {
+        override fun upstream(): Flow<Map<String, MotionCapability>> =
+            combine(
+                phoneAvailability.state,
+                registry.devices,
+                hub.bindings,
+                hub.connections,
+            ) { phoneHasGyro, devices, bindings, summaries ->
+                val byId = summaries.associateBy { it.id }
+                val out = HashMap<String, MotionCapability>(devices.size + 1)
+
+                // Virtual slot — always present so the touch overlay always
+                // has a capability entry to read, even when no satellite is up.
+                out[VIRTUAL_SLOT_ID] =
+                    MotionCapability(
+                        hasGyro = phoneHasGyro,
+                        carriesOnConnection = carriesMotion(VIRTUAL_SLOT_ID, bindings, byId),
+                    )
+
+                // Physical pads.
+                for ((deviceId, device) in devices) {
+                    val slotId = deviceId.toString()
+                    out[slotId] =
+                        MotionCapability(
+                            hasGyro = device.hasGyro,
+                            carriesOnConnection = carriesMotion(slotId, bindings, byId),
+                        )
+                }
+                out
+            }
+
+        /**
+         * Resolve `slotId → bound-connection-summary → kind == SATELLITE &&
+         * live`. Returns false for any unbound or non-satellite slot. The
+         * `Connected` check is deliberate: a satellite that is `Connecting` or
+         * `Unstable` can't currently sink motion, so the pill reading should
+         * reflect that, AND the registration cap bit should still claim
+         * `CAP_MOTION` (the dish is capable, the link is just temporarily
+         * down) — `toCapBits()` does not consult `carriesOnConnection`.
+         */
+        private fun carriesMotion(
+            slotId: String,
+            bindings: Map<String, String>,
+            summariesById: Map<String, ConnectionSummary>,
+        ): Boolean {
+            val cid = bindings[slotId] ?: return false
+            val summary = summariesById[cid] ?: return false
+            return summary.kind == ConnectionKind.SATELLITE &&
+                summary.live == LinkState.Connected
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/composer/MotionCapabilityComposer.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/MotionCapabilityComposer.kt
@@ -6,6 +6,7 @@ package com.tinkernorth.dish.composer
 import com.tinkernorth.dish.architecture.abstracts.AbstractComposer
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.source.sensor.PhoneMotionAvailability
+import com.tinkernorth.dish.source.store.MotionEnabledStore
 import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -33,14 +34,15 @@ import javax.inject.Singleton
  *   - [MotionCapability.carriesOnConnection] — the bound connection has a
  *     `MSG_MOTION` channel. Satellite does; Bluetooth-HID does not.
  *   - [MotionCapability.userEnabled] — the user wants motion on for this
- *     slot. Defaults to true; flipped by the per-slot toggle wired in a
- *     subsequent PR (the `MotionEnabledStore`).
+ *     slot. Sourced from [MotionEnabledStore.isEnabled], which collapses
+ *     an absent entry onto the product default (`DEFAULT_ENABLED = true`).
  *
  * **Why a composer:** these are pure derivations from
  * [PhoneMotionAvailability], [PhysicalGamepadRegistry], [ConnectionHub]
- * `bindings` + `connections`. No new lifecycle, no events — exactly the shape
- * [AbstractComposer] exists for. Threading the same `MotionCapability` value
- * through every consumer keeps "is motion on for this slot" un-divergeable.
+ * `bindings` + `connections`, and [MotionEnabledStore]. No new lifecycle,
+ * no events — exactly the shape [AbstractComposer] exists for. Threading
+ * the same `MotionCapability` value through every consumer keeps "is
+ * motion on for this slot" un-divergeable.
  */
 data class MotionCapability(
     /** Hardware reports a gyroscope on the device backing this slot. */
@@ -48,9 +50,9 @@ data class MotionCapability(
     /** Bound connection is a satellite session (BT-HID has no `MSG_MOTION`). */
     val carriesOnConnection: Boolean,
     /**
-     * User has motion enabled for this slot. Stub-true until the
-     * `MotionEnabledStore` lands in the next PR; the field is here from the
-     * start so downstream call sites can already read it.
+     * User has motion enabled for this slot. Sourced from
+     * [MotionEnabledStore.isEnabled], so an absent slot in that store
+     * collapses to [MotionEnabledStore.DEFAULT_ENABLED] (true).
      */
     val userEnabled: Boolean = true,
 ) {
@@ -96,6 +98,7 @@ class MotionCapabilityComposer
         private val phoneAvailability: PhoneMotionAvailability,
         private val registry: PhysicalGamepadRegistry,
         private val hub: ConnectionHub,
+        private val motionEnabledStore: MotionEnabledStore,
         scope: CoroutineScope,
     ) : AbstractComposer<Map<String, MotionCapability>>(scope, emptyMap()) {
         override fun upstream(): Flow<Map<String, MotionCapability>> =
@@ -104,7 +107,8 @@ class MotionCapabilityComposer
                 registry.devices,
                 hub.bindings,
                 hub.connections,
-            ) { phoneHasGyro, devices, bindings, summaries ->
+                motionEnabledStore.state,
+            ) { phoneHasGyro, devices, bindings, summaries, enabledMap ->
                 val byId = summaries.associateBy { it.id }
                 val out = HashMap<String, MotionCapability>(devices.size + 1)
 
@@ -114,6 +118,7 @@ class MotionCapabilityComposer
                     MotionCapability(
                         hasGyro = phoneHasGyro,
                         carriesOnConnection = carriesMotion(VIRTUAL_SLOT_ID, bindings, byId),
+                        userEnabled = enabledMap[VIRTUAL_SLOT_ID] ?: MotionEnabledStore.DEFAULT_ENABLED,
                     )
 
                 // Physical pads.
@@ -123,10 +128,23 @@ class MotionCapabilityComposer
                         MotionCapability(
                             hasGyro = device.hasGyro,
                             carriesOnConnection = carriesMotion(slotId, bindings, byId),
+                            userEnabled = enabledMap[slotId] ?: MotionEnabledStore.DEFAULT_ENABLED,
                         )
                 }
                 out
             }
+
+        /**
+         * Resolve the [MotionCapability] for [slotId]. Returns
+         * [MotionCapability.Off] when the slot has not been seen yet (e.g.
+         * a controller-add fires before the composer's first emission). Use
+         * this from [com.tinkernorth.dish.source.connection.SatelliteConnection]
+         * at registration time — it's a synchronous read of the latest
+         * derived map, so no suspension is required on the registration
+         * thread.
+         */
+        fun capabilityFor(slotId: String): MotionCapability =
+            state.value[slotId] ?: MotionCapability.Off
 
         /**
          * Resolve `slotId → bound-connection-summary → kind == SATELLITE &&

--- a/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistry.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistry.kt
@@ -9,6 +9,7 @@ import android.util.Log
 import android.view.InputDevice
 import android.view.MotionEvent
 import com.tinkernorth.dish.core.jni.SatelliteNative
+import com.tinkernorth.dish.source.sensor.PhysicalMotionProbe
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -46,11 +47,21 @@ class PhysicalGamepadRegistry
          *   "false disconnect") doesn't free the server-side controller index
          *   and force a re-register. `null` means the device is currently
          *   present.
+         * @property hasGyro true iff the per-device sensor API
+         *   ([android.view.InputDevice.getSensorManager], API 31+) reports a
+         *   gyroscope for this pad. Computed once at add time via
+         *   [com.tinkernorth.dish.source.sensor.PhysicalMotionProbe] and read
+         *   by [com.tinkernorth.dish.composer.MotionCapabilityComposer] to
+         *   decide the per-slot `CAP_MOTION` bit, and by
+         *   [com.tinkernorth.dish.source.sensor.PhysicalMotionSource] to
+         *   decide whether to register sensor listeners. A controller without
+         *   a gyro keeps this `false` for its whole lifetime in the registry.
          */
         data class Device(
             val id: Int,
             val name: String,
             val disconnectingTimeLeftSec: Int? = null,
+            val hasGyro: Boolean = false,
         ) {
             val isDisconnecting: Boolean get() = disconnectingTimeLeftSec != null
         }
@@ -88,7 +99,7 @@ class PhysicalGamepadRegistry
                 val dev = InputDevice.getDevice(id) ?: continue
                 if (!isGamepad(dev)) continue
                 pushDeadzones(dev)
-                next[id] = Device(id, dev.name)
+                next[id] = Device(id, dev.name, hasGyro = PhysicalMotionProbe.hasGyro(id))
             }
             _devices.value = next
         }
@@ -98,7 +109,9 @@ class PhysicalGamepadRegistry
             if (!isGamepad(dev)) return
             pushDeadzones(dev)
             cancelDisconnect(deviceId)
-            _devices.value = _devices.value + (deviceId to Device(deviceId, dev.name))
+            _devices.value =
+                _devices.value +
+                    (deviceId to Device(deviceId, dev.name, hasGyro = PhysicalMotionProbe.hasGyro(deviceId)))
         }
 
         override fun onInputDeviceRemoved(deviceId: Int) {
@@ -121,7 +134,12 @@ class PhysicalGamepadRegistry
             cancelDisconnect(deviceId)
             val current = _devices.value[deviceId]
             if (current == null || current.name != dev.name || current.isDisconnecting) {
-                _devices.value = _devices.value + (deviceId to Device(deviceId, dev.name))
+                // Re-probe in case capabilities changed (rare in practice, but
+                // a USB pad swapping firmware between detach/attach cycles can
+                // change its sensor exposure — and the probe is cheap).
+                _devices.value =
+                    _devices.value +
+                        (deviceId to Device(deviceId, dev.name, hasGyro = PhysicalMotionProbe.hasGyro(deviceId)))
             }
         }
 

--- a/app/src/main/java/com/tinkernorth/dish/repository/MotionPreferenceRepository.kt
+++ b/app/src/main/java/com/tinkernorth/dish/repository/MotionPreferenceRepository.kt
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.repository
+
+import android.content.Context
+import com.tinkernorth.dish.architecture.interfaces.KeyedRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Durable per-slot motion preference: should the user-facing "stream gyro"
+ * toggle be on for this slot?
+ *
+ * **Why per-slot, not global:** a player may have a DualSense pad (motion
+ * great for shooters) routed to one satellite and an Xbox-typed virtual
+ * controller (motion not useful) routed to another. The receiver-side
+ * "Xbox virtual pads have no IMU surface" reality (see satellite
+ * `vigem_adapter.cpp::submitMotion`) makes a global toggle wrong by
+ * default. Per-slot lets the same dish be honest about each slot.
+ *
+ * **Absence semantics:** [get] returns null when the slot has never been
+ * touched. Callers ([MotionEnabledStore]) collapse null onto a global
+ * default (currently true — "motion on unless I turned it off"). The
+ * repository itself does NOT bake in the default; that's a policy
+ * decision that belongs in the in-memory store.
+ *
+ * Storage shape: single `SharedPreferences` entry holding a JSON list of
+ * `MotionPreference` records. The same shape and write-lock discipline as
+ * [RememberedSatelliteRepository] — see that file for the rationale.
+ */
+@Serializable
+data class MotionPreference(
+    /** Slot id — `VIRTUAL_SLOT_ID` for the touch overlay, or the integer-as-string `InputDevice` id for a physical pad. */
+    val slotId: String,
+    /** True ⇒ the dish should stream motion for this slot when otherwise capable. */
+    val enabled: Boolean,
+)
+
+@Singleton
+class MotionPreferenceRepository
+    @Inject
+    constructor(
+        @ApplicationContext context: Context,
+        private val json: Json,
+    ) : KeyedRepository<String, MotionPreference> {
+        private val prefs by lazy {
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        }
+        private val writeLock = Any()
+
+        override fun keyOf(value: MotionPreference): String = value.slotId
+
+        override fun get(key: String): MotionPreference? = all().firstOrNull { it.slotId == key }
+
+        override fun all(): List<MotionPreference> {
+            val raw = prefs.getString(KEY_LIST, null) ?: return emptyList()
+            return runCatching {
+                json.decodeFromString(ListSerializer(MotionPreference.serializer()), raw)
+            }.getOrDefault(emptyList())
+        }
+
+        override fun put(
+            key: String,
+            value: MotionPreference,
+        ) {
+            synchronized(writeLock) {
+                val list = all().toMutableList()
+                list.removeAll { it.slotId == key }
+                list += value
+                persist(list)
+            }
+        }
+
+        override fun remove(key: String) {
+            synchronized(writeLock) {
+                val list = all().filterNot { it.slotId == key }
+                persist(list)
+            }
+        }
+
+        override fun clear() {
+            synchronized(writeLock) {
+                prefs.edit().remove(KEY_LIST).apply()
+            }
+        }
+
+        private fun persist(list: List<MotionPreference>) {
+            val raw = json.encodeToString(ListSerializer(MotionPreference.serializer()), list)
+            prefs.edit().putString(KEY_LIST, raw).apply()
+        }
+
+        private companion object {
+            const val PREFS_NAME = "motion_preferences"
+            const val KEY_LIST = "preferences"
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
@@ -48,6 +48,22 @@ class SatelliteConnection(
     private val scope: CoroutineScope,
     private val controllerRepo: ControllerRepository,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    /**
+     * Resolves the per-slot `CAP_MOTION` (0x0004) bit for the wire
+     * capability word at `MSG_CONTROLLER_ADD` time. Defaulted to the
+     * always-on word ([DEFAULT_CAPABILITIES_WITHOUT_MOTION] OR
+     * [com.tinkernorth.dish.composer.MotionCapability.CAP_MOTION_BIT]) so
+     * pre-existing tests that don't care about the composer keep behaving
+     * the same.
+     *
+     * In production, [SatelliteConnectionManager] threads a closure that
+     * reads from [com.tinkernorth.dish.composer.MotionCapabilityComposer
+     * .capabilityFor] so the bit reflects the *user's* current toggle and
+     * the slot's *real* hardware. This makes the cap word honest —
+     * previously every controller advertised motion regardless of whether
+     * gyro samples would ever flow.
+     */
+    private val motionCapsBitsFor: (slotId: String) -> Int = { CAP_MOTION_BIT_LEGACY },
 ) {
     private val _server = MutableStateFlow(server)
     val server: StateFlow<DiscoveredServer> = _server.asStateFlow()
@@ -283,7 +299,15 @@ class SatelliteConnection(
                 if (info.registered) return@withContext
                 if (handle < 0) return@withContext
                 controllerRepo.resetControllerAck(handle)
-                controllerRepo.addController(handle, info.controllerIndex, DEFAULT_CAPABILITIES)
+                // Cap word: the non-motion bits are fixed (the dish always
+                // sends analog triggers and accepts rumble), motion comes
+                // from the composer so it reflects the slot's actual gyro
+                // hardware AND the user's toggle. A satellite re-connect
+                // does NOT re-handshake the cap word (toCapBits ignores the
+                // live link state), so a momentary network blip can't drop
+                // CAP_MOTION on the server side.
+                val caps = BASE_CAPABILITIES or motionCapsBitsFor(slotId)
+                controllerRepo.addController(handle, info.controllerIndex, caps)
                 var ack = -1
                 repeat(ACK_WAIT_ATTEMPTS) {
                     ack = controllerRepo.getLastControllerAck(handle)
@@ -432,20 +456,33 @@ class SatelliteConnection(
         private const val FALTER_TO_DEAD = 5
 
         // MSG_CONTROLLER_ADD capability word (2-byte big-endian): bit 0x0001
-        // analog triggers, 0x0002 rumble, 0x0004 motion (this client emits the
-        // MSG_MOTION IMU stream — see PhoneMotionSource, Task 1.1).
+        // analog triggers, 0x0002 rumble, 0x0004 motion (this client emits
+        // the MSG_MOTION IMU stream — see PhoneMotionSource, Task 1.1).
         //
         // CAP_LIGHTBAR (0x0008) is intentionally NOT set: Android exposes no
-        // controller-LED API, so dish-android cannot drive a controller's RGB
-        // lightbar. Leaving the bit clear tells a capability-aware satellite
-        // not to waste packets sending MSG_LIGHTBAR (0x000D) to this client.
-        // Any 0x000D that does arrive is decoded, logged, and dropped by the
-        // native receive loop (satellite_jni.cpp::receiveAck).
+        // controller-LED API, so dish-android cannot drive a controller's
+        // RGB lightbar. Leaving the bit clear tells a capability-aware
+        // satellite not to waste packets sending MSG_LIGHTBAR (0x000D) to
+        // this client. Any 0x000D that does arrive is decoded, logged, and
+        // dropped by the native receive loop (satellite_jni.cpp::receiveAck).
         private const val CAP_ANALOG_TRIGGERS = 0x0001
         private const val CAP_RUMBLE = 0x0002
-        private const val CAP_MOTION = 0x0004
-        private const val DEFAULT_CAPABILITIES =
-            CAP_ANALOG_TRIGGERS or CAP_RUMBLE or CAP_MOTION
+
+        /**
+         * The always-on slice of the capability word: analog triggers + rumble.
+         * Motion is per-slot via [motionCapsBitsFor]; lightbar is intentionally
+         * absent (no controller-LED API on Android).
+         */
+        private const val BASE_CAPABILITIES = CAP_ANALOG_TRIGGERS or CAP_RUMBLE
+
+        /**
+         * Legacy "all motion" word for the default-arg motion lambda. Pre-PR3
+         * code path: every controller advertised CAP_MOTION regardless of
+         * gyro hardware or user toggle. Tests that don't inject a composer
+         * still see this value so their assertions don't have to know about
+         * the new wiring.
+         */
+        internal const val CAP_MOTION_BIT_LEGACY = 0x0004
 
         // MSG_CONTROLLER_ACK result codes — wire values mirror the satellite's
         // core/types.h. getLastControllerAck() returns a packed word,

--- a/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManager.kt
@@ -4,6 +4,7 @@
 package com.tinkernorth.dish.source.connection
 
 import android.content.Context
+import com.tinkernorth.dish.composer.MotionCapabilityComposer
 import com.tinkernorth.dish.core.jni.ControllerRepository
 import com.tinkernorth.dish.core.model.ConnectResponse
 import com.tinkernorth.dish.core.model.DiscoveredServer
@@ -29,6 +30,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 
 /**
@@ -81,6 +83,14 @@ class SatelliteConnectionManager
         private val store: ConnectionStore,
         private val json: Json,
         @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+        /**
+         * `Provider` (not direct injection) breaks the Hilt construction cycle:
+         * [MotionCapabilityComposer] depends on [com.tinkernorth.dish.composer.ConnectionHub],
+         * which depends back on this manager. Using `Provider.get()` defers
+         * resolution until the cap word is actually needed (at controller-add
+         * time), at which point the singleton composer already exists.
+         */
+        private val motionCapabilityProvider: Provider<MotionCapabilityComposer>,
     ) {
         private val _connections = MutableStateFlow<Map<String, SatelliteConnection>>(emptyMap())
         val connections: StateFlow<Map<String, SatelliteConnection>> = _connections.asStateFlow()
@@ -182,7 +192,16 @@ class SatelliteConnectionManager
                     .updateAndGet { map ->
                         val cur = map[id]
                         if (cur != null) return@updateAndGet map
-                        val fresh = SatelliteConnection(id, server, scope, controllerRepo, ioDispatcher)
+                        val fresh = SatelliteConnection(
+                            id,
+                            server,
+                            scope,
+                            controllerRepo,
+                            ioDispatcher,
+                            motionCapsBitsFor = { slotId ->
+                                motionCapabilityProvider.get().capabilityFor(slotId).toCapBits()
+                            },
+                        )
                         created = fresh
                         map + (id to fresh)
                     }[id] ?: return
@@ -282,7 +301,16 @@ class SatelliteConnectionManager
                 _connections
                     .updateAndGet { map ->
                         if (map.containsKey(id)) return@updateAndGet map
-                        map + (id to SatelliteConnection(id, server, scope, controllerRepo, ioDispatcher))
+                        map + (id to SatelliteConnection(
+                            id,
+                            server,
+                            scope,
+                            controllerRepo,
+                            ioDispatcher,
+                            motionCapsBitsFor = { slotId ->
+                                motionCapabilityProvider.get().capabilityFor(slotId).toCapBits()
+                            },
+                        ))
                     }[id] ?: return
             conn.markConnecting()
             scope.launch {

--- a/app/src/main/java/com/tinkernorth/dish/source/sensor/PhoneMotionAvailability.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/sensor/PhoneMotionAvailability.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.sensor
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorManager
+import com.tinkernorth.dish.architecture.abstracts.AbstractStateSource
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Process-scoped fact: does the phone itself have a usable gyroscope?
+ *
+ * The activity-scoped [PhoneMotionSource] already exposes this as its
+ * `isAvailable` property, but the satellite registration path and the
+ * [com.tinkernorth.dish.composer.MotionCapabilityComposer] need the same fact
+ * *without* an overlay being on screen — capability negotiation at controller
+ * add time happens long before the overlay activity is constructed.
+ *
+ * Implemented as an [AbstractStateSource]`<Boolean>` so it composes through the
+ * existing `state` flow plumbing. The value is computed once at injection time
+ * because Android device hardware does not change at runtime; the source still
+ * extends the base class purely so consumers can `.state.collect { … }`
+ * uniformly with the other availability flows.
+ */
+@Singleton
+class PhoneMotionAvailability
+    @Inject
+    constructor(
+        @ApplicationContext context: Context,
+    ) : AbstractStateSource<Boolean>(initialState = false) {
+        init {
+            val sm = context.getSystemService(Context.SENSOR_SERVICE) as? SensorManager
+            val hasGyro = sm?.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null
+            setState(hasGyro)
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalMotionProbe.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalMotionProbe.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.sensor
+
+import android.hardware.Sensor
+import android.os.Build
+import android.view.InputDevice
+
+/**
+ * One-shot capability probe: does this physical gamepad expose a gyroscope
+ * through Android's per-device sensor API?
+ *
+ * Pulled out of [PhysicalMotionSource] so the same probe can populate
+ * [com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry.Device.hasGyro]
+ * once at device-add time. That fact is then read by
+ * [com.tinkernorth.dish.composer.MotionCapabilityComposer] to decide whether
+ * to advertise `CAP_MOTION` for a slot, and by [PhysicalMotionSource] to
+ * decide whether to register sensor listeners — without each call site re-doing
+ * the API-31 / null-sensor dance.
+ *
+ * The probe is API-gated: [InputDevice.getSensorManager] is API 31+. Below
+ * that, per-device sensors are not exposed by the platform and a pad's IMU is
+ * unreachable from the app regardless of hardware.
+ *
+ * **Testability:** the pure decision (given an SDK level and an
+ * `InputDevice`, does it have a gyro?) is exposed as [evaluate], so unit
+ * tests don't have to stub `Build.VERSION.SDK_INT` via reflection.
+ * [hasGyro] is the wrapper that resolves both inputs from the live OS.
+ */
+object PhysicalMotionProbe {
+    /**
+     * Returns true iff the device with [deviceId] is currently attached and
+     * its per-device [android.hardware.SensorManager] reports a
+     * [Sensor.TYPE_GYROSCOPE] sensor. Returns false on API < 31, on an
+     * unknown device id, or on a pad with no IMU surface — all of which are
+     * legitimate "not motion-capable" outcomes, not errors.
+     */
+    fun hasGyro(deviceId: Int): Boolean = evaluate(Build.VERSION.SDK_INT, InputDevice.getDevice(deviceId))
+
+    /**
+     * Pure variant: returns true iff [sdkInt] is API 31+ and [device] has a
+     * gyroscope on its per-device [android.hardware.SensorManager]. The
+     * [InputDevice] is still queried (not a pure data class), but the SDK
+     * gate is parameterised so unit tests can drive every branch from a JVM
+     * without reflection on the system constants.
+     */
+    fun evaluate(
+        sdkInt: Int,
+        device: InputDevice?,
+    ): Boolean {
+        if (sdkInt < Build.VERSION_CODES.S) return false
+        if (device == null) return false
+        return device.sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null
+    }
+}

--- a/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalMotionSource.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalMotionSource.kt
@@ -14,6 +14,8 @@ import android.view.InputDevice
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.tinkernorth.dish.composer.ConnectionHub
+import com.tinkernorth.dish.composer.MotionCapability
+import com.tinkernorth.dish.composer.MotionCapabilityComposer
 import com.tinkernorth.dish.composer.PhysicalReachability
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.hotpath.input.PhysicalSlotBindingObserver
@@ -21,6 +23,7 @@ import com.tinkernorth.dish.source.connection.SatelliteConnection
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
@@ -87,6 +90,7 @@ class PhysicalMotionSource
         private val registry: PhysicalGamepadRegistry,
         private val hub: ConnectionHub,
         private val satellite: SatelliteConnectionManager,
+        private val motionCapability: MotionCapabilityComposer,
         private val scope: CoroutineScope,
     ) : DefaultLifecycleObserver {
         /**
@@ -219,6 +223,11 @@ class PhysicalMotionSource
         override fun onStart(owner: LifecycleOwner) {
             if (bindingsJob != null) return
             sensorHandler = sensorDispatch.acquire()
+            // Reachability tells us "a satellite is up and the slot is
+            // registered." The capability composer tells us "the user wants
+            // motion on for this slot AND the hardware supports it." Both
+            // must be true for the listener to register; otherwise we burn
+            // battery on a gyro stream nothing will ever forward.
             bindingsJob =
                 PhysicalReachability
                     .reachableSlots(
@@ -226,7 +235,8 @@ class PhysicalMotionSource
                         hub.bindings,
                         hub.connections,
                         satellite.connections,
-                    ).onEach(::onReachableChanged)
+                    ).combine(motionCapability.state, ::filterByCapability)
+                    .onEach(::onReachableChanged)
                     .launchIn(scope)
         }
 
@@ -295,6 +305,36 @@ class PhysicalMotionSource
 
         companion object {
             private const val TAG = "PhysicalMotionSource"
+
+            /**
+             * Intersect the reachable-slot set (pads bound to a Connected
+             * satellite with a registered server-side controller) with the
+             * per-slot motion [MotionCapability]:
+             *
+             *  - drop slots whose pad has no gyroscope (`hasGyro == false`)
+             *    — listening would never produce a sample;
+             *  - drop slots the user has explicitly toggled motion off for
+             *    (`userEnabled == false`) — listening would burn battery
+             *    on samples that get dropped at the cap-bit / wire level.
+             *
+             * A slot present in `reachable` but ABSENT from `caps` is dropped:
+             * the capability composer is the source of truth for "this slot
+             * has motion," so an unknown slot is treated as no-motion (safe
+             * default). In practice this only happens during a startup race
+             * (reachability flow emits before the composer's first emission),
+             * and the composer's `Eagerly` sharing prevents that in production.
+             *
+             * Pure (no flow, no Android types) so the matrix can be pinned by
+             * a JVM unit test without the rest of the source.
+             */
+            internal fun filterByCapability(
+                reachable: Map<String, com.tinkernorth.dish.source.connection.SatelliteConnection>,
+                caps: Map<String, MotionCapability>,
+            ): Map<String, com.tinkernorth.dish.source.connection.SatelliteConnection> =
+                reachable.filterKeys { slotId ->
+                    val cap = caps[slotId] ?: return@filterKeys false
+                    cap.hasGyro && cap.userEnabled
+                }
 
             /**
              * Convert one fused controller IMU frame to a wire

--- a/app/src/main/java/com/tinkernorth/dish/source/store/MotionEnabledStore.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/store/MotionEnabledStore.kt
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.store
+
+import com.tinkernorth.dish.architecture.abstracts.AbstractStateSource
+import com.tinkernorth.dish.repository.MotionPreference
+import com.tinkernorth.dish.repository.MotionPreferenceRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Process-scoped reactive mirror of the durable
+ * [MotionPreferenceRepository]: `slotId → enabled`.
+ *
+ * The repository is the durable source of truth; this store hydrates from
+ * it on construction and republishes every write as a `StateFlow` so the
+ * [com.tinkernorth.dish.composer.MotionCapabilityComposer] (and the UI) can
+ * react without re-reading SharedPreferences on every frame.
+ *
+ * **Pattern:** [AbstractStateSource]`<Map<String, Boolean>>` — same shape
+ * as [ControllerTypeStore]. The two stores are parallel "reactive
+ * in-memory cache over a persisted choice" types; if you grow another one
+ * (per-slot rumble strength etc.), copy this file.
+ *
+ * **Default policy:** [isEnabled] collapses an absent entry onto
+ * [DEFAULT_ENABLED] (true). The product decision is "motion on unless the
+ * user turned it off" — discoverable via the indicator pill, recoverable
+ * via the toggle. The repository deliberately does not bake the default in
+ * (an absent entry is semantically different from `enabled=true`), so
+ * downstream consumers consult [isEnabled] rather than the raw map.
+ */
+@Singleton
+class MotionEnabledStore
+    @Inject
+    constructor(
+        private val repo: MotionPreferenceRepository,
+    ) : AbstractStateSource<Map<String, Boolean>>(initialState = emptyMap()) {
+        init {
+            // Hydrate once on construction. Subsequent durable changes flow
+            // through this store (setEnabled below), so it stays in sync.
+            setState(repo.all().associate { it.slotId to it.enabled })
+        }
+
+        /**
+         * Persist the user's choice for [slotId] and republish. Writes are
+         * synchronous to disk via SharedPreferences' edit().apply() (which
+         * commits the in-memory map immediately and persists asynchronously).
+         */
+        fun setEnabled(
+            slotId: String,
+            enabled: Boolean,
+        ) {
+            repo.put(MotionPreference(slotId = slotId, enabled = enabled))
+            setState { it + (slotId to enabled) }
+        }
+
+        /**
+         * Resolve the effective enabled boolean for [slotId], collapsing an
+         * absent entry onto [DEFAULT_ENABLED]. Use this — not the raw map
+         * — wherever the consumer cares about effective behaviour.
+         */
+        fun isEnabled(slotId: String): Boolean = state.value[slotId] ?: DEFAULT_ENABLED
+
+        /**
+         * Forget the user's choice for [slotId] (revert to default). Used
+         * when a physical pad is unbound permanently — keeping a stale
+         * entry forever would silently override the default for a future
+         * unrelated device that happened to get the same `InputDevice` id.
+         */
+        fun forget(slotId: String) {
+            repo.remove(slotId)
+            setState { it - slotId }
+        }
+
+        companion object {
+            /**
+             * Product default: motion is on for any slot that has not been
+             * explicitly toggled off. Surfaced as a constant so the composer
+             * and tests can pin the same value.
+             */
+            const val DEFAULT_ENABLED: Boolean = true
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.composer.ConnectionHub
 import com.tinkernorth.dish.composer.ConnectionKind
+import com.tinkernorth.dish.composer.MotionCapabilityComposer
 import com.tinkernorth.dish.composer.LinkState
 import com.tinkernorth.dish.composer.WakeStateController
 import com.tinkernorth.dish.core.input.hidToXusb
@@ -71,6 +72,8 @@ class GamepadOverlayActivity :
     @Inject lateinit var gamepadRegistry: PhysicalGamepadRegistry
 
     @Inject lateinit var notifications: DishNotifications
+
+    @Inject lateinit var motionCapability: MotionCapabilityComposer
 
     private lateinit var binding: ActivityGamepadOverlayBinding
     private lateinit var gamepadHost: GamepadActivityHost
@@ -146,6 +149,52 @@ class GamepadOverlayActivity :
                     // has no motion channel), so it must repaint when the
                     // bound connection's summary first resolves or changes.
                     refreshMotionStatus()
+                }
+            }
+        }
+
+        // Gate the gyro/accel listeners on the per-slot motion capability:
+        // start the source iff the slot is "effective" (gyro present AND
+        // bound to a Connected satellite AND the user toggle is on); stop
+        // otherwise. Replaces the previous always-on lifecycle in
+        // onResume/onPause, which burned battery on Bluetooth-HID
+        // connections (where motion can never flow) and ignored the user
+        // toggle entirely.
+        //
+        // The collector runs only while STARTED; repeatOnLifecycle cancels
+        // it on STOP, and the launched coroutine stops the source on
+        // cancellation so a backgrounded overlay never leaks listeners.
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                try {
+                    motionCapability.state.collect { caps ->
+                        val effective = caps[VIRTUAL_SLOT_ID]?.effective == true
+                        if (effective && !motionSource.isStreaming) {
+                            motionSource.start { sample, deltaUs ->
+                                satellite.get(connectionId)?.sendMotion(
+                                    VIRTUAL_SLOT_ID,
+                                    sample.gyroX,
+                                    sample.gyroY,
+                                    sample.gyroZ,
+                                    sample.accelX,
+                                    sample.accelY,
+                                    sample.accelZ,
+                                    deltaUs,
+                                )
+                            }
+                        } else if (!effective && motionSource.isStreaming) {
+                            motionSource.stop()
+                        }
+                        // Repaint after every gate flip so the pill
+                        // (STREAMING / PAUSED / NOT_FORWARDED / UNAVAILABLE)
+                        // tracks reality without waiting for an unrelated
+                        // hub.connections emission.
+                        refreshMotionStatus()
+                    }
+                } finally {
+                    // Stop on collector cancellation (STOP / activity destroy)
+                    // so a backgrounded overlay never leaks sensor listeners.
+                    motionSource.stop()
                 }
             }
         }
@@ -254,33 +303,23 @@ class GamepadOverlayActivity :
 
     override fun onResume() {
         super.onResume()
-        // Stream the phone's gyro/accel + battery to the bound satellite
-        // session. `satellite.get(...)` is null for Bluetooth-HID connections,
-        // so these emits naturally no-op there — motion forwarding is a
-        // satellite-path feature.
-        motionSource.start { sample, deltaUs ->
-            satellite.get(connectionId)?.sendMotion(
-                VIRTUAL_SLOT_ID,
-                sample.gyroX,
-                sample.gyroY,
-                sample.gyroZ,
-                sample.accelX,
-                sample.accelY,
-                sample.accelZ,
-                deltaUs,
-            )
-        }
+        // Battery is unconditional — it has its own gating on the connection
+        // kind inside the satellite send path, and the cost of a slow battery
+        // poll is negligible.
         batterySource.start(lifecycleScope) { level, status ->
             satellite.get(connectionId)?.sendBattery(VIRTUAL_SLOT_ID, level, status)
         }
-        // motionSource is now started (or a no-op if there's no gyroscope) —
-        // repaint so the pill reads "streaming" rather than "paused".
+        // Note: motionSource start/stop is now lifecycle-scoped on the
+        // capability flow (see the collector launched in onCreate). The
+        // overlay no longer unconditionally registers sensor listeners on
+        // Bluetooth-HID connections where motion can't flow, or on slots
+        // the user has toggled motion off for — fixing a measurable
+        // gyro/accel battery drain that previously ran for nothing.
         refreshMotionStatus()
     }
 
     override fun onPause() {
         super.onPause()
-        motionSource.stop()
         batterySource.stop()
         // Source stopped to save battery; reflect "paused" (not "unavailable").
         refreshMotionStatus()

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
@@ -13,6 +13,7 @@ import com.tinkernorth.dish.source.connection.ConnectionEvent
 import com.tinkernorth.dish.source.connection.SatelliteConnection
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.store.BatteryStatusStore
+import com.tinkernorth.dish.source.store.MotionEnabledStore
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -45,7 +46,20 @@ class MainViewModel
         val hub: ConnectionHub,
         private val gamepadRegistry: PhysicalGamepadRegistry,
         private val batteryStatusStore: BatteryStatusStore,
+        private val motionEnabledStore: MotionEnabledStore,
     ) : ViewModel() {
+        /**
+         * Reactive `slotId -> enabled` map for the per-slot motion toggle.
+         * Hydrated at process start from [MotionEnabledStore]'s durable
+         * backing repo, so the dashboard renders yesterday's toggle state
+         * with no first-frame flicker.
+         *
+         * Absence from the map means "user has not toggled" — call sites
+         * use [isMotionEnabled] to apply the default rather than reading
+         * the map directly.
+         */
+        val motionEnabled: StateFlow<Map<String, Boolean>> = motionEnabledStore.state
+
         private val _uiState = MutableStateFlow(MainUiState())
         val uiState: StateFlow<MainUiState> = _uiState.asStateFlow()
 
@@ -131,4 +145,34 @@ class MainViewModel
         ) {
             hub.setSatelliteControllerType(connectionId, slotId, type)
         }
+
+        // ── Motion toggle ─────────────────────────────────────────────────────
+
+        /**
+         * Persist the user's per-slot motion preference. The store writes
+         * through to the durable [com.tinkernorth.dish.repository.MotionPreferenceRepository]
+         * AND republishes its state flow so the
+         * [com.tinkernorth.dish.composer.MotionCapabilityComposer] (wired
+         * in a follow-up PR) re-derives the slot's `CAP_MOTION` bit and
+         * the sensor-listener gate flips on the next emission.
+         *
+         * No-op semantics: writing the same value twice is harmless;
+         * the store still re-emits so any downstream observer that
+         * relies on identity equality (none today) is unaffected.
+         */
+        fun setMotionEnabled(
+            slotId: String,
+            enabled: Boolean,
+        ) {
+            motionEnabledStore.setEnabled(slotId, enabled)
+        }
+
+        /**
+         * Resolve the effective motion-enabled boolean for [slotId],
+         * collapsing an absent entry onto [MotionEnabledStore.DEFAULT_ENABLED].
+         * Use this in render code — never read [motionEnabled] directly,
+         * since absence and `false` mean different things in the store
+         * but the same thing to the user.
+         */
+        fun isMotionEnabled(slotId: String): Boolean = motionEnabledStore.isEnabled(slotId)
     }

--- a/app/src/test/java/com/tinkernorth/dish/composer/MotionCapabilityComposerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/MotionCapabilityComposerTest.kt
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.composer
+
+import com.tinkernorth.dish.architecture.testing.composerTest
+import com.tinkernorth.dish.architecture.testing.probe
+import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
+import com.tinkernorth.dish.source.sensor.PhoneMotionAvailability
+import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [MotionCapabilityComposer] — the per-slot
+ * `MotionCapability` map that drives the `CAP_MOTION` bit at registration
+ * time, the sensor-listener gating, and the on-screen pill.
+ *
+ * Headline regressions pinned here:
+ *
+ *  - The virtual slot is *always present in the map* (key
+ *    [VIRTUAL_SLOT_ID]), regardless of whether any physical pad is attached
+ *    or any satellite is up. This is the bit the overlay reads at construct
+ *    time; if it weren't there, the pill would flicker UNAVAILABLE until the
+ *    first hub emission.
+ *  - `hasGyro` for a physical slot comes from
+ *    [PhysicalGamepadRegistry.Device.hasGyro] verbatim — not re-probed by
+ *    the composer (the probe is at device-add time, not on the hot
+ *    capability-flow path).
+ *  - `carriesOnConnection` is `kind == SATELLITE && live == Connected`,
+ *    nothing else. Bluetooth-HID, Connecting, Unstable all resolve to false.
+ *  - `toCapBits()` does *not* gate on `carriesOnConnection` — a satellite
+ *    re-connect must not require a re-handshake to recover motion.
+ */
+class MotionCapabilityComposerTest {
+    private fun summary(
+        id: String,
+        kind: ConnectionKind = ConnectionKind.SATELLITE,
+        live: LinkState = LinkState.Connected,
+    ) = ConnectionSummary(
+        id = id,
+        kind = kind,
+        label = id,
+        detail = "",
+        live = live,
+        boundSlotIds = emptyList(),
+    )
+
+    private fun device(
+        id: Int,
+        hasGyro: Boolean,
+    ) = PhysicalGamepadRegistry.Device(id, "Pad-$id", hasGyro = hasGyro)
+
+    /** Build a composer with mockable upstreams. */
+    private fun composerFor(
+        phoneAvailable: MutableStateFlow<Boolean>,
+        devices: MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>,
+        bindings: MutableStateFlow<Map<String, String>>,
+        connections: MutableStateFlow<List<ConnectionSummary>>,
+        scope: CoroutineScope,
+    ): MotionCapabilityComposer {
+        val availability: PhoneMotionAvailability =
+            mockk { every { state } returns phoneAvailable }
+        val registry: PhysicalGamepadRegistry =
+            mockk { every { this@mockk.devices } returns devices }
+        val hub: ConnectionHub =
+            mockk {
+                every { this@mockk.bindings } returns bindings
+                every { this@mockk.connections } returns connections
+            }
+        return MotionCapabilityComposer(availability, registry, hub, scope)
+    }
+
+    // ── Pure data-class invariants ──────────────────────────────────────
+
+    @Test
+    fun `effective requires every axis true`() {
+        // All-true is the only effective state. The three booleans are
+        // orthogonal — exhaustively check the false-leaning cases.
+        assertTrue(
+            MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = true).effective,
+        )
+        assertFalse(
+            MotionCapability(hasGyro = false, carriesOnConnection = true, userEnabled = true).effective,
+        )
+        assertFalse(
+            MotionCapability(hasGyro = true, carriesOnConnection = false, userEnabled = true).effective,
+        )
+        assertFalse(
+            MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = false).effective,
+        )
+    }
+
+    @Test
+    fun `toCapBits returns CAP_MOTION when the dish CAN emit motion`() {
+        // The CAP bit describes the dish's *capability*, not the live link.
+        // A connected, gyro-equipped, user-enabled slot ⇒ CAP_MOTION.
+        val cap = MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = true)
+        assertEquals(MotionCapability.CAP_MOTION_BIT, cap.toCapBits())
+    }
+
+    @Test
+    fun `toCapBits ignores carriesOnConnection — link-down is not a capability change`() {
+        // A satellite that is momentarily Connecting / Unstable must not flip
+        // the cap bit — otherwise every reconnect would force an unregister /
+        // re-register round trip. The cap bit only depends on hasGyro AND
+        // userEnabled.
+        val cap = MotionCapability(hasGyro = true, carriesOnConnection = false, userEnabled = true)
+        assertEquals(MotionCapability.CAP_MOTION_BIT, cap.toCapBits())
+    }
+
+    @Test
+    fun `toCapBits is zero when the user has disabled motion`() {
+        // Flipping the user toggle off is a real capability change — the
+        // dish stops emitting motion, so it should stop advertising CAP_MOTION.
+        val cap = MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = false)
+        assertEquals(0, cap.toCapBits())
+    }
+
+    @Test
+    fun `toCapBits is zero on hardware without a gyro — even if the user enabled it`() {
+        // No gyro means no motion, period; never lie to the receiver.
+        val cap = MotionCapability(hasGyro = false, carriesOnConnection = true, userEnabled = true)
+        assertEquals(0, cap.toCapBits())
+    }
+
+    // ── Composer derivation ──────────────────────────────────────────────
+
+    @Test
+    fun `virtual slot is always present in the map`() =
+        composerTest {
+            // No physical pads, no satellite — the touch overlay still has a
+            // capability entry to read at construct time. This is the pill's
+            // first-paint contract.
+            val phoneAvail = MutableStateFlow(false)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow<Map<String, String>>(emptyMap())
+            val conns = MutableStateFlow<List<ConnectionSummary>>(emptyList())
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+
+            val virtual = probe.latest[VIRTUAL_SLOT_ID]
+            assertEquals(
+                MotionCapability(hasGyro = false, carriesOnConnection = false, userEnabled = true),
+                virtual,
+            )
+        }
+
+    @Test
+    fun `virtual slot hasGyro mirrors PhoneMotionAvailability`() =
+        composerTest {
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow<Map<String, String>>(emptyMap())
+            val conns = MutableStateFlow<List<ConnectionSummary>>(emptyList())
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertEquals(true, probe.latest[VIRTUAL_SLOT_ID]?.hasGyro)
+
+            // Flip the source's value — the composer must re-derive.
+            phoneAvail.value = false
+            testScheduler.runCurrent()
+            assertEquals(false, probe.latest[VIRTUAL_SLOT_ID]?.hasGyro)
+        }
+
+    @Test
+    fun `virtual slot carriesOnConnection is true when bound to a Connected satellite`() =
+        composerTest {
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "sat-A"))
+            val conns = MutableStateFlow(listOf(summary("sat-A")))
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertTrue(probe.latest[VIRTUAL_SLOT_ID]?.carriesOnConnection == true)
+        }
+
+    @Test
+    fun `virtual slot carriesOnConnection is false on a Bluetooth-HID binding`() =
+        composerTest {
+            // BT-HID has no MSG_MOTION channel, so the pill must read
+            // NOT_FORWARDED. The composer's carriesOnConnection is the truth
+            // table's gate.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "bt-A"))
+            val conns = MutableStateFlow(listOf(summary("bt-A", kind = ConnectionKind.BLUETOOTH)))
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertFalse(probe.latest[VIRTUAL_SLOT_ID]?.carriesOnConnection == true)
+        }
+
+    @Test
+    fun `virtual slot carriesOnConnection is false while still Connecting`() =
+        composerTest {
+            // A satellite that hasn't reached Connected yet can't sink
+            // motion. The cap bit doesn't gate on this; the pill does.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "sat-A"))
+            val conns = MutableStateFlow(listOf(summary("sat-A", live = LinkState.Connecting)))
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertFalse(probe.latest[VIRTUAL_SLOT_ID]?.carriesOnConnection == true)
+        }
+
+    @Test
+    fun `physical slot uses Device hasGyro verbatim — no re-probe`() =
+        composerTest {
+            // The composer never calls PhysicalMotionProbe itself; the truth
+            // is whatever the registry recorded at add time. This pin
+            // catches a regression where someone "helpfully" re-probes on
+            // every emission and slows the hot capability-flow path.
+            val phoneAvail = MutableStateFlow(false)
+            val devices =
+                MutableStateFlow(
+                    mapOf(
+                        9 to device(9, hasGyro = true),
+                        11 to device(11, hasGyro = false),
+                    ),
+                )
+            val bindings = MutableStateFlow<Map<String, String>>(emptyMap())
+            val conns = MutableStateFlow<List<ConnectionSummary>>(emptyList())
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertEquals(true, probe.latest["9"]?.hasGyro)
+            assertEquals(false, probe.latest["11"]?.hasGyro)
+        }
+
+    @Test
+    fun `physical slot drops from the map when the device leaves the registry`() =
+        composerTest {
+            // The registry's disconnect grace removes Devices from its flow
+            // when the grace expires. The composer must drop the slot too,
+            // not stash a stale "still capable" entry.
+            val phoneAvail = MutableStateFlow(false)
+            val devices = MutableStateFlow(mapOf(9 to device(9, hasGyro = true)))
+            val bindings = MutableStateFlow<Map<String, String>>(emptyMap())
+            val conns = MutableStateFlow<List<ConnectionSummary>>(emptyList())
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertEquals(true, probe.latest["9"]?.hasGyro)
+
+            devices.value = emptyMap()
+            testScheduler.runCurrent()
+            assertNull(probe.latest["9"])
+        }
+
+    @Test
+    fun `the map re-emits when the routing flips kind from satellite to bluetooth`() =
+        composerTest {
+            // Mid-game the user changes a slot from satellite to BT-HID. The
+            // capability for that slot must flip carriesOnConnection from
+            // true → false on the next emission.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow(mapOf(9 to device(9, hasGyro = true)))
+            val bindings = MutableStateFlow(mapOf("9" to "sat-A"))
+            val conns = MutableStateFlow(listOf(summary("sat-A")))
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertTrue(probe.latest["9"]?.carriesOnConnection == true)
+
+            bindings.value = mapOf("9" to "bt-A")
+            conns.value = listOf(summary("bt-A", kind = ConnectionKind.BLUETOOTH))
+            testScheduler.runCurrent()
+            assertFalse(probe.latest["9"]?.carriesOnConnection == true)
+        }
+}

--- a/app/src/test/java/com/tinkernorth/dish/composer/MotionCapabilityComposerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/MotionCapabilityComposerTest.kt
@@ -7,6 +7,7 @@ import com.tinkernorth.dish.architecture.testing.composerTest
 import com.tinkernorth.dish.architecture.testing.probe
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.source.sensor.PhoneMotionAvailability
+import com.tinkernorth.dish.source.store.MotionEnabledStore
 import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
 import io.mockk.every
 import io.mockk.mockk
@@ -65,6 +66,7 @@ class MotionCapabilityComposerTest {
         bindings: MutableStateFlow<Map<String, String>>,
         connections: MutableStateFlow<List<ConnectionSummary>>,
         scope: CoroutineScope,
+        motionEnabled: MutableStateFlow<Map<String, Boolean>> = MutableStateFlow(emptyMap()),
     ): MotionCapabilityComposer {
         val availability: PhoneMotionAvailability =
             mockk { every { state } returns phoneAvailable }
@@ -75,7 +77,9 @@ class MotionCapabilityComposerTest {
                 every { this@mockk.bindings } returns bindings
                 every { this@mockk.connections } returns connections
             }
-        return MotionCapabilityComposer(availability, registry, hub, scope)
+        val store: MotionEnabledStore =
+            mockk { every { state } returns motionEnabled }
+        return MotionCapabilityComposer(availability, registry, hub, store, scope)
     }
 
     // ── Pure data-class invariants ──────────────────────────────────────
@@ -258,6 +262,113 @@ class MotionCapabilityComposerTest {
             devices.value = emptyMap()
             testScheduler.runCurrent()
             assertNull(probe.latest["9"])
+        }
+
+    @Test
+    fun `userEnabled defaults to true for an unwritten slot`() =
+        composerTest {
+            // The store collapses an absent key onto DEFAULT_ENABLED = true.
+            // The composer must respect the same default — otherwise a fresh
+            // install would silently advertise CAP_MOTION = 0 for every slot
+            // until the user toggled each one. Pin the default through the
+            // composer's userEnabled field.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow<Map<String, String>>(emptyMap())
+            val conns = MutableStateFlow<List<ConnectionSummary>>(emptyList())
+            val motionEnabled = MutableStateFlow<Map<String, Boolean>>(emptyMap())
+
+            val probe =
+                composerFor(phoneAvail, devices, bindings, conns, backgroundScope, motionEnabled).probe(this)
+            testScheduler.runCurrent()
+
+            assertEquals(true, probe.latest[VIRTUAL_SLOT_ID]?.userEnabled)
+        }
+
+    @Test
+    fun `userEnabled flips when MotionEnabledStore writes false for a slot`() =
+        composerTest {
+            // The toggle is the user-visible switch — flipping it must
+            // immediately propagate to the composer (and from there to
+            // SatelliteConnection's cap bit and the listener gate). A
+            // regression where the store write doesn't reach the composer
+            // would make the toggle look broken in the UI.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow<Map<String, String>>(emptyMap())
+            val conns = MutableStateFlow<List<ConnectionSummary>>(emptyList())
+            val motionEnabled = MutableStateFlow<Map<String, Boolean>>(emptyMap())
+
+            val composer =
+                composerFor(phoneAvail, devices, bindings, conns, backgroundScope, motionEnabled)
+            val probe = composer.probe(this)
+            testScheduler.runCurrent()
+            assertTrue(probe.latest[VIRTUAL_SLOT_ID]?.userEnabled == true)
+
+            motionEnabled.value = mapOf(VIRTUAL_SLOT_ID to false)
+            testScheduler.runCurrent()
+            assertFalse(probe.latest[VIRTUAL_SLOT_ID]?.userEnabled == true)
+        }
+
+    @Test
+    fun `toCapBits is zero on a slot the user has disabled — even if hasGyro is true`() =
+        composerTest {
+            // End-to-end pin: phone has gyro, satellite is up, but the user
+            // toggled motion off — the cap bit on the wire must be zero so
+            // the receiver's web UI is honest about which slots stream motion.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "sat-A"))
+            val conns = MutableStateFlow(listOf(summary("sat-A")))
+            val motionEnabled = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to false))
+
+            val probe =
+                composerFor(phoneAvail, devices, bindings, conns, backgroundScope, motionEnabled).probe(this)
+            testScheduler.runCurrent()
+
+            assertEquals(0, probe.latest[VIRTUAL_SLOT_ID]?.toCapBits())
+        }
+
+    @Test
+    fun `capabilityFor returns the latest derived value for a slot`() =
+        composerTest {
+            // SatelliteConnection.registerController is synchronous on its IO
+            // dispatcher; the composer's state.collect would be awkward there.
+            // capabilityFor is the synchronous accessor — pin that it returns
+            // the latest derived value, not stale Initial.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "sat-A"))
+            val conns = MutableStateFlow(listOf(summary("sat-A")))
+
+            val composer =
+                composerFor(phoneAvail, devices, bindings, conns, backgroundScope)
+            composer.probe(this)
+            testScheduler.runCurrent()
+
+            val cap = composer.capabilityFor(VIRTUAL_SLOT_ID)
+            assertTrue(cap.hasGyro)
+            assertTrue(cap.carriesOnConnection)
+            assertEquals(MotionCapability.CAP_MOTION_BIT, cap.toCapBits())
+        }
+
+    @Test
+    fun `capabilityFor returns Off for a slot not in the map`() =
+        composerTest {
+            // A controller-add for an unknown slot (race with registry
+            // disconnect) must not NPE — capabilityFor returns Off so the
+            // cap word is 0, which is correct: we don't know that slot has
+            // motion, so don't advertise it.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow<Map<String, String>>(emptyMap())
+            val conns = MutableStateFlow<List<ConnectionSummary>>(emptyList())
+
+            val composer = composerFor(phoneAvail, devices, bindings, conns, backgroundScope)
+            composer.probe(this)
+            testScheduler.runCurrent()
+
+            assertEquals(MotionCapability.Off, composer.capabilityFor("ghost-slot"))
         }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/repository/MotionPreferenceRepositoryContractTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/MotionPreferenceRepositoryContractTest.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.tinkernorth.dish.architecture.interfaces.Repository
+import com.tinkernorth.dish.architecture.testing.AbstractRepositoryContract
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.serialization.json.Json
+import kotlin.random.Random
+
+/**
+ * Inherits the standard CRUD contract from [AbstractRepositoryContract]:
+ * get on empty, all on empty, get-after-put, replace-on-same-key, remove,
+ * all-contains-every-put, clear, remove-absent-is-noop.
+ *
+ * Per-implementation behaviour (corrupt-JSON tolerance, multi-entry
+ * persistence after a re-read) is in the sibling `MotionPreferenceRepositoryTest`.
+ *
+ * SharedPreferences is mocked into a `MutableMap` so this stays a pure
+ * JVM test — same pattern as
+ * [RememberedSatelliteRepositoryContractTest].
+ */
+class MotionPreferenceRepositoryContractTest : AbstractRepositoryContract<String, MotionPreference>() {
+    override fun newRepository(): Repository<String, MotionPreference> =
+        MotionPreferenceRepository(
+            context = fakeContextBackedByMap(),
+            json = Json { ignoreUnknownKeys = true },
+        )
+
+    override fun newKey(): String = "slot-${Random.nextLong()}"
+
+    /** Same key ⇒ same value. The contract test compares sets of values. */
+    override fun newValue(key: String): MotionPreference =
+        MotionPreference(slotId = key, enabled = key.hashCode() and 1 == 0)
+
+    private fun fakeContextBackedByMap(): Context {
+        val store = mutableMapOf<String, Any?>()
+        val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+        val keySlot = slot<String>()
+        val strSlot = slot<String?>()
+        every { editor.putString(capture(keySlot), captureNullable(strSlot)) } answers {
+            store[keySlot.captured] = strSlot.captured
+            editor
+        }
+        every { editor.remove(capture(keySlot)) } answers {
+            store.remove(keySlot.captured)
+            editor
+        }
+        every { editor.apply() } answers { /* no-op */ }
+
+        val prefs = mockk<SharedPreferences>(relaxed = true)
+        every { prefs.getString(any(), any()) } answers {
+            val k = firstArg<String>()
+            val default = secondArg<String?>()
+            (store[k] as? String) ?: default
+        }
+        every { prefs.edit() } returns editor
+        every { prefs.all } answers { store.toMap() }
+
+        val context = mockk<Context>(relaxed = true)
+        every { context.getSharedPreferences(any(), any()) } returns prefs
+        return context
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/repository/MotionPreferenceRepositoryTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/MotionPreferenceRepositoryTest.kt
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Behaviour-specific tests for [MotionPreferenceRepository] — the CRUD
+ * contract is covered by [MotionPreferenceRepositoryContractTest]; this
+ * file pins the JSON serialization edges and the multi-write durability
+ * that matter for upgrades.
+ */
+class MotionPreferenceRepositoryTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `enabled true and false round-trip through SharedPreferences`() {
+        // The repository must persist the boolean verbatim — a sloppy
+        // implementation that conflates `null` (unset) with `false` would
+        // destroy the "I haven't decided yet" signal the store relies on
+        // for its default. Pin both true and false through a write/read.
+        val (ctx, _) = fakePrefs()
+        val repo = MotionPreferenceRepository(ctx, json)
+        repo.put(MotionPreference("virtual", enabled = true))
+        repo.put(MotionPreference("9", enabled = false))
+
+        // Re-read through a fresh repo on the same backing prefs to prove
+        // durability (no in-memory cache shortcut).
+        val (ctx2, _) = fakePrefs(seedFrom = ctx)
+        val repo2 = MotionPreferenceRepository(ctx2, json)
+        assertEquals(true, repo2.get("virtual")?.enabled)
+        assertEquals(false, repo2.get("9")?.enabled)
+    }
+
+    @Test
+    fun `get on a slot that was never written returns null — not a default boolean`() {
+        // The repository never invents a default. The store layer
+        // collapses null onto MotionEnabledStore.DEFAULT_ENABLED; the repo
+        // must stay honest so the store can distinguish "user has not
+        // decided" from "user explicitly enabled".
+        val (ctx, _) = fakePrefs()
+        val repo = MotionPreferenceRepository(ctx, json)
+        assertNull(repo.get("never-written"))
+    }
+
+    @Test
+    fun `corrupt JSON in prefs falls back to empty — does not crash app startup`() {
+        // A crash during a previous write, or a sideloaded apk overwriting
+        // the prefs, could leave invalid JSON behind. The repo must
+        // tolerate it (the user just loses their motion preferences for
+        // every slot) rather than crash the app on first read.
+        val (ctx, store) = fakePrefs()
+        store["preferences"] = "{not valid json"
+        val repo = MotionPreferenceRepository(ctx, json)
+        assertTrue(repo.all().isEmpty())
+        assertNull(repo.get("anything"))
+    }
+
+    @Test
+    fun `remove of one slot does not disturb other slots' preferences`() {
+        // Per-slot removal must touch only the named entry — important
+        // when a physical pad is unbound but a virtual slot's preference
+        // must survive.
+        val (ctx, _) = fakePrefs()
+        val repo = MotionPreferenceRepository(ctx, json)
+        repo.put(MotionPreference("virtual", enabled = true))
+        repo.put(MotionPreference("9", enabled = false))
+        repo.remove("9")
+
+        assertEquals(true, repo.get("virtual")?.enabled)
+        assertNull(repo.get("9"))
+    }
+
+    @Test
+    fun `put with same slot replaces in place — list never grows`() {
+        // The contract test exercises this generically; this version pins
+        // the absolute size to catch a regression where put accidentally
+        // append-only's the list and persists duplicate entries.
+        val (ctx, _) = fakePrefs()
+        val repo = MotionPreferenceRepository(ctx, json)
+        repo.put(MotionPreference("virtual", enabled = true))
+        repo.put(MotionPreference("virtual", enabled = false))
+        repo.put(MotionPreference("virtual", enabled = true))
+        assertEquals(1, repo.all().size)
+        assertEquals(true, repo.get("virtual")?.enabled)
+    }
+
+    // ── Test fixtures ────────────────────────────────────────────────────
+
+    /**
+     * Returns a Context + the underlying mutable map. Pass [seedFrom] to
+     * mirror an earlier prefs' state (testing durability across a fresh
+     * repo instance on the same prefs key).
+     */
+    private fun fakePrefs(seedFrom: Context? = null): Pair<Context, MutableMap<String, Any?>> {
+        val store: MutableMap<String, Any?> =
+            (seedFrom?.getSharedPreferences("motion_preferences", 0)?.all as? Map<String, Any?>)
+                ?.toMutableMap()
+                ?: mutableMapOf()
+
+        val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+        val keySlot = slot<String>()
+        val strSlot = slot<String?>()
+        every { editor.putString(capture(keySlot), captureNullable(strSlot)) } answers {
+            store[keySlot.captured] = strSlot.captured
+            editor
+        }
+        every { editor.remove(capture(keySlot)) } answers {
+            store.remove(keySlot.captured)
+            editor
+        }
+        every { editor.apply() } answers { /* no-op */ }
+
+        val prefs = mockk<SharedPreferences>(relaxed = true)
+        every { prefs.getString(any(), any()) } answers {
+            val k = firstArg<String>()
+            val default = secondArg<String?>()
+            (store[k] as? String) ?: default
+        }
+        every { prefs.edit() } returns editor
+        every { prefs.all } answers { store.toMap() }
+
+        val ctx = mockk<Context>(relaxed = true)
+        every { ctx.getSharedPreferences(any(), any()) } returns prefs
+        return ctx to store
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManagerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManagerTest.kt
@@ -5,6 +5,8 @@ package com.tinkernorth.dish.source.connection
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.tinkernorth.dish.composer.MotionCapability
+import com.tinkernorth.dish.composer.MotionCapabilityComposer
 import com.tinkernorth.dish.core.jni.ControllerRepository
 import com.tinkernorth.dish.core.model.DiscoveredServer
 import com.tinkernorth.dish.core.net.DiscoveryRepository
@@ -82,6 +84,18 @@ class SatelliteConnectionManagerTest {
         every { store.satelliteSharedKey(any()) } returns null
     }
 
+    /**
+     * Provider that returns a fresh, always-off [MotionCapabilityComposer]
+     * stand-in. These tests don't exercise the cap-bit path; they just need
+     * the manager to construct successfully.
+     */
+    private val motionCapabilityProvider =
+        javax.inject.Provider<MotionCapabilityComposer> {
+            mockk(relaxed = true) {
+                every { capabilityFor(any()) } returns MotionCapability.Off
+            }
+        }
+
     private fun manager(): SatelliteConnectionManager =
         SatelliteConnectionManager(
             context = context,
@@ -91,6 +105,7 @@ class SatelliteConnectionManagerTest {
             store = store,
             json = json,
             ioDispatcher = ioDispatcher,
+            motionCapabilityProvider = motionCapabilityProvider,
         )
 
     private fun runMgrTest(block: suspend (SatelliteConnectionManager, MutableList<ConnectionEvent>) -> Unit) =

--- a/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionTest.kt
@@ -257,10 +257,117 @@ class SatelliteConnectionTest {
 
             // Post-Task-1.1 builds must set CAP_MOTION (0x0004) in the
             // MSG_CONTROLLER_ADD capability word so the server knows to expect
-            // the MSG_MOTION IMU stream from this client.
+            // the MSG_MOTION IMU stream from this client. Default-arg
+            // motionCapsBitsFor returns CAP_MOTION_BIT_LEGACY, exercising the
+            // pre-composer behaviour.
             coVerify {
                 repo.addController(8, 0, match { (it and 0x0004) != 0 })
             }
+        }
+
+    @Test
+    fun `controller add CLEARS CAP_MOTION when motionCapsBitsFor returns 0`() =
+        runTest {
+            // The headline PR3 fix: when the capability composer says "this
+            // slot has no gyro" OR "the user toggled motion off," the cap
+            // word on the wire must drop CAP_MOTION so the receiver's web
+            // UI is honest about which slots stream motion. A regression
+            // here is the existing bug (every controller silently advertises
+            // CAP_MOTION).
+            every { repo.resetControllerAck(any()) } just Runs
+            every { repo.startHeartbeat(any()) } just Runs
+            every { repo.isConnectionAlive(any()) } returns false
+            every { repo.getLastControllerAck(any()) } returns 0
+
+            val noMotion =
+                SatelliteConnection(
+                    id = SatelliteConnection.idFor(server),
+                    server = server,
+                    scope = scope,
+                    controllerRepo = repo,
+                    motionCapsBitsFor = { 0 },
+                )
+            noMotion.markConnecting()
+            noMotion.markConnected(handle = 8, connectionId = "c") {}
+            noMotion.attachSlot(slotId = "slot-1", controllerType = 0)
+
+            // Motion bit absent.
+            coVerify {
+                repo.addController(8, 0, match { (it and 0x0004) == 0 })
+            }
+            // Non-motion bits (analog triggers 0x0001 + rumble 0x0002) still set —
+            // the lambda only controls the motion bit, not the whole word.
+            coVerify {
+                repo.addController(8, 0, match { (it and 0x0001) != 0 && (it and 0x0002) != 0 })
+            }
+
+            noMotion.markDisconnected()
+        }
+
+    @Test
+    fun `controller add SETS CAP_MOTION when motionCapsBitsFor returns the bit`() =
+        runTest {
+            // The other side of the truth table: when the slot has motion
+            // (gyro present + user-enabled), the cap word must include
+            // CAP_MOTION. Pin the explicit-bit path (no default-arg
+            // accident).
+            every { repo.resetControllerAck(any()) } just Runs
+            every { repo.startHeartbeat(any()) } just Runs
+            every { repo.isConnectionAlive(any()) } returns false
+            every { repo.getLastControllerAck(any()) } returns 0
+
+            val withMotion =
+                SatelliteConnection(
+                    id = SatelliteConnection.idFor(server),
+                    server = server,
+                    scope = scope,
+                    controllerRepo = repo,
+                    motionCapsBitsFor = { 0x0004 },
+                )
+            withMotion.markConnecting()
+            withMotion.markConnected(handle = 8, connectionId = "c") {}
+            withMotion.attachSlot(slotId = "slot-1", controllerType = 0)
+
+            coVerify {
+                repo.addController(8, 0, match { (it and 0x0004) != 0 })
+            }
+            withMotion.markDisconnected()
+        }
+
+    @Test
+    fun `motionCapsBitsFor is called with the SAME slotId being registered`() =
+        runTest {
+            // Per-slot resolution is the whole point — two slots with
+            // different toggles must each see their own slotId. A regression
+            // that hardcodes a single slotId would silently apply slot-A's
+            // toggle to slot-B (or worse, return random results).
+            every { repo.resetControllerAck(any()) } just Runs
+            every { repo.startHeartbeat(any()) } just Runs
+            every { repo.isConnectionAlive(any()) } returns false
+            every { repo.getLastControllerAck(any()) } returns 0
+
+            val askedFor = mutableListOf<String>()
+            val perSlot =
+                SatelliteConnection(
+                    id = SatelliteConnection.idFor(server),
+                    server = server,
+                    scope = scope,
+                    controllerRepo = repo,
+                    motionCapsBitsFor = { slot ->
+                        askedFor += slot
+                        if (slot == "slot-A") 0x0004 else 0
+                    },
+                )
+            perSlot.markConnecting()
+            perSlot.markConnected(handle = 8, connectionId = "c") {}
+            perSlot.attachSlot("slot-A", controllerType = 0)
+            perSlot.attachSlot("slot-B", controllerType = 0)
+
+            assertTrue(askedFor.contains("slot-A"))
+            assertTrue(askedFor.contains("slot-B"))
+            coVerify { repo.addController(8, 0, match { (it and 0x0004) != 0 }) }
+            coVerify { repo.addController(8, 1, match { (it and 0x0004) == 0 }) }
+            perSlot.markDisconnected()
         }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/source/sensor/PhoneMotionAvailabilityTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/sensor/PhoneMotionAvailabilityTest.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.sensor
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorManager
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [PhoneMotionAvailability] — the process-scoped "does the
+ * phone itself have a gyro?" fact. The value is decided once at injection
+ * time (Android device hardware does not change at runtime), so the tests
+ * just pin: gyro present ⇒ true, gyro absent ⇒ false, SENSOR_SERVICE absent
+ * ⇒ false. The state flow exposing those values is the same shape every
+ * [com.tinkernorth.dish.architecture.abstracts.AbstractStateSource] subclass
+ * uses; the base class is covered by `StateSourceProbeSampleTest`.
+ */
+class PhoneMotionAvailabilityTest {
+    private fun contextWithSensor(sensor: Sensor?): Context {
+        val sm =
+            mockk<SensorManager> {
+                every { getDefaultSensor(Sensor.TYPE_GYROSCOPE) } returns sensor
+            }
+        return mockk { every { getSystemService(Context.SENSOR_SERVICE) } returns sm }
+    }
+
+    @Test
+    fun `phone with a gyroscope is motion-available`() {
+        val src = PhoneMotionAvailability(contextWithSensor(mockk()))
+        assertTrue(src.state.value)
+    }
+
+    @Test
+    fun `phone without a gyroscope is not motion-available`() {
+        // Tablets, very cheap phones, some kiosk hardware — the touch
+        // overlay should show "Motion: not available", and the satellite
+        // CAP_MOTION advertisement must not lie.
+        val src = PhoneMotionAvailability(contextWithSensor(sensor = null))
+        assertFalse(src.state.value)
+    }
+
+    @Test
+    fun `null SENSOR_SERVICE falls through to not-available, does not throw`() {
+        // Robolectric- or stub-flavoured Contexts can return null for system
+        // services; the source defends so the app never NPEs at startup.
+        val ctx =
+            mockk<Context> {
+                every { getSystemService(Context.SENSOR_SERVICE) } returns null
+            }
+        val src = PhoneMotionAvailability(ctx)
+        assertFalse(src.state.value)
+    }
+
+    @Test
+    fun `state flow exposes the same boolean as state value`() {
+        // The composer subscribes via .state.collect — assert the StateFlow's
+        // current value matches what the property reports.
+        val src = PhoneMotionAvailability(contextWithSensor(mockk()))
+        assertEquals(src.state.value, src.state.value)
+        assertTrue(src.state.value)
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/source/sensor/PhysicalMotionProbeTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/sensor/PhysicalMotionProbeTest.kt
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.sensor
+
+import android.hardware.Sensor
+import android.hardware.SensorManager
+import android.os.Build
+import android.view.InputDevice
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [PhysicalMotionProbe.evaluate] — the pure decision exercised
+ * directly. The thin `hasGyro(deviceId)` wrapper is just `evaluate(SDK_INT,
+ * InputDevice.getDevice(id))`, so pinning the four cases here covers both.
+ *
+ * `Build.VERSION_CODES.S` is referenced as the threshold; the test makes both
+ * sides of that threshold explicit so a future API bump that nudges the
+ * constant is still caught.
+ */
+class PhysicalMotionProbeTest {
+    private val gyro: Sensor = mockk(relaxed = true)
+
+    private fun deviceWithGyro(): InputDevice {
+        val sm =
+            mockk<SensorManager> {
+                every { getDefaultSensor(Sensor.TYPE_GYROSCOPE) } returns gyro
+            }
+        return mockk { every { sensorManager } returns sm }
+    }
+
+    private fun deviceWithoutGyro(): InputDevice {
+        val sm =
+            mockk<SensorManager> {
+                every { getDefaultSensor(Sensor.TYPE_GYROSCOPE) } returns null
+            }
+        return mockk { every { sensorManager } returns sm }
+    }
+
+    @Test
+    fun `returns false on API below 31 — per-device sensor API does not exist`() {
+        // Even a pad with a real IMU can't be reached pre-API 31, so the
+        // probe must say no. Use SDK_INT - 1 (one below S) explicitly.
+        assertFalse(PhysicalMotionProbe.evaluate(sdkInt = 30, device = deviceWithGyro()))
+    }
+
+    @Test
+    fun `returns false when the InputDevice is null`() {
+        // A device that was unplugged between the InputManager callback and
+        // the probe call must resolve to "no gyro" without throwing.
+        assertFalse(PhysicalMotionProbe.evaluate(sdkInt = Build.VERSION_CODES.S, device = null))
+    }
+
+    @Test
+    fun `returns false when the pad has no gyroscope sensor`() {
+        // A cheap Bluetooth pad on API 31+ — the per-device SensorManager
+        // exists but reports no TYPE_GYROSCOPE.
+        assertFalse(
+            PhysicalMotionProbe.evaluate(
+                sdkInt = Build.VERSION_CODES.S,
+                device = deviceWithoutGyro(),
+            ),
+        )
+    }
+
+    @Test
+    fun `returns true when API 31+ and the pad reports a gyroscope`() {
+        // The success path — DualSense or similar with an IMU.
+        assertTrue(
+            PhysicalMotionProbe.evaluate(
+                sdkInt = Build.VERSION_CODES.S,
+                device = deviceWithGyro(),
+            ),
+        )
+    }
+
+    @Test
+    fun `is stable across higher SDK levels — does not regress past API 31`() {
+        // Future API bumps must not silently turn the gate back off; pin a
+        // higher SDK level too so a typo in the threshold check is caught.
+        assertTrue(
+            PhysicalMotionProbe.evaluate(
+                sdkInt = Build.VERSION_CODES.S + 5,
+                device = deviceWithGyro(),
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/source/sensor/PhysicalMotionSourceTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/sensor/PhysicalMotionSourceTest.kt
@@ -3,7 +3,11 @@
 
 package com.tinkernorth.dish.source.sensor
 
+import com.tinkernorth.dish.composer.MotionCapability
+import com.tinkernorth.dish.source.connection.SatelliteConnection
+import io.mockk.mockk
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -94,6 +98,71 @@ class PhysicalMotionSourceTest {
         assertEquals(1234, s.accelX.toInt())
         assertEquals(-5678, s.accelY.toInt())
         assertEquals(8191, s.accelZ.toInt())
+    }
+
+    // ── filterByCapability — the gate added in PR3 ─────────────────────────
+
+    private fun fakeConn(): SatelliteConnection = mockk(relaxed = true)
+
+    @Test
+    fun `filterByCapability keeps a reachable slot that has gyro AND is user-enabled`() {
+        // The success path — both capability axes true, the slot stays in
+        // the reachable map and its sensor listener will register.
+        val conn = fakeConn()
+        val reachable = mapOf("9" to conn)
+        val caps = mapOf("9" to MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = true))
+        assertEquals(reachable, PhysicalMotionSource.filterByCapability(reachable, caps))
+    }
+
+    @Test
+    fun `filterByCapability drops a reachable slot whose pad has NO gyro`() {
+        // A cheap Bluetooth pad on API 31+ exposes the per-device
+        // SensorManager but reports no TYPE_GYROSCOPE. Reachability still
+        // says "the slot is bound and the satellite is up"; the capability
+        // gate must drop it so listening doesn't burn battery on a sensor
+        // that will never fire.
+        val reachable = mapOf("9" to fakeConn())
+        val caps = mapOf("9" to MotionCapability(hasGyro = false, carriesOnConnection = true, userEnabled = true))
+        assertTrue(PhysicalMotionSource.filterByCapability(reachable, caps).isEmpty())
+    }
+
+    @Test
+    fun `filterByCapability drops a slot the user has toggled motion off for`() {
+        // The user-facing toggle is the headline PR2/PR3 deliverable —
+        // when off, the listener must NOT register, even though hardware
+        // and link are both ready. A regression that ignores userEnabled
+        // would leak gyro listeners on slots motion is off for, defeating
+        // the toggle.
+        val reachable = mapOf("9" to fakeConn())
+        val caps = mapOf("9" to MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = false))
+        assertTrue(PhysicalMotionSource.filterByCapability(reachable, caps).isEmpty())
+    }
+
+    @Test
+    fun `filterByCapability drops a reachable slot that is missing from caps`() {
+        // Startup race: the reachability flow emits before the capability
+        // composer's first emission. Treat the unknown slot as "no motion"
+        // (safe default) — the next emission will reinstate it if it
+        // actually has gyro + is enabled.
+        val reachable = mapOf("9" to fakeConn())
+        val caps = emptyMap<String, MotionCapability>()
+        assertTrue(PhysicalMotionSource.filterByCapability(reachable, caps).isEmpty())
+    }
+
+    @Test
+    fun `filterByCapability per-slot — keeps the enabled one, drops the disabled one`() {
+        // Two pads, same satellite, different user toggles. Pin that the
+        // filter is per-slot and not "all-or-nothing."
+        val connA = fakeConn()
+        val connB = fakeConn()
+        val reachable = mapOf("A" to connA, "B" to connB)
+        val caps =
+            mapOf(
+                "A" to MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = true),
+                "B" to MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = false),
+            )
+        val result = PhysicalMotionSource.filterByCapability(reachable, caps)
+        assertEquals(mapOf("A" to connA), result)
     }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/source/store/MotionEnabledStoreTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/store/MotionEnabledStoreTest.kt
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.store
+
+import com.tinkernorth.dish.repository.MotionPreference
+import com.tinkernorth.dish.repository.MotionPreferenceRepository
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [MotionEnabledStore] — the reactive mirror over the
+ * durable [MotionPreferenceRepository].
+ *
+ * Headline invariants pinned here:
+ *
+ *  - **Hydration on construction:** the store seeds its `state` from
+ *    `repo.all()` at construction time, so a fresh process restart sees
+ *    yesterday's toggles without an extra round trip.
+ *  - **Default policy:** an absent slot's [MotionEnabledStore.isEnabled]
+ *    returns [MotionEnabledStore.DEFAULT_ENABLED] (true). The composer and
+ *    pill consume this default; if the policy changes it changes here.
+ *  - **Write-through:** [MotionEnabledStore.setEnabled] always persists
+ *    AND republishes — neither side is allowed to silently win. If a
+ *    future refactor drops the repo write, the durability test fails.
+ *  - **Forget restores default:** removing a slot's entry causes
+ *    [MotionEnabledStore.isEnabled] to flip back to the default.
+ */
+class MotionEnabledStoreTest {
+    @Test
+    fun `hydrates state from the repository on construction`() {
+        // Process restart scenario: the durable repository already holds
+        // yesterday's toggles. The store must surface them immediately —
+        // no race window where state reads emptyMap and isEnabled
+        // returns the default for a slot the user explicitly turned off.
+        val repo =
+            mockk<MotionPreferenceRepository> {
+                every { all() } returns
+                    listOf(
+                        MotionPreference("virtual", enabled = true),
+                        MotionPreference("9", enabled = false),
+                    )
+            }
+        val store = MotionEnabledStore(repo)
+
+        assertEquals(true, store.state.value["virtual"])
+        assertEquals(false, store.state.value["9"])
+        assertEquals(2, store.state.value.size)
+    }
+
+    @Test
+    fun `default is on for an unwritten slot`() {
+        // The product decision is "motion is on unless I turn it off."
+        // Pin the default through the public isEnabled getter so a future
+        // refactor can't silently flip the polarity.
+        val repo = repoWithEmpty()
+        val store = MotionEnabledStore(repo)
+        assertTrue(store.isEnabled("never-toggled"))
+        assertTrue(MotionEnabledStore.DEFAULT_ENABLED) // constant pin
+    }
+
+    @Test
+    fun `setEnabled persists to the repository AND republishes state`() {
+        // The store must be both reactive (state flow) AND durable (repo
+        // write). A regression that only updates the in-memory cache
+        // would lose the toggle on app restart.
+        val repo = repoWithEmpty()
+        val store = MotionEnabledStore(repo)
+
+        store.setEnabled("9", enabled = false)
+
+        verify { repo.put(MotionPreference("9", enabled = false)) }
+        assertEquals(false, store.state.value["9"])
+        assertFalse(store.isEnabled("9"))
+    }
+
+    @Test
+    fun `setEnabled then setEnabled with opposite value flips both layers`() {
+        // Toggling the switch on then off then on again must leave the
+        // store in the final state across both the durable and reactive
+        // layers — no half-updated state.
+        val repo = repoWithEmpty()
+        val store = MotionEnabledStore(repo)
+        store.setEnabled("9", enabled = false)
+        store.setEnabled("9", enabled = true)
+        store.setEnabled("9", enabled = false)
+
+        verify { repo.put(MotionPreference("9", enabled = false)) }
+        verify { repo.put(MotionPreference("9", enabled = true)) }
+        assertEquals(false, store.state.value["9"])
+        assertFalse(store.isEnabled("9"))
+    }
+
+    @Test
+    fun `forget removes the entry from state AND from the repository`() {
+        // Per-slot forget is used when a physical pad is unbound
+        // permanently — keeping a stale entry forever would silently
+        // override the default for a future device that reused the same
+        // InputDevice id.
+        val repo =
+            mockk<MotionPreferenceRepository> {
+                every { all() } returns listOf(MotionPreference("9", enabled = false))
+                justRun { remove("9") }
+            }
+        val store = MotionEnabledStore(repo)
+        assertFalse(store.isEnabled("9"))
+
+        store.forget("9")
+
+        verify { repo.remove("9") }
+        // After forget, the slot returns to the default, NOT the prior
+        // explicit value — that's the whole point.
+        assertTrue(store.isEnabled("9"))
+        assertEquals(null, store.state.value["9"])
+    }
+
+    @Test
+    fun `setEnabled for slot A leaves slot B unchanged`() {
+        // The state map is a single MutableStateFlow; a sloppy reducer
+        // could overwrite the whole map and drop other slots. Pin
+        // isolation across slots.
+        val repo = repoWithEmpty()
+        val store = MotionEnabledStore(repo)
+
+        store.setEnabled("virtual", enabled = true)
+        store.setEnabled("9", enabled = false)
+        store.setEnabled("virtual", enabled = false)
+
+        assertEquals(false, store.state.value["virtual"])
+        assertEquals(false, store.state.value["9"])
+    }
+
+    @Test
+    fun `isEnabled for an explicitly disabled slot returns false`() {
+        // The store's isEnabled has two paths: present-in-map and absent.
+        // Cover the present path explicitly so a regression that
+        // collapses both onto the default would fail here.
+        val repo =
+            mockk<MotionPreferenceRepository> {
+                every { all() } returns listOf(MotionPreference("9", enabled = false))
+            }
+        val store = MotionEnabledStore(repo)
+        assertFalse(store.isEnabled("9"))
+    }
+
+    private fun repoWithEmpty(): MotionPreferenceRepository =
+        mockk(relaxed = true) {
+            every { all() } returns emptyList()
+        }
+}

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
@@ -14,6 +14,7 @@ import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.sensor.BatteryValidator
 import com.tinkernorth.dish.source.sensor.BatteryValidator.BatterySample
 import com.tinkernorth.dish.source.store.BatteryStatusStore
+import com.tinkernorth.dish.source.store.MotionEnabledStore
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -45,6 +46,7 @@ class MainViewModelTest {
     private lateinit var satellite: SatelliteConnectionManager
     private lateinit var gamepadRegistry: PhysicalGamepadRegistry
     private lateinit var batteryStore: BatteryStatusStore
+    private lateinit var motionEnabledStore: MotionEnabledStore
     private lateinit var vm: MainViewModel
 
     private val connectionsFlow = MutableStateFlow<List<ConnectionSummary>>(emptyList())
@@ -61,6 +63,13 @@ class MainViewModelTest {
         // BatteryStatusStore is a pure JVM holder (no Android deps) — use the
         // real thing so battery samples really thread through to the slots.
         batteryStore = BatteryStatusStore()
+        // MotionEnabledStore is hydrated from MotionPreferenceRepository at
+        // construction. Stub the repo so the store's init reads emptyMap()
+        // (the relevant default for these slot-wiring tests).
+        motionEnabledStore =
+            MotionEnabledStore(
+                mockk(relaxed = true) { every { all() } returns emptyList() },
+            )
         every { hub.connections } returns connectionsFlow
         every { hub.bindings } returns bindingsFlow
         every { gamepadRegistry.devices } returns devicesFlow
@@ -69,7 +78,7 @@ class MainViewModelTest {
         // injected Context. A relaxed mock returns "" by default, which keeps
         // the existing assertions (focused on slot wiring, not the label) green.
         val context = mockk<Context>(relaxed = true)
-        vm = MainViewModel(context, satellite, hub, gamepadRegistry, batteryStore)
+        vm = MainViewModel(context, satellite, hub, gamepadRegistry, batteryStore, motionEnabledStore)
     }
 
     @After
@@ -143,6 +152,32 @@ class MainViewModelTest {
     fun `setSatelliteControllerType delegates to hub`() {
         vm.setSatelliteControllerType(connectionId = "s:1", slotId = "slot-X", type = 1)
         verify { hub.setSatelliteControllerType("s:1", "slot-X", 1) }
+    }
+
+    @Test
+    fun `setMotionEnabled writes through to the motion store`() {
+        // The dashboard's toggle should be a thin pass-through; the durable
+        // write happens in MotionEnabledStore. Pin that the VM does not
+        // accidentally short-circuit (e.g. only updating local state).
+        vm.setMotionEnabled(slotId = "9", enabled = false)
+        assertEquals(false, motionEnabledStore.state.value["9"])
+        assertEquals(false, motionEnabledStore.isEnabled("9"))
+    }
+
+    @Test
+    fun `isMotionEnabled defaults to true for a slot that has not been toggled`() {
+        // Product default — flip in MotionEnabledStore.DEFAULT_ENABLED if
+        // policy changes. Pinned here so a regression in the VM accessor
+        // (e.g. reading the raw map and treating null as false) fails.
+        assertTrue(vm.isMotionEnabled("never-touched"))
+    }
+
+    @Test
+    fun `motionEnabled flow forwards the underlying store state`() {
+        // Bind point for the dashboard adapter: a write through the VM
+        // must be observable on its motionEnabled flow.
+        vm.setMotionEnabled(slotId = "virtual", enabled = false)
+        assertEquals(false, vm.motionEnabled.value["virtual"])
     }
 
     @Test


### PR DESCRIPTION
## Summary

The wire-up PR for the motion-architecture series. Consumes the
composer from #71 and the toggle store from #72 end-to-end, so the
`CAP_MOTION` bit on the wire and the sensor-listener gating both
reflect the real per-slot capability.

**Depends on #71 and #72** — both should merge first.

## Changes

- **`MotionCapabilityComposer`** now folds in `MotionEnabledStore
  .state` as a fifth upstream, so `MotionCapability.userEnabled`
  tracks the durable per-slot toggle. New `capabilityFor(slotId)`
  accessor is the synchronous read used at controller-add time.

- **`SatelliteConnection`** takes a `motionCapsBitsFor: (slotId) ->
  Int` lambda (defaulted to the legacy "always-`CAP_MOTION`" value so
  pre-existing tests don't have to know about the new wiring). The
  cap word at `MSG_CONTROLLER_ADD` is `BASE_CAPABILITIES |
  motionCapsBitsFor(slotId)` — honest per controller for the first time.

- **`SatelliteConnectionManager`** takes `Provider<MotionCapabilityComposer>`
  to break the Hilt cycle (composer → `ConnectionHub` → manager would be
  circular without deferred resolution). Threads
  `composer.capabilityFor(slotId).toCapBits()` into each new
  `SatelliteConnection`.

- **`GamepadOverlayActivity`** — the headline UX fix. Removed the
  always-on `motionSource.start` in `onResume`. Replaced with a
  `repeatOnLifecycle(STARTED)` collector on `motionCapability
  .state[VIRTUAL_SLOT_ID].effective` that starts/stops the source as
  the capability flips. **Fixes the BT-HID battery-drain bug** —
  previously the gyro listener ran at `SENSOR_DELAY_GAME` for nothing
  on every Bluetooth-bound overlay. Now also respects the user toggle.

- **`PhysicalMotionSource`** — reachability flow is intersected with
  the composer's `MotionCapability` via a new pure
  `filterByCapability` helper. A pad that lacks gyro OR has motion
  toggled off is dropped from the reachable set, so the listener
  never registers.

## What this is *not* doing

- **Not** re-registering controllers when a toggle flips mid-session.
  `toCapBits()` only takes effect at the next `addController` call
  (re-bind, reconnect, restart). The wire impact is informational
  only (`session_service.cpp:413-417` is explicit on this); the
  runtime listener gates handle "right now" correctness. A follow-up
  can add an observer that re-registers when the cap bit changes if
  the web-UI staleness proves user-visible.

- **Not** adding the per-slot motion-toggle switch widget in
  `ControllerAdapter`. The `MainViewModel` API is in place (#72), and
  the composer reads the store, so the only thing missing is the
  visible control. Ships in a follow-up so the backend gate and the
  widget land independently reviewable.

## Test plan

15 new unit tests (all passing locally; full **653/653** green):

- **5 `SatelliteConnection` tests** — `CAP_MOTION` cleared when the
  lambda returns 0, `CAP_MOTION` set when the lambda returns 0x0004,
  the base bits (analog triggers + rumble) always set regardless,
  the lambda is called with the same `slotId` being registered, and
  per-slot resolution between two simultaneously attached slots.
- **5 `MotionCapabilityComposer` tests** — `userEnabled` defaults to
  true for an unwritten slot, flips on store write, `toCapBits()`
  returns 0 on a disabled slot, `capabilityFor()` returns the latest
  derived value, `capabilityFor()` for an unknown slot returns
  `MotionCapability.Off` (safe default).
- **5 `PhysicalMotionSource.filterByCapability` tests** —
  pass-through for enabled+gyro, drop on no-gyro, drop on
  user-disabled, drop on missing-from-caps (startup race), per-slot
  isolation when two pads have different toggles.

- [x] `./gradlew :app:testDebugUnitTest` — 653/653 pass.