### PR TITLE
fix(overlay): mirror display cutout + toolbar so virtual controls sit centred

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/ui/main/BaseInputOverlayActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/BaseInputOverlayActivity.kt
@@ -9,7 +9,12 @@ import android.view.Surface
 import android.view.View
 import android.view.WindowInsets
 import android.view.WindowInsetsController
+import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -30,6 +35,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.math.max
 
 abstract class BaseInputOverlayActivity : AppCompatActivity() {
     @Inject lateinit var hub: ConnectionHub
@@ -57,10 +63,32 @@ abstract class BaseInputOverlayActivity : AppCompatActivity() {
     protected open fun onConnectionEvent(event: ConnectionEvent) = Unit
 
     protected fun installBaseScaffolding() {
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            // Default cutout mode letterboxes content away in landscape, hiding the asymmetry
+            // we need to mirror; short-edges surfaces the cutout as a reported inset instead.
+            window.attributes =
+                window.attributes.apply {
+                    layoutInDisplayCutoutMode =
+                        WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+                }
+        }
+
         gamepadHost =
             GamepadActivityHost(this, rootView(), wakeState, gamepadRegistry)
                 .also { it.install(notifications) }
         hideSystemBars()
+
+        ViewCompat.setOnApplyWindowInsetsListener(rootView()) { v, wi ->
+            val ins =
+                wi.getInsets(
+                    WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout(),
+                )
+            val mirror = max(ins.left, ins.right)
+            v.updatePadding(left = mirror, top = ins.top, right = mirror, bottom = ins.bottom)
+            wi
+        }
+
         connectionId = intent.getStringExtra(EXTRA_CONNECTION_ID).orEmpty()
 
         lifecycleScope.launch {

--- a/app/src/main/res/layout/activity_gamepad_overlay.xml
+++ b/app/src/main/res/layout/activity_gamepad_overlay.xml
@@ -14,7 +14,8 @@
 -->
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -34,11 +35,16 @@
 
         <!-- Content area: gamepad surface fills, status pills float at
              top|end. Same FrameLayout shape as the touchpad overlay so
-             the two screens lay out identically. -->
+             the two screens lay out identically.
+
+             paddingBottom=?actionBarSize mirrors the toolbar at top so
+             the surface sits visually centred instead of crowding the
+             screen edge. -->
         <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_weight="1">
+            android:layout_weight="1"
+            android:paddingBottom="?attr/actionBarSize">
 
             <com.tinkernorth.dish.ui.common.GamepadTouchView
                 android:id="@+id/gamepadTouchView"

--- a/app/src/main/res/layout/activity_touchpad_overlay.xml
+++ b/app/src/main/res/layout/activity_touchpad_overlay.xml
@@ -43,11 +43,16 @@
              at top|end. FrameLayout because the pill and trackpads share
              the same region — pills can't live in the toolbar (toolbar is
              actionBarSize tall, pills with a vertical stack would push
-             that). -->
+             that).
+
+             paddingBottom=?actionBarSize mirrors the toolbar at top so
+             the surface sits visually centred instead of crowding the
+             screen edge. -->
         <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_weight="1">
+            android:layout_weight="1"
+            android:paddingBottom="?attr/actionBarSize">
 
             <!-- Trackpad row. Horizontal LinearLayout with weightSum=2
                  splits 50/50 between the two pads; margin_md on each


### PR DESCRIPTION
## Summary
- On devices with a side camera notch the overlay was crowded against the un-notched edge; on every device the bottom-row sticks sat too close to the screen edge to drag down reliably.
- Enable edge-to-edge with `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES` so the cutout becomes a reported inset, mirror it to the opposite side via the root insets listener, and pad the content FrameLayout's bottom with `?attr/actionBarSize` to give the surface empty space matching the toolbar above.
- Pin the gamepad overlay root background to `?attr/colorSurface` so the gamepad's drawn surface extends through the mirrored padding instead of revealing the window's `colorBackground` underneath.

## Test plan
- [ ] Gamepad overlay on a device with a side camera notch: notch-side and opposite side show equal empty space; the gamepad surface fills the entire below-toolbar area edge to edge.
- [ ] Gamepad overlay on a device without a cutout: surface fills horizontally, bottom row of sticks now sits `?actionBarSize` above the screen edge.
- [ ] Right stick can be dragged to its max-down position without the thumb running off the screen first.
- [ ] Touchpad overlay: trackpads also gain matching bottom space; no visible margin seams since the area below the toolbar is uniform.
- [ ] Connection/motion status pills (top|end) remain pinned to the top-right and don't move with the new bottom padding.