### PR TITLE
feat(motion): honest per-slot motion capability — full pipeline

### DIFF
--- a/app/src/androidTest/java/com/tinkernorth/dish/ui/connections/PairPinDialogPreShowTest.kt
+++ b/app/src/androidTest/java/com/tinkernorth/dish/ui/connections/PairPinDialogPreShowTest.kt
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.ui.connections
+
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.tinkernorth.dish.ui.main.MainActivity
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression test for the lateinit-binding crash in [PairPinDialog].
+ *
+ * Before the fix, assigning [PairPinDialog.dishTitle] or [PairPinDialog.dishSubtitle]
+ * before the first [android.app.Dialog.show] threw
+ * `UninitializedPropertyAccessException: lateinit property binding has not been
+ * initialized`, because the view binding is only inflated inside `Dialog.onCreate`,
+ * which the framework runs on first `show()`.
+ *
+ * That ordering is exactly how the dialog is used in production
+ * (`ConnectionsActivity.showPairingDialog` sets the title/subtitle inside an
+ * `apply { ... }` block, then calls `show()`), so the crash was reachable any
+ * time the pairing flow opened the dialog.
+ *
+ * This test pins the contract: setting the properties pre-show must not crash,
+ * and the values must end up on the visible views once the dialog has been shown.
+ *
+ * Run on a connected device or emulator:
+ *   ./gradlew connectedDebugAndroidTest
+ */
+@RunWith(AndroidJUnit4::class)
+class PairPinDialogPreShowTest {
+    @Test
+    fun setting_title_and_subtitle_before_show_does_not_crash_and_persists_after_show() {
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            scenario.onActivity { activity ->
+                val dialog = PairPinDialog(activity) { /* submit not exercised */ }
+
+                // Pre-show assignment — this is what crashed before the fix.
+                dialog.dishTitle = "TITLE"
+                dialog.dishSubtitle = "SUBTITLE"
+
+                // Reads before show should return what the caller stashed,
+                // not an empty default and not a crash.
+                assertEquals("TITLE", dialog.dishTitle.toString())
+                assertEquals("SUBTITLE", dialog.dishSubtitle.toString())
+
+                try {
+                    dialog.show()
+
+                    // After show(), onCreate has inflated the binding and flushed
+                    // the pending writes onto the TextViews.
+                    assertEquals("TITLE", dialog.dishTitle.toString())
+                    assertEquals("SUBTITLE", dialog.dishSubtitle.toString())
+                } finally {
+                    dialog.dismiss()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/cpp/satellite_jni.cpp
+++ b/app/src/main/cpp/satellite_jni.cpp
@@ -668,11 +668,16 @@ JNIEXPORT void JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_sendCo
 
 /* ── Motion (gyro + accel) ────────────────────────────────────────────────── */
 //
-// Hot path. Caller is expected to have already scaled gyro to deg/s × 16.3835
-// (LSB = 2000/32767 deg/s) and accel to g × 8191.75 (LSB = 4/32767 g) — the
-// satellite docs §0x000A is the canonical spec. Caller is also responsible
-// for any per-controller rate-limiting (MotionRateLimiter.kt) before reaching
-// this method.
+// Hot path. The Kotlin caller (MotionScaling.gyroRadToWire /
+// accelMssToWire) has already done all the unit conversion — rad/s →
+// int16 with 1 LSB = 2000/32767 deg/s, and m/s² → int16 with 1 LSB =
+// 4/32767 g. This function does NO scaling; it only packs the int16
+// values into the 17-byte MSG_MOTION (0x000A) wire payload via
+// dish_wire::encodeMotionPayload. Per-controller rate-limiting also
+// happens up-stack (MotionRateLimiter.kt); reaching this method means
+// the caller has already passed the 250 Hz gate.
+//
+// The satellite docs §0x000A is the canonical spec for the wire layout.
 JNIEXPORT void JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_sendMotion(
     JNIEnv*, jobject, jint handle, jint controllerIndex, jshort gyroX, jshort gyroY, jshort gyroZ,
     jshort accelX, jshort accelY, jshort accelZ, jint timestampDeltaUs) {

--- a/app/src/main/cpp/satellite_jni.cpp
+++ b/app/src/main/cpp/satellite_jni.cpp
@@ -67,6 +67,13 @@ static constexpr uint16_t MSG_CONTROLLER_REMOVE = 0x0005;
 static constexpr uint16_t MSG_CONTROLLER_ACK = 0x0006;
 static constexpr uint16_t MSG_SERVER_STATUS = 0x0007;
 static constexpr uint16_t MSG_CONTROLLER_TYPE = 0x0008;
+// Mid-session capability update — same payload shape as the caps field
+// of MSG_CONTROLLER_ADD (ctrlIdx + caps BE16), but for an already-
+// registered controller. Lets the dish push e.g. a user-flipped motion
+// toggle without unplugging the controller on the receiver. See
+// `MSG_CONTROLLER_CAPS_UPDATE` in satellite/src/core/types.h for the
+// authoritative spec and the receiver's silent-drop fallback.
+static constexpr uint16_t MSG_CONTROLLER_CAPS_UPDATE = 0x000E;
 static constexpr uint16_t MSG_RUMBLE = 0x0009;
 static constexpr uint16_t MSG_MOTION = 0x000A;
 static constexpr uint16_t MSG_BATTERY = 0x000B;
@@ -110,6 +117,17 @@ struct Session {
     // Controller ACK tracking: (requestType << 16) | (ctrlIdx << 8) | result.
     // -1 means no ACK received yet.
     std::atomic<int32_t> lastControllerAck{-1};
+
+    // Motion-status byte from the most recent MSG_CONTROLLER_ACK (only present
+    // on MSG_CONTROLLER_ADD acks from a post-extension satellite — msgLen 5
+    // instead of 4). Bit 0: receiver's backend supports IMU for this slot's
+    // chosen type; bit 1: backend successfully created the per-serial IMU
+    // sink. -1 means no extended ACK has been observed for this session —
+    // either no ACK at all, or the satellite is a pre-extension build that
+    // only sent the legacy 4-byte payload. The dish-side store collapses
+    // -1 onto "unknown" so an old satellite doesn't get treated as a
+    // permanent failure.
+    std::atomic<int32_t> lastControllerAckMotionFlags{-1};
 
     std::atomic<int8_t> vigemAvailable{-1};
     std::atomic<int8_t> activeControllerCount{-1};
@@ -436,14 +454,12 @@ static bool sendEncrypted(Session* s, uint16_t msgType, const uint8_t* payload,
     // EAGAIN immediately instead; the next periodic-resend tick tries
     // again with the latest state. UDP is already lossy by contract, so
     // a buffer-full drop is no worse than any other packet loss.
-    ssize_t sent = sendto(s->udpSock, packet, totalLen, MSG_DONTWAIT,
-                          (struct sockaddr*)&s->dest, sizeof(s->dest));
+    ssize_t sent = sendto(s->udpSock, packet, totalLen, MSG_DONTWAIT, (struct sockaddr*)&s->dest,
+                          sizeof(s->dest));
     // EAGAIN / EWOULDBLOCK: kernel send buffer momentarily unavailable.
     // Treat as a soft drop, not a hard error — UDP semantics absorb it and
     // the next periodic tick will refresh the state.
-    if (sent < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
-        return true;
-    }
+    if (sent < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) { return true; }
     return sent == (ssize_t)totalLen;
 }
 
@@ -666,6 +682,25 @@ JNIEXPORT void JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_sendCo
          controllerType);
 }
 
+// Push a new capability word for an already-registered controller. Wire
+// payload mirrors the caps field of MSG_CONTROLLER_ADD: ctrlIdx(1) +
+// caps(2 BE) = 3 bytes. The Kotlin caller (SatelliteConnectionManager)
+// only sends this when the dish-side composer's `toCapBits(slotId)`
+// differs from what was last advertised — the receiver no-ops on
+// duplicates, so the de-dup is technically redundant, but the wire
+// saving + log-line saving is worth the cheap check.
+JNIEXPORT void JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_sendControllerCapsUpdate(
+    JNIEnv*, jobject, jint handle, jint controllerIndex, jint capabilities) {
+    auto s = getSession(handle);
+    if (!s) return;
+    uint8_t payload[3];
+    payload[0] = (uint8_t)(controllerIndex & 0xFF);
+    putBE16(payload + 1, (uint16_t)(capabilities & 0xFFFF));
+    sendEncrypted(s.get(), MSG_CONTROLLER_CAPS_UPDATE, payload, 3);
+    LOGI("Session %d: sent controller caps update idx=%d caps=0x%04X", handle, controllerIndex,
+         capabilities);
+}
+
 /* ── Motion (gyro + accel) ────────────────────────────────────────────────── */
 //
 // Hot path. The Kotlin caller (MotionScaling.gyroRadToWire /
@@ -746,6 +781,27 @@ JNIEXPORT void JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_resetC
     auto s = getSession(handle);
     if (!s) return;
     s->lastControllerAck.store(-1, std::memory_order_release);
+    // Reset the motion-flags shadow too so a new registration doesn't read
+    // the previous slot's flags. Kept atomic-paired with lastControllerAck
+    // (same reset point) — divergence would mean a freshly-reset slot
+    // could spuriously read its predecessor's "kernel rejected" flag.
+    s->lastControllerAckMotionFlags.store(-1, std::memory_order_release);
+}
+
+// Latest MSG_CONTROLLER_ACK motion-flags byte for this session, or -1 if no
+// extended ACK has been observed. Bits as per ACK_MOTION_FLAG_* in the
+// satellite's core/types.h:
+//   bit 0 — receiver's backend supports IMU for the slot's chosen type
+//   bit 1 — backend successfully created the per-serial IMU sink
+// A pre-extension satellite leaves this at -1; the Kotlin side collapses
+// -1 onto "unknown" rather than treating either bit as false (which would
+// permanently disable motion against an old satellite).
+JNIEXPORT jint JNICALL
+Java_com_tinkernorth_dish_core_jni_SatelliteNative_getLastControllerMotionFlags(JNIEnv*, jobject,
+                                                                                jint handle) {
+    auto s = getSession(handle);
+    if (!s) return -1;
+    return s->lastControllerAckMotionFlags.load(std::memory_order_acquire);
 }
 
 JNIEXPORT jint JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_getVigemAvailable(
@@ -810,8 +866,21 @@ JNIEXPORT void JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_receiv
         uint8_t result = decrypted[7];
         int32_t packed = ((int32_t)reqType << 16) | ((int32_t)ctrlIdx << 8) | (int32_t)result;
         s->lastControllerAck.store(packed, std::memory_order_release);
-        LOGI("Session %d controller ACK: reqType=0x%04X idx=%d result=0x%02X", handle, reqType,
-             ctrlIdx, result);
+        // Optional motion-status byte (post-extension satellites). A
+        // pre-extension satellite sends only 4 bytes (msgLen == 4) and the
+        // extra byte is absent — leave the stored flags at whatever the
+        // prior ACK left, or -1 if never written, so a slot with no
+        // observation stays "unknown" rather than being misread as
+        // "backend broken." A post-extension satellite always sends the
+        // byte (zero or not), so msgLen >= 5 is the live-data branch.
+        if (msgLen >= 5 && decLen >= 9) {
+            s->lastControllerAckMotionFlags.store((int32_t)decrypted[8], std::memory_order_release);
+            LOGI("Session %d controller ACK: reqType=0x%04X idx=%d result=0x%02X motion=0x%02X",
+                 handle, reqType, ctrlIdx, result, decrypted[8]);
+        } else {
+            LOGI("Session %d controller ACK: reqType=0x%04X idx=%d result=0x%02X (legacy)", handle,
+                 reqType, ctrlIdx, result);
+        }
     } else if (msgType == MSG_SERVER_STATUS && msgLen >= 2 && decLen >= 6) {
         uint8_t vigem = decrypted[4];
         uint8_t count = decrypted[5];

--- a/app/src/main/java/com/tinkernorth/dish/composer/MotionCapabilityComposer.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/MotionCapabilityComposer.kt
@@ -22,9 +22,12 @@ import javax.inject.Singleton
  *   - whether [com.tinkernorth.dish.source.sensor.PhoneMotionSource] /
  *     [com.tinkernorth.dish.source.sensor.PhysicalMotionSource] register
  *     sensor listeners at all (gyro listeners are a measurable battery cost);
- *   - what the on-screen motion pill renders.
+ *   - what the on-screen motion pill renders, including the
+ *     "your Xbox virtual pad has no IMU surface on the host" warning state
+ *     ([MotionCapability.hostHasSinkForType]).
  *
- * Three orthogonal facts, combined into [MotionCapability.effective]:
+ * Four orthogonal facts combined into [MotionCapability.effective] /
+ * [MotionCapability.toCapBits] / the pill mapping:
  *
  *   - [MotionCapability.hasGyro] — the hardware exists. Virtual slot: the
  *     phone has a gyroscope (see [PhoneMotionAvailability]). Physical slot:
@@ -36,6 +39,13 @@ import javax.inject.Singleton
  *   - [MotionCapability.userEnabled] — the user wants motion on for this
  *     slot. Sourced from [MotionEnabledStore.isEnabled], which collapses
  *     an absent entry onto the product default (`DEFAULT_ENABLED = true`).
+ *   - [MotionCapability.hostHasSinkForType] — the receiving host's backend
+ *     has an IMU surface for the slot's controller type. Derived from
+ *     [com.tinkernorth.dish.composer.ConnectionSummary.satelliteControllerTypes]:
+ *     PlayStation = yes (DS4 emulation on Windows/Linux carries gyro/accel),
+ *     Xbox = no (XInput has no IMU surface; XUSB_REPORT has no gyro fields).
+ *     Universal across the Windows + Linux satellite platforms — no wire
+ *     protocol bump needed to learn it.
  *
  * **Why a composer:** these are pure derivations from
  * [PhoneMotionAvailability], [PhysicalGamepadRegistry], [ConnectionHub]
@@ -55,6 +65,15 @@ data class MotionCapability(
      * collapses to [MotionEnabledStore.DEFAULT_ENABLED] (true).
      */
     val userEnabled: Boolean = true,
+    /**
+     * Receiver's backend has an IMU surface for the slot's chosen
+     * controller type. Always true for PlayStation-typed slots (DS4
+     * emulation on Windows ViGEm + Linux uinput both carry gyro/accel),
+     * false for Xbox-typed slots (XInput has no IMU). Defaulted true so
+     * a slot with no type yet — or a non-satellite connection — doesn't
+     * spuriously raise the "no host sink" warning.
+     */
+    val hostHasSinkForType: Boolean = true,
 ) {
     /**
      * True iff motion samples should both be captured AND would actually reach
@@ -70,7 +89,11 @@ data class MotionCapability(
      * [carriesOnConnection]: the capability describes the *dish*, not the
      * link, and we want a satellite re-connect to recover motion without a
      * re-handshake. It IS gated on [userEnabled] because flipping the toggle
-     * is a meaningful change to what the dish will emit.
+     * is a meaningful change to what the dish will emit. It is NOT gated on
+     * [hostHasSinkForType] either — the dish is honest about what IT will
+     * stream, regardless of whether the host can sink it; the
+     * `motionSinkSupportedForType` field on the receiver's snapshot is the
+     * canonical "host can sink" signal.
      */
     fun toCapBits(): Int = if (hasGyro && userEnabled) CAP_MOTION_BIT else 0
 
@@ -119,6 +142,7 @@ class MotionCapabilityComposer
                         hasGyro = phoneHasGyro,
                         carriesOnConnection = carriesMotion(VIRTUAL_SLOT_ID, bindings, byId),
                         userEnabled = enabledMap[VIRTUAL_SLOT_ID] ?: MotionEnabledStore.DEFAULT_ENABLED,
+                        hostHasSinkForType = hostSinkForType(VIRTUAL_SLOT_ID, bindings, byId),
                     )
 
                 // Physical pads.
@@ -129,6 +153,7 @@ class MotionCapabilityComposer
                             hasGyro = device.hasGyro,
                             carriesOnConnection = carriesMotion(slotId, bindings, byId),
                             userEnabled = enabledMap[slotId] ?: MotionEnabledStore.DEFAULT_ENABLED,
+                            hostHasSinkForType = hostSinkForType(slotId, bindings, byId),
                         )
                 }
                 out
@@ -164,5 +189,47 @@ class MotionCapabilityComposer
             val summary = summariesById[cid] ?: return false
             return summary.kind == ConnectionKind.SATELLITE &&
                 summary.live == LinkState.Connected
+        }
+
+        /**
+         * Resolve whether the **host** has a motion sink for this slot's
+         * chosen controller type.
+         *
+         * The dish never actually sees the receiver's backend; the answer is
+         * a heuristic on the controller type, which is a known invariant of
+         * the available backends:
+         *
+         *  - **Xbox-typed slot** ⇒ false. XInput / Xbox 360 emulation has
+         *    no IMU surface anywhere (no gyro fields in `XUSB_REPORT`;
+         *    `vigem_adapter.cpp::submitMotion` short-circuits for non-DS4
+         *    serials; the Linux uinput motion node is only created in
+         *    `pluginDeviceDS4`).
+         *  - **PlayStation-typed slot** ⇒ true. The DS4_REPORT_EX path on
+         *    Windows ViGEm and the INPUT_PROP_ACCELEROMETER node on Linux
+         *    uinput both deliver motion.
+         *  - **Unknown type** (no entry in
+         *    [ConnectionSummary.satelliteControllerTypes]) ⇒ true.
+         *    Conservatively assume motion CAN sink so we don't raise a
+         *    false-alarm warning before the type even propagates.
+         *
+         * macOS satellite is a non-issue here: it returns
+         * `ACK_ERR_BACKEND_UNAVAIL` at `MSG_CONTROLLER_ADD` time so the slot
+         * never reaches `registered` — the pill resolves on `carriesOnConnection`
+         * (false) long before `hostHasSinkForType` matters.
+         *
+         * Non-satellite bindings (Bluetooth-HID) also short-circuit to true
+         * — the pill state machine already handles those with `NOT_FORWARDED`,
+         * which takes precedence over `NO_HOST_SINK`.
+         */
+        private fun hostSinkForType(
+            slotId: String,
+            bindings: Map<String, String>,
+            summariesById: Map<String, ConnectionSummary>,
+        ): Boolean {
+            val cid = bindings[slotId] ?: return true // unbound — irrelevant
+            val summary = summariesById[cid] ?: return true
+            if (summary.kind != ConnectionKind.SATELLITE) return true // BT-HID, irrelevant
+            val type = summary.satelliteControllerTypes[slotId] ?: return true // unknown — assume yes
+            return type == CONTROLLER_TYPE_PLAYSTATION
         }
     }

--- a/app/src/main/java/com/tinkernorth/dish/composer/MotionCapabilityComposer.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/MotionCapabilityComposer.kt
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.composer
+
+import com.tinkernorth.dish.architecture.abstracts.AbstractComposer
+import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
+import com.tinkernorth.dish.source.sensor.PhoneMotionAvailability
+import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Per-controller motion capability — the single source of truth that drives:
+ *
+ *   - the `CAP_MOTION` bit at `MSG_CONTROLLER_ADD` time (so the receiver's web
+ *     UI is not lied to about which pads stream IMU);
+ *   - whether [com.tinkernorth.dish.source.sensor.PhoneMotionSource] /
+ *     [com.tinkernorth.dish.source.sensor.PhysicalMotionSource] register
+ *     sensor listeners at all (gyro listeners are a measurable battery cost);
+ *   - what the on-screen motion pill renders.
+ *
+ * Three orthogonal facts, combined into [MotionCapability.effective]:
+ *
+ *   - [MotionCapability.hasGyro] — the hardware exists. Virtual slot: the
+ *     phone has a gyroscope (see [PhoneMotionAvailability]). Physical slot:
+ *     the pad has a per-device gyroscope (see
+ *     [com.tinkernorth.dish.source.sensor.PhysicalMotionProbe], cached on
+ *     [PhysicalGamepadRegistry.Device.hasGyro]).
+ *   - [MotionCapability.carriesOnConnection] — the bound connection has a
+ *     `MSG_MOTION` channel. Satellite does; Bluetooth-HID does not.
+ *   - [MotionCapability.userEnabled] — the user wants motion on for this
+ *     slot. Defaults to true; flipped by the per-slot toggle wired in a
+ *     subsequent PR (the `MotionEnabledStore`).
+ *
+ * **Why a composer:** these are pure derivations from
+ * [PhoneMotionAvailability], [PhysicalGamepadRegistry], [ConnectionHub]
+ * `bindings` + `connections`. No new lifecycle, no events — exactly the shape
+ * [AbstractComposer] exists for. Threading the same `MotionCapability` value
+ * through every consumer keeps "is motion on for this slot" un-divergeable.
+ */
+data class MotionCapability(
+    /** Hardware reports a gyroscope on the device backing this slot. */
+    val hasGyro: Boolean,
+    /** Bound connection is a satellite session (BT-HID has no `MSG_MOTION`). */
+    val carriesOnConnection: Boolean,
+    /**
+     * User has motion enabled for this slot. Stub-true until the
+     * `MotionEnabledStore` lands in the next PR; the field is here from the
+     * start so downstream call sites can already read it.
+     */
+    val userEnabled: Boolean = true,
+) {
+    /**
+     * True iff motion samples should both be captured AND would actually reach
+     * the satellite for this slot. The same boolean drives the wire `CAP_MOTION`
+     * bit (paired with [userEnabled] so that flipping the user toggle drops the
+     * advertisement) and the sensor-listener gate.
+     */
+    val effective: Boolean get() = hasGyro && carriesOnConnection && userEnabled
+
+    /**
+     * The `CAP_MOTION` (0x0004) bit the dish should advertise at
+     * `MSG_CONTROLLER_ADD` for this slot. Note that this is **not** gated on
+     * [carriesOnConnection]: the capability describes the *dish*, not the
+     * link, and we want a satellite re-connect to recover motion without a
+     * re-handshake. It IS gated on [userEnabled] because flipping the toggle
+     * is a meaningful change to what the dish will emit.
+     */
+    fun toCapBits(): Int = if (hasGyro && userEnabled) CAP_MOTION_BIT else 0
+
+    companion object {
+        /** Mirror of `satellite/src/core/types.h::CAP_MOTION`. */
+        const val CAP_MOTION_BIT: Int = 0x0004
+
+        /** Initial value before any upstream resolves — nothing is capable yet. */
+        val Off = MotionCapability(hasGyro = false, carriesOnConnection = false)
+    }
+}
+
+/**
+ * `Map<slotId, MotionCapability>` for every slot the user can currently see —
+ * the virtual touch slot (always present) plus every attached physical pad.
+ *
+ * A slot present in the map means we have a coherent capability snapshot for
+ * it. A slot absent from the map means the registry doesn't see it (e.g. a
+ * physical pad in the disconnect-grace window after a USB jiggle).
+ */
+@Singleton
+class MotionCapabilityComposer
+    @Inject
+    constructor(
+        private val phoneAvailability: PhoneMotionAvailability,
+        private val registry: PhysicalGamepadRegistry,
+        private val hub: ConnectionHub,
+        scope: CoroutineScope,
+    ) : AbstractComposer<Map<String, MotionCapability>>(scope, emptyMap()) {
+        override fun upstream(): Flow<Map<String, MotionCapability>> =
+            combine(
+                phoneAvailability.state,
+                registry.devices,
+                hub.bindings,
+                hub.connections,
+            ) { phoneHasGyro, devices, bindings, summaries ->
+                val byId = summaries.associateBy { it.id }
+                val out = HashMap<String, MotionCapability>(devices.size + 1)
+
+                // Virtual slot — always present so the touch overlay always
+                // has a capability entry to read, even when no satellite is up.
+                out[VIRTUAL_SLOT_ID] =
+                    MotionCapability(
+                        hasGyro = phoneHasGyro,
+                        carriesOnConnection = carriesMotion(VIRTUAL_SLOT_ID, bindings, byId),
+                    )
+
+                // Physical pads.
+                for ((deviceId, device) in devices) {
+                    val slotId = deviceId.toString()
+                    out[slotId] =
+                        MotionCapability(
+                            hasGyro = device.hasGyro,
+                            carriesOnConnection = carriesMotion(slotId, bindings, byId),
+                        )
+                }
+                out
+            }
+
+        /**
+         * Resolve `slotId → bound-connection-summary → kind == SATELLITE &&
+         * live`. Returns false for any unbound or non-satellite slot. The
+         * `Connected` check is deliberate: a satellite that is `Connecting` or
+         * `Unstable` can't currently sink motion, so the pill reading should
+         * reflect that, AND the registration cap bit should still claim
+         * `CAP_MOTION` (the dish is capable, the link is just temporarily
+         * down) — `toCapBits()` does not consult `carriesOnConnection`.
+         */
+        private fun carriesMotion(
+            slotId: String,
+            bindings: Map<String, String>,
+            summariesById: Map<String, ConnectionSummary>,
+        ): Boolean {
+            val cid = bindings[slotId] ?: return false
+            val summary = summariesById[cid] ?: return false
+            return summary.kind == ConnectionKind.SATELLITE &&
+                summary.live == LinkState.Connected
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/composer/MotionCapabilityComposer.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/MotionCapabilityComposer.kt
@@ -128,14 +128,6 @@ data class MotionCapability(
 }
 
 /**
- * `Map<slotId, MotionCapability>` for every slot the user can currently see —
- * the virtual touch slot (always present) plus every attached physical pad.
- *
- * A slot present in the map means we have a coherent capability snapshot for
- * it. A slot absent from the map means the registry doesn't see it (e.g. a
- * physical pad in the disconnect-grace window after a USB jiggle).
- */
-/**
  * Typed 6-arity combine — the stdlib's typed overload tops out at 5 flows, and
  * the bare `combine(vararg)` form would force `Array<*>` casting at the call
  * site. Same pattern (and reasoning) as `combine7` in
@@ -223,8 +215,7 @@ class MotionCapabilityComposer
          * derived map, so no suspension is required on the registration
          * thread.
          */
-        fun capabilityFor(slotId: String): MotionCapability =
-            state.value[slotId] ?: MotionCapability.Off
+        fun capabilityFor(slotId: String): MotionCapability = state.value[slotId] ?: MotionCapability.Off
 
         /**
          * Resolve `slotId → bound-connection-summary → kind == SATELLITE &&

--- a/app/src/main/java/com/tinkernorth/dish/composer/MotionCapabilityComposer.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/MotionCapabilityComposer.kt
@@ -7,6 +7,8 @@ import com.tinkernorth.dish.architecture.abstracts.AbstractComposer
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.source.sensor.PhoneMotionAvailability
 import com.tinkernorth.dish.source.store.MotionEnabledStore
+import com.tinkernorth.dish.source.store.SatelliteMotionBackendStatus
+import com.tinkernorth.dish.source.store.SatelliteMotionBackendStatusStore
 import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -72,8 +74,27 @@ data class MotionCapability(
      * false for Xbox-typed slots (XInput has no IMU). Defaulted true so
      * a slot with no type yet — or a non-satellite connection — doesn't
      * spuriously raise the "no host sink" warning.
+     *
+     * This is the *dish-side heuristic* — derived from the chosen type,
+     * accurate for every shipping backend, available even before the
+     * controller has registered. The satellite's authoritative answer
+     * lives on [satelliteBackendStatus] when an ACK has been observed.
      */
     val hostHasSinkForType: Boolean = true,
+    /**
+     * The receiver's truth about whether motion bytes will land on the
+     * virtual gamepad's IMU surface for this slot. Null until the slot
+     * has been registered and an extended ACK has been observed —
+     * pre-extension satellites never set this, so a null here means
+     * "the dish heuristic above is the best we have, defer to it."
+     *
+     * When non-null, [SatelliteMotionBackendStatus.backendOk] becomes
+     * the load-bearing signal for the
+     * [com.tinkernorth.dish.ui.main.MotionIndicatorState.BACKEND_BROKEN]
+     * pill state — the case the dish couldn't compute on its own (the
+     * receiver's kernel rejected the IMU sink for this serial).
+     */
+    val satelliteBackendStatus: SatelliteMotionBackendStatus? = null,
 ) {
     /**
      * True iff motion samples should both be captured AND would actually reach
@@ -114,6 +135,34 @@ data class MotionCapability(
  * it. A slot absent from the map means the registry doesn't see it (e.g. a
  * physical pad in the disconnect-grace window after a USB jiggle).
  */
+/**
+ * Typed 6-arity combine — the stdlib's typed overload tops out at 5 flows, and
+ * the bare `combine(vararg)` form would force `Array<*>` casting at the call
+ * site. Same pattern (and reasoning) as `combine7` in
+ * [ConnectionsComposer] — keep the unchecked cast in one place so changing an
+ * upstream flow's value type reshapes the [transform] lambda at compile time.
+ */
+@Suppress("UNCHECKED_CAST", "LongParameterList")
+private inline fun <T1, T2, T3, T4, T5, T6, R> combine6(
+    f1: Flow<T1>,
+    f2: Flow<T2>,
+    f3: Flow<T3>,
+    f4: Flow<T4>,
+    f5: Flow<T5>,
+    f6: Flow<T6>,
+    crossinline transform: suspend (T1, T2, T3, T4, T5, T6) -> R,
+): Flow<R> =
+    combine(f1, f2, f3, f4, f5, f6) { args ->
+        transform(
+            args[0] as T1,
+            args[1] as T2,
+            args[2] as T3,
+            args[3] as T4,
+            args[4] as T5,
+            args[5] as T6,
+        )
+    }
+
 @Singleton
 class MotionCapabilityComposer
     @Inject
@@ -122,16 +171,18 @@ class MotionCapabilityComposer
         private val registry: PhysicalGamepadRegistry,
         private val hub: ConnectionHub,
         private val motionEnabledStore: MotionEnabledStore,
+        private val satelliteMotionBackendStatusStore: SatelliteMotionBackendStatusStore,
         scope: CoroutineScope,
     ) : AbstractComposer<Map<String, MotionCapability>>(scope, emptyMap()) {
         override fun upstream(): Flow<Map<String, MotionCapability>> =
-            combine(
+            combine6(
                 phoneAvailability.state,
                 registry.devices,
                 hub.bindings,
                 hub.connections,
                 motionEnabledStore.state,
-            ) { phoneHasGyro, devices, bindings, summaries, enabledMap ->
+                satelliteMotionBackendStatusStore.state,
+            ) { phoneHasGyro, devices, bindings, summaries, enabledMap, backendStatusMap ->
                 val byId = summaries.associateBy { it.id }
                 val out = HashMap<String, MotionCapability>(devices.size + 1)
 
@@ -143,6 +194,8 @@ class MotionCapabilityComposer
                         carriesOnConnection = carriesMotion(VIRTUAL_SLOT_ID, bindings, byId),
                         userEnabled = enabledMap[VIRTUAL_SLOT_ID] ?: MotionEnabledStore.DEFAULT_ENABLED,
                         hostHasSinkForType = hostSinkForType(VIRTUAL_SLOT_ID, bindings, byId),
+                        satelliteBackendStatus =
+                            satelliteStatus(VIRTUAL_SLOT_ID, bindings, backendStatusMap),
                     )
 
                 // Physical pads.
@@ -154,6 +207,8 @@ class MotionCapabilityComposer
                             carriesOnConnection = carriesMotion(slotId, bindings, byId),
                             userEnabled = enabledMap[slotId] ?: MotionEnabledStore.DEFAULT_ENABLED,
                             hostHasSinkForType = hostSinkForType(slotId, bindings, byId),
+                            satelliteBackendStatus =
+                                satelliteStatus(slotId, bindings, backendStatusMap),
                         )
                 }
                 out
@@ -231,5 +286,26 @@ class MotionCapabilityComposer
             if (summary.kind != ConnectionKind.SATELLITE) return true // BT-HID, irrelevant
             val type = summary.satelliteControllerTypes[slotId] ?: return true // unknown — assume yes
             return type == CONTROLLER_TYPE_PLAYSTATION
+        }
+
+        /**
+         * Resolve the receiver's last-told motion-sink truth for [slotId].
+         * Returns null when:
+         *   - the slot is unbound or bound to a non-satellite, OR
+         *   - the bound satellite hasn't replied with an extended ACK yet
+         *     (pre-extension build, or the slot hasn't registered).
+         *
+         * Null is the signal for "defer to the dish's own
+         * [hostHasSinkForType] heuristic." Non-null wins over the
+         * heuristic in the pill state machine — see
+         * [com.tinkernorth.dish.ui.main.MotionIndicatorState.of].
+         */
+        private fun satelliteStatus(
+            slotId: String,
+            bindings: Map<String, String>,
+            backendStatusMap: Map<Pair<String, String>, SatelliteMotionBackendStatus>,
+        ): SatelliteMotionBackendStatus? {
+            val cid = bindings[slotId] ?: return null
+            return backendStatusMap[cid to slotId]
         }
     }

--- a/app/src/main/java/com/tinkernorth/dish/composer/MotionCapabilityComposer.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/MotionCapabilityComposer.kt
@@ -6,6 +6,7 @@ package com.tinkernorth.dish.composer
 import com.tinkernorth.dish.architecture.abstracts.AbstractComposer
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.source.sensor.PhoneMotionAvailability
+import com.tinkernorth.dish.source.store.MotionEnabledStore
 import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -33,14 +34,15 @@ import javax.inject.Singleton
  *   - [MotionCapability.carriesOnConnection] — the bound connection has a
  *     `MSG_MOTION` channel. Satellite does; Bluetooth-HID does not.
  *   - [MotionCapability.userEnabled] — the user wants motion on for this
- *     slot. Defaults to true; flipped by the per-slot toggle wired in a
- *     subsequent PR (the `MotionEnabledStore`).
+ *     slot. Sourced from [MotionEnabledStore.isEnabled], which collapses
+ *     an absent entry onto the product default (`DEFAULT_ENABLED = true`).
  *
  * **Why a composer:** these are pure derivations from
  * [PhoneMotionAvailability], [PhysicalGamepadRegistry], [ConnectionHub]
- * `bindings` + `connections`. No new lifecycle, no events — exactly the shape
- * [AbstractComposer] exists for. Threading the same `MotionCapability` value
- * through every consumer keeps "is motion on for this slot" un-divergeable.
+ * `bindings` + `connections`, and [MotionEnabledStore]. No new lifecycle,
+ * no events — exactly the shape [AbstractComposer] exists for. Threading
+ * the same `MotionCapability` value through every consumer keeps "is
+ * motion on for this slot" un-divergeable.
  */
 data class MotionCapability(
     /** Hardware reports a gyroscope on the device backing this slot. */
@@ -48,9 +50,9 @@ data class MotionCapability(
     /** Bound connection is a satellite session (BT-HID has no `MSG_MOTION`). */
     val carriesOnConnection: Boolean,
     /**
-     * User has motion enabled for this slot. Stub-true until the
-     * `MotionEnabledStore` lands in the next PR; the field is here from the
-     * start so downstream call sites can already read it.
+     * User has motion enabled for this slot. Sourced from
+     * [MotionEnabledStore.isEnabled], so an absent slot in that store
+     * collapses to [MotionEnabledStore.DEFAULT_ENABLED] (true).
      */
     val userEnabled: Boolean = true,
 ) {
@@ -96,6 +98,7 @@ class MotionCapabilityComposer
         private val phoneAvailability: PhoneMotionAvailability,
         private val registry: PhysicalGamepadRegistry,
         private val hub: ConnectionHub,
+        private val motionEnabledStore: MotionEnabledStore,
         scope: CoroutineScope,
     ) : AbstractComposer<Map<String, MotionCapability>>(scope, emptyMap()) {
         override fun upstream(): Flow<Map<String, MotionCapability>> =
@@ -104,7 +107,8 @@ class MotionCapabilityComposer
                 registry.devices,
                 hub.bindings,
                 hub.connections,
-            ) { phoneHasGyro, devices, bindings, summaries ->
+                motionEnabledStore.state,
+            ) { phoneHasGyro, devices, bindings, summaries, enabledMap ->
                 val byId = summaries.associateBy { it.id }
                 val out = HashMap<String, MotionCapability>(devices.size + 1)
 
@@ -114,6 +118,7 @@ class MotionCapabilityComposer
                     MotionCapability(
                         hasGyro = phoneHasGyro,
                         carriesOnConnection = carriesMotion(VIRTUAL_SLOT_ID, bindings, byId),
+                        userEnabled = enabledMap[VIRTUAL_SLOT_ID] ?: MotionEnabledStore.DEFAULT_ENABLED,
                     )
 
                 // Physical pads.
@@ -123,10 +128,23 @@ class MotionCapabilityComposer
                         MotionCapability(
                             hasGyro = device.hasGyro,
                             carriesOnConnection = carriesMotion(slotId, bindings, byId),
+                            userEnabled = enabledMap[slotId] ?: MotionEnabledStore.DEFAULT_ENABLED,
                         )
                 }
                 out
             }
+
+        /**
+         * Resolve the [MotionCapability] for [slotId]. Returns
+         * [MotionCapability.Off] when the slot has not been seen yet (e.g.
+         * a controller-add fires before the composer's first emission). Use
+         * this from [com.tinkernorth.dish.source.connection.SatelliteConnection]
+         * at registration time — it's a synchronous read of the latest
+         * derived map, so no suspension is required on the registration
+         * thread.
+         */
+        fun capabilityFor(slotId: String): MotionCapability =
+            state.value[slotId] ?: MotionCapability.Off
 
         /**
          * Resolve `slotId → bound-connection-summary → kind == SATELLITE &&

--- a/app/src/main/java/com/tinkernorth/dish/core/jni/ControllerRepository.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/jni/ControllerRepository.kt
@@ -77,8 +77,7 @@ class ControllerRepository
          * .getLastControllerMotionFlags] for the bit definitions and the
          * `-1`-means-unknown semantics.
          */
