### PR TITLE
refactor: strip narration comments missed in #81

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/ui/common/FoldAwareSession.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/FoldAwareSession.kt
@@ -74,9 +74,6 @@ data class HingeInsets(
     }
 }
 
-// Tabletop pushes content below the horizontal hinge so the user can rest the device on a table
-// and reach controls on the bottom half. Book mode is a no-op here because the gamepad/touchpad
-// surfaces already keep their interactive area away from the centre column.
 fun Posture.hingeInsetsFor(view: View): HingeInsets {
     if (this !is Posture.Tabletop) return HingeInsets.NONE
     val loc = IntArray(2)

--- a/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadTouchView.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadTouchView.kt
@@ -201,10 +201,6 @@ class GamepadTouchView
             }
         }
 
-        // D-pad, center, shoulder, and trigger glyphs ship with hardcoded white fills (designed for
-        // the dark surface); tinting them to colorOnSurface inverts them on the light theme so
-        // they don't disappear into the near-white background. Face buttons are brand-coloured
-        // and intentionally skip the tint.
         @Suppress("CyclomaticComplexMethod")
         private fun loadDrawables() {
             val c = context
@@ -250,9 +246,6 @@ class GamepadTouchView
             }
         }
 
-        // mutate() is required because vector drawables share a ConstantState across
-        // ContextCompat.getDrawable() calls — without it, tinting one instance would leak into
-        // every other use of the same resource (e.g. the same analog glyph shown three times).
         private fun loadTinted(
             c: Context,
             id: Int,

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/BaseInputOverlayActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/BaseInputOverlayActivity.kt
@@ -172,9 +172,6 @@ abstract class BaseInputOverlayActivity : AppCompatActivity() {
             windowManager.defaultDisplay?.rotation ?: Surface.ROTATION_0
         }
 
-    // Content frame may not exist on every overlay layout (the base class can host arbitrary
-    // subclasses); skipping silently is the right default rather than forcing every overlay to
-    // declare a hinge target.
     private fun installFoldAwareness() {
         val content = rootView().findViewById<View>(R.id.overlayContentFrame) ?: return
         val origTop = content.paddingTop
@@ -193,8 +190,6 @@ abstract class BaseInputOverlayActivity : AppCompatActivity() {
         posture: Posture,
         origTop: Int,
     ) {
-        // Hinge bounds are in window coordinates and only become meaningful once the view is laid
-        // out, so defer to the next layout pass when the call lands before first measure.
         if (!content.isLaidOut) {
             content.post { applyPostureToContent(content, posture, origTop) }
             return

--- a/app/src/main/res/layout-sw600dp/activity_connections.xml
+++ b/app/src/main/res/layout-sw600dp/activity_connections.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Tablet variant: satellites and Bluetooth sit side-by-side as parallel columns instead of
-     stacked sections. Outer ScrollView is dropped — both lists individually scroll, and the
-     screen no longer needs vertical scrolling on tablet form factors. -->
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"

--- a/app/src/main/res/layout-sw600dp/activity_main.xml
+++ b/app/src/main/res/layout-sw600dp/activity_main.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Tablet variant: header spans full width, body splits into a controllers list (left, dominant)
-     and a sticky connections panel (right). IDs mirror the phone layout so the activity binding
-     resolves unchanged. -->
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"

--- a/app/src/main/res/layout-sw600dp/activity_settings.xml
+++ b/app/src/main/res/layout-sw600dp/activity_settings.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Tablet variant: same vertical card stack as the phone layout, but capped to a readable width
-     so cards don't stretch full-bleed on a wide tablet. Width matches the sw600dp minimum so no
-     overflow can occur on any qualifying device. IDs mirror the phone layout exactly. -->
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_gamepad_overlay.xml
+++ b/app/src/main/res/layout/activity_gamepad_overlay.xml
@@ -33,9 +33,6 @@
             style="@style/Widget.Dish.Toolbar"
             android:layout_width="match_parent" />
 
-        <!-- Content area: gamepad surface fills. paddingBottom=?actionBarSize
-             mirrors the toolbar at top so the surface sits visually
-             centred instead of crowding the screen edge. -->
         <FrameLayout
             android:id="@+id/overlayContentFrame"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_touchpad_overlay.xml
+++ b/app/src/main/res/layout/activity_touchpad_overlay.xml
@@ -39,9 +39,6 @@
             style="@style/Widget.Dish.Toolbar"
             android:layout_width="match_parent" />
 
-        <!-- Content area: trackpads fill the surface. paddingBottom=
-             ?actionBarSize mirrors the toolbar at top so the surface
-             sits visually centred instead of crowding the screen edge. -->
         <FrameLayout
             android:id="@+id/overlayContentFrame"
             android:layout_width="match_parent"


### PR DESCRIPTION
## Summary

Follow-up cleanup to #81 (which merged before this could be added). Applies the same WHY-not-WHAT policy from #78 to comments added in that branch.

Two of these were explicitly flagged in the #81 review (the D-pad glyph-tint rationale and the `mutate()` ConstantState rationale in `GamepadTouchView.kt`); the rest are similar narration removed by the same standard.

## Test plan
- [ ] Compile check — only comment deletions, no code changes.