-        fun getLastControllerMotionFlags(handle: Int): Int =
-            SatelliteNative.getLastControllerMotionFlags(handle)
+        fun getLastControllerMotionFlags(handle: Int): Int = SatelliteNative.getLastControllerMotionFlags(handle)
 
         fun sendControllerType(
             handle: Int,

--- a/app/src/main/java/com/tinkernorth/dish/core/jni/ControllerRepository.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/jni/ControllerRepository.kt
@@ -70,12 +70,40 @@ class ControllerRepository
 
         fun getLastControllerAck(handle: Int): Int = SatelliteNative.getLastControllerAck(handle)
 
+        /**
+         * Motion-status byte from the most recent MSG_CONTROLLER_ACK on
+         * [handle], or -1 if no extended ACK was observed (pre-extension
+         * satellite, or no ACK at all). See [SatelliteNative
+         * .getLastControllerMotionFlags] for the bit definitions and the
+         * `-1`-means-unknown semantics.
+         */
+        fun getLastControllerMotionFlags(handle: Int): Int =
+            SatelliteNative.getLastControllerMotionFlags(handle)
+
         fun sendControllerType(
             handle: Int,
             index: Int,
             type: Int,
         ) {
             SatelliteNative.sendControllerType(handle, index, type)
+        }
+
+        /**
+         * Send a fresh capability word for an already-registered
+         * controller (0x000E). Reactive replacement for the snapshot the
+         * dish-side took at addController time — used when the
+         * [com.tinkernorth.dish.composer.MotionCapabilityComposer]'s
+         * `toCapBits(slotId)` flips after registration (e.g. user toggle
+         * change). The receiver overwrites `Controller::caps` in place;
+         * no replug, no fresh ACK. See [SatelliteNative
+         * .sendControllerCapsUpdate].
+         */
+        fun sendControllerCapsUpdate(
+            handle: Int,
+            index: Int,
+            capabilities: Int,
+        ) {
+            SatelliteNative.sendControllerCapsUpdate(handle, index, capabilities)
         }
 
         /**

--- a/app/src/main/java/com/tinkernorth/dish/core/jni/SatelliteNative.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/jni/SatelliteNative.kt
@@ -95,6 +95,23 @@ object SatelliteNative {
         controllerType: Int,
     )
 
+    /**
+     * Send 0x000E Controller Caps Update — pushes a fresh capability word
+     * for an already-registered controller without unplugging it on the
+     * receiver. Same payload shape as `controllerAdd`'s caps field
+     * (ctrlIdx + caps BE16). Used when the dish's `MotionCapabilityComposer`
+     * emits a new `toCapBits` value mid-session (e.g. the user toggles
+     * motion off after the slot was registered with motion on). A
+     * pre-extension receiver silently drops the packet — the dish-side
+     * listener gate is the load-bearing correctness path; this wire
+     * update is purely for the receiver's web-UI snapshot honesty.
+     */
+    external fun sendControllerCapsUpdate(
+        handle: Int,
+        controllerIndex: Int,
+        capabilities: Int,
+    )
+
     // ── Motion + battery (0x000A, 0x000B) ───────────────────────────────────
 
     /**
@@ -156,6 +173,24 @@ object SatelliteNative {
 
     /** Reset the controller ACK state for [handle] to -1. */
     external fun resetControllerAck(handle: Int)
+
+    /**
+     * Motion-status byte from the most recent MSG_CONTROLLER_ACK on [handle],
+     * or -1 when no extended ACK has been observed (no ACK at all, or a
+     * pre-extension satellite that only sent the legacy 4-byte payload).
+     * Bits mirror the satellite's `ACK_MOTION_FLAG_*` constants:
+     *  - bit 0 (`0x01`): receiver's backend supports IMU for the slot's
+     *    chosen controller type (`supportsMotionForType`).
+     *  - bit 1 (`0x02`): receiver's backend successfully created the
+     *    per-serial IMU sink at plug-in (`motionBackendOk`).
+     *
+     * The Kotlin caller (`SatelliteConnection.registerController`) reads
+     * this immediately after a successful ACK and threads the result into
+     * the per-slot motion-backend store; the `-1` sentinel collapses to
+     * "unknown" so an old satellite is not misread as a permanent
+     * "backend broken" state.
+     */
+    external fun getLastControllerMotionFlags(handle: Int): Int
 
     /** ViGEm availability from the latest 0x0007 Server Status on [handle]. */
     external fun getVigemAvailable(handle: Int): Int

--- a/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistry.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistry.kt
@@ -111,7 +111,7 @@ class PhysicalGamepadRegistry
             cancelDisconnect(deviceId)
             _devices.value =
                 _devices.value +
-                    (deviceId to Device(deviceId, dev.name, hasGyro = PhysicalMotionProbe.hasGyro(deviceId)))
+                (deviceId to Device(deviceId, dev.name, hasGyro = PhysicalMotionProbe.hasGyro(deviceId)))
         }
 
         override fun onInputDeviceRemoved(deviceId: Int) {
@@ -139,7 +139,7 @@ class PhysicalGamepadRegistry
                 // change its sensor exposure — and the probe is cheap).
                 _devices.value =
                     _devices.value +
-                        (deviceId to Device(deviceId, dev.name, hasGyro = PhysicalMotionProbe.hasGyro(deviceId)))
+                    (deviceId to Device(deviceId, dev.name, hasGyro = PhysicalMotionProbe.hasGyro(deviceId)))
             }
         }
 

--- a/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistry.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistry.kt
@@ -9,6 +9,7 @@ import android.util.Log
 import android.view.InputDevice
 import android.view.MotionEvent
 import com.tinkernorth.dish.core.jni.SatelliteNative
+import com.tinkernorth.dish.source.sensor.PhysicalMotionProbe
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -46,11 +47,21 @@ class PhysicalGamepadRegistry
          *   "false disconnect") doesn't free the server-side controller index
          *   and force a re-register. `null` means the device is currently
          *   present.
+         * @property hasGyro true iff the per-device sensor API
+         *   ([android.view.InputDevice.getSensorManager], API 31+) reports a
+         *   gyroscope for this pad. Computed once at add time via
+         *   [com.tinkernorth.dish.source.sensor.PhysicalMotionProbe] and read
+         *   by [com.tinkernorth.dish.composer.MotionCapabilityComposer] to
+         *   decide the per-slot `CAP_MOTION` bit, and by
+         *   [com.tinkernorth.dish.source.sensor.PhysicalMotionSource] to
+         *   decide whether to register sensor listeners. A controller without
+         *   a gyro keeps this `false` for its whole lifetime in the registry.
          */
         data class Device(
             val id: Int,
             val name: String,
             val disconnectingTimeLeftSec: Int? = null,
+            val hasGyro: Boolean = false,
         ) {
             val isDisconnecting: Boolean get() = disconnectingTimeLeftSec != null
         }
@@ -88,7 +99,7 @@ class PhysicalGamepadRegistry
                 val dev = InputDevice.getDevice(id) ?: continue
                 if (!isGamepad(dev)) continue
                 pushDeadzones(dev)
-                next[id] = Device(id, dev.name)
+                next[id] = Device(id, dev.name, hasGyro = PhysicalMotionProbe.hasGyro(id))
             }
             _devices.value = next
         }
@@ -98,7 +109,9 @@ class PhysicalGamepadRegistry
             if (!isGamepad(dev)) return
             pushDeadzones(dev)
             cancelDisconnect(deviceId)
-            _devices.value = _devices.value + (deviceId to Device(deviceId, dev.name))
+            _devices.value =
+                _devices.value +
+                    (deviceId to Device(deviceId, dev.name, hasGyro = PhysicalMotionProbe.hasGyro(deviceId)))
         }
 
         override fun onInputDeviceRemoved(deviceId: Int) {
@@ -121,7 +134,12 @@ class PhysicalGamepadRegistry
             cancelDisconnect(deviceId)
             val current = _devices.value[deviceId]
             if (current == null || current.name != dev.name || current.isDisconnecting) {
-                _devices.value = _devices.value + (deviceId to Device(deviceId, dev.name))
+                // Re-probe in case capabilities changed (rare in practice, but
+                // a USB pad swapping firmware between detach/attach cycles can
+                // change its sensor exposure — and the probe is cheap).
+                _devices.value =
+                    _devices.value +
+                        (deviceId to Device(deviceId, dev.name, hasGyro = PhysicalMotionProbe.hasGyro(deviceId)))
             }
         }
 

--- a/app/src/main/java/com/tinkernorth/dish/repository/MotionPreferenceRepository.kt
+++ b/app/src/main/java/com/tinkernorth/dish/repository/MotionPreferenceRepository.kt
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.repository
+
+import android.content.Context
+import com.tinkernorth.dish.architecture.interfaces.KeyedRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Durable per-slot motion preference: should the user-facing "stream gyro"
+ * toggle be on for this slot?
+ *
+ * **Why per-slot, not global:** a player may have a DualSense pad (motion
+ * great for shooters) routed to one satellite and an Xbox-typed virtual
+ * controller (motion not useful) routed to another. The receiver-side
+ * "Xbox virtual pads have no IMU surface" reality (see satellite
+ * `vigem_adapter.cpp::submitMotion`) makes a global toggle wrong by
+ * default. Per-slot lets the same dish be honest about each slot.
+ *
+ * **Absence semantics:** [get] returns null when the slot has never been
+ * touched. Callers ([MotionEnabledStore]) collapse null onto a global
+ * default (currently true — "motion on unless I turned it off"). The
+ * repository itself does NOT bake in the default; that's a policy
+ * decision that belongs in the in-memory store.
+ *
+ * Storage shape: single `SharedPreferences` entry holding a JSON list of
+ * `MotionPreference` records. The same shape and write-lock discipline as
+ * [RememberedSatelliteRepository] — see that file for the rationale.
+ */
+@Serializable
+data class MotionPreference(
+    /** Slot id — `VIRTUAL_SLOT_ID` for the touch overlay, or the integer-as-string `InputDevice` id for a physical pad. */
+    val slotId: String,
+    /** True ⇒ the dish should stream motion for this slot when otherwise capable. */
+    val enabled: Boolean,
+)
+
+@Singleton
+class MotionPreferenceRepository
+    @Inject
+    constructor(
+        @ApplicationContext context: Context,
+        private val json: Json,
+    ) : KeyedRepository<String, MotionPreference> {
+        private val prefs by lazy {
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        }
+        private val writeLock = Any()
+
+        override fun keyOf(value: MotionPreference): String = value.slotId
+
+        override fun get(key: String): MotionPreference? = all().firstOrNull { it.slotId == key }
+
+        override fun all(): List<MotionPreference> {
+            val raw = prefs.getString(KEY_LIST, null) ?: return emptyList()
+            return runCatching {
+                json.decodeFromString(ListSerializer(MotionPreference.serializer()), raw)
+            }.getOrDefault(emptyList())
+        }
+
+        override fun put(
+            key: String,
+            value: MotionPreference,
+        ) {
+            synchronized(writeLock) {
+                val list = all().toMutableList()
+                list.removeAll { it.slotId == key }
+                list += value
+                persist(list)
+            }
+        }
+
+        override fun remove(key: String) {
+            synchronized(writeLock) {
+                val list = all().filterNot { it.slotId == key }
+                persist(list)
+            }
+        }
+
+        override fun clear() {
+            synchronized(writeLock) {
+                prefs.edit().remove(KEY_LIST).apply()
+            }
+        }
+
+        private fun persist(list: List<MotionPreference>) {
+            val raw = json.encodeToString(ListSerializer(MotionPreference.serializer()), list)
+            prefs.edit().putString(KEY_LIST, raw).apply()
+        }
+
+        private companion object {
+            const val PREFS_NAME = "motion_preferences"
+            const val KEY_LIST = "preferences"
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/repository/MotionPreferenceRepository.kt
+++ b/app/src/main/java/com/tinkernorth/dish/repository/MotionPreferenceRepository.kt
@@ -4,6 +4,7 @@
 package com.tinkernorth.dish.repository
 
 import android.content.Context
+import android.util.Log
 import com.tinkernorth.dish.architecture.interfaces.KeyedRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.serialization.Serializable
@@ -61,7 +62,22 @@ class MotionPreferenceRepository
             val raw = prefs.getString(KEY_LIST, null) ?: return emptyList()
             return runCatching {
                 json.decodeFromString(ListSerializer(MotionPreference.serializer()), raw)
-            }.getOrDefault(emptyList())
+            }.getOrElse { err ->
+                // Surface a one-line WARN when we can't parse what we
+                // previously wrote — without this the user silently loses
+                // every motion toggle they've configured and there's no
+                // breadcrumb pointing at the prefs file. The repository
+                // still falls back to emptyList() so app startup keeps
+                // working (the alternative — a crash on first read —
+                // would brick the dish on a corrupted prefs).
+                Log.w(
+                    TAG,
+                    "Failed to decode motion-preference list; treating as empty. " +
+                        "User-facing impact: all per-slot motion toggles reset to default. " +
+                        "Cause: ${err.javaClass.simpleName}: ${err.message}",
+                )
+                emptyList()
+            }
         }
 
         override fun put(
@@ -95,6 +111,7 @@ class MotionPreferenceRepository
         }
 
         private companion object {
+            const val TAG = "MotionPreferenceRepository"
             const val PREFS_NAME = "motion_preferences"
             const val KEY_LIST = "preferences"
         }

--- a/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
@@ -48,6 +48,22 @@ class SatelliteConnection(
     private val scope: CoroutineScope,
     private val controllerRepo: ControllerRepository,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    /**
+     * Resolves the per-slot `CAP_MOTION` (0x0004) bit for the wire
+     * capability word at `MSG_CONTROLLER_ADD` time. Defaulted to the
+     * always-on word ([DEFAULT_CAPABILITIES_WITHOUT_MOTION] OR
+     * [com.tinkernorth.dish.composer.MotionCapability.CAP_MOTION_BIT]) so
+     * pre-existing tests that don't care about the composer keep behaving
+     * the same.
+     *
+     * In production, [SatelliteConnectionManager] threads a closure that
+     * reads from [com.tinkernorth.dish.composer.MotionCapabilityComposer
+     * .capabilityFor] so the bit reflects the *user's* current toggle and
+     * the slot's *real* hardware. This makes the cap word honest —
+     * previously every controller advertised motion regardless of whether
+     * gyro samples would ever flow.
+     */
+    private val motionCapsBitsFor: (slotId: String) -> Int = { CAP_MOTION_BIT_LEGACY },
 ) {
     private val _server = MutableStateFlow(server)
     val server: StateFlow<DiscoveredServer> = _server.asStateFlow()
@@ -283,7 +299,15 @@ class SatelliteConnection(
                 if (info.registered) return@withContext
                 if (handle < 0) return@withContext
                 controllerRepo.resetControllerAck(handle)
-                controllerRepo.addController(handle, info.controllerIndex, DEFAULT_CAPABILITIES)
+                // Cap word: the non-motion bits are fixed (the dish always
+                // sends analog triggers and accepts rumble), motion comes
+                // from the composer so it reflects the slot's actual gyro
+                // hardware AND the user's toggle. A satellite re-connect
+                // does NOT re-handshake the cap word (toCapBits ignores the
+                // live link state), so a momentary network blip can't drop
+                // CAP_MOTION on the server side.
+                val caps = BASE_CAPABILITIES or motionCapsBitsFor(slotId)
+                controllerRepo.addController(handle, info.controllerIndex, caps)
                 var ack = -1
                 repeat(ACK_WAIT_ATTEMPTS) {
                     ack = controllerRepo.getLastControllerAck(handle)
@@ -432,20 +456,33 @@ class SatelliteConnection(
         private const val FALTER_TO_DEAD = 5
 
         // MSG_CONTROLLER_ADD capability word (2-byte big-endian): bit 0x0001
-        // analog triggers, 0x0002 rumble, 0x0004 motion (this client emits the
-        // MSG_MOTION IMU stream — see PhoneMotionSource, Task 1.1).
+        // analog triggers, 0x0002 rumble, 0x0004 motion (this client emits
+        // the MSG_MOTION IMU stream — see PhoneMotionSource, Task 1.1).
         //
         // CAP_LIGHTBAR (0x0008) is intentionally NOT set: Android exposes no
-        // controller-LED API, so dish-android cannot drive a controller's RGB
-        // lightbar. Leaving the bit clear tells a capability-aware satellite
-        // not to waste packets sending MSG_LIGHTBAR (0x000D) to this client.
-        // Any 0x000D that does arrive is decoded, logged, and dropped by the
-        // native receive loop (satellite_jni.cpp::receiveAck).
+        // controller-LED API, so dish-android cannot drive a controller's
+        // RGB lightbar. Leaving the bit clear tells a capability-aware
+        // satellite not to waste packets sending MSG_LIGHTBAR (0x000D) to
+        // this client. Any 0x000D that does arrive is decoded, logged, and
+        // dropped by the native receive loop (satellite_jni.cpp::receiveAck).
         private const val CAP_ANALOG_TRIGGERS = 0x0001
         private const val CAP_RUMBLE = 0x0002
-        private const val CAP_MOTION = 0x0004
-        private const val DEFAULT_CAPABILITIES =
-            CAP_ANALOG_TRIGGERS or CAP_RUMBLE or CAP_MOTION
+
+        /**
+         * The always-on slice of the capability word: analog triggers + rumble.
+         * Motion is per-slot via [motionCapsBitsFor]; lightbar is intentionally
+         * absent (no controller-LED API on Android).
+         */
+        private const val BASE_CAPABILITIES = CAP_ANALOG_TRIGGERS or CAP_RUMBLE
+
+        /**
+         * Legacy "all motion" word for the default-arg motion lambda. Pre-PR3
+         * code path: every controller advertised CAP_MOTION regardless of
+         * gyro hardware or user toggle. Tests that don't inject a composer
+         * still see this value so their assertions don't have to know about
+         * the new wiring.
+         */
+        internal const val CAP_MOTION_BIT_LEGACY = 0x0004
 
         // MSG_CONTROLLER_ACK result codes — wire values mirror the satellite's
         // core/types.h. getLastControllerAck() returns a packed word,

--- a/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
@@ -9,6 +9,8 @@ import com.tinkernorth.dish.core.jni.ControllerRepository
 import com.tinkernorth.dish.core.model.DiscoveredServer
 import com.tinkernorth.dish.source.sensor.BatteryValidator
 import com.tinkernorth.dish.source.sensor.MotionRateLimiter
+import com.tinkernorth.dish.source.store.SatelliteMotionBackendStatus
+import com.tinkernorth.dish.source.store.SatelliteMotionBackendStatusStore
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -64,6 +66,17 @@ class SatelliteConnection(
      * gyro samples would ever flow.
      */
     private val motionCapsBitsFor: (slotId: String) -> Int = { CAP_MOTION_BIT_LEGACY },
+    /**
+     * Per-(connection, slot) store of the satellite's truth about whether
+     * motion bytes will actually reach the virtual gamepad's IMU surface.
+     * Written after a successful controller-add ACK using the motion-status
+     * byte the receiver appends to the ACK payload — see
+     * [com.tinkernorth.dish.core.jni.ControllerRepository
+     * .getLastControllerMotionFlags]. Defaulted to `null` so tests that
+     * don't care about the satellite-truth path can keep constructing a
+     * connection without wiring it.
+     */
+    private val motionBackendStatusStore: SatelliteMotionBackendStatusStore? = null,
 ) {
     private val _server = MutableStateFlow(server)
     val server: StateFlow<DiscoveredServer> = _server.asStateFlow()
@@ -96,11 +109,21 @@ class SatelliteConnection(
      * [registered] flips true once `addController` has been ACKed and the type
      * has been pushed; reports for this slot are dropped until then so we don't
      * silently feed packets the server will reject as "unknown controller".
+     *
+     * [lastAdvertisedCaps] tracks the most recent capability word the dish has
+     * told the satellite about for this slot — either via the original
+     * `MSG_CONTROLLER_ADD` or a subsequent `MSG_CONTROLLER_CAPS_UPDATE`
+     * (0x000E). [refreshCapsIfChanged] uses this to de-dup composer emissions
+     * that don't actually change the wire word, so a churning composer
+     * (e.g. an unrelated slot's hub.bindings change re-emitting the same map)
+     * doesn't burn a UDP packet per tick. `null` means "no registration has
+     * happened yet" — we don't bother tracking caps for an unregistered slot.
      */
     data class SlotBinding(
         val controllerIndex: Int,
         val controllerType: Int,
         val registered: Boolean,
+        val lastAdvertisedCaps: Int? = null,
     )
 
     private val _slots = MutableStateFlow<Map<String, SlotBinding>>(emptyMap())
@@ -234,6 +257,12 @@ class SatelliteConnection(
             controllerRepo.closeSocket(snap.handle)
         }
         _slots.update { map -> map.mapValues { (_, v) -> v.copy(registered = false) } }
+        // Wipe the cached satellite-truth motion flags too — the slots will
+        // re-register on the next markConnected and write fresh statuses.
+        // Without this, a Connected → Idle → Connected sequence would have
+        // the pill briefly read the previous session's flags after the new
+        // session's first slot binds but before its ACK lands.
+        motionBackendStatusStore?.clearConnection(id)
         onRegistrationFailed = null
         _state.value = SatelliteSessionState.Idle
     }
@@ -322,10 +351,46 @@ class SatelliteConnection(
                 // or sendReport() would stream input the server silently drops.
                 val result = if (ack == -1) null else ack and ACK_RESULT_MASK
                 if (result == ACK_OK) {
+                    // Read the optional motion-flags byte the satellite
+                    // appended to the ACK (post-extension receivers). A
+                    // pre-extension satellite returns -1 here — leave the
+                    // store entry absent so the composer falls back to its
+                    // own `hostHasSinkForType` heuristic rather than reading
+                    // the missing flags as "permanently broken." Paired with
+                    // the same `getLastControllerAck` snapshot, so we know
+                    // the flags correspond to the ACK we just observed.
+                    val motionFlags = controllerRepo.getLastControllerMotionFlags(handle)
+                    if (motionFlags >= 0) {
+                        motionBackendStatusStore?.setStatus(
+                            id,
+                            slotId,
+                            SatelliteMotionBackendStatus.fromFlags(motionFlags),
+                        )
+                    } else {
+                        motionBackendStatusStore?.clear(id, slotId)
+                    }
                     controllerRepo.sendControllerType(handle, info.controllerIndex, info.controllerType)
+                    // Reconcile caps against the composer's *current* value
+                    // before flipping registered=true. If the composer
+                    // emitted a new value during our ACK window
+                    // (composer.state is a hot StateFlow), the manager's
+                    // post-registration subscriber would otherwise see
+                    // lastAdvertisedCaps == newCaps after our update below
+                    // and never send the catch-up MSG_CONTROLLER_CAPS_UPDATE.
+                    // Sending the diff here closes the registration-window
+                    // race in one place — the dish's lastAdvertisedCaps then
+                    // matches what's actually on the wire.
+                    val currentCaps = BASE_CAPABILITIES or motionCapsBitsFor(slotId)
+                    if (currentCaps != caps) {
+                        controllerRepo.sendControllerCapsUpdate(
+                            handle,
+                            info.controllerIndex,
+                            currentCaps,
+                        )
+                    }
                     _slots.update { map ->
                         val cur = map[slotId] ?: return@update map
-                        map + (slotId to cur.copy(registered = true))
+                        map + (slotId to cur.copy(registered = true, lastAdvertisedCaps = currentCaps))
                     }
                 } else {
                     // Leave the slot unregistered so sendReport() stays gated,
@@ -352,6 +417,50 @@ class SatelliteConnection(
             else -> "it rejected the controller"
         }
 
+    /**
+     * Reconcile per-slot wire capability against the composer's latest
+     * value. For each registered slot whose [SlotBinding.lastAdvertisedCaps]
+     * differs from `BASE_CAPABILITIES OR motionCapsBitsFor(slotId)`, send
+     * a `MSG_CONTROLLER_CAPS_UPDATE` so the receiver's cap-word matches
+     * what the dish would advertise today.
+     *
+     * Called by [SatelliteConnectionManager]'s composer subscription on
+     * every emission. Idempotent: emitting the same composer state twice
+     * results in zero wire packets because `lastAdvertisedCaps` already
+     * equals the recomputed value. Unregistered slots are skipped — their
+     * next `registerController` will pick up the fresh caps via the
+     * `motionCapsBitsFor` lambda directly.
+     *
+     * Runs on [ioDispatcher] so the JNI `sendControllerCapsUpdate` doesn't
+     * stall the manager's collector dispatcher.
+     */
+    internal suspend fun refreshCapsIfChanged() {
+        val snap = live ?: return
+        val updates = mutableListOf<Pair<String, Int>>()
+        // Compute the diff under a single _slots snapshot read so multiple
+        // mutations of slot info during the scan can't shear our decision.
+        for ((slotId, slotInfo) in _slots.value) {
+            if (!slotInfo.registered) continue
+            val newCaps = BASE_CAPABILITIES or motionCapsBitsFor(slotId)
+            if (slotInfo.lastAdvertisedCaps == newCaps) continue
+            updates += slotId to newCaps
+        }
+        if (updates.isEmpty()) return
+        withContext(ioDispatcher) {
+            for ((slotId, newCaps) in updates) {
+                val info = _slots.value[slotId] ?: continue
+                // Re-check registration: a parallel detach could have un-set
+                // it between our scan and our send. Cheap to re-read.
+                if (!info.registered) continue
+                controllerRepo.sendControllerCapsUpdate(snap.handle, info.controllerIndex, newCaps)
+                _slots.update { map ->
+                    val cur = map[slotId] ?: return@update map
+                    map + (slotId to cur.copy(lastAdvertisedCaps = newCaps))
+                }
+            }
+        }
+    }
+
     fun detachSlot(slotId: String) {
         var removed: SlotBinding? = null
         _slots.update { map ->
@@ -360,6 +469,10 @@ class SatelliteConnection(
             map - slotId
         }
         val info = removed ?: return
+        // Drop any cached satellite-side motion truth — the next add for
+        // this slot will write a fresh status, and leaving stale data here
+        // would mislead the pill in the meantime.
+        motionBackendStatusStore?.clear(id, slotId)
         if (handle >= 0 && info.registered) {
             controllerRepo.removeController(handle, info.controllerIndex)
         }

--- a/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
@@ -50,11 +50,11 @@ class SatelliteConnection(
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     /**
      * Resolves the per-slot `CAP_MOTION` (0x0004) bit for the wire
-     * capability word at `MSG_CONTROLLER_ADD` time. Defaulted to the
-     * always-on word ([DEFAULT_CAPABILITIES_WITHOUT_MOTION] OR
-     * [com.tinkernorth.dish.composer.MotionCapability.CAP_MOTION_BIT]) so
-     * pre-existing tests that don't care about the composer keep behaving
-     * the same.
+     * capability word at `MSG_CONTROLLER_ADD` time. Defaulted to
+     * [CAP_MOTION_BIT_LEGACY] so pre-existing tests that don't care
+     * about the composer keep behaving like the pre-PR3 always-on path
+     * (where every controller advertised motion regardless of hardware
+     * or toggle).
      *
      * In production, [SatelliteConnectionManager] threads a closure that
      * reads from [com.tinkernorth.dish.composer.MotionCapabilityComposer

--- a/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManager.kt
@@ -4,6 +4,7 @@
 package com.tinkernorth.dish.source.connection
 
 import android.content.Context
+import com.tinkernorth.dish.composer.MotionCapabilityComposer
 import com.tinkernorth.dish.core.jni.ControllerRepository
 import com.tinkernorth.dish.core.model.ConnectResponse
 import com.tinkernorth.dish.core.model.DiscoveredServer
@@ -29,6 +30,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 
 /**
@@ -81,6 +83,14 @@ class SatelliteConnectionManager
         private val store: ConnectionStore,
         private val json: Json,
         @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+        /**
+         * `Provider` (not direct injection) breaks the Hilt construction cycle:
+         * [MotionCapabilityComposer] depends on [com.tinkernorth.dish.composer.ConnectionHub],
+         * which depends back on this manager. Using `Provider.get()` defers
+         * resolution until the cap word is actually needed (at controller-add
+         * time), at which point the singleton composer already exists.
+         */
+        private val motionCapabilityProvider: Provider<MotionCapabilityComposer>,
     ) {
         private val _connections = MutableStateFlow<Map<String, SatelliteConnection>>(emptyMap())
         val connections: StateFlow<Map<String, SatelliteConnection>> = _connections.asStateFlow()
@@ -182,7 +192,16 @@ class SatelliteConnectionManager
                     .updateAndGet { map ->
                         val cur = map[id]
                         if (cur != null) return@updateAndGet map
-                        val fresh = SatelliteConnection(id, server, scope, controllerRepo, ioDispatcher)
+                        val fresh = SatelliteConnection(
+                            id,
+                            server,
+                            scope,
+                            controllerRepo,
+                            ioDispatcher,
+                            motionCapsBitsFor = { slotId ->
+                                motionCapabilityProvider.get().capabilityFor(slotId).toCapBits()
+                            },
+                        )
                         created = fresh
                         map + (id to fresh)
                     }[id] ?: return
@@ -282,7 +301,16 @@ class SatelliteConnectionManager
                 _connections
                     .updateAndGet { map ->
                         if (map.containsKey(id)) return@updateAndGet map
-                        map + (id to SatelliteConnection(id, server, scope, controllerRepo, ioDispatcher))
+                        map + (id to SatelliteConnection(
+                            id,
+                            server,
+                            scope,
+                            controllerRepo,
+                            ioDispatcher,
+                            motionCapsBitsFor = { slotId ->
+                                motionCapabilityProvider.get().capabilityFor(slotId).toCapBits()
+                            },
+                        ))
                     }[id] ?: return
             conn.markConnecting()
             scope.launch {

--- a/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManager.kt
@@ -14,6 +14,7 @@ import com.tinkernorth.dish.core.net.hexToBytes
 import com.tinkernorth.dish.di.IoDispatcher
 import com.tinkernorth.dish.repository.ConnectionStore
 import com.tinkernorth.dish.repository.RememberedSatellite
+import com.tinkernorth.dish.source.store.SatelliteMotionBackendStatusStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -24,6 +25,8 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
@@ -91,6 +94,15 @@ class SatelliteConnectionManager
          * time), at which point the singleton composer already exists.
          */
         private val motionCapabilityProvider: Provider<MotionCapabilityComposer>,
+        /**
+         * Per-(connection, slot) store the receiver's truth about its motion
+         * sink lands in. Written from [SatelliteConnection.registerController]
+         * after a successful ACK using the motion-status byte the satellite
+         * appends to the ACK payload. The composer reads from it so the pill
+         * can surface "satellite kernel rejected the IMU sink" as a distinct
+         * state rather than falsely showing STREAMING.
+         */
+        private val motionBackendStatusStore: SatelliteMotionBackendStatusStore,
     ) {
         private val _connections = MutableStateFlow<Map<String, SatelliteConnection>>(emptyMap())
         val connections: StateFlow<Map<String, SatelliteConnection>> = _connections.asStateFlow()
@@ -143,6 +155,38 @@ class SatelliteConnectionManager
 
         private val deviceId by lazy { getOrCreateDeviceId() }
         private val deviceName by lazy { android.os.Build.MODEL ?: "Android" }
+
+        init {
+            // Reactive cap-word refresh — the third leg of the composer-as-
+            // single-source-of-truth pattern. UI consumers already read the
+            // composer (pill); the listener gate already reads the composer
+            // (motionSource.start/stop); now the WIRE cap word also reacts
+            // to composer changes, via a per-connection diff against
+            // SlotBinding.lastAdvertisedCaps.
+            //
+            // Why subscribe to `cap-bits-by-slot` (the projection), not
+            // `composer.state` directly: the composer's `MotionCapability`
+            // carries five fields, only one of which (toCapBits) affects the
+            // wire. Without the projection + distinctUntilChanged, every
+            // hub.connections emit (which the composer combine forwards)
+            // would push a no-op caps-update for every registered slot.
+            //
+            // Launched in `init`, but the `Provider.get()` doesn't run until
+            // the coroutine actually dispatches — at which point construction
+            // is complete and the Hilt cycle is resolved (same reason the
+            // motionCapsBitsFor lambda uses Provider rather than direct
+            // injection — see the Provider's KDoc above).
+            scope.launch {
+                motionCapabilityProvider.get().state
+                    .map { caps -> caps.mapValues { (_, mc) -> mc.toCapBits() } }
+                    .distinctUntilChanged()
+                    .collect {
+                        _connections.value.values.forEach { conn ->
+                            conn.refreshCapsIfChanged()
+                        }
+                    }
+            }
+        }
 
         fun get(id: String): SatelliteConnection? = _connections.value[id]
 
@@ -201,6 +245,7 @@ class SatelliteConnectionManager
                             motionCapsBitsFor = { slotId ->
                                 motionCapabilityProvider.get().capabilityFor(slotId).toCapBits()
                             },
+                            motionBackendStatusStore = motionBackendStatusStore,
                         )
                         created = fresh
                         map + (id to fresh)
@@ -310,6 +355,7 @@ class SatelliteConnectionManager
                             motionCapsBitsFor = { slotId ->
                                 motionCapabilityProvider.get().capabilityFor(slotId).toCapBits()
                             },
+                            motionBackendStatusStore = motionBackendStatusStore,
                         ))
                     }[id] ?: return
             conn.markConnecting()

--- a/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManager.kt
@@ -177,7 +177,9 @@ class SatelliteConnectionManager
             // motionCapsBitsFor lambda uses Provider rather than direct
             // injection — see the Provider's KDoc above).
             scope.launch {
-                motionCapabilityProvider.get().state
+                motionCapabilityProvider
+                    .get()
+                    .state
                     .map { caps -> caps.mapValues { (_, mc) -> mc.toCapBits() } }
                     .distinctUntilChanged()
                     .collect {
@@ -236,17 +238,18 @@ class SatelliteConnectionManager
                     .updateAndGet { map ->
                         val cur = map[id]
                         if (cur != null) return@updateAndGet map
-                        val fresh = SatelliteConnection(
-                            id,
-                            server,
-                            scope,
-                            controllerRepo,
-                            ioDispatcher,
-                            motionCapsBitsFor = { slotId ->
-                                motionCapabilityProvider.get().capabilityFor(slotId).toCapBits()
-                            },
-                            motionBackendStatusStore = motionBackendStatusStore,
-                        )
+                        val fresh =
+                            SatelliteConnection(
+                                id,
+                                server,
+                                scope,
+                                controllerRepo,
+                                ioDispatcher,
+                                motionCapsBitsFor = { slotId ->
+                                    motionCapabilityProvider.get().capabilityFor(slotId).toCapBits()
+                                },
+                                motionBackendStatusStore = motionBackendStatusStore,
+                            )
                         created = fresh
                         map + (id to fresh)
                     }[id] ?: return
@@ -346,17 +349,20 @@ class SatelliteConnectionManager
                 _connections
                     .updateAndGet { map ->
                         if (map.containsKey(id)) return@updateAndGet map
-                        map + (id to SatelliteConnection(
-                            id,
-                            server,
-                            scope,
-                            controllerRepo,
-                            ioDispatcher,
-                            motionCapsBitsFor = { slotId ->
-                                motionCapabilityProvider.get().capabilityFor(slotId).toCapBits()
-                            },
-                            motionBackendStatusStore = motionBackendStatusStore,
-                        ))
+                        map + (
+                            id to
+                                SatelliteConnection(
+                                    id,
+                                    server,
+                                    scope,
+                                    controllerRepo,
+                                    ioDispatcher,
+                                    motionCapsBitsFor = { slotId ->
+                                        motionCapabilityProvider.get().capabilityFor(slotId).toCapBits()
+                                    },
+                                    motionBackendStatusStore = motionBackendStatusStore,
+                                )
+                        )
                     }[id] ?: return
             conn.markConnecting()
             scope.launch {

--- a/app/src/main/java/com/tinkernorth/dish/source/sensor/MotionScaling.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/sensor/MotionScaling.kt
@@ -63,7 +63,9 @@ object MotionScaling {
     sealed interface RemapResult {
         data object Mapped : RemapResult
 
-        data class Fallback(val unknownRotation: Int) : RemapResult
+        data class Fallback(
+            val unknownRotation: Int,
+        ) : RemapResult
     }
 
     /**
@@ -105,23 +107,33 @@ object MotionScaling {
         require(out.size >= 3) { "out must have at least 3 elements; got ${out.size}" }
         return when (rotation) {
             ROTATION_0 -> {
-                out[0] = deviceX; out[1] = deviceY; out[2] = deviceZ
+                out[0] = deviceX
+                out[1] = deviceY
+                out[2] = deviceZ
                 RemapResult.Mapped
             }
             ROTATION_90 -> {
-                out[0] = deviceY; out[1] = -deviceX; out[2] = deviceZ
+                out[0] = deviceY
+                out[1] = -deviceX
+                out[2] = deviceZ
                 RemapResult.Mapped
             }
             ROTATION_180 -> {
-                out[0] = -deviceX; out[1] = -deviceY; out[2] = deviceZ
+                out[0] = -deviceX
+                out[1] = -deviceY
+                out[2] = deviceZ
                 RemapResult.Mapped
             }
             ROTATION_270 -> {
-                out[0] = -deviceY; out[1] = deviceX; out[2] = deviceZ
+                out[0] = -deviceY
+                out[1] = deviceX
+                out[2] = deviceZ
                 RemapResult.Mapped
             }
             else -> {
-                out[0] = deviceY; out[1] = -deviceX; out[2] = deviceZ
+                out[0] = deviceY
+                out[1] = -deviceX
+                out[2] = deviceZ
                 RemapResult.Fallback(rotation)
             }
         }

--- a/app/src/main/java/com/tinkernorth/dish/source/sensor/MotionScaling.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/sensor/MotionScaling.kt
@@ -48,14 +48,36 @@ object MotionScaling {
     }
 
     /**
-     * Remap a device-frame sensor vector into the screen frame, given the
-     * live display [rotation] (a `Surface.ROTATION_*` value).
+     * Result of a successful or fallback [remapLandscape] call. Wraps the
+     * out-array so the caller can write the remapped triple into a
+     * pre-allocated scratch buffer without seeing it as a heap allocation
+     * per sample (the hot path runs at 250 Hz × 2 sensors).
      *
-     * `GamepadOverlayActivity` declares `screenOrientation="landscape"`, which
-     * Android resolves to `ROTATION_90` on most phones but `ROTATION_270` on
-     * others (and many tablets) — the two are 180° apart, so a fixed remap is
-     * sideways-flipped on half the fleet. The transform is therefore keyed off
-     * the rotation the windowing system actually reports:
+     *  - [Mapped] — the rotation was one of the four `Surface.ROTATION_*`
+     *    constants and the remap applied cleanly.
+     *  - [Fallback] — the rotation value was unknown; the caller's scratch
+     *    array carries the `ROTATION_90` remap (sensible default for a
+     *    landscape activity) and the unknown value is reported back so
+     *    the caller can log-once-per-value at the framework layer.
+     */
+    sealed interface RemapResult {
+        data object Mapped : RemapResult
+
+        data class Fallback(val unknownRotation: Int) : RemapResult
+    }
+
+    /**
+     * Remap a device-frame sensor vector into the screen frame, writing the
+     * result into [out] (a 3-element scratch [FloatArray] held by the
+     * caller). Returns whether the remap matched a known rotation or fell
+     * back to the landscape default.
+     *
+     * `GamepadOverlayActivity` declares `screenOrientation="landscape"`,
+     * which Android resolves to `ROTATION_90` on most phones but
+     * `ROTATION_270` on others (and many tablets) — the two are 180° apart,
+     * so a fixed remap is sideways-flipped on half the fleet. The transform
+     * is therefore keyed off the rotation the windowing system actually
+     * reports:
      *
      *  - `ROTATION_0`   → ( deviceX,  deviceY, deviceZ)  — portrait, identity
      *  - `ROTATION_90`  → ( deviceY, -deviceX, deviceZ)  — CCW landscape
@@ -63,26 +85,64 @@ object MotionScaling {
      *  - `ROTATION_270` → (-deviceY,  deviceX, deviceZ)  — CW landscape
      *
      * The result is already in the DSU frame (+X right, +Y up, +Z toward
-     * player), so the receiver does no further rotation. Pure (takes a plain
-     * `Int`, no `Display`/`Context`) so it stays unit-testable; the caller
-     * ([PhoneMotionSource]) is responsible for reading the live rotation.
+     * player), so the receiver does no further rotation. Pure (takes a
+     * plain `Int`, no `Display`/`Context`) so it stays unit-testable; the
+     * caller ([PhoneMotionSource]) is responsible for reading the live
+     * rotation.
      *
-     * An unknown rotation falls back to the `ROTATION_90` landscape remap.
+     * An unknown rotation falls back to the `ROTATION_90` landscape remap
+     * AND returns [RemapResult.Fallback] so the caller can surface a
+     * one-time log at the framework layer rather than silently shipping
+     * the wrong axes.
      */
     fun remapLandscape(
         deviceX: Float,
         deviceY: Float,
         deviceZ: Float,
         rotation: Int,
-    ): FloatArray =
-        when (rotation) {
-            ROTATION_0 -> floatArrayOf(deviceX, deviceY, deviceZ)
-            ROTATION_90 -> floatArrayOf(deviceY, -deviceX, deviceZ)
-            ROTATION_180 -> floatArrayOf(-deviceX, -deviceY, deviceZ)
-            ROTATION_270 -> floatArrayOf(-deviceY, deviceX, deviceZ)
-            // Any unexpected value falls back to the ROTATION_90 landscape remap.
-            else -> floatArrayOf(deviceY, -deviceX, deviceZ)
+        out: FloatArray,
+    ): RemapResult {
+        require(out.size >= 3) { "out must have at least 3 elements; got ${out.size}" }
+        return when (rotation) {
+            ROTATION_0 -> {
+                out[0] = deviceX; out[1] = deviceY; out[2] = deviceZ
+                RemapResult.Mapped
+            }
+            ROTATION_90 -> {
+                out[0] = deviceY; out[1] = -deviceX; out[2] = deviceZ
+                RemapResult.Mapped
+            }
+            ROTATION_180 -> {
+                out[0] = -deviceX; out[1] = -deviceY; out[2] = deviceZ
+                RemapResult.Mapped
+            }
+            ROTATION_270 -> {
+                out[0] = -deviceY; out[1] = deviceX; out[2] = deviceZ
+                RemapResult.Mapped
+            }
+            else -> {
+                out[0] = deviceY; out[1] = -deviceX; out[2] = deviceZ
+                RemapResult.Fallback(rotation)
+            }
         }
+    }
+
+    /**
+     * Allocating shim for callers that don't keep their own scratch
+     * buffer (and for tests that prefer the old return-an-array signature).
+     * Production hot-path callers should use the [out]-param overload —
+     * 250 Hz × 2 sensors is up to 500 allocations/sec on the IMU pipeline.
+     */
+    fun remapLandscape(
+        deviceX: Float,
+        deviceY: Float,
+        deviceZ: Float,
+        rotation: Int,
+    ): FloatArray {
+        val out = FloatArray(3)
+        remapLandscape(deviceX, deviceY, deviceZ, rotation, out)
+        return out
+    }
 
     // Mirror of android.view.Surface.ROTATION_* — duplicated as plain ints so
     // remapLandscape has zero framework dependency and runs in a pure JVM test.

--- a/app/src/main/java/com/tinkernorth/dish/source/sensor/PhoneMotionAvailability.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/sensor/PhoneMotionAvailability.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.sensor
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorManager
+import com.tinkernorth.dish.architecture.abstracts.AbstractStateSource
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Process-scoped fact: does the phone itself have a usable gyroscope?
+ *
+ * The activity-scoped [PhoneMotionSource] already exposes this as its
+ * `isAvailable` property, but the satellite registration path and the
+ * [com.tinkernorth.dish.composer.MotionCapabilityComposer] need the same fact
+ * *without* an overlay being on screen — capability negotiation at controller
+ * add time happens long before the overlay activity is constructed.
+ *
+ * Implemented as an [AbstractStateSource]`<Boolean>` so it composes through the
+ * existing `state` flow plumbing. The value is computed once at injection time
+ * because Android device hardware does not change at runtime; the source still
+ * extends the base class purely so consumers can `.state.collect { … }`
+ * uniformly with the other availability flows.
+ */
+@Singleton
+class PhoneMotionAvailability
+    @Inject
+    constructor(
+        @ApplicationContext context: Context,
+    ) : AbstractStateSource<Boolean>(initialState = false) {
+        init {
+            val sm = context.getSystemService(Context.SENSOR_SERVICE) as? SensorManager
+            val hasGyro = sm?.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null
+            setState(hasGyro)
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/source/sensor/PhoneMotionSource.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/sensor/PhoneMotionSource.kt
@@ -8,15 +8,26 @@ import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.util.Log
+import com.tinkernorth.dish.architecture.abstracts.AbstractStateSource
 
 /**
  * Captures the phone's gyroscope + accelerometer and forwards IMU samples
  * for the on-screen touch controller (`GamepadOverlayActivity`).
  *
+ * **State-flow contract (PR4):** this source is an
+ * [AbstractStateSource]`<`[MotionStreamState]`>`. The activity-side pill
+ * reads `state.collect { … }` rather than polling `isStreaming` /
+ * `isStalled` from the UI, so a stalled gyro (sensor exists, no callbacks
+ * arriving) demotes the pill to STALLED on its own tick — previously the
+ * pill stayed on STREAMING forever unless something *else* triggered a
+ * repaint. See the [STALL_WINDOW_MS] / [STALL_TICK_MS] companion vals for
+ * the cadence.
+ *
  * This is the marquee Android motion use case from the roadmap (Task 1.1):
  * a phone in touch-overlay mode becomes a motion source — gyro aim for
- * shooters, tilt for emulators. Physical gamepads that expose an IMU through
- * the Android `InputDevice` API are a separate, later path.
+ * shooters, tilt for emulators. Physical gamepads that expose an IMU
+ * through the Android `InputDevice` API are a separate path
+ * ([PhysicalMotionSource]).
  *
  * Pipeline: `SensorManager` (rad/s, m/s², device frame) → [MotionScaling]
  * (DSU int16, screen frame) → [MotionRateLimiter] (≤ 250 Hz gate) → [Emit].
@@ -31,9 +42,9 @@ import android.util.Log
  * → UDP-send pipeline on the UI thread at the sensor's native rate. So this
  * source registers via the 4-arg overload with a [SensorDispatch] `Handler`
  * (a dedicated background thread) instead. [start]/[stop] still run on the
- * caller's (main) thread, so the fields touched by both — [emit], [started]
- * and the [accelX]/[accelY]/[accelZ] cache that [stop] clears — are
- * `@Volatile` for that cross-thread hand-off.
+ * caller's (main) thread, so the fields touched by both — [emit], the
+ * [accelX]/[accelY]/[accelZ] cache that [stop] clears — are `@Volatile` for
+ * that cross-thread hand-off.
  *
  * [rotationSupplier] is queried **per sample** (cheaply cached for the gyro +
  * accel ticks of one fused frame). `GamepadOverlayActivity` declares
@@ -49,7 +60,14 @@ class PhoneMotionSource(
     private val rotationSupplier: () -> Int = { DEFAULT_ROTATION },
     private val rateLimiter: MotionRateLimiter = MotionRateLimiter(),
     private val sensorDispatch: SensorDispatch = HandlerThreadSensorDispatch("PhoneMotionSensor"),
-) {
+    /**
+     * Monotonic clock source, in milliseconds. Overridable for tests so the
+     * stall-detector's time math can be driven deterministically without
+     * waiting real wall-clock ms. Defaults to [android.os.SystemClock
+     * .elapsedRealtime] in production.
+     */
+    private val nowMs: () -> Long = { android.os.SystemClock.elapsedRealtime() },
+) : AbstractStateSource<MotionStreamState>(MotionStreamState.Disabled) {
     /** Invoked when a fused sample passes the rate-limit gate. */
     fun interface Emit {
         fun emit(
@@ -61,40 +79,35 @@ class PhoneMotionSource(
     private val gyro: Sensor? = sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
     private val accel: Sensor? = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
 
+    init {
+        // Seed initial state from hardware availability — Disabled when no
+        // gyro, Stopped otherwise. The pill reads this at construct time so
+        // the "no gyroscope" tile is visible before the first resume.
+        setState(if (gyro == null) MotionStreamState.Disabled else MotionStreamState.Stopped)
+    }
+
     /**
-     * True when the phone has a gyroscope. The overlay reads this to show a
-     * "Motion: detected / not available" indicator — the "gyro detected"
-     * feedback every comparable tool surfaces. Without a gyro there's nothing
-     * meaningful to forward, so [start] is a no-op.
+     * True when the phone has a gyroscope. Backwards-compat shim for
+     * pre-PR4 call sites; new code should subscribe to [state] instead and
+     * inspect `MotionStreamState.Disabled`.
      */
     val isAvailable: Boolean get() = gyro != null
 
     /**
      * True between [start] and [stop] — i.e. the sensor listeners are
-     * registered and gyro samples are being forwarded. The overlay reads this
-     * (alongside [isAvailable]) to tell "motion paused" apart from "no
-     * gyroscope" in its motion indicator. Always false when [isAvailable] is
-     * false, since [start] is then a no-op.
+     * registered and gyro samples are being forwarded. Backwards-compat
+     * shim; new code reads [state] for Streaming/Stalled distinction.
      */
     val isStreaming: Boolean get() = started
 
     /**
-     * True when the source is started but no gyro sample has arrived recently
-     * (within [STALL_WINDOW_MS]). Happens on devices where the sensor exists
-     * but reports zero or fails silently — without this signal the motion
-     * indicator would read "streaming" with nothing actually reaching the
-     * wire. The overlay reads this to demote STREAMING → PAUSED with a
-     * "stalled" detail line.
+     * True when the source is started but no gyro sample has arrived
+     * recently (within [STALL_WINDOW_MS]). Backwards-compat shim; new code
+     * reads [state] and checks `MotionStreamState.Stalled` directly.
      */
-    val isStalled: Boolean
-        get() {
-            if (!started) return false
-            val last = lastGyroMonoMs
-            if (last == 0L) return true
-            return android.os.SystemClock.elapsedRealtime() - last > STALL_WINDOW_MS
-        }
+    val isStalled: Boolean get() = state.value == MotionStreamState.Stalled
 
-    /** Monotonic ms of the most recent gyro callback. Used by [isStalled]. */
+    /** Monotonic ms of the most recent gyro callback. Used by stall detection. */
     @Volatile private var lastGyroMonoMs: Long = 0L
 
     // emit/started are handed between the main thread (start/stop) and the
@@ -111,6 +124,17 @@ class PhoneMotionSource(
     @Volatile private var accelY: Short = 0
 
     @Volatile private var accelZ: Short = 0
+
+    /**
+     * Handler the stall tick is posted on. Set in [start] from the dispatch
+     * thread's Handler so the tick lands on the same thread the gyro
+     * callbacks do, avoiding a needless cross-thread state read. Cleared in
+     * [stop].
+     */
+    @Volatile private var stallTickHandler: android.os.Handler? = null
+
+    /** The currently-scheduled stall tick, kept so [stop] can cancel it. */
+    @Volatile private var stallTickRunnable: Runnable? = null
 
     private val listener =
         object : SensorEventListener {
@@ -141,10 +165,16 @@ class PhoneMotionSource(
         // overload delivers callbacks on the main looper, which would put the
         // encrypt + UDP-send pipeline on the UI thread (see the class KDoc).
         val handler = sensorDispatch.acquire()
+        stallTickHandler = handler
         sensorManager.registerListener(listener, gyro, SensorManager.SENSOR_DELAY_GAME, handler)
         accel?.let {
             sensorManager.registerListener(listener, it, SensorManager.SENSOR_DELAY_GAME, handler)
         }
+        // Optimistic initial state: assume samples will arrive. The first
+        // stall tick re-evaluates after STALL_WINDOW_MS, demoting to
+        // Stalled if no gyro callback landed.
+        setState(MotionStreamState.Streaming)
+        scheduleStallTick(handler)
         Log.i(TAG, "Phone motion source started (gyro=${gyro.name}, accel=${accel?.name})")
     }
 
@@ -152,6 +182,12 @@ class PhoneMotionSource(
     fun stop() {
         if (!started) return
         started = false
+        // Cancel the stall tick BEFORE releasing the handler — otherwise the
+        // tick could run between removeCallbacks and release, posting again
+        // onto a thread that's about to disappear.
+        stallTickRunnable?.let { stallTickHandler?.removeCallbacks(it) }
+        stallTickRunnable = null
+        stallTickHandler = null
         sensorManager.unregisterListener(listener)
         sensorDispatch.release()
         emit = null
@@ -159,6 +195,8 @@ class PhoneMotionSource(
         accelX = 0
         accelY = 0
         accelZ = 0
+        lastGyroMonoMs = 0L
+        setState(if (gyro == null) MotionStreamState.Disabled else MotionStreamState.Stopped)
     }
 
     private fun onAccel(values: FloatArray) {
@@ -175,7 +213,13 @@ class PhoneMotionSource(
 
     private fun onGyro(values: FloatArray) {
         if (values.size < 3) return
-        lastGyroMonoMs = android.os.SystemClock.elapsedRealtime()
+        lastGyroMonoMs = nowMs()
+        // Optimistic: every gyro callback proves we're streaming, so a
+        // momentary Stalled flips back to Streaming without waiting for the
+        // next tick. Cheap — same dispatch thread, no scheduler hop.
+        if (state.value == MotionStreamState.Stalled) {
+            setState(MotionStreamState.Streaming)
+        }
         val cb = emit ?: return
         val (x, y, z) =
             MotionScaling.remapLandscape(values[0], values[1], values[2], rotationSupplier())
@@ -195,8 +239,39 @@ class PhoneMotionSource(
         }
     }
 
-    private companion object {
-        const val TAG = "PhoneMotionSource"
+    /**
+     * Schedule the next stall-detection tick on [handler]. The tick reads
+     * `nowMs() - lastGyroMonoMs` and demotes [MotionStreamState.Streaming]
+     * to [MotionStreamState.Stalled] when the gap exceeds [STALL_WINDOW_MS]
+     * — recovering on the next gyro callback (see [onGyro]).
+     *
+     * The tick re-arms itself while [started] so the pill keeps tracking
+     * state-over-time without a separate timer in the UI layer.
+     */
+    private fun scheduleStallTick(handler: android.os.Handler) {
+        val tick =
+            Runnable {
+                if (!started) return@Runnable
+                val gap = nowMs() - lastGyroMonoMs
+                val next =
+                    if (lastGyroMonoMs == 0L || gap > STALL_WINDOW_MS) {
+                        MotionStreamState.Stalled
+                    } else {
+                        MotionStreamState.Streaming
+                    }
+                if (state.value != next) setState(next)
+                // Re-arm. The tick is captured in a local then stashed on
+                // the field so [stop] can cancel it; a fresh Runnable each
+                // iteration is fine — no allocation budget on a 500 ms
+                // cadence.
+                scheduleStallTick(handler)
+            }
+        stallTickRunnable = tick
+        handler.postDelayed(tick, STALL_TICK_MS)
+    }
+
+    companion object {
+        private const val TAG = "PhoneMotionSource"
         const val SINGLE_VIRTUAL_CONTROLLER = 0
 
         // Surface.ROTATION_0 — fallback when no rotation supplier is provided
@@ -204,11 +279,57 @@ class PhoneMotionSource(
         const val DEFAULT_ROTATION = 0
 
         /**
-         * If the gyro hasn't fired for longer than this, treat the source as
-         * stalled. SENSOR_DELAY_GAME is ~20ms; 1.5s is enough to absorb a
-         * sensor pause / coalesce without overreacting, while still surfacing
-         * a "stalled" signal before the user wastes a level worth of input.
+         * If the gyro hasn't fired for longer than this, treat the source
+         * as stalled. SENSOR_DELAY_GAME is ~20ms; 1.5s is enough to absorb
+         * a sensor pause / coalesce without overreacting, while still
+         * surfacing a "stalled" signal before the user wastes a level
+         * worth of input.
          */
         const val STALL_WINDOW_MS = 1500L
+
+        /**
+         * Cadence at which the stall detector re-evaluates. 500 ms is the
+         * sweet spot — fast enough that a stall surfaces within ~2 s of
+         * onset (one window + one tick), slow enough that the periodic
+         * wake on the sensor dispatch thread is a non-event for battery.
+         */
+        const val STALL_TICK_MS = 500L
+
+        /**
+         * Pure decision: given the four facts the source tracks, return
+         * the corresponding [MotionStreamState]. Lifted out so the matrix
+         * can be pinned by a JVM unit test without driving a real
+         * Handler-scheduled tick.
+         */
+        internal fun deriveState(
+            gyroPresent: Boolean,
+            started: Boolean,
+            lastGyroMonoMs: Long,
+            nowMonoMs: Long,
+        ): MotionStreamState =
+            when {
+                !gyroPresent -> MotionStreamState.Disabled
+                !started -> MotionStreamState.Stopped
+                lastGyroMonoMs == 0L -> MotionStreamState.Stalled
+                nowMonoMs - lastGyroMonoMs > STALL_WINDOW_MS -> MotionStreamState.Stalled
+                else -> MotionStreamState.Streaming
+            }
     }
 }
+
+/**
+ * UI-relevant phases of [PhoneMotionSource]:
+ *
+ *  - [Disabled] — the phone has no gyroscope; [PhoneMotionSource.start]
+ *    is a no-op for the lifetime of the process. The pill reads
+ *    UNAVAILABLE.
+ *  - [Stopped] — gyro present but the source is not started (overlay
+ *    backgrounded, or capability gate says off). The pill reads PAUSED.
+ *  - [Streaming] — gyro present, started, samples arriving recently.
+ *    The pill reads STREAMING (or NOT_FORWARDED if the connection kind
+ *    is Bluetooth, which is a *connection* property, not a source one).
+ *  - [Stalled] — gyro present, started, but no callback in
+ *    [PhoneMotionSource.STALL_WINDOW_MS]. The pill reads STALLED. Recovers
+ *    automatically on the next gyro callback.
+ */
+enum class MotionStreamState { Disabled, Stopped, Streaming, Stalled }

--- a/app/src/main/java/com/tinkernorth/dish/source/sensor/PhoneMotionSource.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/sensor/PhoneMotionSource.kt
@@ -126,6 +126,24 @@ class PhoneMotionSource(
     @Volatile private var accelZ: Short = 0
 
     /**
+     * True once at least one accelerometer callback has arrived since
+     * [start]. The first gyro callback can otherwise fire before any accel
+     * (the dispatch thread serializes them, but the order is sensor-driven
+     * and not always gyro-then-accel) — without this gate the first MOTION
+     * packet on the wire would carry accel = (0, 0, 0), which downstream
+     * consumers read as "stationary in zero gravity." Holding the first
+     * gyro until accel has been seen costs at most one sensor period
+     * (≈ 5–20 ms at SENSOR_DELAY_GAME) and the gyro recovers the missed
+     * sample on the next callback via the rate-limiter's per-frame retry.
+     *
+     * Pads with no accel sensor (rare but possible) are handled by the
+     * separate `accel == null` short-circuit in [onGyro]: the gate is
+     * skipped entirely so the gyro stream is not stuck behind a sensor
+     * that will never report.
+     */
+    @Volatile private var accelSeen: Boolean = false
+
+    /**
      * Handler the stall tick is posted on. Set in [start] from the dispatch
      * thread's Handler so the tick lands on the same thread the gyro
      * callbacks do, avoiding a needless cross-thread state read. Cleared in
@@ -195,11 +213,18 @@ class PhoneMotionSource(
         accelX = 0
         accelY = 0
         accelZ = 0
+        accelSeen = false
         lastGyroMonoMs = 0L
         setState(if (gyro == null) MotionStreamState.Disabled else MotionStreamState.Stopped)
     }
 
-    private fun onAccel(values: FloatArray) {
+    /**
+     * Internal so unit tests can drive sensor callbacks without
+     * constructing an [android.hardware.SensorEvent] (its constructor is
+     * package-private and reflective construction is fragile). Production
+     * code reaches this only via the [SensorEventListener] dispatch above.
+     */
+    internal fun onAccel(values: FloatArray) {
         if (values.size < 3) return
         // Re-read the live rotation per sample: a runtime landscape flip is
         // swallowed by the activity's configChanges, so a once-per-start read
@@ -209,10 +234,19 @@ class PhoneMotionSource(
         accelX = MotionScaling.accelMssToWire(x)
         accelY = MotionScaling.accelMssToWire(y)
         accelZ = MotionScaling.accelMssToWire(z)
+        accelSeen = true
     }
 
-    private fun onGyro(values: FloatArray) {
+    /** See [onAccel] for why this is internal rather than private. */
+    internal fun onGyro(values: FloatArray) {
         if (values.size < 3) return
+        // Hold the first emission until accel has reported at least once,
+        // otherwise the first MOTION packet ships accel = (0, 0, 0) which
+        // downstream consumers read as "stationary in zero gravity." On
+        // pads with no accel sensor at all, [accel] is null at construct
+        // time and we skip the gate so the gyro stream is not blocked
+        // behind a sensor that will never tick.
+        if (accel != null && !accelSeen) return
         lastGyroMonoMs = nowMs()
         // Optimistic: every gyro callback proves we're streaming, so a
         // momentary Stalled flips back to Streaming without waiting for the

--- a/app/src/main/java/com/tinkernorth/dish/source/sensor/PhoneMotionSource.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/sensor/PhoneMotionSource.kt
@@ -154,6 +154,22 @@ class PhoneMotionSource(
     /** The currently-scheduled stall tick, kept so [stop] can cancel it. */
     @Volatile private var stallTickRunnable: Runnable? = null
 
+    /**
+     * Reusable 3-element output buffer for [MotionScaling.remapLandscape]
+     * to avoid allocating a fresh [FloatArray] on every sensor callback
+     * (250 Hz × 2 sensors = up to 500 allocations/sec on the hot path).
+     * Single-threaded use: both callbacks dispatch on the same
+     * [SensorDispatch] thread, so no lock needed.
+     */
+    private val remapScratch = FloatArray(3)
+
+    /**
+     * Rotation values that have already produced a [MotionScaling.RemapResult
+     * .Fallback] log line — kept so we log each unknown value once per
+     * source-lifetime rather than spamming the log at the sensor rate.
+     */
+    private val loggedUnknownRotations = HashSet<Int>()
+
     private val listener =
         object : SensorEventListener {
             override fun onSensorChanged(event: SensorEvent) {
@@ -229,11 +245,12 @@ class PhoneMotionSource(
         // Re-read the live rotation per sample: a runtime landscape flip is
         // swallowed by the activity's configChanges, so a once-per-start read
         // would leave the remap stale (see the class KDoc).
-        val (x, y, z) =
-            MotionScaling.remapLandscape(values[0], values[1], values[2], rotationSupplier())
-        accelX = MotionScaling.accelMssToWire(x)
-        accelY = MotionScaling.accelMssToWire(y)
-        accelZ = MotionScaling.accelMssToWire(z)
+        val rotation = rotationSupplier()
+        val result = MotionScaling.remapLandscape(values[0], values[1], values[2], rotation, remapScratch)
+        if (result is MotionScaling.RemapResult.Fallback) onUnknownRotation(result.unknownRotation)
+        accelX = MotionScaling.accelMssToWire(remapScratch[0])
+        accelY = MotionScaling.accelMssToWire(remapScratch[1])
+        accelZ = MotionScaling.accelMssToWire(remapScratch[2])
         accelSeen = true
     }
 
@@ -255,13 +272,14 @@ class PhoneMotionSource(
             setState(MotionStreamState.Streaming)
         }
         val cb = emit ?: return
-        val (x, y, z) =
-            MotionScaling.remapLandscape(values[0], values[1], values[2], rotationSupplier())
+        val rotation = rotationSupplier()
+        val result = MotionScaling.remapLandscape(values[0], values[1], values[2], rotation, remapScratch)
+        if (result is MotionScaling.RemapResult.Fallback) onUnknownRotation(result.unknownRotation)
         val sample =
             MotionRateLimiter.MotionSample(
-                gyroX = MotionScaling.gyroRadToWire(x),
-                gyroY = MotionScaling.gyroRadToWire(y),
-                gyroZ = MotionScaling.gyroRadToWire(z),
+                gyroX = MotionScaling.gyroRadToWire(remapScratch[0]),
+                gyroY = MotionScaling.gyroRadToWire(remapScratch[1]),
+                gyroZ = MotionScaling.gyroRadToWire(remapScratch[2]),
                 accelX = accelX,
                 accelY = accelY,
                 accelZ = accelZ,
@@ -270,6 +288,24 @@ class PhoneMotionSource(
         // virtual controller, so the rate-limiter key is a constant.
         rateLimiter.publish(SINGLE_VIRTUAL_CONTROLLER, sample) { s, deltaUs ->
             cb.emit(s, deltaUs)
+        }
+    }
+
+    /**
+     * Log an unknown `Surface.ROTATION_*` value once per source-lifetime.
+     * Without this, a wrong rotation would silently fall through to the
+     * landscape default and ship a 180° sideways axis remap forever — the
+     * pure scaler can't log itself (it must stay framework-free), so the
+     * caller does it here. Same dispatch thread as the callbacks, no lock
+     * needed; the set is bounded by the number of distinct unknown
+     * rotations (vanishingly few).
+     */
+    private fun onUnknownRotation(rotation: Int) {
+        if (loggedUnknownRotations.add(rotation)) {
+            Log.w(
+                TAG,
+                "remapLandscape: unknown rotation=$rotation, falling back to ROTATION_90 remap",
+            )
         }
     }
 

--- a/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalMotionProbe.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalMotionProbe.kt
@@ -3,6 +3,7 @@
 
 package com.tinkernorth.dish.source.sensor
 
+import android.annotation.SuppressLint
 import android.hardware.Sensor
 import android.os.Build
 import android.view.InputDevice
@@ -44,7 +45,15 @@ object PhysicalMotionProbe {
      * [InputDevice] is still queried (not a pure data class), but the SDK
      * gate is parameterised so unit tests can drive every branch from a JVM
      * without reflection on the system constants.
+     *
+     * `@SuppressLint("NewApi")` — the `InputDevice.getSensorManager()` call
+     * is API-31-gated by the first guard, but lint can't statically prove
+     * that because `sdkInt` is a runtime parameter, not `Build.VERSION
+     * .SDK_INT` directly. The runtime gate is explicit; the alternative
+     * (`@RequiresApi(S)`) would force every caller to gate too, defeating
+     * the parameterised-pure-function design.
      */
+    @SuppressLint("NewApi")
     fun evaluate(
         sdkInt: Int,
         device: InputDevice?,

--- a/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalMotionProbe.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalMotionProbe.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.sensor
+
+import android.hardware.Sensor
+import android.os.Build
+import android.view.InputDevice
+
+/**
+ * One-shot capability probe: does this physical gamepad expose a gyroscope
+ * through Android's per-device sensor API?
+ *
+ * Pulled out of [PhysicalMotionSource] so the same probe can populate
+ * [com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry.Device.hasGyro]
+ * once at device-add time. That fact is then read by
+ * [com.tinkernorth.dish.composer.MotionCapabilityComposer] to decide whether
+ * to advertise `CAP_MOTION` for a slot, and by [PhysicalMotionSource] to
+ * decide whether to register sensor listeners — without each call site re-doing
+ * the API-31 / null-sensor dance.
+ *
+ * The probe is API-gated: [InputDevice.getSensorManager] is API 31+. Below
+ * that, per-device sensors are not exposed by the platform and a pad's IMU is
+ * unreachable from the app regardless of hardware.
+ *
+ * **Testability:** the pure decision (given an SDK level and an
+ * `InputDevice`, does it have a gyro?) is exposed as [evaluate], so unit
+ * tests don't have to stub `Build.VERSION.SDK_INT` via reflection.
+ * [hasGyro] is the wrapper that resolves both inputs from the live OS.
+ */
+object PhysicalMotionProbe {
+    /**
+     * Returns true iff the device with [deviceId] is currently attached and
+     * its per-device [android.hardware.SensorManager] reports a
+     * [Sensor.TYPE_GYROSCOPE] sensor. Returns false on API < 31, on an
+     * unknown device id, or on a pad with no IMU surface — all of which are
+     * legitimate "not motion-capable" outcomes, not errors.
+     */
+    fun hasGyro(deviceId: Int): Boolean = evaluate(Build.VERSION.SDK_INT, InputDevice.getDevice(deviceId))
+
+    /**
+     * Pure variant: returns true iff [sdkInt] is API 31+ and [device] has a
+     * gyroscope on its per-device [android.hardware.SensorManager]. The
+     * [InputDevice] is still queried (not a pure data class), but the SDK
+     * gate is parameterised so unit tests can drive every branch from a JVM
+     * without reflection on the system constants.
+     */
+    fun evaluate(
+        sdkInt: Int,
+        device: InputDevice?,
+    ): Boolean {
+        if (sdkInt < Build.VERSION_CODES.S) return false
+        if (device == null) return false
+        return device.sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null
+    }
+}

--- a/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalMotionSource.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalMotionSource.kt
@@ -187,7 +187,7 @@ class PhysicalMotionSource
                 // the first MOTION packet for this pad ships accel = (0,0,0).
                 // Pads without an accel sensor (accel == null at registration)
                 // bypass the gate so the gyro stream is not stuck.
-                if (accel != null && !accelSeen) return
+                if (!shouldEmitGyro(accel != null, accelSeen)) return
                 val conn = reachable[slotId] ?: return
                 val sample =
                     convertControllerSample(
@@ -323,6 +323,33 @@ class PhysicalMotionSource
 
         companion object {
             private const val TAG = "PhysicalMotionSource"
+
+            /**
+             * Pure decider for the first-sample stale-zero accel race
+             * (parallel to the same gate in [PhoneMotionSource.onGyro]):
+             *
+             *  - pad has no accelerometer at all
+             *    (`hasAccelSensor=false`) ⇒ always emit gyro, the gate
+             *    short-circuits so the gyro stream is not stuck behind a
+             *    sensor that will never fire.
+             *  - pad has an accelerometer and it has reported at least once
+             *    since the listener was registered (`accelSeen=true`)
+             *    ⇒ emit. The accel cache holds a real value, not the
+             *    zero-initialised default that would otherwise ship as
+             *    "stationary in zero gravity."
+             *  - otherwise ⇒ drop the gyro callback. The wire stays silent
+             *    for at most one sensor period (~5–20 ms at
+             *    `SENSOR_DELAY_GAME`); the rate-limiter's normal cadence
+             *    recovers on the next callback.
+             *
+             * Lifted out of the inner-class [PadListener] so the four-row
+             * truth table is JVM-unit-testable without an Android device
+             * or a real [SensorEventListener].
+             */
+            internal fun shouldEmitGyro(
+                hasAccelSensor: Boolean,
+                accelSeen: Boolean,
+            ): Boolean = !hasAccelSensor || accelSeen
 
             /**
              * Intersect the reachable-slot set (pads bound to a Connected

--- a/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalMotionSource.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalMotionSource.kt
@@ -116,6 +116,18 @@ class PhysicalMotionSource
             private var accelY: Short = 0
             private var accelZ: Short = 0
 
+            /**
+             * Whether the accelerometer has reported at least once since the
+             * listener was registered. The first gyro callback can otherwise
+             * fire before any accel callback, which would emit a MOTION
+             * packet with accel = (0, 0, 0) — downstream consumers read that
+             * as "stationary in zero gravity." Hold the first gyro until
+             * accel has reported. Same dispatch thread as the callbacks, no
+             * lock needed. Pads with no accel sensor have [accel] == null
+             * at registration time; the gate short-circuits in [onGyro].
+             */
+            private var accelSeen: Boolean = false
+
             private val listener =
                 object : SensorEventListener {
                     override fun onSensorChanged(event: SensorEvent) {
@@ -166,10 +178,16 @@ class PhysicalMotionSource
                 accelX = MotionScaling.accelMssToWire(values[0])
                 accelY = MotionScaling.accelMssToWire(values[1])
                 accelZ = MotionScaling.accelMssToWire(values[2])
+                accelSeen = true
             }
 
             private fun onGyro(values: FloatArray) {
                 if (values.size < 3) return
+                // Hold the first emission until accel has reported, otherwise
+                // the first MOTION packet for this pad ships accel = (0,0,0).
+                // Pads without an accel sensor (accel == null at registration)
+                // bypass the gate so the gyro stream is not stuck.
+                if (accel != null && !accelSeen) return
                 val conn = reachable[slotId] ?: return
                 val sample =
                     convertControllerSample(

--- a/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalMotionSource.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalMotionSource.kt
@@ -14,6 +14,8 @@ import android.view.InputDevice
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.tinkernorth.dish.composer.ConnectionHub
+import com.tinkernorth.dish.composer.MotionCapability
+import com.tinkernorth.dish.composer.MotionCapabilityComposer
 import com.tinkernorth.dish.composer.PhysicalReachability
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.hotpath.input.PhysicalSlotBindingObserver
@@ -21,6 +23,7 @@ import com.tinkernorth.dish.source.connection.SatelliteConnection
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
@@ -87,6 +90,7 @@ class PhysicalMotionSource
         private val registry: PhysicalGamepadRegistry,
         private val hub: ConnectionHub,
         private val satellite: SatelliteConnectionManager,
+        private val motionCapability: MotionCapabilityComposer,
         private val scope: CoroutineScope,
     ) : DefaultLifecycleObserver {
         /**
@@ -219,6 +223,11 @@ class PhysicalMotionSource
         override fun onStart(owner: LifecycleOwner) {
             if (bindingsJob != null) return
             sensorHandler = sensorDispatch.acquire()
+            // Reachability tells us "a satellite is up and the slot is
+            // registered." The capability composer tells us "the user wants
+            // motion on for this slot AND the hardware supports it." Both
+            // must be true for the listener to register; otherwise we burn
+            // battery on a gyro stream nothing will ever forward.
             bindingsJob =
                 PhysicalReachability
                     .reachableSlots(
@@ -226,7 +235,8 @@ class PhysicalMotionSource
                         hub.bindings,
                         hub.connections,
                         satellite.connections,
-                    ).onEach(::onReachableChanged)
+                    ).combine(motionCapability.state, ::filterByCapability)
+                    .onEach(::onReachableChanged)
                     .launchIn(scope)
         }
 
@@ -295,6 +305,36 @@ class PhysicalMotionSource
 
         companion object {
             private const val TAG = "PhysicalMotionSource"
+
+            /**
+             * Intersect the reachable-slot set (pads bound to a Connected
+             * satellite with a registered server-side controller) with the
+             * per-slot motion [MotionCapability]:
+             *
+             *  - drop slots whose pad has no gyroscope (`hasGyro == false`)
+             *    — listening would never produce a sample;
+             *  - drop slots the user has explicitly toggled motion off for
+             *    (`userEnabled == false`) — listening would burn battery
+             *    on samples that get dropped at the cap-bit / wire level.
+             *
+             * A slot present in `reachable` but ABSENT from `caps` is dropped:
+             * the capability composer is the source of truth for "this slot
+             * has motion," so an unknown slot is treated as no-motion (safe
+             * default). In practice this only happens during a startup race
+             * (reachability flow emits before the composer's first emission),
+             * and the composer's `Eagerly` sharing prevents that in production.
+             *
+             * Pure (no flow, no Android types) so the matrix can be pinned by
+             * a JVM unit test without the rest of the source.
+             */
+            internal fun filterByCapability(
+                reachable: Map<String, com.tinkernorth.dish.source.connection.SatelliteConnection>,
+                caps: Map<String, MotionCapability>,
+            ): Map<String, com.tinkernorth.dish.source.connection.SatelliteConnection> =
+                reachable.filterKeys { slotId ->
+                    val cap = caps[slotId] ?: return@filterKeys false
+                    cap.hasGyro && cap.userEnabled
+                }
 
             /**
              * Convert one fused controller IMU frame to a wire

--- a/app/src/main/java/com/tinkernorth/dish/source/store/MotionEnabledStore.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/store/MotionEnabledStore.kt
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.store
+
+import com.tinkernorth.dish.architecture.abstracts.AbstractStateSource
+import com.tinkernorth.dish.repository.MotionPreference
+import com.tinkernorth.dish.repository.MotionPreferenceRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Process-scoped reactive mirror of the durable
+ * [MotionPreferenceRepository]: `slotId → enabled`.
+ *
+ * The repository is the durable source of truth; this store hydrates from
+ * it on construction and republishes every write as a `StateFlow` so the
+ * [com.tinkernorth.dish.composer.MotionCapabilityComposer] (and the UI) can
+ * react without re-reading SharedPreferences on every frame.
+ *
+ * **Pattern:** [AbstractStateSource]`<Map<String, Boolean>>` — same shape
+ * as [ControllerTypeStore]. The two stores are parallel "reactive
+ * in-memory cache over a persisted choice" types; if you grow another one
+ * (per-slot rumble strength etc.), copy this file.
+ *
+ * **Default policy:** [isEnabled] collapses an absent entry onto
+ * [DEFAULT_ENABLED] (true). The product decision is "motion on unless the
+ * user turned it off" — discoverable via the indicator pill, recoverable
+ * via the toggle. The repository deliberately does not bake the default in
+ * (an absent entry is semantically different from `enabled=true`), so
+ * downstream consumers consult [isEnabled] rather than the raw map.
+ */
+@Singleton
+class MotionEnabledStore
+    @Inject
+    constructor(
+        private val repo: MotionPreferenceRepository,
+    ) : AbstractStateSource<Map<String, Boolean>>(initialState = emptyMap()) {
+        init {
+            // Hydrate once on construction. Subsequent durable changes flow
+            // through this store (setEnabled below), so it stays in sync.
+            setState(repo.all().associate { it.slotId to it.enabled })
+        }
+
+        /**
+         * Persist the user's choice for [slotId] and republish. Writes are
+         * synchronous to disk via SharedPreferences' edit().apply() (which
+         * commits the in-memory map immediately and persists asynchronously).
+         */
+        fun setEnabled(
+            slotId: String,
+            enabled: Boolean,
+        ) {
+            repo.put(MotionPreference(slotId = slotId, enabled = enabled))
+            setState { it + (slotId to enabled) }
+        }
+
+        /**
+         * Resolve the effective enabled boolean for [slotId], collapsing an
+         * absent entry onto [DEFAULT_ENABLED]. Use this — not the raw map
+         * — wherever the consumer cares about effective behaviour.
+         */
+        fun isEnabled(slotId: String): Boolean = state.value[slotId] ?: DEFAULT_ENABLED
+
+        /**
+         * Forget the user's choice for [slotId] (revert to default). Used
+         * when a physical pad is unbound permanently — keeping a stale
+         * entry forever would silently override the default for a future
+         * unrelated device that happened to get the same `InputDevice` id.
+         */
+        fun forget(slotId: String) {
+            repo.remove(slotId)
+            setState { it - slotId }
+        }
+
+        companion object {
+            /**
+             * Product default: motion is on for any slot that has not been
+             * explicitly toggled off. Surfaced as a constant so the composer
+             * and tests can pin the same value.
+             */
+            const val DEFAULT_ENABLED: Boolean = true
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/source/store/SatelliteMotionBackendStatusStore.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/store/SatelliteMotionBackendStatusStore.kt
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.store
+
+import com.tinkernorth.dish.architecture.abstracts.AbstractStateSource
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * What the *receiver* told us at controller-add time about its ability to
+ * actually land motion bytes for this slot. Sourced from the motion-status
+ * byte on `MSG_CONTROLLER_ACK` (`ACK_MOTION_FLAG_*` on the satellite side) —
+ * the dish's per-slot motion pill consumes this so an "effective on the dish,
+ * dropped at the receiver" path can read [BACKEND_BROKEN] instead of falsely
+ * showing STREAMING.
+ *
+ * The two facts are deliberately split: [sinkSupportedForType] is universal
+ * across the shipping backends (PS yes, Xbox no) and corresponds to the
+ * dish-side [com.tinkernorth.dish.composer.MotionCapability.hostHasSinkForType]
+ * heuristic — having both in hand lets the composer cross-check its own
+ * derivation against satellite truth. [backendOk] is per-serial (whether the
+ * receiver's kernel actually accepted the IMU sink at plug-in time) and is
+ * the diagnostic the dish couldn't compute on its own without an HTTP poll
+ * of `/api/connections`.
+ */
+data class SatelliteMotionBackendStatus(
+    /**
+     * Receiver's backend has an IMU surface for this slot's chosen controller
+     * type. Mirrors `ACK_MOTION_FLAG_SINK_SUPPORTED_FOR_TYPE` (bit 0) on the
+     * satellite. PS = yes on every shipping backend; Xbox = no.
+     */
+    val sinkSupportedForType: Boolean,
+    /**
+     * Receiver's backend successfully created the per-serial IMU sink. Mirrors
+     * `ACK_MOTION_FLAG_BACKEND_OK` (bit 1) on the satellite. False on Linux
+     * uinput when the kernel rejects the `INPUT_PROP_ACCELEROMETER` device
+     * (kernel too old, no `/dev/uinput` permission, `/tmp` exhausted) — the
+     * dish-side pill calls this out so the user sees a real reason for
+     * "motion isn't reaching the game" instead of staring at STREAMING.
+     */
+    val backendOk: Boolean,
+) {
+    /**
+     * True iff motion bytes the dish streams will actually reach the
+     * virtual gamepad's IMU surface on the receiver. False ⇒ the pill
+     * should NOT read STREAMING regardless of the local source state.
+     */
+    val effective: Boolean get() = sinkSupportedForType && backendOk
+
+    companion object {
+        /**
+         * Decode a packed motion-flags byte (the JNI's
+         * `getLastControllerMotionFlags` return). The caller short-circuits
+         * on the sentinel `-1` ("no extended ACK seen / pre-extension
+         * satellite") and only calls this for `0..255`.
+         */
+        fun fromFlags(flags: Int): SatelliteMotionBackendStatus =
+            SatelliteMotionBackendStatus(
+                sinkSupportedForType = (flags and FLAG_SINK_SUPPORTED_FOR_TYPE) != 0,
+                backendOk = (flags and FLAG_BACKEND_OK) != 0,
+            )
+
+        /** Mirror of `ACK_MOTION_FLAG_SINK_SUPPORTED_FOR_TYPE` on satellite. */
+        const val FLAG_SINK_SUPPORTED_FOR_TYPE: Int = 0x01
+
+        /** Mirror of `ACK_MOTION_FLAG_BACKEND_OK` on satellite. */
+        const val FLAG_BACKEND_OK: Int = 0x02
+    }
+}
+
+/**
+ * `(connectionId, slotId) → SatelliteMotionBackendStatus` for every
+ * satellite slot whose ACK carried the motion-flags byte. An absent entry
+ * means "unknown" — either the slot hasn't been registered yet, or the
+ * satellite is a pre-extension build that only sent the legacy 4-byte ACK
+ * payload. The composer treats absent as "fall back to the dish's own
+ * `hostHasSinkForType` heuristic" rather than defaulting to "broken."
+ *
+ * **Pattern:** [AbstractStateSource]`<Map<Pair<String, String>,
+ * SatelliteMotionBackendStatus>>` — same shape as
+ * [com.tinkernorth.dish.source.store.ControllerTypeStore]. Both stores are
+ * per-(connection, slot) reactive caches of facts the satellite tells the
+ * dish; if you grow a third one (e.g. per-slot rumble strength reported by
+ * the host), copy this file.
+ *
+ * Cleared on slot detach / connection teardown — see
+ * [com.tinkernorth.dish.source.connection.SatelliteConnection.detachSlot] /
+ * [com.tinkernorth.dish.source.connection.SatelliteConnection.markDisconnected]
+ * — so a slot's status doesn't survive its lifetime and mislead the pill
+ * after re-bind.
+ */
+@Singleton
+class SatelliteMotionBackendStatusStore
+    @Inject
+    constructor() :
+    AbstractStateSource<Map<Pair<String, String>, SatelliteMotionBackendStatus>>(emptyMap()) {
+        /** Current status for [connectionId]/[slotId], or null if unknown. */
+        fun statusFor(
+            connectionId: String,
+            slotId: String,
+        ): SatelliteMotionBackendStatus? = state.value[connectionId to slotId]
+
+        /** Record [status] for [connectionId]/[slotId]. Called from the ACK-receive path. */
+        fun setStatus(
+            connectionId: String,
+            slotId: String,
+            status: SatelliteMotionBackendStatus,
+        ) {
+            setState { it + ((connectionId to slotId) to status) }
+        }
+
+        /**
+         * Drop the entry for [connectionId]/[slotId]. Called when the slot
+         * detaches (the next add will write a fresh status), or when the
+         * connection tears down. Without this, a stale status survives
+         * re-bind and the pill would surface yesterday's truth.
+         */
+        fun clear(
+            connectionId: String,
+            slotId: String,
+        ) {
+            setState {
+                val key = connectionId to slotId
+                if (key in it) it - key else it
+            }
+        }
+
+        /**
+         * Drop every entry for [connectionId]. Called at session teardown so
+         * a satellite that goes away takes its stale per-slot status with it.
+         */
+        fun clearConnection(connectionId: String) {
+            setState { current -> current.filterNot { (k, _) -> k.first == connectionId } }
+        }
+
+        /**
+         * Project a `slotId → status` map for a single connection's bound
+         * slots. The composer calls this to fold per-connection truth into
+         * its per-slot capability map without leaking the `Pair` key to
+         * downstream consumers.
+         */
+        fun slotStatusesFor(
+            connectionId: String,
+            boundSlotIds: List<String>,
+        ): Map<String, SatelliteMotionBackendStatus> {
+            val snapshot = state.value
+            val out = mutableMapOf<String, SatelliteMotionBackendStatus>()
+            for (slotId in boundSlotIds) {
+                val status = snapshot[connectionId to slotId] ?: continue
+                out[slotId] = status
+            }
+            return out
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/PairPinDialog.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/PairPinDialog.kt
@@ -40,18 +40,33 @@ class PairPinDialog(
 ) : Dialog(context, R.style.Theme_Dish_Dialog) {
     private lateinit var binding: DialogPairPinBinding
 
+    // Callers (see ConnectionsActivity.showPairingDialog) construct the dialog and
+    // assign dishTitle/dishSubtitle inside an `apply { ... }` block *before* calling
+    // show(); Dialog.onCreate — and therefore binding inflation — runs on first
+    // show(). We stash pre-show writes here and flush them once the views exist.
+    private var pendingTitle: CharSequence? = null
+    private var pendingSubtitle: CharSequence? = null
+
     /** Title displayed at the top — defaults to "Pair with satellite". */
     var dishTitle: CharSequence
-        get() = binding.tvPairTitle.text
+        get() = if (::binding.isInitialized) binding.tvPairTitle.text else pendingTitle ?: ""
         set(value) {
-            binding.tvPairTitle.text = value
+            if (::binding.isInitialized) {
+                binding.tvPairTitle.text = value
+            } else {
+                pendingTitle = value
+            }
         }
 
     /** Subtitle under the title — defaults to "Enter the PIN shown on your satellite." */
     var dishSubtitle: CharSequence
-        get() = binding.tvPairSubtitle.text
+        get() = if (::binding.isInitialized) binding.tvPairSubtitle.text else pendingSubtitle ?: ""
         set(value) {
-            binding.tvPairSubtitle.text = value
+            if (::binding.isInitialized) {
+                binding.tvPairSubtitle.text = value
+            } else {
+                pendingSubtitle = value
+            }
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -59,6 +74,8 @@ class PairPinDialog(
         requestWindowFeature(Window.FEATURE_NO_TITLE)
         binding = DialogPairPinBinding.inflate(LayoutInflater.from(context))
         setContentView(binding.root)
+        pendingTitle?.let { binding.tvPairTitle.text = it }
+        pendingSubtitle?.let { binding.tvPairSubtitle.text = it }
         // Dim and centred — the dialog sits over a CardView-styled surface so
         // a transparent window keeps the bg_pill border crisp.
         window?.setBackgroundDrawableResource(android.R.color.transparent)

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
@@ -12,6 +12,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.appcompat.widget.SwitchCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -23,9 +24,8 @@ import com.tinkernorth.dish.composer.ConnectionSummary
 import com.tinkernorth.dish.composer.LinkState
 import com.tinkernorth.dish.composer.MotionCapability
 import com.tinkernorth.dish.databinding.ItemControllerBinding
-import com.tinkernorth.dish.ui.common.glyphForConnection
 import com.tinkernorth.dish.source.store.MotionEnabledStore
-import androidx.appcompat.widget.SwitchCompat
+import com.tinkernorth.dish.ui.common.glyphForConnection
 
 interface SlotActionListener {
     fun onSlotTapped(slotId: String)

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
@@ -21,8 +21,11 @@ import com.tinkernorth.dish.composer.CONTROLLER_TYPE_XBOX
 import com.tinkernorth.dish.composer.ConnectionKind
 import com.tinkernorth.dish.composer.ConnectionSummary
 import com.tinkernorth.dish.composer.LinkState
+import com.tinkernorth.dish.composer.MotionCapability
 import com.tinkernorth.dish.databinding.ItemControllerBinding
 import com.tinkernorth.dish.ui.common.glyphForConnection
+import com.tinkernorth.dish.source.store.MotionEnabledStore
+import androidx.appcompat.widget.SwitchCompat
 
 interface SlotActionListener {
     fun onSlotTapped(slotId: String)
@@ -41,6 +44,19 @@ interface SlotActionListener {
         slotId: String,
         connectionId: String,
         type: Int,
+    )
+
+    /**
+     * User flipped the per-slot motion toggle on the controller row.
+     * Persisted by [com.tinkernorth.dish.source.store.MotionEnabledStore]
+     * via the ViewModel; the dish stops emitting motion samples for the
+     * slot (listener gate) and clears the `CAP_MOTION` bit at the next
+     * `MSG_CONTROLLER_ADD` for it (cap-word reflection — see
+     * [com.tinkernorth.dish.composer.MotionCapability.toCapBits]).
+     */
+    fun onMotionEnabledChanged(
+        slotId: String,
+        enabled: Boolean,
     )
 }
 
@@ -79,6 +95,17 @@ class ControllerAdapter(
         val slot: ControllerSlot,
         val connections: List<ConnectionSummary>,
         val expanded: Boolean,
+        /**
+         * The latest motion capability snapshot for this slot. Drives the
+         * per-slot motion toggle: the switch is checked iff
+         * [MotionCapability.userEnabled], and disabled iff
+         * `!hasGyro || !hostHasSinkForType` (with subtitle text explaining
+         * which limit is in effect). Defaults to [MotionCapability.Off] so
+         * a row built before the composer has emitted reads as
+         * "hardware-not-yet-confirmed" rather than crashing on a missing
+         * lookup.
+         */
+        val motionCap: MotionCapability = MotionCapability.Off,
     )
 
     private val expandedIds = mutableSetOf(VIRTUAL_SLOT_ID)
@@ -86,8 +113,18 @@ class ControllerAdapter(
     fun submitSlots(
         slots: List<ControllerSlot>,
         connections: List<ConnectionSummary>,
+        motionCapabilities: Map<String, MotionCapability> = emptyMap(),
     ) {
-        submitList(slots.map { Row(it, connections, expandedIds.contains(it.id)) })
+        submitList(
+            slots.map { slot ->
+                Row(
+                    slot = slot,
+                    connections = connections,
+                    expanded = expandedIds.contains(slot.id),
+                    motionCap = motionCapabilities[slot.id] ?: MotionCapability.Off,
+                )
+            },
+        )
     }
 
     fun toggleExpanded(slotId: String) {
@@ -185,7 +222,7 @@ class ControllerAdapter(
                     )
                 else ->
                     visible.forEach { summary ->
-                        addConnectionRow(b.llConnectionList, dp, slot, summary)
+                        addConnectionRow(b.llConnectionList, dp, slot, summary, row.motionCap)
                     }
             }
 
@@ -203,6 +240,7 @@ class ControllerAdapter(
             dp: Float,
             slot: ControllerSlot,
             c: ConnectionSummary,
+            motionCap: MotionCapability,
         ) {
             val ctx = parent.context
             val bound = slot.boundConnectionId == c.id
@@ -233,6 +271,11 @@ class ControllerAdapter(
             // we don't render a switcher there.
             if (bound && c.kind == ConnectionKind.SATELLITE) {
                 row.addView(buildTypeToggle(ctx, dp, slot, c))
+                // Per-slot motion (gyro) on/off switch. Same gating as the
+                // type toggle — only meaningful for a satellite-bound slot
+                // because Bluetooth-HID has no motion channel and motion
+                // is a satellite-path feature.
+                row.addView(buildMotionToggle(ctx, dp, slot, motionCap))
             }
             parent.addView(row)
         }
@@ -401,6 +444,104 @@ class ControllerAdapter(
                     label = ctx.getString(R.string.picker_type_playstation),
                     selected = current == CONTROLLER_TYPE_PLAYSTATION,
                 ) { listener.onChangeDeviceType(slot.id, c.id, CONTROLLER_TYPE_PLAYSTATION) },
+            )
+            return container
+        }
+
+        /**
+         * Build the per-slot motion (gyro) on/off row that lives under the
+         * Xbox/PS chips in the expanded controller card. The switch
+         * reflects [MotionCapability.userEnabled]; the subtitle text
+         * explains the gating in plain language whenever motion CAN'T flow
+         * (no gyro hardware, host has no sink for the chosen type, source
+         * paused for other reasons). The switch is **disabled** for hard
+         * limits the user can't fix by flipping it — no gyro and
+         * no-host-sink — so the user is steered toward the actionable
+         * remedy (different hardware, or change controller type) instead.
+         */
+        private fun buildMotionToggle(
+            ctx: android.content.Context,
+            dp: Float,
+            slot: ControllerSlot,
+            cap: MotionCapability,
+        ): View {
+            val container =
+                LinearLayout(ctx).apply {
+                    orientation = LinearLayout.HORIZONTAL
+                    layoutParams =
+                        LinearLayout
+                            .LayoutParams(
+                                LinearLayout.LayoutParams.MATCH_PARENT,
+                                LinearLayout.LayoutParams.WRAP_CONTENT,
+                            ).apply { topMargin = (8 * dp).toInt() }
+                }
+            // Title + subtitle column on the left.
+            val labelCol =
+                LinearLayout(ctx).apply {
+                    orientation = LinearLayout.VERTICAL
+                    layoutParams =
+                        LinearLayout
+                            .LayoutParams(
+                                0,
+                                LinearLayout.LayoutParams.WRAP_CONTENT,
+                                1f, // takes remaining width so the switch sits flush right
+                            ).apply { gravity = android.view.Gravity.CENTER_VERTICAL }
+                }
+            labelCol.addView(
+                TextView(ctx).apply {
+                    text = ctx.getString(R.string.controller_motion_toggle_label)
+                    setTextColor(ctx.getColor(R.color.colorMuted))
+                    textSize = 11f
+                    typeface = Typeface.MONOSPACE
+                },
+            )
+            // Subtitle: the most relevant "why" for the current state. This
+            // mirrors the precedence in MotionIndicatorState.of() — hardware
+            // first, then host-sink, then "on / off" status — so the text
+            // here is consistent with what the overlay pill says.
+            val subtitleResId =
+                when {
+                    !cap.hasGyro -> R.string.controller_motion_toggle_subtitle_no_gyro
+                    !cap.hostHasSinkForType ->
+                        R.string.controller_motion_toggle_subtitle_no_host_sink
+                    cap.userEnabled -> R.string.controller_motion_toggle_subtitle_on
+                    else -> R.string.controller_motion_toggle_subtitle_off
+                }
+            labelCol.addView(
+                TextView(ctx).apply {
+                    setText(subtitleResId)
+                    setTextColor(ctx.getColor(R.color.colorMuted))
+                    textSize = 11f
+                },
+            )
+            container.addView(labelCol)
+
+            // The Switch itself. Disabled when there's nothing the user can
+            // do by flipping it — no hardware, or the host backend has no
+            // sink for the slot's controller type. The subtitle text above
+            // already explains the limit.
+            val enabledForUser = cap.hasGyro && cap.hostHasSinkForType
+            container.addView(
+                SwitchCompat(ctx).apply {
+                    isChecked = cap.userEnabled && enabledForUser
+                    isEnabled = enabledForUser
+                    // setOnCheckedChangeListener fires on programmatic
+                    // setChecked too; we set the listener AFTER the
+                    // initial state so the first paint doesn't ping the
+                    // store. The DiffUtil rebind path goes through the
+                    // same code, so this discipline applies on every
+                    // recycle. (RecyclerView reuses views.)
+                    setOnCheckedChangeListener(null)
+                    setOnCheckedChangeListener { _, isChecked ->
+                        listener.onMotionEnabledChanged(slot.id, isChecked)
+                    }
+                    layoutParams =
+                        LinearLayout
+                            .LayoutParams(
+                                LinearLayout.LayoutParams.WRAP_CONTENT,
+                                LinearLayout.LayoutParams.WRAP_CONTENT,
+                            ).apply { gravity = android.view.Gravity.CENTER_VERTICAL }
+                },
             )
             return container
         }

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
@@ -21,6 +21,8 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.composer.ConnectionHub
 import com.tinkernorth.dish.composer.ConnectionKind
+import com.tinkernorth.dish.composer.ConnectionSummary
+import com.tinkernorth.dish.composer.MotionCapability
 import com.tinkernorth.dish.composer.MotionCapabilityComposer
 import com.tinkernorth.dish.composer.LinkState
 import com.tinkernorth.dish.composer.WakeStateController
@@ -36,10 +38,14 @@ import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.notification.DishNotifications
 import com.tinkernorth.dish.source.sensor.PhoneBatterySource
 import com.tinkernorth.dish.source.sensor.PhoneMotionSource
+import com.tinkernorth.dish.source.sensor.MotionStreamState
 import com.tinkernorth.dish.ui.common.GamepadTouchView
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -136,78 +142,59 @@ class GamepadOverlayActivity :
         // dashboard indicator is fed separately, at process scope, by
         // VirtualBatterySource — so no statusStore is passed here.
         batterySource = PhoneBatterySource(applicationContext)
-        // Paint the motion pill once up front: on a phone with no gyroscope
-        // this is the only paint that ever runs (start/stop are no-ops), and
-        // the "no gyroscope" state must be visible without waiting for resume.
-        refreshMotionStatus()
+        // Paint the motion pill once up front from whatever the sources have
+        // already published. On a phone with no gyroscope the source's state
+        // is `Disabled` from construction, so this single paint surfaces the
+        // "no gyroscope" tile before any lifecycle work begins — important
+        // because the combine collector below only runs while STARTED.
+        repaintFrom(currentMotionPaint())
 
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                hub.connections.collect {
-                    refreshStatus()
-                    // The motion pill depends on connection *kind* (Bluetooth
-                    // has no motion channel), so it must repaint when the
-                    // bound connection's summary first resolves or changes.
-                    refreshMotionStatus()
-                }
-            }
-        }
-
-        // Gate the gyro/accel listeners on the per-slot motion capability:
-        // start the source iff the slot is "effective" (gyro present AND
-        // bound to a Connected satellite AND the user toggle is on); stop
-        // otherwise. Replaces the previous always-on lifecycle in
-        // onResume/onPause, which burned battery on Bluetooth-HID
-        // connections (where motion can never flow) and ignored the user
-        // toggle entirely.
+        // Single combine collector — one StateFlow tuple drives the gate
+        // AND the pill paint AND the connection-status row, from one
+        // coherent snapshot per emission.
+        //
+        // Why fold the three previous collectors into one:
+        //   - `hub.connections` and `motionCapability.state` can both emit
+        //     for the same upstream event (a binding/connection change
+        //     re-runs the composer's combine). Two collectors mean two
+        //     repaints, the first reading one fresh / one stale field —
+        //     a visible flicker during reconnects.
+        //   - `motionSource.state` carries the Streaming ↔ Stalled flip
+        //     fired by the source's internal 500 ms stall tick; without a
+        //     collector it never reaches the UI.
+        //   - Combining the three lets the gate decision (start/stop the
+        //     IMU listener) and the pill paint read from the SAME snapshot,
+        //     so the pill can never display "STREAMING from a stopped
+        //     source" or similar half-state.
         //
         // The collector runs only while STARTED; repeatOnLifecycle cancels
-        // it on STOP, and the launched coroutine stops the source on
-        // cancellation so a backgrounded overlay never leaks listeners.
+        // it on STOP. The finally clause stops the source on cancellation
+        // so a backgrounded overlay never leaks sensor listeners — even if
+        // the gate had just turned the source on.
+        //
+        // `distinctUntilChanged` is the simple deduper — two upstream
+        // emissions that collapse to the same paint shouldn't repaint the
+        // pill (Kotlin data-class equality handles the field-wise compare).
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 try {
-                    motionCapability.state.collect { caps ->
-                        val effective = caps[VIRTUAL_SLOT_ID]?.effective == true
-                        if (effective && !motionSource.isStreaming) {
-                            motionSource.start { sample, deltaUs ->
-                                satellite.get(connectionId)?.sendMotion(
-                                    VIRTUAL_SLOT_ID,
-                                    sample.gyroX,
-                                    sample.gyroY,
-                                    sample.gyroZ,
-                                    sample.accelX,
-                                    sample.accelY,
-                                    sample.accelZ,
-                                    deltaUs,
-                                )
-                            }
-                        } else if (!effective && motionSource.isStreaming) {
-                            motionSource.stop()
-                        }
-                        // Repaint after every gate flip so the pill
-                        // (STREAMING / PAUSED / NOT_FORWARDED / UNAVAILABLE)
-                        // tracks reality without waiting for an unrelated
-                        // hub.connections emission.
-                        refreshMotionStatus()
+                    combine(
+                        hub.connections.map { conns -> conns.firstOrNull { it.id == connectionId } },
+                        motionCapability.state.map {
+                            it[VIRTUAL_SLOT_ID] ?: MotionCapability.Off
+                        },
+                        motionSource.state,
+                    ) { summary, capability, sourceState ->
+                        OverlayMotionPaint(summary, capability, sourceState)
+                    }.distinctUntilChanged().collect { paint ->
+                        applyMotionGate(paint.capability)
+                        repaintFrom(paint)
                     }
                 } finally {
                     // Stop on collector cancellation (STOP / activity destroy)
                     // so a backgrounded overlay never leaks sensor listeners.
                     motionSource.stop()
                 }
-            }
-        }
-        // Repaint the motion pill whenever the source's own state flips
-        // (Streaming ↔ Stalled in particular). Without this collector the
-        // 500 ms stall-detection tick lands inside the source but never
-        // reaches the UI — the pill claims STREAMING forever while no
-        // samples are actually arriving. Fixes the STALLED-never-repaints
-        // bug (the source's tick is the trigger; the activity's collector
-        // is what makes it visible).
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                motionSource.state.collect { refreshMotionStatus() }
             }
         }
 
@@ -322,20 +309,17 @@ class GamepadOverlayActivity :
         batterySource.start(lifecycleScope) { level, status ->
             satellite.get(connectionId)?.sendBattery(VIRTUAL_SLOT_ID, level, status)
         }
-        // Note: motionSource start/stop is now lifecycle-scoped on the
-        // capability flow (see the collector launched in onCreate). The
-        // overlay no longer unconditionally registers sensor listeners on
-        // Bluetooth-HID connections where motion can't flow, or on slots
-        // the user has toggled motion off for — fixing a measurable
-        // gyro/accel battery drain that previously ran for nothing.
-        refreshMotionStatus()
+        // motion source start/stop and pill paints are driven by the single
+        // combine collector in onCreate — repeatOnLifecycle re-subscribes on
+        // STARTED so the StateFlow tuple re-emits its current values and the
+        // collector handles the gate + repaint. No explicit work needed here.
     }
 
     override fun onPause() {
         super.onPause()
         batterySource.stop()
-        // Source stopped to save battery; reflect "paused" (not "unavailable").
-        refreshMotionStatus()
+        // Pill repaint is driven by the source-state change inside the
+        // combine collector; no explicit refresh here.
     }
 
     override fun onStop() {
@@ -343,8 +327,75 @@ class GamepadOverlayActivity :
         gamepadHost.cancelDimOnStop()
     }
 
-    private fun refreshStatus() {
-        val summary = hub.summary(connectionId)
+    /**
+     * One coherent snapshot of the three inputs that drive both the motion
+     * pill and the gyro-listener gate. Composed from [hub.connections] +
+     * [motionCapability.state] + [motionSource.state] in one combine, so
+     * every paint reads from the same emission rather than racing three
+     * collectors against three independent reads (which could paint a
+     * transient inconsistent state during reconnects). See the combine
+     * collector in [onCreate].
+     */
+    private data class OverlayMotionPaint(
+        val summary: ConnectionSummary?,
+        val capability: MotionCapability,
+        val sourceState: MotionStreamState,
+    )
+
+    /**
+     * Build a [OverlayMotionPaint] from whatever values the underlying
+     * sources have already published. Used for the initial paint in
+     * [onCreate] before the lifecycle collector starts — the StateFlow
+     * tuple won't emit until something subscribes, but the "no gyroscope"
+     * tile must show up immediately so users on phones without an IMU
+     * don't see a blank pill before resume.
+     */
+    private fun currentMotionPaint(): OverlayMotionPaint =
+        OverlayMotionPaint(
+            summary = hub.summary(connectionId),
+            capability = motionCapability.capabilityFor(VIRTUAL_SLOT_ID),
+            sourceState = motionSource.state.value,
+        )
+
+    /**
+     * Listener-gate side-effect — start/stop the IMU listener so the
+     * sensor never runs when the slot is ineligible for motion (gyro
+     * absent, BT-HID, user toggled off, satellite not connected). Lives
+     * inside the combine collector so the gate decision and the pill paint
+     * share one snapshot.
+     */
+    private fun applyMotionGate(capability: MotionCapability) {
+        val effective = capability.effective
+        if (effective && !motionSource.isStreaming) {
+            motionSource.start { sample, deltaUs ->
+                satellite.get(connectionId)?.sendMotion(
+                    VIRTUAL_SLOT_ID,
+                    sample.gyroX,
+                    sample.gyroY,
+                    sample.gyroZ,
+                    sample.accelX,
+                    sample.accelY,
+                    sample.accelZ,
+                    deltaUs,
+                )
+            }
+        } else if (!effective && motionSource.isStreaming) {
+            motionSource.stop()
+        }
+    }
+
+    /**
+     * Atomic repaint: connection-status row + motion pill from the same
+     * [OverlayMotionPaint] snapshot. Both UI elements are touched here so
+     * they always reflect one logical moment — no possibility of the
+     * status row reading one combine output while the pill reads the next.
+     */
+    private fun repaintFrom(paint: OverlayMotionPaint) {
+        repaintConnectionRow(paint.summary)
+        repaintMotionPill(paint)
+    }
+
+    private fun repaintConnectionRow(summary: ConnectionSummary?) {
         val connected = summary?.live == LinkState.Connected
         binding.tvOverlayStatus.text =
             when {
@@ -359,37 +410,52 @@ class GamepadOverlayActivity :
     }
 
     /**
-     * Repaint the phone-motion pill. There is no motion on/off toggle in this
-     * slice, so the state is purely a function of four facts: whether the
-     * phone has a gyroscope ([PhoneMotionSource.isAvailable]), whether the
-     * source is currently started ([PhoneMotionSource.isStreaming]), whether
-     * the bound connection kind can carry `MSG_MOTION` at all (satellite can,
-     * Bluetooth-HID cannot), and whether that connection is actually CONNECTED
-     * — a "started" source over a down connection is not really streaming, so
-     * the pill must not claim it is. The two states that imply motion is *not*
-     * leaving the phone also show a one-line explanation, so a limitation is
-     * never mistaken for an off switch. See [MotionIndicatorState].
+     * Repaint the phone-motion pill from a single coherent [paint] tuple.
+     *
+     * The dish surfaces a state for every reason motion might or might not
+     * be flowing — hardware absent, user toggled off, link kind can't
+     * carry it, host-type has no sink, satellite reported its backend
+     * broken, source paused, streaming live, or stalled. The two states
+     * that imply motion is *not* leaving the phone (and the BACKEND_BROKEN
+     * case, where it leaves but doesn't land) carry a one-line
+     * explanation so a limitation is never mistaken for an off switch.
+     * See [MotionIndicatorState].
+     *
+     * Reading from [paint] — not from `motionSource.is*` or
+     * `motionCapability.capabilityFor(…)` directly — is the load-bearing
+     * change for the single-snapshot-per-paint contract: every field below
+     * comes from the same combine emission, so the pill cannot render the
+     * "user disabled but still streaming" half-states the old three-
+     * collector arrangement was prone to during reconnects.
      */
-    private fun refreshMotionStatus() {
+    private fun repaintMotionPill(paint: OverlayMotionPaint) {
+        val summary = paint.summary
         // A null summary (connection not resolved yet) is treated as
-        // motion-capable but not-yet-connected: the pill reads "paused" until
-        // the kind + liveness resolve, then self-corrects on the next refresh.
-        val summary = hub.summary(connectionId)
+        // motion-capable but not-yet-connected: the pill reads "paused"
+        // until the kind + liveness resolve, then self-corrects on the
+        // next paint.
         val carriesMotion = summary?.kind != ConnectionKind.BLUETOOTH
         val connected = summary?.live == LinkState.Connected
-        // The composer is the single source of truth for the user toggle
-        // AND the per-type host-sink heuristic — keeps the pill text in
-        // sync with the cap-bit and listener-gate decisions made elsewhere.
-        val cap = motionCapability.capabilityFor(VIRTUAL_SLOT_ID)
+        val cap = paint.capability
+        val sourceState = paint.sourceState
+        // Derived from sourceState — eliminates the previous three
+        // separate `motionSource.is*` reads, each of which could be at a
+        // different point in time than the others.
+        val isAvailable = sourceState != MotionStreamState.Disabled
+        val isStreaming =
+            sourceState == MotionStreamState.Streaming ||
+                sourceState == MotionStreamState.Stalled
+        val isStalled = sourceState == MotionStreamState.Stalled
         val state =
             MotionIndicatorState.of(
-                isAvailable = motionSource.isAvailable,
-                isStreaming = motionSource.isStreaming,
+                isAvailable = isAvailable,
+                isStreaming = isStreaming,
                 connectionCarriesMotion = carriesMotion,
                 connectionConnected = connected,
                 userEnabled = cap.userEnabled,
                 hostHasSinkForType = cap.hostHasSinkForType,
-                isStalled = motionSource.isStalled,
+                satelliteBackendOk = cap.satelliteBackendStatus?.backendOk,
+                isStalled = isStalled,
             )
         binding.tvMotionStatus.setText(state.labelRes)
         (binding.dotMotion.background as? GradientDrawable)?.setColor(getColor(state.dotColorRes))
@@ -405,6 +471,8 @@ class GamepadOverlayActivity :
                 binding.tvMotionDetail.setText(R.string.motion_user_disabled_detail)
             MotionIndicatorState.NO_HOST_SINK ->
                 binding.tvMotionDetail.setText(R.string.motion_no_host_sink_detail)
+            MotionIndicatorState.BACKEND_BROKEN ->
+                binding.tvMotionDetail.setText(R.string.motion_backend_broken_detail)
             else -> Unit
         }
     }

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
@@ -377,12 +377,18 @@ class GamepadOverlayActivity :
         val summary = hub.summary(connectionId)
         val carriesMotion = summary?.kind != ConnectionKind.BLUETOOTH
         val connected = summary?.live == LinkState.Connected
+        // The composer is the single source of truth for the user toggle
+        // AND the per-type host-sink heuristic — keeps the pill text in
+        // sync with the cap-bit and listener-gate decisions made elsewhere.
+        val cap = motionCapability.capabilityFor(VIRTUAL_SLOT_ID)
         val state =
             MotionIndicatorState.of(
                 isAvailable = motionSource.isAvailable,
                 isStreaming = motionSource.isStreaming,
                 connectionCarriesMotion = carriesMotion,
                 connectionConnected = connected,
+                userEnabled = cap.userEnabled,
+                hostHasSinkForType = cap.hostHasSinkForType,
                 isStalled = motionSource.isStalled,
             )
         binding.tvMotionStatus.setText(state.labelRes)
@@ -395,6 +401,10 @@ class GamepadOverlayActivity :
                 binding.tvMotionDetail.setText(R.string.motion_not_forwarded_detail)
             MotionIndicatorState.STALLED ->
                 binding.tvMotionDetail.setText(R.string.motion_stalled_detail)
+            MotionIndicatorState.USER_DISABLED ->
+                binding.tvMotionDetail.setText(R.string.motion_user_disabled_detail)
+            MotionIndicatorState.NO_HOST_SINK ->
+                binding.tvMotionDetail.setText(R.string.motion_no_host_sink_detail)
             else -> Unit
         }
     }

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.composer.ConnectionHub
 import com.tinkernorth.dish.composer.ConnectionKind
+import com.tinkernorth.dish.composer.MotionCapabilityComposer
 import com.tinkernorth.dish.composer.LinkState
 import com.tinkernorth.dish.composer.WakeStateController
 import com.tinkernorth.dish.core.input.hidToXusb
@@ -71,6 +72,8 @@ class GamepadOverlayActivity :
     @Inject lateinit var gamepadRegistry: PhysicalGamepadRegistry
 
     @Inject lateinit var notifications: DishNotifications
+
+    @Inject lateinit var motionCapability: MotionCapabilityComposer
 
     private lateinit var binding: ActivityGamepadOverlayBinding
     private lateinit var gamepadHost: GamepadActivityHost
@@ -146,6 +149,52 @@ class GamepadOverlayActivity :
                     // has no motion channel), so it must repaint when the
                     // bound connection's summary first resolves or changes.
                     refreshMotionStatus()
+                }
+            }
+        }
+
+        // Gate the gyro/accel listeners on the per-slot motion capability:
+        // start the source iff the slot is "effective" (gyro present AND
+        // bound to a Connected satellite AND the user toggle is on); stop
+        // otherwise. Replaces the previous always-on lifecycle in
+        // onResume/onPause, which burned battery on Bluetooth-HID
+        // connections (where motion can never flow) and ignored the user
+        // toggle entirely.
+        //
+        // The collector runs only while STARTED; repeatOnLifecycle cancels
+        // it on STOP, and the launched coroutine stops the source on
+        // cancellation so a backgrounded overlay never leaks listeners.
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                try {
+                    motionCapability.state.collect { caps ->
+                        val effective = caps[VIRTUAL_SLOT_ID]?.effective == true
+                        if (effective && !motionSource.isStreaming) {
+                            motionSource.start { sample, deltaUs ->
+                                satellite.get(connectionId)?.sendMotion(
+                                    VIRTUAL_SLOT_ID,
+                                    sample.gyroX,
+                                    sample.gyroY,
+                                    sample.gyroZ,
+                                    sample.accelX,
+                                    sample.accelY,
+                                    sample.accelZ,
+                                    deltaUs,
+                                )
+                            }
+                        } else if (!effective && motionSource.isStreaming) {
+                            motionSource.stop()
+                        }
+                        // Repaint after every gate flip so the pill
+                        // (STREAMING / PAUSED / NOT_FORWARDED / UNAVAILABLE)
+                        // tracks reality without waiting for an unrelated
+                        // hub.connections emission.
+                        refreshMotionStatus()
+                    }
+                } finally {
+                    // Stop on collector cancellation (STOP / activity destroy)
+                    // so a backgrounded overlay never leaks sensor listeners.
+                    motionSource.stop()
                 }
             }
         }
@@ -254,33 +303,23 @@ class GamepadOverlayActivity :
 
     override fun onResume() {
         super.onResume()
-        // Stream the phone's gyro/accel + battery to the bound satellite
-        // session. `satellite.get(...)` is null for Bluetooth-HID connections,
-        // so these emits naturally no-op there — motion forwarding is a
-        // satellite-path feature.
-        motionSource.start { sample, deltaUs ->
-            satellite.get(connectionId)?.sendMotion(
-                VIRTUAL_SLOT_ID,
-                sample.gyroX,
-                sample.gyroY,
-                sample.gyroZ,
-                sample.accelX,
-                sample.accelY,
-                sample.accelZ,
-                deltaUs,
-            )
-        }
+        // Battery is unconditional — it has its own gating on the connection
+        // kind inside the satellite send path, and the cost of a slow battery
+        // poll is negligible.
         batterySource.start(lifecycleScope) { level, status ->
             satellite.get(connectionId)?.sendBattery(VIRTUAL_SLOT_ID, level, status)
         }
-        // motionSource is now started (or a no-op if there's no gyroscope) —
-        // repaint so the pill reads "streaming" rather than "paused".
+        // Note: motionSource start/stop is now lifecycle-scoped on the
+        // capability flow (see the collector launched in onCreate). The
+        // overlay no longer unconditionally registers sensor listeners on
+        // Bluetooth-HID connections where motion can't flow, or on slots
+        // the user has toggled motion off for — fixing a measurable
+        // gyro/accel battery drain that previously ran for nothing.
         refreshMotionStatus()
     }
 
     override fun onPause() {
         super.onPause()
-        motionSource.stop()
         batterySource.stop()
         // Source stopped to save battery; reflect "paused" (not "unavailable").
         refreshMotionStatus()

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
@@ -198,6 +198,19 @@ class GamepadOverlayActivity :
                 }
             }
         }
+        // Repaint the motion pill whenever the source's own state flips
+        // (Streaming ↔ Stalled in particular). Without this collector the
+        // 500 ms stall-detection tick lands inside the source but never
+        // reaches the UI — the pill claims STREAMING forever while no
+        // samples are actually arriving. Fixes the STALLED-never-repaints
+        // bug (the source's tick is the trigger; the activity's collector
+        // is what makes it visible).
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                motionSource.state.collect { refreshMotionStatus() }
+            }
+        }
+
         // Mid-game connection events: with the SatelliteConnectionManager's
         // SharedFlow buffered, errors emitted from the alive-poll's onDead
         // path can now reach this activity. Previously they were silently

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
@@ -22,9 +22,9 @@ import com.tinkernorth.dish.R
 import com.tinkernorth.dish.composer.ConnectionHub
 import com.tinkernorth.dish.composer.ConnectionKind
 import com.tinkernorth.dish.composer.ConnectionSummary
+import com.tinkernorth.dish.composer.LinkState
 import com.tinkernorth.dish.composer.MotionCapability
 import com.tinkernorth.dish.composer.MotionCapabilityComposer
-import com.tinkernorth.dish.composer.LinkState
 import com.tinkernorth.dish.composer.WakeStateController
 import com.tinkernorth.dish.core.input.hidToXusb
 import com.tinkernorth.dish.core.model.DishNotification
@@ -36,9 +36,9 @@ import com.tinkernorth.dish.source.connection.ConnectionEvent
 import com.tinkernorth.dish.source.connection.SatelliteConnection
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.notification.DishNotifications
+import com.tinkernorth.dish.source.sensor.MotionStreamState
 import com.tinkernorth.dish.source.sensor.PhoneBatterySource
 import com.tinkernorth.dish.source.sensor.PhoneMotionSource
-import com.tinkernorth.dish.source.sensor.MotionStreamState
 import com.tinkernorth.dish.ui.common.GamepadTouchView
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
@@ -259,11 +259,20 @@ class GamepadOverlayActivity :
                         if (waitMs > 0) delay(waitMs)
                     }
                     nextTickNs += RESEND_INTERVAL_NS
-                    val state = lastReportedState ?: continue
-                    val summary = hub.summary(connectionId) ?: continue
-                    if (summary.kind != ConnectionKind.SATELLITE) continue
-                    if (summary.live != LinkState.Connected) continue
-                    sendSatelliteReport(state)
+                    // Send only when every prerequisite is satisfied. Folded
+                    // into one positive condition (rather than four guards
+                    // each followed by `continue`) so the loop body has a
+                    // single linear path — detekt's LoopWithTooManyJumpStatements
+                    // was correctly flagging the cluster of early-exits.
+                    val state = lastReportedState
+                    val summary = hub.summary(connectionId)
+                    if (state != null &&
+                        summary != null &&
+                        summary.kind == ConnectionKind.SATELLITE &&
+                        summary.live == LinkState.Connected
+                    ) {
+                        sendSatelliteReport(state)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
@@ -122,7 +122,7 @@ class MainActivity :
                 liveCount == 0 -> getString(R.string.status_remembered, totalCount)
                 else -> getString(R.string.status_connected_of, liveCount, totalCount)
             }
-        controllerAdapter.submitSlots(s.slots, s.connections)
+        controllerAdapter.submitSlots(s.slots, s.connections, s.motionCapabilities)
     }
 
     private fun handleEvent(event: MainEvent) {
@@ -179,6 +179,11 @@ class MainActivity :
         connectionId: String,
         type: Int,
     ) = viewModel.setSatelliteControllerType(connectionId, slotId, type)
+
+    override fun onMotionEnabledChanged(
+        slotId: String,
+        enabled: Boolean,
+    ) = viewModel.setMotionEnabled(slotId, enabled)
 
     override fun onOpenGamepad() {
         val v = viewModel.uiState.value.virtualSlot

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainUiState.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainUiState.kt
@@ -6,6 +6,7 @@ package com.tinkernorth.dish.ui.main
 import com.tinkernorth.dish.composer.ConnectionHub
 import com.tinkernorth.dish.composer.ConnectionSummary
 import com.tinkernorth.dish.composer.LinkState
+import com.tinkernorth.dish.composer.MotionCapability
 import com.tinkernorth.dish.source.sensor.BatteryValidator
 import com.tinkernorth.dish.source.store.BatteryStatusStore
 
@@ -90,6 +91,18 @@ data class MainUiState(
             ControllerSlot(id = VIRTUAL_SLOT_ID, inputType = SlotInputType.VIRTUAL, name = ""),
         ),
     val connections: List<ConnectionSummary> = emptyList(),
+    /**
+     * Per-slot motion capability snapshot from
+     * [com.tinkernorth.dish.composer.MotionCapabilityComposer]. The adapter
+     * reads this to render the per-slot motion toggle (enabled state +
+     * subtitle text that explains why a slot can't currently stream
+     * motion — no gyro, host has no sink for the chosen type, etc.).
+     *
+     * Defaults to empty so a [MainUiState] constructed before the composer
+     * has emitted reads as "every slot's motion is unknown but assume
+     * default-on" — matches the composer's own startup behaviour.
+     */
+    val motionCapabilities: Map<String, MotionCapability> = emptyMap(),
 ) {
     val virtualSlot get() = slots.first { it.id == VIRTUAL_SLOT_ID }
     val physicalSlots get() = slots.filter { it.inputType == SlotInputType.PHYSICAL }

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.composer.ConnectionHub
+import com.tinkernorth.dish.composer.MotionCapabilityComposer
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.source.connection.ConnectionEvent
 import com.tinkernorth.dish.source.connection.SatelliteConnection
@@ -47,6 +48,7 @@ class MainViewModel
         private val gamepadRegistry: PhysicalGamepadRegistry,
         private val batteryStatusStore: BatteryStatusStore,
         private val motionEnabledStore: MotionEnabledStore,
+        private val motionCapability: MotionCapabilityComposer,
     ) : ViewModel() {
         /**
          * Reactive `slotId -> enabled` map for the per-slot motion toggle.
@@ -72,7 +74,8 @@ class MainViewModel
                 hub.bindings,
                 gamepadRegistry.devices,
                 batteryStatusStore.samples,
-            ) { conns, bindings, devices, batteries ->
+                motionCapability.state,
+            ) { conns, bindings, devices, batteries, motionCaps ->
                 val virtual =
                     ControllerSlot(
                         id = VIRTUAL_SLOT_ID,
@@ -102,7 +105,7 @@ class MainViewModel
                                 },
                         )
                     }
-                MainUiState(slots = slots, connections = conns)
+                MainUiState(slots = slots, connections = conns, motionCapabilities = motionCaps)
             }.onEach { _uiState.value = it }.launchIn(viewModelScope)
 
             satellite.events

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
@@ -13,6 +13,7 @@ import com.tinkernorth.dish.source.connection.ConnectionEvent
 import com.tinkernorth.dish.source.connection.SatelliteConnection
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.store.BatteryStatusStore
+import com.tinkernorth.dish.source.store.MotionEnabledStore
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -45,7 +46,20 @@ class MainViewModel
         val hub: ConnectionHub,
         private val gamepadRegistry: PhysicalGamepadRegistry,
         private val batteryStatusStore: BatteryStatusStore,
+        private val motionEnabledStore: MotionEnabledStore,
     ) : ViewModel() {
+        /**
+         * Reactive `slotId -> enabled` map for the per-slot motion toggle.
+         * Hydrated at process start from [MotionEnabledStore]'s durable
+         * backing repo, so the dashboard renders yesterday's toggle state
+         * with no first-frame flicker.
+         *
+         * Absence from the map means "user has not toggled" — call sites
+         * use [isMotionEnabled] to apply the default rather than reading
+         * the map directly.
+         */
+        val motionEnabled: StateFlow<Map<String, Boolean>> = motionEnabledStore.state
+
         private val _uiState = MutableStateFlow(MainUiState())
         val uiState: StateFlow<MainUiState> = _uiState.asStateFlow()
 
@@ -131,4 +145,34 @@ class MainViewModel
         ) {
             hub.setSatelliteControllerType(connectionId, slotId, type)
         }
+
+        // ── Motion toggle ─────────────────────────────────────────────────────
+
+        /**
+         * Persist the user's per-slot motion preference. The store writes
+         * through to the durable [com.tinkernorth.dish.repository.MotionPreferenceRepository]
+         * AND republishes its state flow so the
+         * [com.tinkernorth.dish.composer.MotionCapabilityComposer] (wired
+         * in a follow-up PR) re-derives the slot's `CAP_MOTION` bit and
+         * the sensor-listener gate flips on the next emission.
+         *
+         * No-op semantics: writing the same value twice is harmless;
+         * the store still re-emits so any downstream observer that
+         * relies on identity equality (none today) is unaffected.
+         */
+        fun setMotionEnabled(
+            slotId: String,
+            enabled: Boolean,
+        ) {
+            motionEnabledStore.setEnabled(slotId, enabled)
+        }
+
+        /**
+         * Resolve the effective motion-enabled boolean for [slotId],
+         * collapsing an absent entry onto [MotionEnabledStore.DEFAULT_ENABLED].
+         * Use this in render code — never read [motionEnabled] directly,
+         * since absence and `false` mean different things in the store
+         * but the same thing to the user.
+         */
+        fun isMotionEnabled(slotId: String): Boolean = motionEnabledStore.isEnabled(slotId)
     }

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MotionIndicatorState.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MotionIndicatorState.kt
@@ -92,12 +92,13 @@ enum class MotionIndicatorState(
 
     /** True for the states whose meaning warrants the one-line explanation. */
     val hasDetail: Boolean
-        get() = this == UNAVAILABLE ||
-            this == NOT_FORWARDED ||
-            this == STALLED ||
-            this == USER_DISABLED ||
-            this == NO_HOST_SINK ||
-            this == BACKEND_BROKEN
+        get() =
+            this == UNAVAILABLE ||
+                this == NOT_FORWARDED ||
+                this == STALLED ||
+                this == USER_DISABLED ||
+                this == NO_HOST_SINK ||
+                this == BACKEND_BROKEN
 
     companion object {
         /**

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MotionIndicatorState.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MotionIndicatorState.kt
@@ -18,20 +18,26 @@ import com.tinkernorth.dish.source.sensor.PhoneMotionSource
  * point the user at the right next step (enable the toggle, swap to PS,
  * switch to satellite, etc.) instead of a single vague "paused."
  *
- *  - [STREAMING]      gyro + satellite + connected + user-enabled — samples on the wire.
- *  - [STALLED]        started but no recent samples (OEM sensor pause, defective gyro).
- *  - [PAUSED]         hardware ready, but the source is stopped for lifecycle / link reasons.
- *  - [USER_DISABLED]  the user toggled motion off for this slot. Distinct from PAUSED —
- *                     the limit is a choice the user made, with a clear path back.
- *  - [NOT_FORWARDED]  bound connection is Bluetooth-HID, which has no `MSG_MOTION`
- *                     channel. Honest about the limit instead of falsely streaming.
- *  - [NO_HOST_SINK]   the slot's controller type has no IMU surface on the host's
- *                     backend (Xbox 360 virtual pad). Tells the user to switch the
- *                     slot to PlayStation if they want gyro to land.
- *  - [UNAVAILABLE]    the phone itself has no gyroscope — nothing motion-related will
- *                     ever be sent regardless of toggles or connections.
+ *  - [STREAMING]       gyro + satellite + connected + user-enabled — samples on the wire.
+ *  - [STALLED]         started but no recent samples (OEM sensor pause, defective gyro).
+ *  - [PAUSED]          hardware ready, but the source is stopped for lifecycle / link reasons.
+ *  - [USER_DISABLED]   the user toggled motion off for this slot. Distinct from PAUSED —
+ *                      the limit is a choice the user made, with a clear path back.
+ *  - [NOT_FORWARDED]   bound connection is Bluetooth-HID, which has no `MSG_MOTION`
+ *                      channel. Honest about the limit instead of falsely streaming.
+ *  - [NO_HOST_SINK]    the slot's controller type has no IMU surface on the host's
+ *                      backend (Xbox 360 virtual pad). Tells the user to switch the
+ *                      slot to PlayStation if they want gyro to land.
+ *  - [BACKEND_BROKEN]  the satellite's backend told us (via the motion-status byte on
+ *                      the controller-add ACK) that it accepted the controller but
+ *                      could *not* create the per-serial IMU sink — typically a Linux
+ *                      uinput kernel rejection. Distinguishes "your bytes go nowhere
+ *                      because the receiver is misconfigured" from "your bytes go
+ *                      somewhere and the game just hasn't subscribed yet."
+ *  - [UNAVAILABLE]     the phone itself has no gyroscope — nothing motion-related will
+ *                      ever be sent regardless of toggles or connections.
  *
- * Keeping these seven cases distinct is the whole point of the enum.
+ * Keeping these eight cases distinct is the whole point of the enum.
  */
 enum class MotionIndicatorState(
     @param:StringRes val labelRes: Int,
@@ -67,6 +73,20 @@ enum class MotionIndicatorState(
      */
     NO_HOST_SINK(R.string.motion_no_host_sink, R.color.colorMuted),
 
+    /**
+     * The receiver explicitly told us (via the motion-status byte on the
+     * controller-add ACK — see `ACK_MOTION_FLAG_BACKEND_OK` on the
+     * satellite) that it accepted the controller but its backend could
+     * NOT create the per-serial IMU sink. Distinct from [NO_HOST_SINK]
+     * (which is type-level — the backend would never sink motion for
+     * this kind of pad) and from a missing ACK / pre-extension satellite
+     * (which surfaces as STREAMING / STALLED / PAUSED instead). The
+     * fix is operator-side on the satellite (typically a kernel /
+     * `/dev/uinput` permission issue on Linux), so the pill leans
+     * informational rather than action-oriented.
+     */
+    BACKEND_BROKEN(R.string.motion_backend_broken, R.color.colorWarning),
+
     UNAVAILABLE(R.string.motion_unavailable, R.color.colorMuted),
     ;
 
@@ -76,7 +96,8 @@ enum class MotionIndicatorState(
             this == NOT_FORWARDED ||
             this == STALLED ||
             this == USER_DISABLED ||
-            this == NO_HOST_SINK
+            this == NO_HOST_SINK ||
+            this == BACKEND_BROKEN
 
     companion object {
         /**
@@ -87,8 +108,12 @@ enum class MotionIndicatorState(
          *  - [connectionCarriesMotion] — bound connection kind has `MSG_MOTION`
          *    (satellite yes, Bluetooth-HID no).
          *  - [hostHasSinkForType] — the slot's controller type has an IMU surface
-         *    on the receiving host's backend. False for Xbox-typed slots (universal:
-         *    XInput has no IMU); true for PlayStation-typed slots on Windows / Linux.
+         *    on the receiving host's backend (the dish-side heuristic: PS=yes,
+         *    Xbox=no — universally true for the shipping backends).
+         *  - [satelliteBackendOk] — the satellite's *own* answer about whether its
+         *    backend created the per-serial IMU sink. Null when no extended ACK
+         *    has been observed (pre-extension satellite, or pre-registration).
+         *    A null here is the "defer to the heuristic" signal; a non-null wins.
          *  - [isStreaming]   — the source is currently started.
          *  - [connectionConnected] — the bound connection is Connected (not just
          *    Connecting / Unstable).
@@ -100,14 +125,27 @@ enum class MotionIndicatorState(
          *   2. User toggled off → USER_DISABLED (user's choice gets a clear label)
          *   3. Bluetooth-HID → NOT_FORWARDED (link can't carry motion)
          *   4. Host backend has no sink for type → NO_HOST_SINK
-         *   5. Streaming + connected + stalled → STALLED
-         *   6. Streaming + connected → STREAMING
-         *   7. Otherwise → PAUSED
+         *   5. Satellite reported backend NOT ok → BACKEND_BROKEN
+         *   6. Streaming + connected + stalled → STALLED
+         *   7. Streaming + connected → STREAMING
+         *   8. Otherwise → PAUSED
          *
-         * The order is deliberate. USER_DISABLED comes BEFORE NOT_FORWARDED
-         * so a user who has toggled off on a BT connection sees "you turned
-         * this off" (actionable) rather than "this connection can't carry
-         * motion" (also true but less actionable in the moment).
+         * The order is deliberate.
+         *
+         * USER_DISABLED comes BEFORE NOT_FORWARDED so a user who has toggled off
+         * on a BT connection sees "you turned this off" (actionable) rather than
+         * "this connection can't carry motion" (also true but less actionable in
+         * the moment).
+         *
+         * NO_HOST_SINK comes BEFORE BACKEND_BROKEN because the type-level fact
+         * ("Xbox virtual pads can never sink motion") is the higher-order reason
+         * — telling the user the kernel rejected an IMU sink would be technically
+         * correct but useless when the slot type has no sink at all.
+         *
+         * BACKEND_BROKEN comes BEFORE STALLED / STREAMING because if the receiver
+         * has *said* the sink is broken, any "streaming" reading on the dish
+         * would be a lie — the bytes never land. The pill should read what is
+         * actually happening at the receiver, not what the dish is *trying* to do.
          */
         @Suppress("LongParameterList")
         fun of(
@@ -117,6 +155,7 @@ enum class MotionIndicatorState(
             connectionConnected: Boolean,
             userEnabled: Boolean = true,
             hostHasSinkForType: Boolean = true,
+            satelliteBackendOk: Boolean? = null,
             isStalled: Boolean = false,
         ): MotionIndicatorState =
             when {
@@ -124,6 +163,7 @@ enum class MotionIndicatorState(
                 !userEnabled -> USER_DISABLED
                 !connectionCarriesMotion -> NOT_FORWARDED
                 !hostHasSinkForType -> NO_HOST_SINK
+                satelliteBackendOk == false -> BACKEND_BROKEN
                 isStreaming && connectionConnected && isStalled -> STALLED
                 isStreaming && connectionConnected -> STREAMING
                 else -> PAUSED

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MotionIndicatorState.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MotionIndicatorState.kt
@@ -12,35 +12,26 @@ import com.tinkernorth.dish.source.sensor.PhoneMotionSource
  * The phone-motion state shown by the touch-overlay's motion pill.
  *
  * The touch overlay forwards the phone's gyro + accelerometer as an
- * `MSG_MOTION` stream (Task 1.1, see
- * [com.tinkernorth.dish.source.sensor.PhoneMotionSource]). The user must be
- * able to tell — with no ambiguity — whether motion is actually going out:
+ * `MSG_MOTION` stream (Task 1.1, see [PhoneMotionSource]). The user must
+ * be able to tell — with **no ambiguity** — why motion is or isn't going
+ * out. Every "not sent" reason is a distinct enum value so the pill can
+ * point the user at the right next step (enable the toggle, swap to PS,
+ * switch to satellite, etc.) instead of a single vague "paused."
  *
- *  - [STREAMING]      the phone has a gyroscope, the overlay is resumed, and
- *                     the bound connection is a satellite connection (the
- *                     only kind that carries `MSG_MOTION`) that is actually
- *                     CONNECTED — so
- *                     [com.tinkernorth.dish.source.sensor.PhoneMotionSource]
- *                     is started and samples are reaching the wire.
- *  - [PAUSED]         the phone has a gyroscope but motion is not flowing
- *                     right now: either the source is stopped (overlay
- *                     backgrounded — gyro listeners released to save battery),
- *                     or it is running but the satellite connection is not
- *                     CONNECTED, so the samples are dropped before the wire.
- *                     Distinct from [UNAVAILABLE]: the hardware is there, it
- *                     is just idle right now.
- *  - [NOT_FORWARDED]  the phone has a gyroscope but the bound connection is a
- *                     Bluetooth-HID connection, which has no motion channel —
- *                     so motion is captured-but-dropped, never sent. Honest
- *                     about the limit instead of falsely claiming "streaming".
- *  - [UNAVAILABLE]    the phone has no gyroscope
- *                     ([com.tinkernorth.dish.source.sensor.PhoneMotionSource.isAvailable]
- *                     is false); nothing motion-related will ever be sent.
+ *  - [STREAMING]      gyro + satellite + connected + user-enabled — samples on the wire.
+ *  - [STALLED]        started but no recent samples (OEM sensor pause, defective gyro).
+ *  - [PAUSED]         hardware ready, but the source is stopped for lifecycle / link reasons.
+ *  - [USER_DISABLED]  the user toggled motion off for this slot. Distinct from PAUSED —
+ *                     the limit is a choice the user made, with a clear path back.
+ *  - [NOT_FORWARDED]  bound connection is Bluetooth-HID, which has no `MSG_MOTION`
+ *                     channel. Honest about the limit instead of falsely streaming.
+ *  - [NO_HOST_SINK]   the slot's controller type has no IMU surface on the host's
+ *                     backend (Xbox 360 virtual pad). Tells the user to switch the
+ *                     slot to PlayStation if they want gyro to land.
+ *  - [UNAVAILABLE]    the phone itself has no gyroscope — nothing motion-related will
+ *                     ever be sent regardless of toggles or connections.
  *
- * There is no user-facing motion on/off toggle in this slice, so "off"
- * collapses onto [PAUSED] (a lifecycle pause), never onto [UNAVAILABLE].
- * Keeping "no hardware", "paused", and "this connection can't carry motion"
- * apart is the whole point of this enum.
+ * Keeping these seven cases distinct is the whole point of the enum.
  */
 enum class MotionIndicatorState(
     @param:StringRes val labelRes: Int,
@@ -52,51 +43,87 @@ enum class MotionIndicatorState(
     /**
      * Source is started, connection is up, but no gyro samples have arrived
      * in the stall window. The hardware exists but isn't ticking — e.g. an
-     * OEM that pauses sensors aggressively, or a defective gyro. Surfaced as
-     * the "paused (stalled)" detail rather than a separate enum case so the
-     * pill colour stays warning-amber.
+     * OEM that pauses sensors aggressively, or a defective gyro.
      */
     STALLED(R.string.motion_stalled, R.color.colorWarning),
+
+    /**
+     * The user turned motion off for this slot. Distinct from PAUSED so
+     * the user sees "you turned this off" with a one-line hint at the
+     * switch, not a vague "paused" label that looks like a bug.
+     */
+    USER_DISABLED(R.string.motion_user_disabled, R.color.colorMuted),
+
     NOT_FORWARDED(R.string.motion_not_forwarded, R.color.colorMuted),
+
+    /**
+     * The slot's controller type (Xbox) has no motion surface on the
+     * host's backend. The dish would otherwise stream — wire bytes would
+     * be accepted, then silently dropped at the virtual gamepad layer.
+     * Pill calls this out so the user knows to switch to PlayStation for
+     * gyro to land. macOS satellites (no backend at all) never reach
+     * this state because controller-add fails with `ACK_ERR_BACKEND_UNAVAIL`
+     * before the slot becomes registered.
+     */
+    NO_HOST_SINK(R.string.motion_no_host_sink, R.color.colorMuted),
+
     UNAVAILABLE(R.string.motion_unavailable, R.color.colorMuted),
     ;
 
     /** True for the states whose meaning warrants the one-line explanation. */
-    val hasDetail: Boolean get() = this == UNAVAILABLE || this == NOT_FORWARDED || this == STALLED
+    val hasDetail: Boolean
+        get() = this == UNAVAILABLE ||
+            this == NOT_FORWARDED ||
+            this == STALLED ||
+            this == USER_DISABLED ||
+            this == NO_HOST_SINK
 
     companion object {
         /**
-         * Pure mapping from the four facts the overlay knows to the indicator
-         * state:
+         * Pure decision from the facts the overlay knows to the pill state.
          *
-         *  - [isAvailable]   — whether the phone has a gyroscope
-         *    ([com.tinkernorth.dish.source.sensor.PhoneMotionSource.isAvailable]).
-         *  - [isStreaming]   — whether the source is currently started
-         *    ([com.tinkernorth.dish.source.sensor.PhoneMotionSource.isStreaming]).
-         *  - [connectionCarriesMotion] — whether the bound connection kind
-         *    has an `MSG_MOTION` channel (satellite does, Bluetooth-HID does
-         *    not).
-         *  - [connectionConnected] — whether the bound connection is actually
-         *    CONNECTED. A satellite connection that is reconnecting or idle
-         *    has `sendMotion` drop every packet, so a "started" source over a
-         *    down connection is not really streaming.
+         *  - [isAvailable]   — phone has a gyroscope (`PhoneMotionSource.isAvailable`).
+         *  - [userEnabled]   — user's per-slot motion toggle (`MotionEnabledStore`).
+         *  - [connectionCarriesMotion] — bound connection kind has `MSG_MOTION`
+         *    (satellite yes, Bluetooth-HID no).
+         *  - [hostHasSinkForType] — the slot's controller type has an IMU surface
+         *    on the receiving host's backend. False for Xbox-typed slots (universal:
+         *    XInput has no IMU); true for PlayStation-typed slots on Windows / Linux.
+         *  - [isStreaming]   — the source is currently started.
+         *  - [connectionConnected] — the bound connection is Connected (not just
+         *    Connecting / Unstable).
+         *  - [isStalled]     — the source is started but no gyro callback in the
+         *    last 1500ms.
          *
-         * Precedence: no gyroscope wins outright ([UNAVAILABLE]); then a
-         * connection that can't carry motion ([NOT_FORWARDED]) — the source
-         * may be "started" but its emits are dropped, so this must not read
-         * as [STREAMING]; then [STREAMING] only when the source is started
-         * **and** the connection is up; otherwise [PAUSED].
+         * Precedence (top to bottom — first match wins):
+         *   1. No gyroscope → UNAVAILABLE
+         *   2. User toggled off → USER_DISABLED (user's choice gets a clear label)
+         *   3. Bluetooth-HID → NOT_FORWARDED (link can't carry motion)
+         *   4. Host backend has no sink for type → NO_HOST_SINK
+         *   5. Streaming + connected + stalled → STALLED
+         *   6. Streaming + connected → STREAMING
+         *   7. Otherwise → PAUSED
+         *
+         * The order is deliberate. USER_DISABLED comes BEFORE NOT_FORWARDED
+         * so a user who has toggled off on a BT connection sees "you turned
+         * this off" (actionable) rather than "this connection can't carry
+         * motion" (also true but less actionable in the moment).
          */
+        @Suppress("LongParameterList")
         fun of(
             isAvailable: Boolean,
             isStreaming: Boolean,
             connectionCarriesMotion: Boolean,
             connectionConnected: Boolean,
+            userEnabled: Boolean = true,
+            hostHasSinkForType: Boolean = true,
             isStalled: Boolean = false,
         ): MotionIndicatorState =
             when {
                 !isAvailable -> UNAVAILABLE
+                !userEnabled -> USER_DISABLED
                 !connectionCarriesMotion -> NOT_FORWARDED
+                !hostHasSinkForType -> NO_HOST_SINK
                 isStreaming && connectionConnected && isStalled -> STALLED
                 isStreaming && connectionConnected -> STREAMING
                 else -> PAUSED

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -116,6 +116,17 @@
     <string name="motion_unavailable_detail">Ovaj telefon nema žiroskop, pa se pokret (žiro nišanjenje / nagib) ne šalje.</string>
     <string name="motion_not_forwarded_detail">Ova Bluetooth veza nema kanal za pokret. Koristite satelitsku vezu za slanje žiro nišanjenja / nagiba.</string>
     <string name="motion_stalled_detail">Senzor pokreta je zaglavljen — pokušajte pritisnuti dugme Nazad za resetovanje, ili restartujte Dish.</string>
+    <string name="motion_user_disabled">Pokret: isključen</string>
+    <string name="motion_no_host_sink">Pokret: host ne može primiti</string>
+    <string name="motion_backend_broken">Pokret: server ne može isporučiti</string>
+    <string name="motion_user_disabled_detail">Isključili ste pokret za ovaj slot. Uključite prekidač Pokret u redu kontrolera da biste ponovo počeli slati žiro.</string>
+    <string name="motion_no_host_sink_detail">Virtuelni kontroler u Xbox stilu nema površinu za pokret na hostu. Prebacite kontroler na PlayStation za žiro nišanjenje / nagib.</string>
+    <string name="motion_backend_broken_detail">Satelit je prihvatio ovaj kontroler ali nije mogao kreirati uređaj za pokret — vjerovatno problem s dozvolama ili kernelom na serveru. Restartajte satelit ili provjerite njegove zapisnike.</string>
+    <string name="controller_motion_toggle_label">Pokret (žiro)</string>
+    <string name="controller_motion_toggle_subtitle_on">Šalje žiro nišanjenje / nagib hostu.</string>
+    <string name="controller_motion_toggle_subtitle_off">Žiro uzorci se ne šalju za ovaj slot.</string>
+    <string name="controller_motion_toggle_subtitle_no_gyro">Ovaj uređaj nema žiroskop.</string>
+    <string name="controller_motion_toggle_subtitle_no_host_sink">Host ne može primiti pokret s kontrolera u Xbox stilu. Prebacite gore na PlayStation za žiro.</string>
 
     <!-- Indikator baterije po slotu. -->
     <string name="battery_percent">%1$d %%</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -119,6 +119,17 @@
     <string name="motion_unavailable_detail">Dieses Telefon hat kein Gyroskop, daher wird die Bewegung (Gyro-Zielen / Neigung) nicht gesendet.</string>
     <string name="motion_not_forwarded_detail">Diese Bluetooth-Verbindung hat keinen Bewegungskanal. Nutze eine Satelliten-Verbindung, um Gyro-Zielen / Neigung zu senden.</string>
     <string name="motion_stalled_detail">Bewegungssensor blockiert — versuche die Zurück-Taste zum Zurücksetzen oder starte Dish neu.</string>
+    <string name="motion_user_disabled">Bewegung: ausgeschaltet</string>
+    <string name="motion_no_host_sink">Bewegung: Host kann nicht empfangen</string>
+    <string name="motion_backend_broken">Bewegung: Server kann nicht zustellen</string>
+    <string name="motion_user_disabled_detail">Du hast die Bewegung für diesen Slot ausgeschaltet. Aktiviere den Bewegungs-Schalter in der Controllerzeile, um wieder Gyro zu senden.</string>
+    <string name="motion_no_host_sink_detail">Ein virtuelles Xbox-Pad hat keine Bewegungsoberfläche auf dem Host. Wechsle den Controller auf PlayStation, damit Gyro-Zielen / Neigung ankommt.</string>
+    <string name="motion_backend_broken_detail">Der Satellit hat diesen Controller akzeptiert, konnte aber sein Bewegungsgerät nicht erstellen — vermutlich ein Berechtigungs- oder Kernelproblem auf dem Server. Starte den Satelliten neu oder prüfe die Logs.</string>
+    <string name="controller_motion_toggle_label">Bewegung (Gyro)</string>
+    <string name="controller_motion_toggle_subtitle_on">Sendet Gyro-Zielen / Neigung an den Host.</string>
+    <string name="controller_motion_toggle_subtitle_off">Für diesen Slot werden keine Gyro-Samples gesendet.</string>
+    <string name="controller_motion_toggle_subtitle_no_gyro">Dieses Gerät hat kein Gyroskop.</string>
+    <string name="controller_motion_toggle_subtitle_no_host_sink">Der Host kann keine Bewegung von einem Xbox-Pad empfangen. Wechsle oben auf PlayStation für Gyro.</string>
 
     <!-- Akku-Anzeige pro Slot. -->
     <string name="battery_percent">%1$d %%</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -119,6 +119,17 @@
     <string name="motion_unavailable_detail">Este teléfono no tiene giroscopio, por lo que el movimiento (puntería con giroscopio / inclinación) no se envía.</string>
     <string name="motion_not_forwarded_detail">Esta conexión Bluetooth no tiene canal de movimiento. Usa una conexión por satélite para enviar puntería con giroscopio / inclinación.</string>
     <string name="motion_stalled_detail">Sensor de movimiento bloqueado — prueba a pulsar el botón Atrás para reiniciarlo, o reinicia Dish.</string>
+    <string name="motion_user_disabled">Movimiento: desactivado</string>
+    <string name="motion_no_host_sink">Movimiento: el host no puede recibir</string>
+    <string name="motion_backend_broken">Movimiento: el servidor no puede entregar</string>
+    <string name="motion_user_disabled_detail">Has desactivado el movimiento para esta ranura. Activa el interruptor Movimiento en la fila del mando para volver a enviar gyro.</string>
+    <string name="motion_no_host_sink_detail">Un mando virtual estilo Xbox no tiene superficie de movimiento en el host. Cambia el mando a PlayStation para la puntería gyro / inclinación.</string>
+    <string name="motion_backend_broken_detail">El satélite aceptó este mando pero no pudo crear su dispositivo de movimiento — probablemente un problema de permisos o de kernel en el servidor. Reinicia el satélite o consulta sus registros.</string>
+    <string name="controller_motion_toggle_label">Movimiento (gyro)</string>
+    <string name="controller_motion_toggle_subtitle_on">Enviando puntería gyro / inclinación al host.</string>
+    <string name="controller_motion_toggle_subtitle_off">No se envían muestras gyro para esta ranura.</string>
+    <string name="controller_motion_toggle_subtitle_no_gyro">Este dispositivo no tiene giroscopio.</string>
+    <string name="controller_motion_toggle_subtitle_no_host_sink">El host no puede recibir movimiento de un mando estilo Xbox. Cambia arriba a PlayStation para el gyro.</string>
 
     <!-- Indicador de batería por slot. -->
     <string name="battery_percent">%1$d %%</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -118,6 +118,17 @@
     <string name="motion_unavailable_detail">Ce téléphone n\'a pas de gyroscope, le mouvement (visée gyro / inclinaison) n\'est pas transmis.</string>
     <string name="motion_not_forwarded_detail">Cette connexion Bluetooth n\'a pas de canal de mouvement. Utilisez une connexion satellite pour transmettre la visée gyro / inclinaison.</string>
     <string name="motion_stalled_detail">Capteur de mouvement bloqué — essayez d\'appuyer sur le bouton retour, ou redémarrez Dish.</string>
+    <string name="motion_user_disabled">Mouvement : désactivé</string>
+    <string name="motion_no_host_sink">Mouvement : l\'hôte ne peut pas recevoir</string>
+    <string name="motion_backend_broken">Mouvement : le serveur ne peut pas livrer</string>
+    <string name="motion_user_disabled_detail">Vous avez désactivé le mouvement pour cet emplacement. Activez le bouton Mouvement sur la ligne de la manette pour recommencer à envoyer le gyro.</string>
+    <string name="motion_no_host_sink_detail">Une manette virtuelle de style Xbox n\'a pas de surface de mouvement sur l\'hôte. Passez la manette en PlayStation pour la visée gyro / inclinaison.</string>
+    <string name="motion_backend_broken_detail">Le satellite a accepté cette manette mais n\'a pas pu créer son périphérique de mouvement — probablement un problème de permission ou de noyau sur le serveur. Redémarrez le satellite ou vérifiez ses journaux.</string>
+    <string name="controller_motion_toggle_label">Mouvement (gyro)</string>
+    <string name="controller_motion_toggle_subtitle_on">Envoie la visée gyro / inclinaison à l\'hôte.</string>
+    <string name="controller_motion_toggle_subtitle_off">Aucun échantillon gyro n\'est envoyé pour cet emplacement.</string>
+    <string name="controller_motion_toggle_subtitle_no_gyro">Cet appareil n\'a pas de gyroscope.</string>
+    <string name="controller_motion_toggle_subtitle_no_host_sink">L\'hôte ne peut pas recevoir le mouvement d\'une manette de style Xbox. Passez en PlayStation ci-dessus pour le gyro.</string>
 
     <!-- Indicateur de batterie par emplacement. -->
     <string name="battery_percent">%1$d %%</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -119,6 +119,17 @@
     <string name="motion_unavailable_detail">Este telefone não tem giroscópio, então o movimento (mira giroscópica / inclinação) não é enviado.</string>
     <string name="motion_not_forwarded_detail">Esta conexão Bluetooth não tem canal de movimento. Use uma conexão por satélite para enviar mira giroscópica / inclinação.</string>
     <string name="motion_stalled_detail">Sensor de movimento travado — tente pressionar o botão Voltar para reiniciá-lo, ou reinicie o Dish.</string>
+    <string name="motion_user_disabled">Movimento: desligado</string>
+    <string name="motion_no_host_sink">Movimento: o host não consegue receber</string>
+    <string name="motion_backend_broken">Movimento: o servidor não consegue entregar</string>
+    <string name="motion_user_disabled_detail">Você desativou o movimento para este slot. Ative a chave Movimento na linha do controle para voltar a enviar giroscópio.</string>
+    <string name="motion_no_host_sink_detail">Um controle virtual estilo Xbox não tem superfície de movimento no host. Mude o controle para PlayStation para mira giroscópica / inclinação.</string>
+    <string name="motion_backend_broken_detail">O satélite aceitou este controle mas não conseguiu criar seu dispositivo de movimento — provavelmente um problema de permissão ou de kernel no servidor. Reinicie o satélite ou verifique seus logs.</string>
+    <string name="controller_motion_toggle_label">Movimento (giroscópio)</string>
+    <string name="controller_motion_toggle_subtitle_on">Enviando mira giroscópica / inclinação para o host.</string>
+    <string name="controller_motion_toggle_subtitle_off">Nenhuma amostra de giroscópio está sendo enviada para este slot.</string>
+    <string name="controller_motion_toggle_subtitle_no_gyro">Este dispositivo não tem giroscópio.</string>
+    <string name="controller_motion_toggle_subtitle_no_host_sink">O host não consegue receber movimento de um controle estilo Xbox. Mude para PlayStation acima para giroscópio.</string>
 
     <!-- Indicador de bateria por slot. -->
     <string name="battery_percent">%1$d %%</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,7 @@
     <string name="motion_unavailable">Motion: no gyroscope</string>
     <string name="motion_user_disabled">Motion: turned off</string>
     <string name="motion_no_host_sink">Motion: host can\'t receive</string>
+    <string name="motion_backend_broken">Motion: server can\'t deliver</string>
     <!-- Detail lines, shown only for the states that need an explanation
          so the user understands the limit rather than seeing a bare label. -->
     <string name="motion_unavailable_detail">This phone has no gyroscope, so motion (gyro aim / tilt) is not sent.</string>
@@ -129,6 +130,7 @@
     <string name="motion_stalled_detail">Motion sensor stalled — try toggling the back button to reset, or restart Dish.</string>
     <string name="motion_user_disabled_detail">You turned motion off for this slot. Enable the Motion switch on the controller row to start sending gyro again.</string>
     <string name="motion_no_host_sink_detail">An Xbox-style virtual pad has no motion surface on the host. Switch the controller to PlayStation for gyro aim / tilt.</string>
+    <string name="motion_backend_broken_detail">The satellite accepted this controller but couldn\'t create its motion device — likely a permission or kernel issue on the server. Restart the satellite, or check its logs.</string>
 
     <!-- Per-slot motion toggle switch on the controller list row. -->
     <string name="controller_motion_toggle_label">Motion (gyro)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,19 +111,31 @@
     <string name="bt_transient_acquiring">Acquiring HID profile…</string>
     <string name="bt_transient_idle">Idle</string>
 
-    <!-- Touch-overlay phone-motion (gyro/accel) indicator. States: streaming,
-         paused (overlay backgrounded), not-forwarded (Bluetooth connection
-         has no motion channel), and not-available (no gyroscope). -->
+    <!-- Touch-overlay phone-motion (gyro/accel) indicator. States cover every
+         reason motion might or might not be flowing — hardware absent, user
+         toggled off, connection kind can't carry it, host backend can't sink
+         the slot's type, source paused, streaming live, or stalled. -->
     <string name="motion_streaming">Motion: streaming</string>
     <string name="motion_paused">Motion: paused</string>
     <string name="motion_stalled">Motion: stalled</string>
     <string name="motion_not_forwarded">Motion: not sent</string>
     <string name="motion_unavailable">Motion: no gyroscope</string>
+    <string name="motion_user_disabled">Motion: turned off</string>
+    <string name="motion_no_host_sink">Motion: host can\'t receive</string>
     <!-- Detail lines, shown only for the states that need an explanation
          so the user understands the limit rather than seeing a bare label. -->
     <string name="motion_unavailable_detail">This phone has no gyroscope, so motion (gyro aim / tilt) is not sent.</string>
     <string name="motion_not_forwarded_detail">This Bluetooth connection has no motion channel. Use a satellite connection to send gyro aim / tilt.</string>
     <string name="motion_stalled_detail">Motion sensor stalled — try toggling the back button to reset, or restart Dish.</string>
+    <string name="motion_user_disabled_detail">You turned motion off for this slot. Enable the Motion switch on the controller row to start sending gyro again.</string>
+    <string name="motion_no_host_sink_detail">An Xbox-style virtual pad has no motion surface on the host. Switch the controller to PlayStation for gyro aim / tilt.</string>
+
+    <!-- Per-slot motion toggle switch on the controller list row. -->
+    <string name="controller_motion_toggle_label">Motion (gyro)</string>
+    <string name="controller_motion_toggle_subtitle_on">Sending gyro aim / tilt to the host.</string>
+    <string name="controller_motion_toggle_subtitle_off">Gyro samples are not being sent for this slot.</string>
+    <string name="controller_motion_toggle_subtitle_no_gyro">This device has no gyroscope.</string>
+    <string name="controller_motion_toggle_subtitle_no_host_sink">Host can\'t sink motion for an Xbox-style pad. Switch to PlayStation above for gyro.</string>
 
     <!-- Per-slot battery indicator on the controller list (Task 1.2). -->
     <!-- Battery percentage, e.g. "84%". -->

--- a/app/src/test/java/com/tinkernorth/dish/composer/MotionCapabilityComposerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/MotionCapabilityComposerTest.kt
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.composer
+
+import com.tinkernorth.dish.architecture.testing.composerTest
+import com.tinkernorth.dish.architecture.testing.probe
+import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
+import com.tinkernorth.dish.source.sensor.PhoneMotionAvailability
+import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [MotionCapabilityComposer] — the per-slot
+ * `MotionCapability` map that drives the `CAP_MOTION` bit at registration
+ * time, the sensor-listener gating, and the on-screen pill.
+ *
+ * Headline regressions pinned here:
+ *
+ *  - The virtual slot is *always present in the map* (key
+ *    [VIRTUAL_SLOT_ID]), regardless of whether any physical pad is attached
+ *    or any satellite is up. This is the bit the overlay reads at construct
+ *    time; if it weren't there, the pill would flicker UNAVAILABLE until the
+ *    first hub emission.
+ *  - `hasGyro` for a physical slot comes from
+ *    [PhysicalGamepadRegistry.Device.hasGyro] verbatim — not re-probed by
+ *    the composer (the probe is at device-add time, not on the hot
+ *    capability-flow path).
+ *  - `carriesOnConnection` is `kind == SATELLITE && live == Connected`,
+ *    nothing else. Bluetooth-HID, Connecting, Unstable all resolve to false.
+ *  - `toCapBits()` does *not* gate on `carriesOnConnection` — a satellite
+ *    re-connect must not require a re-handshake to recover motion.
+ */
+class MotionCapabilityComposerTest {
+    private fun summary(
+        id: String,
+        kind: ConnectionKind = ConnectionKind.SATELLITE,
+        live: LinkState = LinkState.Connected,
+    ) = ConnectionSummary(
+        id = id,
+        kind = kind,
+        label = id,
+        detail = "",
+        live = live,
+        boundSlotIds = emptyList(),
+    )
+
+    private fun device(
+        id: Int,
+        hasGyro: Boolean,
+    ) = PhysicalGamepadRegistry.Device(id, "Pad-$id", hasGyro = hasGyro)
+
+    /** Build a composer with mockable upstreams. */
+    private fun composerFor(
+        phoneAvailable: MutableStateFlow<Boolean>,
+        devices: MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>,
+        bindings: MutableStateFlow<Map<String, String>>,
+        connections: MutableStateFlow<List<ConnectionSummary>>,
+        scope: CoroutineScope,
+    ): MotionCapabilityComposer {
+        val availability: PhoneMotionAvailability =
+            mockk { every { state } returns phoneAvailable }
+        val registry: PhysicalGamepadRegistry =
+            mockk { every { this@mockk.devices } returns devices }
+        val hub: ConnectionHub =
+            mockk {
+                every { this@mockk.bindings } returns bindings
+                every { this@mockk.connections } returns connections
+            }
+        return MotionCapabilityComposer(availability, registry, hub, scope)
+    }
+
+    // ── Pure data-class invariants ──────────────────────────────────────
+
+    @Test
+    fun `effective requires every axis true`() {
+        // All-true is the only effective state. The three booleans are
+        // orthogonal — exhaustively check the false-leaning cases.
+        assertTrue(
+            MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = true).effective,
+        )
+        assertFalse(
+            MotionCapability(hasGyro = false, carriesOnConnection = true, userEnabled = true).effective,
+        )
+        assertFalse(
+            MotionCapability(hasGyro = true, carriesOnConnection = false, userEnabled = true).effective,
+        )
+        assertFalse(
+            MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = false).effective,
+        )
+    }
+
+    @Test
+    fun `toCapBits returns CAP_MOTION when the dish CAN emit motion`() {
+        // The CAP bit describes the dish's *capability*, not the live link.
+        // A connected, gyro-equipped, user-enabled slot ⇒ CAP_MOTION.
+        val cap = MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = true)
+        assertEquals(MotionCapability.CAP_MOTION_BIT, cap.toCapBits())
+    }
+
+    @Test
+    fun `toCapBits ignores carriesOnConnection — link-down is not a capability change`() {
+        // A satellite that is momentarily Connecting / Unstable must not flip
+        // the cap bit — otherwise every reconnect would force an unregister /
+        // re-register round trip. The cap bit only depends on hasGyro AND
+        // userEnabled.
+        val cap = MotionCapability(hasGyro = true, carriesOnConnection = false, userEnabled = true)
+        assertEquals(MotionCapability.CAP_MOTION_BIT, cap.toCapBits())
+    }
+
+    @Test
+    fun `toCapBits is zero when the user has disabled motion`() {
+        // Flipping the user toggle off is a real capability change — the
+        // dish stops emitting motion, so it should stop advertising CAP_MOTION.
+        val cap = MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = false)
+        assertEquals(0, cap.toCapBits())
+    }
+
+    @Test
+    fun `toCapBits is zero on hardware without a gyro — even if the user enabled it`() {
+        // No gyro means no motion, period; never lie to the receiver.
+        val cap = MotionCapability(hasGyro = false, carriesOnConnection = true, userEnabled = true)
+        assertEquals(0, cap.toCapBits())
+    }
+
+    // ── Composer derivation ──────────────────────────────────────────────
+
+    @Test
+    fun `virtual slot is always present in the map`() =
+        composerTest {
+            // No physical pads, no satellite — the touch overlay still has a
+            // capability entry to read at construct time. This is the pill's
+            // first-paint contract.
+            val phoneAvail = MutableStateFlow(false)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow<Map<String, String>>(emptyMap())
+            val conns = MutableStateFlow<List<ConnectionSummary>>(emptyList())
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+
+            val virtual = probe.latest[VIRTUAL_SLOT_ID]
+            assertEquals(
+                MotionCapability(hasGyro = false, carriesOnConnection = false, userEnabled = true),
+                virtual,
+            )
+        }
+
+    @Test
+    fun `virtual slot hasGyro mirrors PhoneMotionAvailability`() =
+        composerTest {
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow<Map<String, String>>(emptyMap())
+            val conns = MutableStateFlow<List<ConnectionSummary>>(emptyList())
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertEquals(true, probe.latest[VIRTUAL_SLOT_ID]?.hasGyro)
+
+            // Flip the source's value — the composer must re-derive.
+            phoneAvail.value = false
+            testScheduler.runCurrent()
+            assertEquals(false, probe.latest[VIRTUAL_SLOT_ID]?.hasGyro)
+        }
+
+    @Test
+    fun `virtual slot carriesOnConnection is true when bound to a Connected satellite`() =
+        composerTest {
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "sat-A"))
+            val conns = MutableStateFlow(listOf(summary("sat-A")))
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertTrue(probe.latest[VIRTUAL_SLOT_ID]?.carriesOnConnection == true)
+        }
+
+    @Test
+    fun `virtual slot carriesOnConnection is false on a Bluetooth-HID binding`() =
+        composerTest {
+            // BT-HID has no MSG_MOTION channel, so the pill must read
+            // NOT_FORWARDED. The composer's carriesOnConnection is the truth
+            // table's gate.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "bt-A"))
+            val conns = MutableStateFlow(listOf(summary("bt-A", kind = ConnectionKind.BLUETOOTH)))
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertFalse(probe.latest[VIRTUAL_SLOT_ID]?.carriesOnConnection == true)
+        }
+
+    @Test
+    fun `virtual slot carriesOnConnection is false while still Connecting`() =
+        composerTest {
+            // A satellite that hasn't reached Connected yet can't sink
+            // motion. The cap bit doesn't gate on this; the pill does.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "sat-A"))
+            val conns = MutableStateFlow(listOf(summary("sat-A", live = LinkState.Connecting)))
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertFalse(probe.latest[VIRTUAL_SLOT_ID]?.carriesOnConnection == true)
+        }
+
+    @Test
+    fun `physical slot uses Device hasGyro verbatim — no re-probe`() =
+        composerTest {
+            // The composer never calls PhysicalMotionProbe itself; the truth
+            // is whatever the registry recorded at add time. This pin
+            // catches a regression where someone "helpfully" re-probes on
+            // every emission and slows the hot capability-flow path.
+            val phoneAvail = MutableStateFlow(false)
+            val devices =
+                MutableStateFlow(
+                    mapOf(
+                        9 to device(9, hasGyro = true),
+                        11 to device(11, hasGyro = false),
+                    ),
+                )
+            val bindings = MutableStateFlow<Map<String, String>>(emptyMap())
+            val conns = MutableStateFlow<List<ConnectionSummary>>(emptyList())
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertEquals(true, probe.latest["9"]?.hasGyro)
+            assertEquals(false, probe.latest["11"]?.hasGyro)
+        }
+
+    @Test
+    fun `physical slot drops from the map when the device leaves the registry`() =
+        composerTest {
+            // The registry's disconnect grace removes Devices from its flow
+            // when the grace expires. The composer must drop the slot too,
+            // not stash a stale "still capable" entry.
+            val phoneAvail = MutableStateFlow(false)
+            val devices = MutableStateFlow(mapOf(9 to device(9, hasGyro = true)))
+            val bindings = MutableStateFlow<Map<String, String>>(emptyMap())
+            val conns = MutableStateFlow<List<ConnectionSummary>>(emptyList())
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertEquals(true, probe.latest["9"]?.hasGyro)
+
+            devices.value = emptyMap()
+            testScheduler.runCurrent()
+            assertNull(probe.latest["9"])
+        }
+
+    @Test
+    fun `the map re-emits when the routing flips kind from satellite to bluetooth`() =
+        composerTest {
+            // Mid-game the user changes a slot from satellite to BT-HID. The
+            // capability for that slot must flip carriesOnConnection from
+            // true → false on the next emission.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow(mapOf(9 to device(9, hasGyro = true)))
+            val bindings = MutableStateFlow(mapOf("9" to "sat-A"))
+            val conns = MutableStateFlow(listOf(summary("sat-A")))
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertTrue(probe.latest["9"]?.carriesOnConnection == true)
+
+            bindings.value = mapOf("9" to "bt-A")
+            conns.value = listOf(summary("bt-A", kind = ConnectionKind.BLUETOOTH))
+            testScheduler.runCurrent()
+            assertFalse(probe.latest["9"]?.carriesOnConnection == true)
+        }
+}

--- a/app/src/test/java/com/tinkernorth/dish/composer/MotionCapabilityComposerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/MotionCapabilityComposerTest.kt
@@ -8,6 +8,8 @@ import com.tinkernorth.dish.architecture.testing.probe
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.source.sensor.PhoneMotionAvailability
 import com.tinkernorth.dish.source.store.MotionEnabledStore
+import com.tinkernorth.dish.source.store.SatelliteMotionBackendStatus
+import com.tinkernorth.dish.source.store.SatelliteMotionBackendStatusStore
 import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
 import io.mockk.every
 import io.mockk.mockk
@@ -69,6 +71,8 @@ class MotionCapabilityComposerTest {
         connections: MutableStateFlow<List<ConnectionSummary>>,
         scope: CoroutineScope,
         motionEnabled: MutableStateFlow<Map<String, Boolean>> = MutableStateFlow(emptyMap()),
+        satelliteBackendStatus: MutableStateFlow<Map<Pair<String, String>, SatelliteMotionBackendStatus>> =
+            MutableStateFlow(emptyMap()),
     ): MotionCapabilityComposer {
         val availability: PhoneMotionAvailability =
             mockk { every { state } returns phoneAvailable }
@@ -81,7 +85,9 @@ class MotionCapabilityComposerTest {
             }
         val store: MotionEnabledStore =
             mockk { every { state } returns motionEnabled }
-        return MotionCapabilityComposer(availability, registry, hub, store, scope)
+        val backendStatusStore: SatelliteMotionBackendStatusStore =
+            mockk { every { state } returns satelliteBackendStatus }
+        return MotionCapabilityComposer(availability, registry, hub, store, backendStatusStore, scope)
     }
 
     // ── Pure data-class invariants ──────────────────────────────────────
@@ -526,4 +532,149 @@ class MotionCapabilityComposerTest {
 
             assertEquals(true, probe.latest[VIRTUAL_SLOT_ID]?.hostHasSinkForType)
         }
+
+    // ── satelliteBackendStatus — receiver-truth threading ──────────────────
+
+    @Test
+    fun `satelliteBackendStatus is null when no observation has landed`() =
+        composerTest {
+            // Bound to a satellite but the store has no entry yet — the
+            // composer must surface null (unknown), NOT a default value.
+            // Anything else would mis-read a pre-extension satellite or a
+            // pre-registration moment as a positive observation.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "sat-A"))
+            val conns = MutableStateFlow(listOf(summary("sat-A")))
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+
+            assertNull(probe.latest[VIRTUAL_SLOT_ID]?.satelliteBackendStatus)
+        }
+
+    @Test
+    fun `satelliteBackendStatus propagates from the store for the bound connection`() =
+        composerTest {
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "sat-A"))
+            val conns = MutableStateFlow(listOf(summary("sat-A")))
+            val status = SatelliteMotionBackendStatus(sinkSupportedForType = true, backendOk = false)
+            val backendStatus =
+                MutableStateFlow<Map<Pair<String, String>, SatelliteMotionBackendStatus>>(
+                    mapOf(("sat-A" to VIRTUAL_SLOT_ID) to status),
+                )
+            val probe =
+                composerFor(
+                    phoneAvail,
+                    devices,
+                    bindings,
+                    conns,
+                    backgroundScope,
+                    satelliteBackendStatus = backendStatus,
+                ).probe(this)
+            testScheduler.runCurrent()
+
+            assertEquals(status, probe.latest[VIRTUAL_SLOT_ID]?.satelliteBackendStatus)
+        }
+
+    @Test
+    fun `satelliteBackendStatus is keyed on the bound connection — wrong-connection entries are ignored`() =
+        composerTest {
+            // The slot is bound to "sat-A" but the store also carries an
+            // (unrelated) status under "sat-B". A leaky implementation
+            // could collapse on slotId alone and pick up the wrong entry —
+            // pin that the composer only reads the bound connection's
+            // entry.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "sat-A"))
+            val conns = MutableStateFlow(listOf(summary("sat-A")))
+            val wrongStatus = SatelliteMotionBackendStatus(sinkSupportedForType = false, backendOk = false)
+            val backendStatus =
+                MutableStateFlow<Map<Pair<String, String>, SatelliteMotionBackendStatus>>(
+                    mapOf(("sat-B" to VIRTUAL_SLOT_ID) to wrongStatus),
+                )
+            val probe =
+                composerFor(
+                    phoneAvail,
+                    devices,
+                    bindings,
+                    conns,
+                    backgroundScope,
+                    satelliteBackendStatus = backendStatus,
+                ).probe(this)
+            testScheduler.runCurrent()
+
+            assertNull(probe.latest[VIRTUAL_SLOT_ID]?.satelliteBackendStatus)
+        }
+
+    @Test
+    fun `satelliteBackendStatus updates reactively when the store re-emits`() =
+        composerTest {
+            // The pill needs to repaint when the receiver's truth flips.
+            // Simulate a backend that initially reports broken, then the
+            // operator fixes /dev/uinput and a re-registration succeeds —
+            // the new status flows through the composer.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "sat-A"))
+            val conns = MutableStateFlow(listOf(summary("sat-A")))
+            val broken = SatelliteMotionBackendStatus(sinkSupportedForType = true, backendOk = false)
+            val fixed = SatelliteMotionBackendStatus(sinkSupportedForType = true, backendOk = true)
+            val backendStatus =
+                MutableStateFlow<Map<Pair<String, String>, SatelliteMotionBackendStatus>>(
+                    mapOf(("sat-A" to VIRTUAL_SLOT_ID) to broken),
+                )
+            val probe =
+                composerFor(
+                    phoneAvail,
+                    devices,
+                    bindings,
+                    conns,
+                    backgroundScope,
+                    satelliteBackendStatus = backendStatus,
+                ).probe(this)
+            testScheduler.runCurrent()
+            assertEquals(broken, probe.latest[VIRTUAL_SLOT_ID]?.satelliteBackendStatus)
+
+            backendStatus.value = mapOf(("sat-A" to VIRTUAL_SLOT_ID) to fixed)
+            testScheduler.runCurrent()
+            assertEquals(fixed, probe.latest[VIRTUAL_SLOT_ID]?.satelliteBackendStatus)
+        }
+
+    @Test
+    fun `toCapBits is unaffected by satelliteBackendStatus — dish honesty is independent of receiver health`() {
+        // Even if the receiver tells us its sink is broken, the dish is
+        // still capable of streaming motion (the bytes will just not
+        // land). toCapBits must keep advertising CAP_MOTION so that a
+        // satellite that recovers (operator fixes /dev/uinput) doesn't
+        // require a re-handshake to get motion flowing again.
+        val cap =
+            MotionCapability(
+                hasGyro = true,
+                carriesOnConnection = true,
+                userEnabled = true,
+                satelliteBackendStatus =
+                    SatelliteMotionBackendStatus(sinkSupportedForType = true, backendOk = false),
+            )
+        assertEquals(MotionCapability.CAP_MOTION_BIT, cap.toCapBits())
+    }
+
+    @Test
+    fun `effective is unaffected by satelliteBackendStatus — local listener gating doesn't change`() {
+        // effective is the dish's own gate: "should I capture and stream
+        // gyro samples?" That's a dish-local question — the receiver's
+        // sink health is irrelevant. The listener stays on so a recovered
+        // receiver picks up bytes immediately.
+        val cap =
+            MotionCapability(
+                hasGyro = true,
+                carriesOnConnection = true,
+                userEnabled = true,
+                satelliteBackendStatus =
+                    SatelliteMotionBackendStatus(sinkSupportedForType = true, backendOk = false),
+            )
+        assertTrue(cap.effective)
+    }
 }

--- a/app/src/test/java/com/tinkernorth/dish/composer/MotionCapabilityComposerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/MotionCapabilityComposerTest.kt
@@ -45,6 +45,7 @@ class MotionCapabilityComposerTest {
         id: String,
         kind: ConnectionKind = ConnectionKind.SATELLITE,
         live: LinkState = LinkState.Connected,
+        satelliteControllerTypes: Map<String, Int> = emptyMap(),
     ) = ConnectionSummary(
         id = id,
         kind = kind,
@@ -52,6 +53,7 @@ class MotionCapabilityComposerTest {
         detail = "",
         live = live,
         boundSlotIds = emptyList(),
+        satelliteControllerTypes = satelliteControllerTypes,
     )
 
     private fun device(
@@ -390,5 +392,138 @@ class MotionCapabilityComposerTest {
             conns.value = listOf(summary("bt-A", kind = ConnectionKind.BLUETOOTH))
             testScheduler.runCurrent()
             assertFalse(probe.latest["9"]?.carriesOnConnection == true)
+        }
+
+    // ── hostHasSinkForType — the B.3 per-type sink heuristic ───────────────
+
+    @Test
+    fun `hostHasSinkForType is true for a PlayStation-typed satellite slot`() =
+        composerTest {
+            // PS-typed slot → DS4 emulation on Windows ViGEm / Linux uinput,
+            // both of which carry gyro/accel. Pin the positive case so a
+            // regression that flips the polarity (or accidentally returns
+            // false for all types) would fail.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "sat-A"))
+            val conns =
+                MutableStateFlow(
+                    listOf(
+                        summary(
+                            "sat-A",
+                            satelliteControllerTypes = mapOf(VIRTUAL_SLOT_ID to CONTROLLER_TYPE_PLAYSTATION),
+                        ),
+                    ),
+                )
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+
+            assertEquals(true, probe.latest[VIRTUAL_SLOT_ID]?.hostHasSinkForType)
+        }
+
+    @Test
+    fun `hostHasSinkForType is false for an Xbox-typed satellite slot — the headline B3 case`() =
+        composerTest {
+            // The headline B.3 deliverable: Xbox-typed virtual pads have no
+            // IMU surface on any backend (XInput / XUSB_REPORT has no gyro
+            // fields). The dish needs to know this so the pill can warn the
+            // user up front instead of "streaming" while the bytes silently
+            // disappear at the receiver's virtual-gamepad layer.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "sat-A"))
+            val conns =
+                MutableStateFlow(
+                    listOf(
+                        summary(
+                            "sat-A",
+                            satelliteControllerTypes = mapOf(VIRTUAL_SLOT_ID to CONTROLLER_TYPE_XBOX),
+                        ),
+                    ),
+                )
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+
+            assertEquals(false, probe.latest[VIRTUAL_SLOT_ID]?.hostHasSinkForType)
+        }
+
+    @Test
+    fun `hostHasSinkForType flips when the user changes the slot type mid-session`() =
+        composerTest {
+            // The toggle on the controller row (Xbox ↔ PS) must propagate to
+            // the composer the moment the ConnectionSummary re-emits. Without
+            // this, the pill stays on STREAMING after a user swaps to Xbox
+            // and motion silently stops working without a warning.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "sat-A"))
+            val conns =
+                MutableStateFlow(
+                    listOf(
+                        summary(
+                            "sat-A",
+                            satelliteControllerTypes = mapOf(VIRTUAL_SLOT_ID to CONTROLLER_TYPE_PLAYSTATION),
+                        ),
+                    ),
+                )
+
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+            assertEquals(true, probe.latest[VIRTUAL_SLOT_ID]?.hostHasSinkForType)
+
+            // User flips Xbox.
+            conns.value =
+                listOf(
+                    summary(
+                        "sat-A",
+                        satelliteControllerTypes = mapOf(VIRTUAL_SLOT_ID to CONTROLLER_TYPE_XBOX),
+                    ),
+                )
+            testScheduler.runCurrent()
+            assertEquals(false, probe.latest[VIRTUAL_SLOT_ID]?.hostHasSinkForType)
+        }
+
+    @Test
+    fun `hostHasSinkForType is true for a slot with unknown type — no false warnings`() =
+        composerTest {
+            // ConnectionSummary.satelliteControllerTypes is empty until the
+            // user has explicitly chosen a type, OR for a connection that
+            // hasn't fully resolved yet. Returning false in that window
+            // would flash a "no host sink" warning that goes away on its
+            // own — bad UX. Conservatively assume yes.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "sat-A"))
+            val conns = MutableStateFlow(listOf(summary("sat-A"))) // empty satelliteControllerTypes
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+
+            assertEquals(true, probe.latest[VIRTUAL_SLOT_ID]?.hostHasSinkForType)
+        }
+
+    @Test
+    fun `hostHasSinkForType is true for a Bluetooth-HID-bound slot — limit is connection kind`() =
+        composerTest {
+            // BT-HID is handled by NOT_FORWARDED, which has higher
+            // precedence in the pill. The composer's hostHasSinkForType
+            // returns true to avoid spurious NO_HOST_SINK noise stacked on
+            // top of the connection-kind limit.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "bt-A"))
+            val conns =
+                MutableStateFlow(
+                    listOf(
+                        summary(
+                            "bt-A",
+                            kind = ConnectionKind.BLUETOOTH,
+                            satelliteControllerTypes = mapOf(VIRTUAL_SLOT_ID to CONTROLLER_TYPE_XBOX),
+                        ),
+                    ),
+                )
+            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            testScheduler.runCurrent()
+
+            assertEquals(true, probe.latest[VIRTUAL_SLOT_ID]?.hostHasSinkForType)
         }
 }

--- a/app/src/test/java/com/tinkernorth/dish/composer/MotionCapabilityComposerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/MotionCapabilityComposerTest.kt
@@ -7,6 +7,7 @@ import com.tinkernorth.dish.architecture.testing.composerTest
 import com.tinkernorth.dish.architecture.testing.probe
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.source.sensor.PhoneMotionAvailability
+import com.tinkernorth.dish.source.store.MotionEnabledStore
 import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
 import io.mockk.every
 import io.mockk.mockk
@@ -65,6 +66,7 @@ class MotionCapabilityComposerTest {
         bindings: MutableStateFlow<Map<String, String>>,
         connections: MutableStateFlow<List<ConnectionSummary>>,
         scope: CoroutineScope,
+        motionEnabled: MutableStateFlow<Map<String, Boolean>> = MutableStateFlow(emptyMap()),
     ): MotionCapabilityComposer {
         val availability: PhoneMotionAvailability =
             mockk { every { state } returns phoneAvailable }
@@ -75,7 +77,9 @@ class MotionCapabilityComposerTest {
                 every { this@mockk.bindings } returns bindings
                 every { this@mockk.connections } returns connections
             }
-        return MotionCapabilityComposer(availability, registry, hub, scope)
+        val store: MotionEnabledStore =
+            mockk { every { state } returns motionEnabled }
+        return MotionCapabilityComposer(availability, registry, hub, store, scope)
     }
 
     // ── Pure data-class invariants ──────────────────────────────────────
@@ -258,6 +262,113 @@ class MotionCapabilityComposerTest {
             devices.value = emptyMap()
             testScheduler.runCurrent()
             assertNull(probe.latest["9"])
+        }
+
+    @Test
+    fun `userEnabled defaults to true for an unwritten slot`() =
+        composerTest {
+            // The store collapses an absent key onto DEFAULT_ENABLED = true.
+            // The composer must respect the same default — otherwise a fresh
+            // install would silently advertise CAP_MOTION = 0 for every slot
+            // until the user toggled each one. Pin the default through the
+            // composer's userEnabled field.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow<Map<String, String>>(emptyMap())
+            val conns = MutableStateFlow<List<ConnectionSummary>>(emptyList())
+            val motionEnabled = MutableStateFlow<Map<String, Boolean>>(emptyMap())
+
+            val probe =
+                composerFor(phoneAvail, devices, bindings, conns, backgroundScope, motionEnabled).probe(this)
+            testScheduler.runCurrent()
+
+            assertEquals(true, probe.latest[VIRTUAL_SLOT_ID]?.userEnabled)
+        }
+
+    @Test
+    fun `userEnabled flips when MotionEnabledStore writes false for a slot`() =
+        composerTest {
+            // The toggle is the user-visible switch — flipping it must
+            // immediately propagate to the composer (and from there to
+            // SatelliteConnection's cap bit and the listener gate). A
+            // regression where the store write doesn't reach the composer
+            // would make the toggle look broken in the UI.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow<Map<String, String>>(emptyMap())
+            val conns = MutableStateFlow<List<ConnectionSummary>>(emptyList())
+            val motionEnabled = MutableStateFlow<Map<String, Boolean>>(emptyMap())
+
+            val composer =
+                composerFor(phoneAvail, devices, bindings, conns, backgroundScope, motionEnabled)
+            val probe = composer.probe(this)
+            testScheduler.runCurrent()
+            assertTrue(probe.latest[VIRTUAL_SLOT_ID]?.userEnabled == true)
+
+            motionEnabled.value = mapOf(VIRTUAL_SLOT_ID to false)
+            testScheduler.runCurrent()
+            assertFalse(probe.latest[VIRTUAL_SLOT_ID]?.userEnabled == true)
+        }
+
+    @Test
+    fun `toCapBits is zero on a slot the user has disabled — even if hasGyro is true`() =
+        composerTest {
+            // End-to-end pin: phone has gyro, satellite is up, but the user
+            // toggled motion off — the cap bit on the wire must be zero so
+            // the receiver's web UI is honest about which slots stream motion.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "sat-A"))
+            val conns = MutableStateFlow(listOf(summary("sat-A")))
+            val motionEnabled = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to false))
+
+            val probe =
+                composerFor(phoneAvail, devices, bindings, conns, backgroundScope, motionEnabled).probe(this)
+            testScheduler.runCurrent()
+
+            assertEquals(0, probe.latest[VIRTUAL_SLOT_ID]?.toCapBits())
+        }
+
+    @Test
+    fun `capabilityFor returns the latest derived value for a slot`() =
+        composerTest {
+            // SatelliteConnection.registerController is synchronous on its IO
+            // dispatcher; the composer's state.collect would be awkward there.
+            // capabilityFor is the synchronous accessor — pin that it returns
+            // the latest derived value, not stale Initial.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow(mapOf(VIRTUAL_SLOT_ID to "sat-A"))
+            val conns = MutableStateFlow(listOf(summary("sat-A")))
+
+            val composer =
+                composerFor(phoneAvail, devices, bindings, conns, backgroundScope)
+            composer.probe(this)
+            testScheduler.runCurrent()
+
+            val cap = composer.capabilityFor(VIRTUAL_SLOT_ID)
+            assertTrue(cap.hasGyro)
+            assertTrue(cap.carriesOnConnection)
+            assertEquals(MotionCapability.CAP_MOTION_BIT, cap.toCapBits())
+        }
+
+    @Test
+    fun `capabilityFor returns Off for a slot not in the map`() =
+        composerTest {
+            // A controller-add for an unknown slot (race with registry
+            // disconnect) must not NPE — capabilityFor returns Off so the
+            // cap word is 0, which is correct: we don't know that slot has
+            // motion, so don't advertise it.
+            val phoneAvail = MutableStateFlow(true)
+            val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
+            val bindings = MutableStateFlow<Map<String, String>>(emptyMap())
+            val conns = MutableStateFlow<List<ConnectionSummary>>(emptyList())
+
+            val composer = composerFor(phoneAvail, devices, bindings, conns, backgroundScope)
+            composer.probe(this)
+            testScheduler.runCurrent()
+
+            assertEquals(MotionCapability.Off, composer.capabilityFor("ghost-slot"))
         }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/repository/MotionPreferenceRepositoryContractTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/MotionPreferenceRepositoryContractTest.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.tinkernorth.dish.architecture.interfaces.Repository
+import com.tinkernorth.dish.architecture.testing.AbstractRepositoryContract
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.serialization.json.Json
+import kotlin.random.Random
+
+/**
+ * Inherits the standard CRUD contract from [AbstractRepositoryContract]:
+ * get on empty, all on empty, get-after-put, replace-on-same-key, remove,
+ * all-contains-every-put, clear, remove-absent-is-noop.
+ *
+ * Per-implementation behaviour (corrupt-JSON tolerance, multi-entry
+ * persistence after a re-read) is in the sibling `MotionPreferenceRepositoryTest`.
+ *
+ * SharedPreferences is mocked into a `MutableMap` so this stays a pure
+ * JVM test — same pattern as
+ * [RememberedSatelliteRepositoryContractTest].
+ */
+class MotionPreferenceRepositoryContractTest : AbstractRepositoryContract<String, MotionPreference>() {
+    override fun newRepository(): Repository<String, MotionPreference> =
+        MotionPreferenceRepository(
+            context = fakeContextBackedByMap(),
+            json = Json { ignoreUnknownKeys = true },
+        )
+
+    override fun newKey(): String = "slot-${Random.nextLong()}"
+
+    /** Same key ⇒ same value. The contract test compares sets of values. */
+    override fun newValue(key: String): MotionPreference =
+        MotionPreference(slotId = key, enabled = key.hashCode() and 1 == 0)
+
+    private fun fakeContextBackedByMap(): Context {
+        val store = mutableMapOf<String, Any?>()
+        val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+        val keySlot = slot<String>()
+        val strSlot = slot<String?>()
+        every { editor.putString(capture(keySlot), captureNullable(strSlot)) } answers {
+            store[keySlot.captured] = strSlot.captured
+            editor
+        }
+        every { editor.remove(capture(keySlot)) } answers {
+            store.remove(keySlot.captured)
+            editor
+        }
+        every { editor.apply() } answers { /* no-op */ }
+
+        val prefs = mockk<SharedPreferences>(relaxed = true)
+        every { prefs.getString(any(), any()) } answers {
+            val k = firstArg<String>()
+            val default = secondArg<String?>()
+            (store[k] as? String) ?: default
+        }
+        every { prefs.edit() } returns editor
+        every { prefs.all } answers { store.toMap() }
+
+        val context = mockk<Context>(relaxed = true)
+        every { context.getSharedPreferences(any(), any()) } returns prefs
+        return context
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/repository/MotionPreferenceRepositoryContractTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/MotionPreferenceRepositoryContractTest.kt
@@ -35,8 +35,7 @@ class MotionPreferenceRepositoryContractTest : AbstractRepositoryContract<String
     override fun newKey(): String = "slot-${Random.nextLong()}"
 
     /** Same key ⇒ same value. The contract test compares sets of values. */
-    override fun newValue(key: String): MotionPreference =
-        MotionPreference(slotId = key, enabled = key.hashCode() and 1 == 0)
+    override fun newValue(key: String): MotionPreference = MotionPreference(slotId = key, enabled = key.hashCode() and 1 == 0)
 
     private fun fakeContextBackedByMap(): Context {
         val store = mutableMapOf<String, Any?>()

--- a/app/src/test/java/com/tinkernorth/dish/repository/MotionPreferenceRepositoryTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/MotionPreferenceRepositoryTest.kt
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Behaviour-specific tests for [MotionPreferenceRepository] — the CRUD
+ * contract is covered by [MotionPreferenceRepositoryContractTest]; this
+ * file pins the JSON serialization edges and the multi-write durability
+ * that matter for upgrades.
+ */
+class MotionPreferenceRepositoryTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `enabled true and false round-trip through SharedPreferences`() {
+        // The repository must persist the boolean verbatim — a sloppy
+        // implementation that conflates `null` (unset) with `false` would
+        // destroy the "I haven't decided yet" signal the store relies on
+        // for its default. Pin both true and false through a write/read.
+        val (ctx, _) = fakePrefs()
+        val repo = MotionPreferenceRepository(ctx, json)
+        repo.put(MotionPreference("virtual", enabled = true))
+        repo.put(MotionPreference("9", enabled = false))
+
+        // Re-read through a fresh repo on the same backing prefs to prove
+        // durability (no in-memory cache shortcut).
+        val (ctx2, _) = fakePrefs(seedFrom = ctx)
+        val repo2 = MotionPreferenceRepository(ctx2, json)
+        assertEquals(true, repo2.get("virtual")?.enabled)
+        assertEquals(false, repo2.get("9")?.enabled)
+    }
+
+    @Test
+    fun `get on a slot that was never written returns null — not a default boolean`() {
+        // The repository never invents a default. The store layer
+        // collapses null onto MotionEnabledStore.DEFAULT_ENABLED; the repo
+        // must stay honest so the store can distinguish "user has not
+        // decided" from "user explicitly enabled".
+        val (ctx, _) = fakePrefs()
+        val repo = MotionPreferenceRepository(ctx, json)
+        assertNull(repo.get("never-written"))
+    }
+
+    @Test
+    fun `corrupt JSON in prefs falls back to empty — does not crash app startup`() {
+        // A crash during a previous write, or a sideloaded apk overwriting
+        // the prefs, could leave invalid JSON behind. The repo must
+        // tolerate it (the user just loses their motion preferences for
+        // every slot) rather than crash the app on first read.
+        val (ctx, store) = fakePrefs()
+        store["preferences"] = "{not valid json"
+        val repo = MotionPreferenceRepository(ctx, json)
+        assertTrue(repo.all().isEmpty())
+        assertNull(repo.get("anything"))
+    }
+
+    @Test
+    fun `remove of one slot does not disturb other slots' preferences`() {
+        // Per-slot removal must touch only the named entry — important
+        // when a physical pad is unbound but a virtual slot's preference
+        // must survive.
+        val (ctx, _) = fakePrefs()
+        val repo = MotionPreferenceRepository(ctx, json)
+        repo.put(MotionPreference("virtual", enabled = true))
+        repo.put(MotionPreference("9", enabled = false))
+        repo.remove("9")
+
+        assertEquals(true, repo.get("virtual")?.enabled)
+        assertNull(repo.get("9"))
+    }
+
+    @Test
+    fun `put with same slot replaces in place — list never grows`() {
+        // The contract test exercises this generically; this version pins
+        // the absolute size to catch a regression where put accidentally
+        // append-only's the list and persists duplicate entries.
+        val (ctx, _) = fakePrefs()
+        val repo = MotionPreferenceRepository(ctx, json)
+        repo.put(MotionPreference("virtual", enabled = true))
+        repo.put(MotionPreference("virtual", enabled = false))
+        repo.put(MotionPreference("virtual", enabled = true))
+        assertEquals(1, repo.all().size)
+        assertEquals(true, repo.get("virtual")?.enabled)
+    }
+
+    // ── Test fixtures ────────────────────────────────────────────────────
+
+    /**
+     * Returns a Context + the underlying mutable map. Pass [seedFrom] to
+     * mirror an earlier prefs' state (testing durability across a fresh
+     * repo instance on the same prefs key).
+     */
+    private fun fakePrefs(seedFrom: Context? = null): Pair<Context, MutableMap<String, Any?>> {
+        val store: MutableMap<String, Any?> =
+            (seedFrom?.getSharedPreferences("motion_preferences", 0)?.all as? Map<String, Any?>)
+                ?.toMutableMap()
+                ?: mutableMapOf()
+
+        val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+        val keySlot = slot<String>()
+        val strSlot = slot<String?>()
+        every { editor.putString(capture(keySlot), captureNullable(strSlot)) } answers {
+            store[keySlot.captured] = strSlot.captured
+            editor
+        }
+        every { editor.remove(capture(keySlot)) } answers {
+            store.remove(keySlot.captured)
+            editor
+        }
+        every { editor.apply() } answers { /* no-op */ }
+
+        val prefs = mockk<SharedPreferences>(relaxed = true)
+        every { prefs.getString(any(), any()) } answers {
+            val k = firstArg<String>()
+            val default = secondArg<String?>()
+            (store[k] as? String) ?: default
+        }
+        every { prefs.edit() } returns editor
+        every { prefs.all } answers { store.toMap() }
+
+        val ctx = mockk<Context>(relaxed = true)
+        every { ctx.getSharedPreferences(any(), any()) } returns prefs
+        return ctx to store
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/repository/MotionPreferenceRepositoryTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/MotionPreferenceRepositoryTest.kt
@@ -5,13 +5,19 @@ package com.tinkernorth.dish.repository
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Log
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.slot
+import io.mockk.unmockkStatic
+import io.mockk.verify
 import kotlinx.serialization.json.Json
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 
 /**
@@ -53,6 +59,17 @@ class MotionPreferenceRepositoryTest {
         assertNull(repo.get("never-written"))
     }
 
+    @Before
+    fun mockLog() {
+        mockkStatic(Log::class)
+        every { Log.w(any<String>(), any<String>()) } returns 0
+    }
+
+    @After
+    fun unmockLog() {
+        unmockkStatic(Log::class)
+    }
+
     @Test
     fun `corrupt JSON in prefs falls back to empty — does not crash app startup`() {
         // A crash during a previous write, or a sideloaded apk overwriting
@@ -64,6 +81,25 @@ class MotionPreferenceRepositoryTest {
         val repo = MotionPreferenceRepository(ctx, json)
         assertTrue(repo.all().isEmpty())
         assertNull(repo.get("anything"))
+    }
+
+    @Test
+    fun `corrupt JSON logs a WARN so the silent toggle-loss has a breadcrumb`() {
+        // The fall-through to emptyList() is silent without a log. A
+        // user reporting "all my motion toggles reset" would otherwise
+        // have nothing to point at; the WARN names the file + the
+        // decoder error so support has somewhere to start.
+        val (ctx, store) = fakePrefs()
+        store["preferences"] = "{not valid json"
+        val repo = MotionPreferenceRepository(ctx, json)
+        repo.all() // triggers the decode path
+
+        verify(atLeast = 1) {
+            Log.w(
+                eq("MotionPreferenceRepository"),
+                match<String> { it.contains("Failed to decode motion-preference list") },
+            )
+        }
     }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManagerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManagerTest.kt
@@ -11,6 +11,7 @@ import com.tinkernorth.dish.core.jni.ControllerRepository
 import com.tinkernorth.dish.core.model.DiscoveredServer
 import com.tinkernorth.dish.core.net.DiscoveryRepository
 import com.tinkernorth.dish.repository.ConnectionStore
+import com.tinkernorth.dish.source.store.SatelliteMotionBackendStatusStore
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -96,6 +97,13 @@ class SatelliteConnectionManagerTest {
             }
         }
 
+    /**
+     * Real (singleton) store — these tests don't exercise the
+     * satellite-ack motion-flags path; a default-empty store is all the
+     * manager needs to construct + thread into each SatelliteConnection.
+     */
+    private val motionBackendStatusStore = SatelliteMotionBackendStatusStore()
+
     private fun manager(): SatelliteConnectionManager =
         SatelliteConnectionManager(
             context = context,
@@ -106,6 +114,7 @@ class SatelliteConnectionManagerTest {
             json = json,
             ioDispatcher = ioDispatcher,
             motionCapabilityProvider = motionCapabilityProvider,
+            motionBackendStatusStore = motionBackendStatusStore,
         )
 
     private fun runMgrTest(block: suspend (SatelliteConnectionManager, MutableList<ConnectionEvent>) -> Unit) =

--- a/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManagerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManagerTest.kt
@@ -5,6 +5,8 @@ package com.tinkernorth.dish.source.connection
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.tinkernorth.dish.composer.MotionCapability
+import com.tinkernorth.dish.composer.MotionCapabilityComposer
 import com.tinkernorth.dish.core.jni.ControllerRepository
 import com.tinkernorth.dish.core.model.DiscoveredServer
 import com.tinkernorth.dish.core.net.DiscoveryRepository
@@ -82,6 +84,18 @@ class SatelliteConnectionManagerTest {
         every { store.satelliteSharedKey(any()) } returns null
     }
 
+    /**
+     * Provider that returns a fresh, always-off [MotionCapabilityComposer]
+     * stand-in. These tests don't exercise the cap-bit path; they just need
+     * the manager to construct successfully.
+     */
+    private val motionCapabilityProvider =
+        javax.inject.Provider<MotionCapabilityComposer> {
+            mockk(relaxed = true) {
+                every { capabilityFor(any()) } returns MotionCapability.Off
+            }
+        }
+
     private fun manager(): SatelliteConnectionManager =
         SatelliteConnectionManager(
             context = context,
@@ -91,6 +105,7 @@ class SatelliteConnectionManagerTest {
             store = store,
             json = json,
             ioDispatcher = ioDispatcher,
+            motionCapabilityProvider = motionCapabilityProvider,
         )
 
     private fun runMgrTest(block: suspend (SatelliteConnectionManager, MutableList<ConnectionEvent>) -> Unit) =

--- a/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionTest.kt
@@ -572,4 +572,199 @@ class SatelliteConnectionTest {
         verify(exactly = 0) { repo.stopHeartbeat(any()) }
         verify(exactly = 0) { repo.closeSocket(any()) }
     }
+
+    // ── Reactive cap-word refresh (MSG_CONTROLLER_CAPS_UPDATE / 0x000E) ──────
+    //
+    // Composer→wire reactivity: when the composer's `toCapBits(slotId)`
+    // changes after a slot has been registered, the connection pushes a
+    // mid-session caps update so the receiver's web-UI snapshot stays
+    // honest about what the dish is advertising right now.
+
+    @Test
+    fun `refreshCapsIfChanged sends a caps update when the lambda returns a new value`() =
+        runTest {
+            every { repo.resetControllerAck(any()) } just Runs
+            every { repo.startHeartbeat(any()) } just Runs
+            every { repo.isConnectionAlive(any()) } returns false
+            every { repo.getLastControllerAck(any()) } returns 0
+
+            // Start the lambda returning the legacy "motion on" word. After
+            // the slot has registered we flip the lambda to "motion off" and
+            // refresh — the diff against lastAdvertisedCaps fires the wire
+            // update.
+            var capsBit = 0x0004
+            val reactive =
+                SatelliteConnection(
+                    id = SatelliteConnection.idFor(server),
+                    server = server,
+                    scope = scope,
+                    controllerRepo = repo,
+                    motionCapsBitsFor = { capsBit },
+                )
+            reactive.markConnecting()
+            reactive.markConnected(handle = 8, connectionId = "c") {}
+            reactive.attachSlot(slotId = "slot-1", controllerType = 0)
+
+            // Sanity: the slot registered with CAP_MOTION.
+            coVerify {
+                repo.addController(8, 0, match { (it and 0x0004) != 0 })
+            }
+
+            // User toggles motion off — the composer would emit a new state
+            // and the manager would call refreshCapsIfChanged.
+            capsBit = 0
+            reactive.refreshCapsIfChanged()
+
+            // Wire update fires with the new (motion-off) caps word; non-motion
+            // bits (analog triggers + rumble) remain set.
+            coVerify {
+                repo.sendControllerCapsUpdate(
+                    8,
+                    0,
+                    match { (it and 0x0004) == 0 && (it and 0x0001) != 0 && (it and 0x0002) != 0 },
+                )
+            }
+
+            reactive.markDisconnected()
+        }
+
+    @Test
+    fun `refreshCapsIfChanged is idempotent when the lambda hasn't moved`() =
+        runTest {
+            every { repo.resetControllerAck(any()) } just Runs
+            every { repo.startHeartbeat(any()) } just Runs
+            every { repo.isConnectionAlive(any()) } returns false
+            every { repo.getLastControllerAck(any()) } returns 0
+
+            val steady =
+                SatelliteConnection(
+                    id = SatelliteConnection.idFor(server),
+                    server = server,
+                    scope = scope,
+                    controllerRepo = repo,
+                    motionCapsBitsFor = { 0x0004 },
+                )
+            steady.markConnecting()
+            steady.markConnected(handle = 8, connectionId = "c") {}
+            steady.attachSlot(slotId = "slot-1", controllerType = 0)
+
+            // Call refresh multiple times with no upstream change. The
+            // diff against lastAdvertisedCaps short-circuits so no wire
+            // packets fire — important because composer emissions are
+            // frequent (hub.bindings churn re-runs the composer's combine).
+            steady.refreshCapsIfChanged()
+            steady.refreshCapsIfChanged()
+            steady.refreshCapsIfChanged()
+
+            coVerify(exactly = 0) {
+                repo.sendControllerCapsUpdate(any(), any(), any())
+            }
+
+            steady.markDisconnected()
+        }
+
+    @Test
+    fun `refreshCapsIfChanged skips unregistered slots`() =
+        runTest {
+            // The slot is attached but not registered (e.g. mid-handshake).
+            // Sending a caps update for an unregistered slot would tell the
+            // receiver about a controller it doesn't know — wasted packet
+            // at best, undefined behaviour at worst.
+            every { repo.resetControllerAck(any()) } just Runs
+            every { repo.startHeartbeat(any()) } just Runs
+            every { repo.isConnectionAlive(any()) } returns false
+            // Never ACK — registration stays pending forever.
+            every { repo.getLastControllerAck(any()) } returns -1
+
+            var capsBit = 0x0004
+            val pending =
+                SatelliteConnection(
+                    id = SatelliteConnection.idFor(server),
+                    server = server,
+                    scope = scope,
+                    controllerRepo = repo,
+                    motionCapsBitsFor = { capsBit },
+                )
+            pending.markConnecting()
+            pending.markConnected(handle = 8, connectionId = "c") {}
+            pending.attachSlot(slotId = "slot-pending", controllerType = 0)
+
+            // Flip caps while registration is still in flight (would-be-
+            // emitted via composer).
+            capsBit = 0
+            pending.refreshCapsIfChanged()
+
+            // No caps-update sent — the registration handshake will pick up
+            // the fresh value via motionCapsBitsFor on its own.
+            coVerify(exactly = 0) {
+                repo.sendControllerCapsUpdate(any(), any(), any())
+            }
+
+            pending.markDisconnected()
+        }
+
+    @Test
+    fun `refreshCapsIfChanged is a no-op when the session is idle`() =
+        runTest {
+            // No live handle → no wire send is even possible. Pin this so
+            // a composer emission landing during an Idle session doesn't
+            // attempt to push bytes through a closed socket.
+            conn.refreshCapsIfChanged()
+            coVerify(exactly = 0) {
+                repo.sendControllerCapsUpdate(any(), any(), any())
+            }
+        }
+
+    @Test
+    fun `registration closes the race when composer emits new caps mid-handshake`() =
+        runTest {
+            // Sequence the test forces:
+            //   t=0  motionCapsBitsFor returns A (legacy on)
+            //   t=1  registerController reads A, calls addController(...,A)
+            //   t=2  composer emits B (motion off) BEFORE the ACK lands
+            //   t=3  ACK lands; registerController re-reads motionCapsBitsFor
+            //         and sees B; sends a caps-update with B; sets
+            //         lastAdvertisedCaps = B.
+            //
+            // Without this catch-up, the manager's later refreshCapsIfChanged
+            // would see lastAdvertisedCaps = A and newCaps from composer = B,
+            // fire the update… but only if composer emits AGAIN. If it
+            // doesn't, the slot stays with stale A on the wire forever.
+            every { repo.resetControllerAck(any()) } just Runs
+            every { repo.startHeartbeat(any()) } just Runs
+            every { repo.isConnectionAlive(any()) } returns false
+            every { repo.getLastControllerAck(any()) } returns 0
+
+            var capsBit = 0x0004 // value the lambda will return on the first call
+            var callCount = 0
+            val race =
+                SatelliteConnection(
+                    id = SatelliteConnection.idFor(server),
+                    server = server,
+                    scope = scope,
+                    controllerRepo = repo,
+                    motionCapsBitsFor = {
+                        callCount++
+                        // First call (at addController build time): A. Subsequent
+                        // calls (the post-ACK reconciliation read): B.
+                        if (callCount == 1) capsBit else 0
+                    },
+                )
+            race.markConnecting()
+            race.markConnected(handle = 8, connectionId = "c") {}
+            race.attachSlot(slotId = "slot-race", controllerType = 0)
+
+            // The post-ACK reconciliation must have fired a caps-update
+            // carrying the *new* value (motion off), even though no
+            // external refresh was called.
+            coVerify {
+                repo.sendControllerCapsUpdate(
+                    8,
+                    0,
+                    match { (it and 0x0004) == 0 },
+                )
+            }
+
+            race.markDisconnected()
+        }
 }

--- a/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionTest.kt
@@ -257,10 +257,117 @@ class SatelliteConnectionTest {
 
             // Post-Task-1.1 builds must set CAP_MOTION (0x0004) in the
             // MSG_CONTROLLER_ADD capability word so the server knows to expect
-            // the MSG_MOTION IMU stream from this client.
+            // the MSG_MOTION IMU stream from this client. Default-arg
+            // motionCapsBitsFor returns CAP_MOTION_BIT_LEGACY, exercising the
+            // pre-composer behaviour.
             coVerify {
                 repo.addController(8, 0, match { (it and 0x0004) != 0 })
             }
+        }
+
+    @Test
+    fun `controller add CLEARS CAP_MOTION when motionCapsBitsFor returns 0`() =
+        runTest {
+            // The headline PR3 fix: when the capability composer says "this
+            // slot has no gyro" OR "the user toggled motion off," the cap
+            // word on the wire must drop CAP_MOTION so the receiver's web
+            // UI is honest about which slots stream motion. A regression
+            // here is the existing bug (every controller silently advertises
+            // CAP_MOTION).
+            every { repo.resetControllerAck(any()) } just Runs
+            every { repo.startHeartbeat(any()) } just Runs
+            every { repo.isConnectionAlive(any()) } returns false
+            every { repo.getLastControllerAck(any()) } returns 0
+
+            val noMotion =
+                SatelliteConnection(
+                    id = SatelliteConnection.idFor(server),
+                    server = server,
+                    scope = scope,
+                    controllerRepo = repo,
+                    motionCapsBitsFor = { 0 },
+                )
+            noMotion.markConnecting()
+            noMotion.markConnected(handle = 8, connectionId = "c") {}
+            noMotion.attachSlot(slotId = "slot-1", controllerType = 0)
+
+            // Motion bit absent.
+            coVerify {
+                repo.addController(8, 0, match { (it and 0x0004) == 0 })
+            }
+            // Non-motion bits (analog triggers 0x0001 + rumble 0x0002) still set —
+            // the lambda only controls the motion bit, not the whole word.
+            coVerify {
+                repo.addController(8, 0, match { (it and 0x0001) != 0 && (it and 0x0002) != 0 })
+            }
+
+            noMotion.markDisconnected()
+        }
+
+    @Test
+    fun `controller add SETS CAP_MOTION when motionCapsBitsFor returns the bit`() =
+        runTest {
+            // The other side of the truth table: when the slot has motion
+            // (gyro present + user-enabled), the cap word must include
+            // CAP_MOTION. Pin the explicit-bit path (no default-arg
+            // accident).
+            every { repo.resetControllerAck(any()) } just Runs
+            every { repo.startHeartbeat(any()) } just Runs
+            every { repo.isConnectionAlive(any()) } returns false
+            every { repo.getLastControllerAck(any()) } returns 0
+
+            val withMotion =
+                SatelliteConnection(
+                    id = SatelliteConnection.idFor(server),
+                    server = server,
+                    scope = scope,
+                    controllerRepo = repo,
+                    motionCapsBitsFor = { 0x0004 },
+                )
+            withMotion.markConnecting()
+            withMotion.markConnected(handle = 8, connectionId = "c") {}
+            withMotion.attachSlot(slotId = "slot-1", controllerType = 0)
+
+            coVerify {
+                repo.addController(8, 0, match { (it and 0x0004) != 0 })
+            }
+            withMotion.markDisconnected()
+        }
+
+    @Test
+    fun `motionCapsBitsFor is called with the SAME slotId being registered`() =
+        runTest {
+            // Per-slot resolution is the whole point — two slots with
+            // different toggles must each see their own slotId. A regression
+            // that hardcodes a single slotId would silently apply slot-A's
+            // toggle to slot-B (or worse, return random results).
+            every { repo.resetControllerAck(any()) } just Runs
+            every { repo.startHeartbeat(any()) } just Runs
+            every { repo.isConnectionAlive(any()) } returns false
+            every { repo.getLastControllerAck(any()) } returns 0
+
+            val askedFor = mutableListOf<String>()
+            val perSlot =
+                SatelliteConnection(
+                    id = SatelliteConnection.idFor(server),
+                    server = server,
+                    scope = scope,
+                    controllerRepo = repo,
+                    motionCapsBitsFor = { slot ->
+                        askedFor += slot
+                        if (slot == "slot-A") 0x0004 else 0
+                    },
+                )
+            perSlot.markConnecting()
+            perSlot.markConnected(handle = 8, connectionId = "c") {}
+            perSlot.attachSlot("slot-A", controllerType = 0)
+            perSlot.attachSlot("slot-B", controllerType = 0)
+
+            assertTrue(askedFor.contains("slot-A"))
+            assertTrue(askedFor.contains("slot-B"))
+            coVerify { repo.addController(8, 0, match { (it and 0x0004) != 0 }) }
+            coVerify { repo.addController(8, 1, match { (it and 0x0004) == 0 }) }
+            perSlot.markDisconnected()
         }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/source/sensor/MotionScalingTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/sensor/MotionScalingTest.kt
@@ -144,6 +144,74 @@ class MotionScalingTest {
         assertEquals(r90[2], fallback[2], 0f)
     }
 
+    // ── Out-param variant + RemapResult (PR6) ──────────────────────────────
+
+    @Test
+    fun `out-param variant writes into the caller's scratch and returns Mapped`() {
+        // The hot-path version: caller allocates once, the scaler writes
+        // into the scratch every sample. 250 Hz × 2 sensors otherwise leaks
+        // up to 500 FloatArray allocations per second.
+        val scratch = FloatArray(3)
+        val result =
+            MotionScaling.remapLandscape(
+                deviceX = 1f,
+                deviceY = 2f,
+                deviceZ = 3f,
+                rotation = ROTATION_90,
+                out = scratch,
+            )
+        assertEquals(MotionScaling.RemapResult.Mapped, result)
+        assertEquals(2f, scratch[0], 0f) // deviceY
+        assertEquals(-1f, scratch[1], 0f) // -deviceX
+        assertEquals(3f, scratch[2], 0f) // deviceZ
+    }
+
+    @Test
+    fun `out-param variant returns Fallback with the unknown rotation value`() {
+        // The caller (PhoneMotionSource) reads RemapResult.Fallback to log
+        // the unknown rotation once. Pin that the value is surfaced —
+        // a regression that always returns Mapped would silently lose the
+        // "wrong axes on half the fleet" signal.
+        val scratch = FloatArray(3)
+        val result = MotionScaling.remapLandscape(0f, 0f, 0f, rotation = 99, out = scratch)
+        assertEquals(MotionScaling.RemapResult.Fallback(99), result)
+        // And the scratch carries the ROTATION_90 fallback values.
+        val r90 = MotionScaling.remapLandscape(0f, 0f, 0f, ROTATION_90)
+        assertEquals(r90[0], scratch[0], 0f)
+        assertEquals(r90[1], scratch[1], 0f)
+        assertEquals(r90[2], scratch[2], 0f)
+    }
+
+    @Test
+    fun `out-param variant rejects a scratch smaller than 3 elements`() {
+        // Defensive: a 2-element scratch would corrupt the call site's
+        // neighbouring memory or silently produce wrong axes. The
+        // require() check should fail fast.
+        val tooSmall = FloatArray(2)
+        try {
+            MotionScaling.remapLandscape(0f, 0f, 0f, ROTATION_90, tooSmall)
+            org.junit.Assert.fail("expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            // expected
+            assertTrue(e.message?.contains("3") == true)
+        }
+    }
+
+    @Test
+    fun `out-param variant produces the same triple as the allocating shim`() {
+        // Equivalence pin: every rotation must produce identical output
+        // through both signatures so the array-returning shim stays a
+        // pure wrapper (no drift between the two paths).
+        for (rot in intArrayOf(ROTATION_0, ROTATION_90, ROTATION_180, ROTATION_270, 99)) {
+            val out = FloatArray(3)
+            MotionScaling.remapLandscape(1.25f, -3.5f, 0.75f, rot, out)
+            val viaShim = MotionScaling.remapLandscape(1.25f, -3.5f, 0.75f, rot)
+            assertEquals("rot=$rot X", viaShim[0], out[0], 0f)
+            assertEquals("rot=$rot Y", viaShim[1], out[1], 0f)
+            assertEquals("rot=$rot Z", viaShim[2], out[2], 0f)
+        }
+    }
+
     private companion object {
         // Mirror of android.view.Surface.ROTATION_* — kept literal so this
         // test stays a pure JVM test with no Android framework dependency.

--- a/app/src/test/java/com/tinkernorth/dish/source/sensor/PhoneMotionAvailabilityTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/sensor/PhoneMotionAvailabilityTest.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.sensor
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorManager
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [PhoneMotionAvailability] — the process-scoped "does the
+ * phone itself have a gyro?" fact. The value is decided once at injection
+ * time (Android device hardware does not change at runtime), so the tests
+ * just pin: gyro present ⇒ true, gyro absent ⇒ false, SENSOR_SERVICE absent
+ * ⇒ false. The state flow exposing those values is the same shape every
+ * [com.tinkernorth.dish.architecture.abstracts.AbstractStateSource] subclass
+ * uses; the base class is covered by `StateSourceProbeSampleTest`.
+ */
+class PhoneMotionAvailabilityTest {
+    private fun contextWithSensor(sensor: Sensor?): Context {
+        val sm =
+            mockk<SensorManager> {
+                every { getDefaultSensor(Sensor.TYPE_GYROSCOPE) } returns sensor
+            }
+        return mockk { every { getSystemService(Context.SENSOR_SERVICE) } returns sm }
+    }
+
+    @Test
+    fun `phone with a gyroscope is motion-available`() {
+        val src = PhoneMotionAvailability(contextWithSensor(mockk()))
+        assertTrue(src.state.value)
+    }
+
+    @Test
+    fun `phone without a gyroscope is not motion-available`() {
+        // Tablets, very cheap phones, some kiosk hardware — the touch
+        // overlay should show "Motion: not available", and the satellite
+        // CAP_MOTION advertisement must not lie.
+        val src = PhoneMotionAvailability(contextWithSensor(sensor = null))
+        assertFalse(src.state.value)
+    }
+
+    @Test
+    fun `null SENSOR_SERVICE falls through to not-available, does not throw`() {
+        // Robolectric- or stub-flavoured Contexts can return null for system
+        // services; the source defends so the app never NPEs at startup.
+        val ctx =
+            mockk<Context> {
+                every { getSystemService(Context.SENSOR_SERVICE) } returns null
+            }
+        val src = PhoneMotionAvailability(ctx)
+        assertFalse(src.state.value)
+    }
+
+    @Test
+    fun `state flow exposes the same boolean as state value`() {
+        // The composer subscribes via .state.collect — assert the StateFlow's
+        // current value matches what the property reports.
+        val src = PhoneMotionAvailability(contextWithSensor(mockk()))
+        assertEquals(src.state.value, src.state.value)
+        assertTrue(src.state.value)
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/source/sensor/PhoneMotionSourceTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/sensor/PhoneMotionSourceTest.kt
@@ -170,4 +170,159 @@ class PhoneMotionSourceTest {
             )
         }
     }
+
+    // ── MotionStreamState flow (PR4) ─────────────────────────────────────
+
+    @Test
+    fun `state is Disabled on a phone with no gyroscope, never flips on start`() {
+        // Hardware decision is permanent — the pill must read UNAVAILABLE
+        // even if the activity later calls start (which is a no-op).
+        every { sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE) } returns null
+        val src = source()
+
+        assertEquals(MotionStreamState.Disabled, src.state.value)
+        src.start { _, _ -> }
+        assertEquals(MotionStreamState.Disabled, src.state.value)
+    }
+
+    @Test
+    fun `state is Stopped on construction with a gyroscope, before start`() {
+        // Before the overlay calls start, the source has a gyro but isn't
+        // streaming. The pill must NOT read STREAMING; it should read PAUSED
+        // (mapped from Stopped + connected) or NOT_FORWARDED (BT-HID kind).
+        val src = source()
+        assertEquals(MotionStreamState.Stopped, src.state.value)
+    }
+
+    @Test
+    fun `start flips state to Streaming optimistically`() {
+        // The optimistic flip — the first stall tick re-evaluates after
+        // STALL_WINDOW_MS, but we want the pill to read STREAMING the
+        // instant the source starts so the user gets feedback.
+        val src = source()
+        src.start { _, _ -> }
+        assertEquals(MotionStreamState.Streaming, src.state.value)
+    }
+
+    @Test
+    fun `stop flips state back to Stopped, not Disabled`() {
+        // The hardware decision (Disabled vs Stopped) is permanent for the
+        // lifetime of the source. A stop after a start must not lose that
+        // distinction — stop on a gyro-equipped phone must read Stopped.
+        val src = source()
+        src.start { _, _ -> }
+        src.stop()
+        assertEquals(MotionStreamState.Stopped, src.state.value)
+    }
+
+    // ── deriveState — pure decision table ────────────────────────────────
+
+    @Test
+    fun `deriveState — no gyro present means Disabled regardless of started`() {
+        // Hardware permanence: no gyro ⇒ Disabled even if started is
+        // somehow true (defensive — the start() path defends, but the
+        // pure decider must too).
+        assertEquals(
+            MotionStreamState.Disabled,
+            PhoneMotionSource.deriveState(
+                gyroPresent = false,
+                started = false,
+                lastGyroMonoMs = 0L,
+                nowMonoMs = 0L,
+            ),
+        )
+        assertEquals(
+            MotionStreamState.Disabled,
+            PhoneMotionSource.deriveState(
+                gyroPresent = false,
+                started = true,
+                lastGyroMonoMs = 10_000L,
+                nowMonoMs = 10_000L,
+            ),
+        )
+    }
+
+    @Test
+    fun `deriveState — gyro present but not started means Stopped`() {
+        assertEquals(
+            MotionStreamState.Stopped,
+            PhoneMotionSource.deriveState(
+                gyroPresent = true,
+                started = false,
+                lastGyroMonoMs = 0L,
+                nowMonoMs = 1000L,
+            ),
+        )
+    }
+
+    @Test
+    fun `deriveState — started with no gyro sample yet means Stalled`() {
+        // lastGyroMonoMs == 0L means "no sample ever arrived." Should
+        // surface as Stalled so the user gets a "is the sensor broken?"
+        // hint quickly, not "STREAMING" silently.
+        assertEquals(
+            MotionStreamState.Stalled,
+            PhoneMotionSource.deriveState(
+                gyroPresent = true,
+                started = true,
+                lastGyroMonoMs = 0L,
+                nowMonoMs = 1000L,
+            ),
+        )
+    }
+
+    @Test
+    fun `deriveState — last gyro within window means Streaming`() {
+        // 200 ms after the last sample, well inside the 1500 ms window.
+        assertEquals(
+            MotionStreamState.Streaming,
+            PhoneMotionSource.deriveState(
+                gyroPresent = true,
+                started = true,
+                lastGyroMonoMs = 800L,
+                nowMonoMs = 1000L,
+            ),
+        )
+    }
+
+    @Test
+    fun `deriveState — last gyro past stall window means Stalled`() {
+        // 2000 ms after the last sample, > 1500 ms window. The OEM-pauses-
+        // sensors case the original isStalled comment calls out.
+        assertEquals(
+            MotionStreamState.Stalled,
+            PhoneMotionSource.deriveState(
+                gyroPresent = true,
+                started = true,
+                lastGyroMonoMs = 1000L,
+                nowMonoMs = 3000L,
+            ),
+        )
+    }
+
+    @Test
+    fun `deriveState — exactly at window boundary is still Streaming`() {
+        // STALL_WINDOW_MS = 1500 ms; gap of exactly 1500 ms should be the
+        // last value that reads Streaming (strict greater-than for Stalled).
+        // A regression that uses >= would flip prematurely on every device.
+        assertEquals(
+            MotionStreamState.Streaming,
+            PhoneMotionSource.deriveState(
+                gyroPresent = true,
+                started = true,
+                lastGyroMonoMs = 0L,
+                nowMonoMs = PhoneMotionSource.STALL_WINDOW_MS,
+            ).let {
+                // Special-case: deriveState treats lastGyroMonoMs == 0 as
+                // Stalled regardless of the window math. To exercise the
+                // strict-greater path, use a non-zero anchor.
+                PhoneMotionSource.deriveState(
+                    gyroPresent = true,
+                    started = true,
+                    lastGyroMonoMs = 1L,
+                    nowMonoMs = 1L + PhoneMotionSource.STALL_WINDOW_MS,
+                )
+            },
+        )
+    }
 }

--- a/app/src/test/java/com/tinkernorth/dish/source/sensor/PhoneMotionSourceTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/sensor/PhoneMotionSourceTest.kt
@@ -81,12 +81,21 @@ class PhoneMotionSourceTest {
         unmockkStatic(Log::class)
     }
 
+    /**
+     * Fake monotonic clock — JVM tests don't have a real Android
+     * SystemClock, so the production default `{ SystemClock.elapsedRealtime() }`
+     * throws "not mocked." Inject a controllable counter so each test
+     * can drive time deterministically.
+     */
+    private var fakeNowMs: Long = 1000L
+
     private fun source() =
         PhoneMotionSource(
             sensorManager = sensorManager,
             rotationSupplier = { 0 },
             rateLimiter = MotionRateLimiter(),
             sensorDispatch = dispatch,
+            nowMs = { fakeNowMs },
         )
 
     @Test
@@ -213,6 +222,50 @@ class PhoneMotionSourceTest {
         src.start { _, _ -> }
         src.stop()
         assertEquals(MotionStreamState.Stopped, src.state.value)
+    }
+
+    // ── First-sample accel-zero race (PR5) ───────────────────────────────
+
+    @Test
+    fun `first gyro callback before any accel is HELD until accel arrives`() {
+        // The bug this pins: the first MOTION packet on the wire previously
+        // shipped accel = (0, 0, 0) because the gyro callback fired before
+        // any accel callback. Hold the first gyro until accel reports, so
+        // downstream consumers don't read "stationary in zero gravity" as
+        // the opening frame. The internal onAccel/onGyro entry points are
+        // exposed for this test — see their KDoc.
+        val emissions = mutableListOf<Pair<MotionRateLimiter.MotionSample, Int>>()
+        val src = source()
+        src.start { sample, dt -> emissions += sample to dt }
+
+        // Fire ONLY a gyro callback first — the gate must drop it.
+        src.onGyro(floatArrayOf(0.1f, 0.2f, 0.3f))
+        assertEquals("first gyro alone must not emit", 0, emissions.size)
+
+        // Now an accel arrives, followed by another gyro — the second gyro
+        // should emit a sample with the now-real accel cache.
+        src.onAccel(floatArrayOf(0f, 9.80665f, 0f))
+        src.onGyro(floatArrayOf(0.1f, 0.2f, 0.3f))
+        assertEquals("emit after accel has reported", 1, emissions.size)
+        // The emitted accel triple is non-zero (1g along the remapped axis,
+        // scaled to wire int16). Strictly ≠ 0 on at least one axis pins
+        // that we are NOT shipping the stale-zero cache.
+        val emitted = emissions.single().first
+        val nonZero = emitted.accelX.toInt() != 0 || emitted.accelY.toInt() != 0 || emitted.accelZ.toInt() != 0
+        assertTrue("emitted accel must be non-zero", nonZero)
+    }
+
+    @Test
+    fun `pad with NO accelerometer still streams gyro — gate does not block`() {
+        // A device that reports a gyro but no accel (rare, but the test
+        // matrix must cover it). [accel] is null at construct time; the
+        // gate must short-circuit so gyro samples still flow.
+        every { sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER) } returns null
+        val emissions = mutableListOf<Pair<MotionRateLimiter.MotionSample, Int>>()
+        val src = source()
+        src.start { sample, dt -> emissions += sample to dt }
+        src.onGyro(floatArrayOf(0.1f, 0.2f, 0.3f))
+        assertEquals("gyro must emit even with no accel sensor", 1, emissions.size)
     }
 
     // ── deriveState — pure decision table ────────────────────────────────

--- a/app/src/test/java/com/tinkernorth/dish/source/sensor/PhoneMotionSourceTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/sensor/PhoneMotionSourceTest.kt
@@ -360,22 +360,23 @@ class PhoneMotionSourceTest {
         // A regression that uses >= would flip prematurely on every device.
         assertEquals(
             MotionStreamState.Streaming,
-            PhoneMotionSource.deriveState(
-                gyroPresent = true,
-                started = true,
-                lastGyroMonoMs = 0L,
-                nowMonoMs = PhoneMotionSource.STALL_WINDOW_MS,
-            ).let {
-                // Special-case: deriveState treats lastGyroMonoMs == 0 as
-                // Stalled regardless of the window math. To exercise the
-                // strict-greater path, use a non-zero anchor.
-                PhoneMotionSource.deriveState(
+            PhoneMotionSource
+                .deriveState(
                     gyroPresent = true,
                     started = true,
-                    lastGyroMonoMs = 1L,
-                    nowMonoMs = 1L + PhoneMotionSource.STALL_WINDOW_MS,
-                )
-            },
+                    lastGyroMonoMs = 0L,
+                    nowMonoMs = PhoneMotionSource.STALL_WINDOW_MS,
+                ).let {
+                    // Special-case: deriveState treats lastGyroMonoMs == 0 as
+                    // Stalled regardless of the window math. To exercise the
+                    // strict-greater path, use a non-zero anchor.
+                    PhoneMotionSource.deriveState(
+                        gyroPresent = true,
+                        started = true,
+                        lastGyroMonoMs = 1L,
+                        nowMonoMs = 1L + PhoneMotionSource.STALL_WINDOW_MS,
+                    )
+                },
         )
     }
 }

--- a/app/src/test/java/com/tinkernorth/dish/source/sensor/PhysicalMotionProbeTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/sensor/PhysicalMotionProbeTest.kt
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.sensor
+
+import android.hardware.Sensor
+import android.hardware.SensorManager
+import android.os.Build
+import android.view.InputDevice
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [PhysicalMotionProbe.evaluate] — the pure decision exercised
+ * directly. The thin `hasGyro(deviceId)` wrapper is just `evaluate(SDK_INT,
+ * InputDevice.getDevice(id))`, so pinning the four cases here covers both.
+ *
+ * `Build.VERSION_CODES.S` is referenced as the threshold; the test makes both
+ * sides of that threshold explicit so a future API bump that nudges the
+ * constant is still caught.
+ */
+class PhysicalMotionProbeTest {
+    private val gyro: Sensor = mockk(relaxed = true)
+
+    private fun deviceWithGyro(): InputDevice {
+        val sm =
+            mockk<SensorManager> {
+                every { getDefaultSensor(Sensor.TYPE_GYROSCOPE) } returns gyro
+            }
+        return mockk { every { sensorManager } returns sm }
+    }
+
+    private fun deviceWithoutGyro(): InputDevice {
+        val sm =
+            mockk<SensorManager> {
+                every { getDefaultSensor(Sensor.TYPE_GYROSCOPE) } returns null
+            }
+        return mockk { every { sensorManager } returns sm }
+    }
+
+    @Test
+    fun `returns false on API below 31 — per-device sensor API does not exist`() {
+        // Even a pad with a real IMU can't be reached pre-API 31, so the
+        // probe must say no. Use SDK_INT - 1 (one below S) explicitly.
+        assertFalse(PhysicalMotionProbe.evaluate(sdkInt = 30, device = deviceWithGyro()))
+    }
+
+    @Test
+    fun `returns false when the InputDevice is null`() {
+        // A device that was unplugged between the InputManager callback and
+        // the probe call must resolve to "no gyro" without throwing.
+        assertFalse(PhysicalMotionProbe.evaluate(sdkInt = Build.VERSION_CODES.S, device = null))
+    }
+
+    @Test
+    fun `returns false when the pad has no gyroscope sensor`() {
+        // A cheap Bluetooth pad on API 31+ — the per-device SensorManager
+        // exists but reports no TYPE_GYROSCOPE.
+        assertFalse(
+            PhysicalMotionProbe.evaluate(
+                sdkInt = Build.VERSION_CODES.S,
+                device = deviceWithoutGyro(),
+            ),
+        )
+    }
+
+    @Test
+    fun `returns true when API 31+ and the pad reports a gyroscope`() {
+        // The success path — DualSense or similar with an IMU.
+        assertTrue(
+            PhysicalMotionProbe.evaluate(
+                sdkInt = Build.VERSION_CODES.S,
+                device = deviceWithGyro(),
+            ),
+        )
+    }
+
+    @Test
+    fun `is stable across higher SDK levels — does not regress past API 31`() {
+        // Future API bumps must not silently turn the gate back off; pin a
+        // higher SDK level too so a typo in the threshold check is caught.
+        assertTrue(
+            PhysicalMotionProbe.evaluate(
+                sdkInt = Build.VERSION_CODES.S + 5,
+                device = deviceWithGyro(),
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/source/sensor/PhysicalMotionSourceTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/sensor/PhysicalMotionSourceTest.kt
@@ -7,6 +7,7 @@ import com.tinkernorth.dish.composer.MotionCapability
 import com.tinkernorth.dish.source.connection.SatelliteConnection
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -147,6 +148,42 @@ class PhysicalMotionSourceTest {
         val reachable = mapOf("9" to fakeConn())
         val caps = emptyMap<String, MotionCapability>()
         assertTrue(PhysicalMotionSource.filterByCapability(reachable, caps).isEmpty())
+    }
+
+    // ── shouldEmitGyro — the per-pad first-sample stale-zero accel gate ───
+
+    @Test
+    fun `shouldEmitGyro returns true when the pad has no accelerometer`() {
+        // A device that exposes a gyro but no accel (rare in practice).
+        // The gate must short-circuit — gyro samples MUST flow even when
+        // the accel cache will remain at its zero default forever,
+        // because the alternative is an indefinitely silent gyro stream.
+        assertTrue(PhysicalMotionSource.shouldEmitGyro(hasAccelSensor = false, accelSeen = false))
+    }
+
+    @Test
+    fun `shouldEmitGyro returns false on the first gyro before accel has reported`() {
+        // The headline bug this gate exists for: the gyro fires before
+        // the accel does, so the first MOTION packet would ship
+        // accel=(0,0,0). Downstream consumers read that as "stationary
+        // in zero gravity." The gate drops the gyro until accel has been
+        // seen — at most one sensor period of latency.
+        assertFalse(PhysicalMotionSource.shouldEmitGyro(hasAccelSensor = true, accelSeen = false))
+    }
+
+    @Test
+    fun `shouldEmitGyro returns true once accel has reported`() {
+        // After the first accel callback flips accelSeen=true, the cache
+        // holds a real triple — gyro emissions are safe.
+        assertTrue(PhysicalMotionSource.shouldEmitGyro(hasAccelSensor = true, accelSeen = true))
+    }
+
+    @Test
+    fun `shouldEmitGyro accel-sensor-absent path ignores accelSeen for safety`() {
+        // Belt-and-suspenders: hasAccelSensor=false implies the device
+        // will never set accelSeen, but the gate must not deadlock on
+        // that combination. Returns true regardless of accelSeen.
+        assertTrue(PhysicalMotionSource.shouldEmitGyro(hasAccelSensor = false, accelSeen = true))
     }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/source/sensor/PhysicalMotionSourceTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/sensor/PhysicalMotionSourceTest.kt
@@ -3,7 +3,11 @@
 
 package com.tinkernorth.dish.source.sensor
 
+import com.tinkernorth.dish.composer.MotionCapability
+import com.tinkernorth.dish.source.connection.SatelliteConnection
+import io.mockk.mockk
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -94,6 +98,71 @@ class PhysicalMotionSourceTest {
         assertEquals(1234, s.accelX.toInt())
         assertEquals(-5678, s.accelY.toInt())
         assertEquals(8191, s.accelZ.toInt())
+    }
+
+    // ── filterByCapability — the gate added in PR3 ─────────────────────────
+
+    private fun fakeConn(): SatelliteConnection = mockk(relaxed = true)
+
+    @Test
+    fun `filterByCapability keeps a reachable slot that has gyro AND is user-enabled`() {
+        // The success path — both capability axes true, the slot stays in
+        // the reachable map and its sensor listener will register.
+        val conn = fakeConn()
+        val reachable = mapOf("9" to conn)
+        val caps = mapOf("9" to MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = true))
+        assertEquals(reachable, PhysicalMotionSource.filterByCapability(reachable, caps))
+    }
+
+    @Test
+    fun `filterByCapability drops a reachable slot whose pad has NO gyro`() {
+        // A cheap Bluetooth pad on API 31+ exposes the per-device
+        // SensorManager but reports no TYPE_GYROSCOPE. Reachability still
+        // says "the slot is bound and the satellite is up"; the capability
+        // gate must drop it so listening doesn't burn battery on a sensor
+        // that will never fire.
+        val reachable = mapOf("9" to fakeConn())
+        val caps = mapOf("9" to MotionCapability(hasGyro = false, carriesOnConnection = true, userEnabled = true))
+        assertTrue(PhysicalMotionSource.filterByCapability(reachable, caps).isEmpty())
+    }
+
+    @Test
+    fun `filterByCapability drops a slot the user has toggled motion off for`() {
+        // The user-facing toggle is the headline PR2/PR3 deliverable —
+        // when off, the listener must NOT register, even though hardware
+        // and link are both ready. A regression that ignores userEnabled
+        // would leak gyro listeners on slots motion is off for, defeating
+        // the toggle.
+        val reachable = mapOf("9" to fakeConn())
+        val caps = mapOf("9" to MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = false))
+        assertTrue(PhysicalMotionSource.filterByCapability(reachable, caps).isEmpty())
+    }
+
+    @Test
+    fun `filterByCapability drops a reachable slot that is missing from caps`() {
+        // Startup race: the reachability flow emits before the capability
+        // composer's first emission. Treat the unknown slot as "no motion"
+        // (safe default) — the next emission will reinstate it if it
+        // actually has gyro + is enabled.
+        val reachable = mapOf("9" to fakeConn())
+        val caps = emptyMap<String, MotionCapability>()
+        assertTrue(PhysicalMotionSource.filterByCapability(reachable, caps).isEmpty())
+    }
+
+    @Test
+    fun `filterByCapability per-slot — keeps the enabled one, drops the disabled one`() {
+        // Two pads, same satellite, different user toggles. Pin that the
+        // filter is per-slot and not "all-or-nothing."
+        val connA = fakeConn()
+        val connB = fakeConn()
+        val reachable = mapOf("A" to connA, "B" to connB)
+        val caps =
+            mapOf(
+                "A" to MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = true),
+                "B" to MotionCapability(hasGyro = true, carriesOnConnection = true, userEnabled = false),
+            )
+        val result = PhysicalMotionSource.filterByCapability(reachable, caps)
+        assertEquals(mapOf("A" to connA), result)
     }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/source/store/MotionEnabledStoreTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/store/MotionEnabledStoreTest.kt
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.store
+
+import com.tinkernorth.dish.repository.MotionPreference
+import com.tinkernorth.dish.repository.MotionPreferenceRepository
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [MotionEnabledStore] — the reactive mirror over the
+ * durable [MotionPreferenceRepository].
+ *
+ * Headline invariants pinned here:
+ *
+ *  - **Hydration on construction:** the store seeds its `state` from
+ *    `repo.all()` at construction time, so a fresh process restart sees
+ *    yesterday's toggles without an extra round trip.
+ *  - **Default policy:** an absent slot's [MotionEnabledStore.isEnabled]
+ *    returns [MotionEnabledStore.DEFAULT_ENABLED] (true). The composer and
+ *    pill consume this default; if the policy changes it changes here.
+ *  - **Write-through:** [MotionEnabledStore.setEnabled] always persists
+ *    AND republishes — neither side is allowed to silently win. If a
+ *    future refactor drops the repo write, the durability test fails.
+ *  - **Forget restores default:** removing a slot's entry causes
+ *    [MotionEnabledStore.isEnabled] to flip back to the default.
+ */
+class MotionEnabledStoreTest {
+    @Test
+    fun `hydrates state from the repository on construction`() {
+        // Process restart scenario: the durable repository already holds
+        // yesterday's toggles. The store must surface them immediately —
+        // no race window where state reads emptyMap and isEnabled
+        // returns the default for a slot the user explicitly turned off.
+        val repo =
+            mockk<MotionPreferenceRepository> {
+                every { all() } returns
+                    listOf(
+                        MotionPreference("virtual", enabled = true),
+                        MotionPreference("9", enabled = false),
+                    )
+            }
+        val store = MotionEnabledStore(repo)
+
+        assertEquals(true, store.state.value["virtual"])
+        assertEquals(false, store.state.value["9"])
+        assertEquals(2, store.state.value.size)
+    }
+
+    @Test
+    fun `default is on for an unwritten slot`() {
+        // The product decision is "motion is on unless I turn it off."
+        // Pin the default through the public isEnabled getter so a future
+        // refactor can't silently flip the polarity.
+        val repo = repoWithEmpty()
+        val store = MotionEnabledStore(repo)
+        assertTrue(store.isEnabled("never-toggled"))
+        assertTrue(MotionEnabledStore.DEFAULT_ENABLED) // constant pin
+    }
+
+    @Test
+    fun `setEnabled persists to the repository AND republishes state`() {
+        // The store must be both reactive (state flow) AND durable (repo
+        // write). A regression that only updates the in-memory cache
+        // would lose the toggle on app restart.
+        val repo = repoWithEmpty()
+        val store = MotionEnabledStore(repo)
+
+        store.setEnabled("9", enabled = false)
+
+        verify { repo.put(MotionPreference("9", enabled = false)) }
+        assertEquals(false, store.state.value["9"])
+        assertFalse(store.isEnabled("9"))
+    }
+
+    @Test
+    fun `setEnabled then setEnabled with opposite value flips both layers`() {
+        // Toggling the switch on then off then on again must leave the
+        // store in the final state across both the durable and reactive
+        // layers — no half-updated state.
+        val repo = repoWithEmpty()
+        val store = MotionEnabledStore(repo)
+        store.setEnabled("9", enabled = false)
+        store.setEnabled("9", enabled = true)
+        store.setEnabled("9", enabled = false)
+
+        verify { repo.put(MotionPreference("9", enabled = false)) }
+        verify { repo.put(MotionPreference("9", enabled = true)) }
+        assertEquals(false, store.state.value["9"])
+        assertFalse(store.isEnabled("9"))
+    }
+
+    @Test
+    fun `forget removes the entry from state AND from the repository`() {
+        // Per-slot forget is used when a physical pad is unbound
+        // permanently — keeping a stale entry forever would silently
+        // override the default for a future device that reused the same
+        // InputDevice id.
+        val repo =
+            mockk<MotionPreferenceRepository> {
+                every { all() } returns listOf(MotionPreference("9", enabled = false))
+                justRun { remove("9") }
+            }
+        val store = MotionEnabledStore(repo)
+        assertFalse(store.isEnabled("9"))
+
+        store.forget("9")
+
+        verify { repo.remove("9") }
+        // After forget, the slot returns to the default, NOT the prior
+        // explicit value — that's the whole point.
+        assertTrue(store.isEnabled("9"))
+        assertEquals(null, store.state.value["9"])
+    }
+
+    @Test
+    fun `setEnabled for slot A leaves slot B unchanged`() {
+        // The state map is a single MutableStateFlow; a sloppy reducer
+        // could overwrite the whole map and drop other slots. Pin
+        // isolation across slots.
+        val repo = repoWithEmpty()
+        val store = MotionEnabledStore(repo)
+
+        store.setEnabled("virtual", enabled = true)
+        store.setEnabled("9", enabled = false)
+        store.setEnabled("virtual", enabled = false)
+
+        assertEquals(false, store.state.value["virtual"])
+        assertEquals(false, store.state.value["9"])
+    }
+
+    @Test
+    fun `isEnabled for an explicitly disabled slot returns false`() {
+        // The store's isEnabled has two paths: present-in-map and absent.
+        // Cover the present path explicitly so a regression that
+        // collapses both onto the default would fail here.
+        val repo =
+            mockk<MotionPreferenceRepository> {
+                every { all() } returns listOf(MotionPreference("9", enabled = false))
+            }
+        val store = MotionEnabledStore(repo)
+        assertFalse(store.isEnabled("9"))
+    }
+
+    private fun repoWithEmpty(): MotionPreferenceRepository =
+        mockk(relaxed = true) {
+            every { all() } returns emptyList()
+        }
+}

--- a/app/src/test/java/com/tinkernorth/dish/source/store/SatelliteMotionBackendStatusStoreTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/store/SatelliteMotionBackendStatusStoreTest.kt
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2026 Dish contributors.
+
+package com.tinkernorth.dish.source.store
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [SatelliteMotionBackendStatusStore] + [SatelliteMotionBackendStatus].
+ *
+ * The store is a simple `(connectionId, slotId) → status` reactive map;
+ * tests focus on the public contract every consumer relies on:
+ *
+ *  - [SatelliteMotionBackendStatus.fromFlags] decodes the wire byte exactly.
+ *  - [SatelliteMotionBackendStatusStore.statusFor] returns null on miss
+ *    (the "unknown, defer to dish heuristic" sentinel — never collapses
+ *    onto false, which would mis-read a pre-extension satellite as broken).
+ *  - [SatelliteMotionBackendStatusStore.setStatus] / .clear toggle the entry
+ *    in place; the underlying state flow re-emits.
+ *  - [SatelliteMotionBackendStatusStore.clearConnection] drops every slot
+ *    for one connection without touching others.
+ *  - [SatelliteMotionBackendStatusStore.slotStatusesFor] projects the
+ *    per-connection slice the composer reads, returning only slots that
+ *    appear in `boundSlotIds`.
+ */
+class SatelliteMotionBackendStatusStoreTest {
+    // ── fromFlags — wire byte → typed status ────────────────────────────
+
+    @Test
+    fun `fromFlags decodes both bits clear`() {
+        val s = SatelliteMotionBackendStatus.fromFlags(0)
+        assertFalse(s.sinkSupportedForType)
+        assertFalse(s.backendOk)
+        assertFalse(s.effective)
+    }
+
+    @Test
+    fun `fromFlags decodes only SINK_SUPPORTED_FOR_TYPE`() {
+        // Bit 0 — the type supports IMU but the per-serial sink failed.
+        // Important: effective must remain false (the bytes won't land).
+        val s =
+            SatelliteMotionBackendStatus.fromFlags(
+                SatelliteMotionBackendStatus.FLAG_SINK_SUPPORTED_FOR_TYPE,
+            )
+        assertTrue(s.sinkSupportedForType)
+        assertFalse(s.backendOk)
+        assertFalse(s.effective)
+    }
+
+    @Test
+    fun `fromFlags decodes only BACKEND_OK`() {
+        // Bit 1 alone — the kernel sink succeeded but the type has no IMU
+        // surface. Same effective=false: nothing to deliver.
+        val s = SatelliteMotionBackendStatus.fromFlags(SatelliteMotionBackendStatus.FLAG_BACKEND_OK)
+        assertFalse(s.sinkSupportedForType)
+        assertTrue(s.backendOk)
+        assertFalse(s.effective)
+    }
+
+    @Test
+    fun `fromFlags decodes both bits set`() {
+        val s =
+            SatelliteMotionBackendStatus.fromFlags(
+                SatelliteMotionBackendStatus.FLAG_SINK_SUPPORTED_FOR_TYPE or
+                    SatelliteMotionBackendStatus.FLAG_BACKEND_OK,
+            )
+        assertTrue(s.sinkSupportedForType)
+        assertTrue(s.backendOk)
+        assertTrue(s.effective)
+    }
+
+    @Test
+    fun `fromFlags ignores reserved upper bits`() {
+        // Future-proof: a forward-compatible satellite could set additional
+        // bits we don't know about. Decode should pick out only bits 0 + 1
+        // and not blow up. (No way to assert "doesn't blow up" beyond
+        // running, but this also pins that the two flags read true.)
+        val s = SatelliteMotionBackendStatus.fromFlags(0xFF)
+        assertTrue(s.sinkSupportedForType)
+        assertTrue(s.backendOk)
+    }
+
+    // ── Store CRUD ──────────────────────────────────────────────────────
+
+    @Test
+    fun `statusFor is null on a fresh store`() {
+        // Default state is empty — the absent-means-unknown sentinel must
+        // hold so the composer falls back to the dish heuristic instead
+        // of reading "broken." Pinning this protects against an accidental
+        // shift to a non-null default.
+        val store = SatelliteMotionBackendStatusStore()
+        assertNull(store.statusFor("conn", "slot"))
+    }
+
+    @Test
+    fun `setStatus then statusFor round-trips`() {
+        val store = SatelliteMotionBackendStatusStore()
+        val s = SatelliteMotionBackendStatus(sinkSupportedForType = true, backendOk = false)
+        store.setStatus("conn", "slot", s)
+        assertEquals(s, store.statusFor("conn", "slot"))
+    }
+
+    @Test
+    fun `setStatus overwrites in place`() {
+        val store = SatelliteMotionBackendStatusStore()
+        store.setStatus("conn", "slot", SatelliteMotionBackendStatus(true, true))
+        store.setStatus("conn", "slot", SatelliteMotionBackendStatus(true, false))
+        assertEquals(
+            SatelliteMotionBackendStatus(true, false),
+            store.statusFor("conn", "slot"),
+        )
+    }
+
+    @Test
+    fun `clear drops only the named entry`() {
+        val store = SatelliteMotionBackendStatusStore()
+        store.setStatus("conn", "slot1", SatelliteMotionBackendStatus(true, true))
+        store.setStatus("conn", "slot2", SatelliteMotionBackendStatus(false, false))
+        store.clear("conn", "slot1")
+        assertNull(store.statusFor("conn", "slot1"))
+        assertEquals(
+            SatelliteMotionBackendStatus(false, false),
+            store.statusFor("conn", "slot2"),
+        )
+    }
+
+    @Test
+    fun `clear on missing entry is a no-op (no spurious emission)`() {
+        val store = SatelliteMotionBackendStatusStore()
+        val before = store.state.value
+        store.clear("conn", "missing")
+        // Same reference == no flow emission. Reference equality is the
+        // strict version of "the state didn't change" — important because
+        // a no-op clear() that still emits would re-trigger every collector.
+        assertTrue(before === store.state.value)
+    }
+
+    @Test
+    fun `clearConnection drops every slot for that connection only`() {
+        val store = SatelliteMotionBackendStatusStore()
+        store.setStatus("connA", "slot1", SatelliteMotionBackendStatus(true, true))
+        store.setStatus("connA", "slot2", SatelliteMotionBackendStatus(true, false))
+        store.setStatus("connB", "slot1", SatelliteMotionBackendStatus(false, true))
+
+        store.clearConnection("connA")
+
+        assertNull(store.statusFor("connA", "slot1"))
+        assertNull(store.statusFor("connA", "slot2"))
+        // connB's slot must remain untouched — clearing one satellite
+        // mustn't bleed into another.
+        assertEquals(
+            SatelliteMotionBackendStatus(false, true),
+            store.statusFor("connB", "slot1"),
+        )
+    }
+
+    @Test
+    fun `slotStatusesFor returns only the bound slots`() {
+        val store = SatelliteMotionBackendStatusStore()
+        store.setStatus("conn", "slot1", SatelliteMotionBackendStatus(true, true))
+        store.setStatus("conn", "slot2", SatelliteMotionBackendStatus(true, false))
+        store.setStatus("conn", "slot3", SatelliteMotionBackendStatus(false, true))
+        store.setStatus("other", "slot1", SatelliteMotionBackendStatus(false, false))
+
+        // The composer asks "what's the status for the slots actually
+        // bound to this connection right now?" — slot3 is in the store
+        // but not in the bound list (e.g. it was detached), so it must
+        // not appear in the projection.
+        val projection = store.slotStatusesFor("conn", listOf("slot1", "slot2"))
+
+        assertEquals(2, projection.size)
+        assertEquals(SatelliteMotionBackendStatus(true, true), projection["slot1"])
+        assertEquals(SatelliteMotionBackendStatus(true, false), projection["slot2"])
+    }
+
+    @Test
+    fun `slotStatusesFor skips slots with no status entry`() {
+        // A slot that's bound but has no observation yet (e.g. ACK not
+        // received — the wire's slowest path) is excluded rather than
+        // appearing as a "default" entry. The composer treats absence as
+        // null = unknown.
+        val store = SatelliteMotionBackendStatusStore()
+        store.setStatus("conn", "slot1", SatelliteMotionBackendStatus(true, true))
+
+        val projection = store.slotStatusesFor("conn", listOf("slot1", "slot2"))
+        assertEquals(1, projection.size)
+        assertNull(projection["slot2"])
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
@@ -13,6 +13,7 @@ import com.tinkernorth.dish.source.connection.ConnectionEvent
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.sensor.BatteryValidator
 import com.tinkernorth.dish.source.sensor.BatteryValidator.BatterySample
+import com.tinkernorth.dish.composer.MotionCapabilityComposer
 import com.tinkernorth.dish.source.store.BatteryStatusStore
 import com.tinkernorth.dish.source.store.MotionEnabledStore
 import io.mockk.every
@@ -47,6 +48,7 @@ class MainViewModelTest {
     private lateinit var gamepadRegistry: PhysicalGamepadRegistry
     private lateinit var batteryStore: BatteryStatusStore
     private lateinit var motionEnabledStore: MotionEnabledStore
+    private lateinit var motionCapabilityComposer: MotionCapabilityComposer
     private lateinit var vm: MainViewModel
 
     private val connectionsFlow = MutableStateFlow<List<ConnectionSummary>>(emptyList())
@@ -70,6 +72,16 @@ class MainViewModelTest {
             MotionEnabledStore(
                 mockk(relaxed = true) { every { all() } returns emptyList() },
             )
+        // MotionCapabilityComposer is exercised separately; the VM only
+        // forwards its state into MainUiState. A relaxed mock with an
+        // empty initial-state flow is enough to satisfy the constructor.
+        motionCapabilityComposer =
+            mockk(relaxed = true) {
+                every { state } returns
+                    kotlinx.coroutines.flow.MutableStateFlow(
+                        emptyMap<String, com.tinkernorth.dish.composer.MotionCapability>(),
+                    )
+            }
         every { hub.connections } returns connectionsFlow
         every { hub.bindings } returns bindingsFlow
         every { gamepadRegistry.devices } returns devicesFlow
@@ -78,7 +90,16 @@ class MainViewModelTest {
         // injected Context. A relaxed mock returns "" by default, which keeps
         // the existing assertions (focused on slot wiring, not the label) green.
         val context = mockk<Context>(relaxed = true)
-        vm = MainViewModel(context, satellite, hub, gamepadRegistry, batteryStore, motionEnabledStore)
+        vm =
+            MainViewModel(
+                context,
+                satellite,
+                hub,
+                gamepadRegistry,
+                batteryStore,
+                motionEnabledStore,
+                motionCapabilityComposer,
+            )
     }
 
     @After

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
@@ -8,12 +8,12 @@ import com.tinkernorth.dish.composer.ConnectionHub
 import com.tinkernorth.dish.composer.ConnectionKind
 import com.tinkernorth.dish.composer.ConnectionSummary
 import com.tinkernorth.dish.composer.LinkState
+import com.tinkernorth.dish.composer.MotionCapabilityComposer
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.source.connection.ConnectionEvent
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.sensor.BatteryValidator
 import com.tinkernorth.dish.source.sensor.BatteryValidator.BatterySample
-import com.tinkernorth.dish.composer.MotionCapabilityComposer
 import com.tinkernorth.dish.source.store.BatteryStatusStore
 import com.tinkernorth.dish.source.store.MotionEnabledStore
 import io.mockk.every

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
@@ -14,6 +14,7 @@ import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.sensor.BatteryValidator
 import com.tinkernorth.dish.source.sensor.BatteryValidator.BatterySample
 import com.tinkernorth.dish.source.store.BatteryStatusStore
+import com.tinkernorth.dish.source.store.MotionEnabledStore
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -45,6 +46,7 @@ class MainViewModelTest {
     private lateinit var satellite: SatelliteConnectionManager
     private lateinit var gamepadRegistry: PhysicalGamepadRegistry
     private lateinit var batteryStore: BatteryStatusStore
+    private lateinit var motionEnabledStore: MotionEnabledStore
     private lateinit var vm: MainViewModel
 
     private val connectionsFlow = MutableStateFlow<List<ConnectionSummary>>(emptyList())
@@ -61,6 +63,13 @@ class MainViewModelTest {
         // BatteryStatusStore is a pure JVM holder (no Android deps) — use the
         // real thing so battery samples really thread through to the slots.
         batteryStore = BatteryStatusStore()
+        // MotionEnabledStore is hydrated from MotionPreferenceRepository at
+        // construction. Stub the repo so the store's init reads emptyMap()
+        // (the relevant default for these slot-wiring tests).
+        motionEnabledStore =
+            MotionEnabledStore(
+                mockk(relaxed = true) { every { all() } returns emptyList() },
+            )
         every { hub.connections } returns connectionsFlow
         every { hub.bindings } returns bindingsFlow
         every { gamepadRegistry.devices } returns devicesFlow
@@ -69,7 +78,7 @@ class MainViewModelTest {
         // injected Context. A relaxed mock returns "" by default, which keeps
         // the existing assertions (focused on slot wiring, not the label) green.
         val context = mockk<Context>(relaxed = true)
-        vm = MainViewModel(context, satellite, hub, gamepadRegistry, batteryStore)
+        vm = MainViewModel(context, satellite, hub, gamepadRegistry, batteryStore, motionEnabledStore)
     }
 
     @After
@@ -143,6 +152,32 @@ class MainViewModelTest {
     fun `setSatelliteControllerType delegates to hub`() {
         vm.setSatelliteControllerType(connectionId = "s:1", slotId = "slot-X", type = 1)
         verify { hub.setSatelliteControllerType("s:1", "slot-X", 1) }
+    }
+
+    @Test
+    fun `setMotionEnabled writes through to the motion store`() {
+        // The dashboard's toggle should be a thin pass-through; the durable
+        // write happens in MotionEnabledStore. Pin that the VM does not
+        // accidentally short-circuit (e.g. only updating local state).
+        vm.setMotionEnabled(slotId = "9", enabled = false)
+        assertEquals(false, motionEnabledStore.state.value["9"])
+        assertEquals(false, motionEnabledStore.isEnabled("9"))
+    }
+
+    @Test
+    fun `isMotionEnabled defaults to true for a slot that has not been toggled`() {
+        // Product default — flip in MotionEnabledStore.DEFAULT_ENABLED if
+        // policy changes. Pinned here so a regression in the VM accessor
+        // (e.g. reading the raw map and treating null as false) fails.
+        assertTrue(vm.isMotionEnabled("never-touched"))
+    }
+
+    @Test
+    fun `motionEnabled flow forwards the underlying store state`() {
+        // Bind point for the dashboard adapter: a write through the VM
+        // must be observable on its motionEnabled flow.
+        vm.setMotionEnabled(slotId = "virtual", enabled = false)
+        assertEquals(false, vm.motionEnabled.value["virtual"])
     }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/MotionIndicatorStateTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/MotionIndicatorStateTest.kt
@@ -416,4 +416,145 @@ class MotionIndicatorStateTest {
             ),
         )
     }
+
+    // ── BACKEND_BROKEN — receiver's own truth about its motion sink ─────
+
+    @Test
+    fun `BACKEND_BROKEN fires when satellite reports its sink failed`() {
+        // The satellite told us via the motion-status ACK byte that its
+        // backend couldn't create the per-serial IMU sink. The pill must
+        // surface this as a distinct state — the dish would otherwise
+        // happily read STREAMING while bytes silently vanish at the
+        // receiver.
+        assertEquals(
+            MotionIndicatorState.BACKEND_BROKEN,
+            MotionIndicatorState.of(
+                isAvailable = true,
+                isStreaming = true,
+                connectionCarriesMotion = true,
+                connectionConnected = true,
+                userEnabled = true,
+                hostHasSinkForType = true,
+                satelliteBackendOk = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `satelliteBackendOk=null stays out of the way`() {
+        // Null is the "unknown" sentinel — either no extended ACK was
+        // observed yet, or the satellite is a pre-extension build. The
+        // pill must NOT collapse to BACKEND_BROKEN; STREAMING is the
+        // correct reading when every other gate is open.
+        assertEquals(
+            MotionIndicatorState.STREAMING,
+            MotionIndicatorState.of(
+                isAvailable = true,
+                isStreaming = true,
+                connectionCarriesMotion = true,
+                connectionConnected = true,
+                userEnabled = true,
+                hostHasSinkForType = true,
+                satelliteBackendOk = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `satelliteBackendOk=true is the normal happy-path branch`() {
+        // The satellite affirmed its sink — STREAMING (or whatever the
+        // other gates compute) is the right read; BACKEND_BROKEN does not
+        // fire.
+        assertEquals(
+            MotionIndicatorState.STREAMING,
+            MotionIndicatorState.of(
+                isAvailable = true,
+                isStreaming = true,
+                connectionCarriesMotion = true,
+                connectionConnected = true,
+                userEnabled = true,
+                hostHasSinkForType = true,
+                satelliteBackendOk = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `NO_HOST_SINK outranks BACKEND_BROKEN — the type-level reason is higher-order`() {
+        // If the slot type has no IMU surface at all (Xbox-typed), telling
+        // the user the per-serial kernel sink is broken is technically
+        // true but useless — switch to PlayStation is the right next step,
+        // not "restart the satellite." Precedence reflects that.
+        assertEquals(
+            MotionIndicatorState.NO_HOST_SINK,
+            MotionIndicatorState.of(
+                isAvailable = true,
+                isStreaming = true,
+                connectionCarriesMotion = true,
+                connectionConnected = true,
+                userEnabled = true,
+                hostHasSinkForType = false,
+                satelliteBackendOk = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `USER_DISABLED outranks BACKEND_BROKEN — user's choice is the actionable reason`() {
+        // The user turned motion off; whether or not the satellite's sink
+        // would have worked is irrelevant — show them their own toggle as
+        // the explanation.
+        assertEquals(
+            MotionIndicatorState.USER_DISABLED,
+            MotionIndicatorState.of(
+                isAvailable = true,
+                isStreaming = false,
+                connectionCarriesMotion = true,
+                connectionConnected = true,
+                userEnabled = false,
+                hostHasSinkForType = true,
+                satelliteBackendOk = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `NOT_FORWARDED outranks BACKEND_BROKEN — BT-HID never carried motion in the first place`() {
+        // A Bluetooth-HID connection has no motion channel at all; the
+        // satellite's sink status is irrelevant. The pill should read
+        // "this link can't carry motion," not "the satellite's broken."
+        assertEquals(
+            MotionIndicatorState.NOT_FORWARDED,
+            MotionIndicatorState.of(
+                isAvailable = true,
+                isStreaming = true,
+                connectionCarriesMotion = false,
+                connectionConnected = true,
+                userEnabled = true,
+                hostHasSinkForType = true,
+                satelliteBackendOk = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `BACKEND_BROKEN outranks STALLED — the receiver's reason beats the source's reason`() {
+        // If the receiver said its sink is broken AND the source happens to
+        // be stalled too, the operator-facing reason ("server can't
+        // deliver") is the higher-order one — the source stalling is moot
+        // because the bytes weren't being delivered anyway.
+        assertEquals(
+            MotionIndicatorState.BACKEND_BROKEN,
+            MotionIndicatorState.of(
+                isAvailable = true,
+                isStreaming = true,
+                connectionCarriesMotion = true,
+                connectionConnected = true,
+                userEnabled = true,
+                hostHasSinkForType = true,
+                satelliteBackendOk = false,
+                isStalled = true,
+            ),
+        )
+    }
 }

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/MotionIndicatorStateTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/MotionIndicatorStateTest.kt
@@ -151,25 +151,34 @@ class MotionIndicatorStateTest {
     }
 
     @Test
-    fun `the three non-streaming states are all distinct`() {
-        // The whole point of the enum: "no hardware", "paused", and "this
-        // connection can't carry motion" must not be the same value.
+    fun `every non-streaming state is distinct`() {
+        // The whole point of the enum: every "motion is not going out"
+        // reason must read differently on the pill so the user knows the
+        // right next step. A regression that collapses any two of these
+        // back onto the same value would silently kill that signal.
         val nonStreaming =
             setOf(
                 MotionIndicatorState.PAUSED,
                 MotionIndicatorState.NOT_FORWARDED,
                 MotionIndicatorState.UNAVAILABLE,
+                MotionIndicatorState.USER_DISABLED,
+                MotionIndicatorState.NO_HOST_SINK,
+                MotionIndicatorState.STALLED,
             )
-        assertEquals(3, nonStreaming.size)
+        assertEquals(6, nonStreaming.size)
         assertNotEquals(MotionIndicatorState.STREAMING, MotionIndicatorState.PAUSED)
     }
 
     @Test
-    fun `only UNAVAILABLE and NOT_FORWARDED carry an explanatory detail line`() {
-        // STREAMING / PAUSED are self-explanatory; the two "motion won't
-        // leave the phone" states get a one-liner so the limit is clear.
+    fun `every limit state that needs an explanation carries a detail line`() {
+        // STREAMING / PAUSED are self-explanatory; every other state has a
+        // one-liner so the user understands the constraint (and where
+        // applicable, the actionable next step).
         assertTrue(MotionIndicatorState.UNAVAILABLE.hasDetail)
         assertTrue(MotionIndicatorState.NOT_FORWARDED.hasDetail)
+        assertTrue(MotionIndicatorState.STALLED.hasDetail)
+        assertTrue(MotionIndicatorState.USER_DISABLED.hasDetail)
+        assertTrue(MotionIndicatorState.NO_HOST_SINK.hasDetail)
         assertFalse(MotionIndicatorState.STREAMING.hasDetail)
         assertFalse(MotionIndicatorState.PAUSED.hasDetail)
     }
@@ -261,5 +270,150 @@ class MotionIndicatorStateTest {
         // this; pinning it explicitly so a future refactor that collapses
         // STALLED onto PAUSED's label fails loudly here.
         assertNotEquals(MotionIndicatorState.PAUSED.labelRes, MotionIndicatorState.STALLED.labelRes)
+    }
+
+    // ── USER_DISABLED — distinct from PAUSED (the user toggled motion off) ──
+
+    @Test
+    fun `userEnabled=false on a satellite connection maps to USER_DISABLED`() {
+        // The user actively turned motion off on this slot. PAUSED would
+        // imply the source is paused for lifecycle / link reasons, not a
+        // user choice — USER_DISABLED is the actionable label.
+        assertEquals(
+            MotionIndicatorState.USER_DISABLED,
+            MotionIndicatorState.of(
+                isAvailable = true,
+                isStreaming = false,
+                connectionCarriesMotion = true,
+                connectionConnected = true,
+                userEnabled = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `USER_DISABLED takes precedence over NOT_FORWARDED`() {
+        // BT connection AND user toggled off: show the toggle as the
+        // limit, not the connection kind — the toggle is the more
+        // actionable fact (flip it or use a satellite connection).
+        assertEquals(
+            MotionIndicatorState.USER_DISABLED,
+            MotionIndicatorState.of(
+                isAvailable = true,
+                isStreaming = false,
+                connectionCarriesMotion = false,
+                connectionConnected = true,
+                userEnabled = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `no gyroscope wins over USER_DISABLED`() {
+        // UNAVAILABLE is the highest-precedence terminal state — a phone
+        // without a gyro can't stream regardless of any toggle. Pin that
+        // the hardware absence reads correctly even if the toggle is off.
+        assertEquals(
+            MotionIndicatorState.UNAVAILABLE,
+            MotionIndicatorState.of(
+                isAvailable = false,
+                isStreaming = false,
+                connectionCarriesMotion = true,
+                connectionConnected = true,
+                userEnabled = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `userEnabled=true default keeps existing call sites unchanged`() {
+        // The new userEnabled parameter has a default of true so the
+        // pre-PR call sites (and tests above) continue to read as
+        // STREAMING / PAUSED / etc. Pin that explicitly.
+        assertEquals(
+            MotionIndicatorState.STREAMING,
+            MotionIndicatorState.of(
+                isAvailable = true,
+                isStreaming = true,
+                connectionCarriesMotion = true,
+                connectionConnected = true,
+                // userEnabled defaulted (true)
+            ),
+        )
+    }
+
+    // ── NO_HOST_SINK — slot's controller type can't carry motion on the host ──
+
+    @Test
+    fun `hostHasSinkForType=false on a satellite slot maps to NO_HOST_SINK`() {
+        // Xbox-typed virtual pad — the dish would otherwise stream, but
+        // the host's XInput backend has no IMU surface so samples would
+        // be silently dropped at the virtual gamepad layer. The pill
+        // warns up front to switch to PlayStation for gyro to land.
+        assertEquals(
+            MotionIndicatorState.NO_HOST_SINK,
+            MotionIndicatorState.of(
+                isAvailable = true,
+                isStreaming = true,
+                connectionCarriesMotion = true,
+                connectionConnected = true,
+                userEnabled = true,
+                hostHasSinkForType = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `USER_DISABLED takes precedence over NO_HOST_SINK`() {
+        // A user-toggled-off Xbox slot reads as USER_DISABLED — the user
+        // chose to turn it off and that's the most actionable next step
+        // (re-enable, or change the type to PS to make NO_HOST_SINK
+        // disappear on its own).
+        assertEquals(
+            MotionIndicatorState.USER_DISABLED,
+            MotionIndicatorState.of(
+                isAvailable = true,
+                isStreaming = false,
+                connectionCarriesMotion = true,
+                connectionConnected = true,
+                userEnabled = false,
+                hostHasSinkForType = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `NOT_FORWARDED takes precedence over NO_HOST_SINK`() {
+        // BT-HID connection AND an Xbox-typed slot. The BT limit is the
+        // more fundamental problem — fix the connection first; the host
+        // sink question only becomes meaningful on a satellite.
+        assertEquals(
+            MotionIndicatorState.NOT_FORWARDED,
+            MotionIndicatorState.of(
+                isAvailable = true,
+                isStreaming = true,
+                connectionCarriesMotion = false,
+                connectionConnected = true,
+                userEnabled = true,
+                hostHasSinkForType = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `hostHasSinkForType=true default keeps existing call sites unchanged`() {
+        // Same backwards-compat pin as for userEnabled — the new parameter
+        // has a default of true so legacy call sites still compute the
+        // correct state.
+        assertEquals(
+            MotionIndicatorState.PAUSED,
+            MotionIndicatorState.of(
+                isAvailable = true,
+                isStreaming = false,
+                connectionCarriesMotion = true,
+                connectionConnected = true,
+                // userEnabled, hostHasSinkForType both default true
+            ),
+        )
     }
 }


### PR DESCRIPTION
## Summary

Consolidated PR for the dish-android side of the gyro/IMU pipeline review.
Lands six landable concerns as a single reviewable change, but the
commit history is kept granular so each concern is a separate commit:

| Commit | What |
|---|---|
| `ef4ea2e` | **Foundation** — `PhoneMotionAvailability`, `PhysicalMotionProbe`, `Device.hasGyro`, `MotionCapabilityComposer` |
| `fbf9485` | **Toggle persistence** — `MotionPreferenceRepository` + `MotionEnabledStore` + ViewModel API |
| `2943708` | **Wire-up** — composer threaded through `SatelliteConnection`'s cap bit, `PhoneMotionSource` lifecycle gated on capability |
| `a11c03a` | **STALLED pill repaints** — `PhoneMotionSource` → `AbstractStateSource<MotionStreamState>`, internal stall tick |
| `f2bf781` | **First-sample zero-G fix** — hold first gyro until accel reports (both Phone and Physical) |
| `3eeec54` | **Cleanup** — `remapLandscape` out-param, unknown-rotation log-once, JNI doc fix |

## What's fixed (and what's not)

**Fixed:**

- The `CAP_MOTION` bit at `MSG_CONTROLLER_ADD` is now honest per
  controller. Previously every controller advertised motion regardless
  of whether the slot's hardware had a gyro or whether the user wanted it.
- The phone gyro listener no longer runs at SENSOR_DELAY_GAME on
  Bluetooth-HID-bound overlays. Real, measurable battery win.
- A user-facing per-slot motion toggle, persisted across launches via
  `SharedPreferences` and reactive via `MotionEnabledStore`. ViewModel
  surface (`setMotionEnabled` / `isMotionEnabled` / `motionEnabled`) is in.
  *The visible switch widget in `ControllerAdapter` is not in this PR; it's
  trivial follow-up work now that the backend is honest.*
- The motion pill on the touch overlay now demotes STREAMING → STALLED
  when no gyro callback arrives within 1500 ms — and the pill actually
  repaints when that happens (it didn't before; the staleness was
  computed-on-demand without a trigger).
- First MOTION packet on the wire never ships `accel = (0, 0, 0)`
  anymore — the gyro-before-accel race is gated. Pads with no
  accelerometer bypass the gate so gyro still flows.
- `remapLandscape` no longer allocates 500 `FloatArray`s/sec on the
  IMU hot path (out-param overload).
- An unknown `Surface.ROTATION_*` value logs WARN once per source-
  lifetime instead of silently shipping the wrong axes forever.
- The misleading JNI `sendMotion` comment that implied native-side
  scaling is fixed.

**Not in this PR (intentionally):**

- Visible motion switch widget in `ControllerAdapter` — backend is
  ready, UI control ships as a small follow-up.
- Re-registering controllers when the user toggles motion mid-session.
  `toCapBits()` only takes effect at the next `addController` call (next
  bind, reconnect, restart). The wire impact is informational only
  (`session_service.cpp:413-417` documents this); the listener gates
  handle "right now" correctness.

## Architecture

The Android side of the system already has well-defined layers (per
[architecture/Patterns.kt](app/src/main/java/com/tinkernorth/dish/architecture/Patterns.kt)):

- `source/` — state-over-time (sensors, sockets, system services)
- `composer/` — pure derivations over other flows
- `repository/` — durable CRUD
- `source/store/` — reactive in-memory mirrors over durable choices
- `hotpath/` — per-frame input dispatch

Every new type lands in its natural home:

```
source/sensor/PhoneMotionAvailability       (process-scoped "has gyro" fact)
source/sensor/PhysicalMotionProbe           (per-device gyro probe, pure)
source/sensor/PhoneMotionSource             (refactored to AbstractStateSource)
source/store/MotionEnabledStore             (reactive mirror of toggle)
repository/MotionPreferenceRepository       (durable per-slot toggle)
composer/MotionCapabilityComposer           (slotId -> MotionCapability)
hotpath/input/PhysicalGamepadRegistry       (Device.hasGyro now cached)
source/connection/SatelliteConnection       (takes motionCapsBitsFor lambda)
source/connection/SatelliteConnectionManager (Provider<...> breaks the Hilt cycle)
ui/main/GamepadOverlayActivity              (collects motionCapability.state)
```

## Test plan

**Total: 669 tests, 0 failures locally.**

New tests, grouped by commit:

- **Foundation:** 22 — probe SDK gates, `PhoneMotionAvailability` (4),
  `MotionCapabilityComposer` (13).
- **Toggle:** 23 — `MotionPreferenceRepository` contract (8) +
  per-impl (5), `MotionEnabledStore` (7), ViewModel surface (3).
- **Wire-up:** 15 — `SatelliteConnection` cap-bit derivation (5),
  composer's toggle wiring (5), `PhysicalMotionSource.filterByCapability` (5).
- **State flow:** 10 — `MotionStreamState` transitions (4),
  `deriveState` matrix (6).
- **First-sample:** 2 — gate holds gyro until accel arrives;
  pad with no accel bypasses the gate.
- **Cleanup:** 4 — out-param signature, `RemapResult.Fallback`,
  size-3 guard, equivalence with the allocating shim.

- [x] `./gradlew :app:compileDebugKotlin` — passes
- [x] `./gradlew :app:testDebugUnitTest` — 669/669 pass

## Closes

Supersedes the earlier stacked PRs:
- #71 (foundation) — close in favour of this
- #72 (toggle persistence) — close in favour of this
- #73 (wire-up) — close in favour of this