### PR TITLE
feat(overlay): keep-app-open hint while streaming + low-power explainer

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/hotpath/overlay/GamepadActivityHost.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/overlay/GamepadActivityHost.kt
@@ -48,6 +48,7 @@ class GamepadActivityHost(
                         flLowPowerOverlay = bindings.flLowPowerOverlay,
                         tvLowPowerTime = bindings.tvLowPowerTime,
                         tvLowPowerStatus = bindings.tvLowPowerStatus,
+                        llStreamingHint = bindings.llStreamingHint,
                     )
                 activeControllerCount = { wakeState.streamingSlotCount.value }
             }

--- a/app/src/main/java/com/tinkernorth/dish/source/lowpower/LowPowerManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/lowpower/LowPowerManager.kt
@@ -25,6 +25,7 @@ class LowPowerManager(
         val flLowPowerOverlay: FrameLayout,
         val tvLowPowerTime: TextView,
         val tvLowPowerStatus: TextView,
+        val llStreamingHint: LinearLayout,
     )
 
     var views: Views? = null
@@ -32,6 +33,8 @@ class LowPowerManager(
     var activeControllerCount: () -> Int = { 0 }
 
     enum class State { IDLE, COUNTDOWN, ACTIVE }
+
+    private var isStreaming = false
 
     private var savedBrightness = -1f
     private val inactivityHandler = Handler(Looper.getMainLooper())
@@ -41,11 +44,13 @@ class LowPowerManager(
     private val inactivityRunnable = Runnable { startCountdown() }
 
     fun onLockStateChanged(active: Boolean) {
+        isStreaming = active
         if (active && state.value == State.IDLE) {
             resetInactivityTimer()
         } else if (!active) {
             cancel()
         }
+        applyStreamingHintVisibility()
     }
 
     fun onUserInteraction() {
@@ -61,6 +66,7 @@ class LowPowerManager(
                 views?.llCountdownBanner?.visibility = View.GONE
                 setState(State.IDLE)
                 resetInactivityTimer()
+                applyStreamingHintVisibility()
             }
             State.IDLE -> resetInactivityTimer()
         }
@@ -86,6 +92,7 @@ class LowPowerManager(
         setState(State.COUNTDOWN)
         val v = views ?: return
         v.llCountdownBanner.visibility = View.VISIBLE
+        applyStreamingHintVisibility()
         v.tvCountdownSeconds.text = String.format(Locale.getDefault(), "%d", COUNTDOWN_SECONDS)
         countdownTimer?.cancel()
         countdownTimer =
@@ -105,6 +112,7 @@ class LowPowerManager(
         setState(State.ACTIVE)
         val v = views ?: return
         v.llCountdownBanner.visibility = View.GONE
+        applyStreamingHintVisibility()
         val lp = window.attributes
         savedBrightness = lp.screenBrightness
         lp.screenBrightness = MIN_BRIGHTNESS
@@ -127,6 +135,13 @@ class LowPowerManager(
         lp.screenBrightness = if (savedBrightness >= 0) savedBrightness else -1f
         window.attributes = lp
         savedBrightness = -1f
+        applyStreamingHintVisibility()
+    }
+
+    private fun applyStreamingHintVisibility() {
+        val v = views ?: return
+        v.llStreamingHint.visibility =
+            if (isStreaming && state.value == State.IDLE) View.VISIBLE else View.GONE
     }
 
     fun refreshStatus() {

--- a/app/src/main/res/layout/overlay_low_power.xml
+++ b/app/src/main/res/layout/overlay_low_power.xml
@@ -4,7 +4,37 @@
      labels sandwiching the clock and a faint "TAP TO WAKE" affordance.
      View IDs and root types are preserved so LowPowerManager.Views still binds.
 -->
-<merge xmlns:android="http://schemas.android.com/apk/res/android">
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <LinearLayout
+        android:id="@+id/llStreamingHint"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|center_horizontal"
+        android:layout_marginBottom="@dimen/spacing_6xl"
+        android:background="@drawable/bg_pill"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:paddingHorizontal="@dimen/spacing_5xl"
+        android:paddingVertical="@dimen/spacing_lg"
+        android:alpha="0.85"
+        android:visibility="gone">
+
+        <ImageView
+            android:layout_width="@dimen/icon_card_glyph"
+            android:layout_height="@dimen/icon_card_glyph"
+            android:src="@drawable/ic_overlay_link"
+            app:tint="@color/colorPrimary"
+            android:importantForAccessibility="no"
+            android:layout_marginEnd="@dimen/spacing_md" />
+
+        <TextView
+            style="@style/TextAppearance.Dish.Label.Accent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/low_power_streaming_hint" />
+    </LinearLayout>
 
     <!-- ── Countdown banner (shown ~5s before the dim kicks in) ─────────── -->
     <LinearLayout
@@ -99,6 +129,16 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_2xl"
                 android:text="@string/low_power_status_idle" />
+
+            <TextView
+                android:id="@+id/tvLowPowerDimBody"
+                style="@style/TextAppearance.Dish.Body"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_lg"
+                android:maxWidth="280dp"
+                android:gravity="center_horizontal"
+                android:text="@string/low_power_dim_body" />
         </LinearLayout>
 
         <!-- Faint affordance — screen is dimmed to ~1% brightness so this

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -247,6 +247,8 @@
         <item quantity="few">Vezano · %1$d kontrolera</item>
         <item quantity="other">Vezano · %1$d kontrolera</item>
     </plurals>
+    <string name="low_power_streaming_hint">STRIMING · NE ZATVARAJTE APLIKACIJU</string>
+    <string name="low_power_dim_body">Striming se nastavlja dok je ekran zatamnjen — ne zatvarajte Dish.</string>
 
     <!-- Link na politiku privatnosti (u Postavkama) i zajednička poruka greške. -->
     <string name="menu_privacy_policy">Politika privatnosti</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -244,6 +244,8 @@
         <item quantity="one">Verknüpft · %1$d Controller</item>
         <item quantity="other">Verknüpft · %1$d Controller</item>
     </plurals>
+    <string name="low_power_streaming_hint">STREAMING · APP OFFEN LASSEN</string>
+    <string name="low_power_dim_body">Streaming läuft im gedimmten Modus weiter — Dish nicht schließen.</string>
 
     <!-- Datenschutzerklärung-Link (in den Einstellungen) und gemeinsame Fehlermeldung. -->
     <string name="menu_privacy_policy">Datenschutzerklärung</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -248,6 +248,8 @@
         <item quantity="many">Enlazados · %1$d mandos</item>
         <item quantity="other">Enlazados · %1$d mandos</item>
     </plurals>
+    <string name="low_power_streaming_hint">TRANSMITIENDO · MANTÉN LA APP ABIERTA</string>
+    <string name="low_power_dim_body">La transmisión sigue con la pantalla atenuada — no cierres Dish.</string>
 
     <!-- Enlace a la Política de privacidad (en Ajustes) y mensaje de error compartido. -->
     <string name="menu_privacy_policy">Política de privacidad</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -247,6 +247,8 @@
         <item quantity="many">Liées · %1$d manettes</item>
         <item quantity="other">Liées · %1$d manettes</item>
     </plurals>
+    <string name="low_power_streaming_hint">DIFFUSION · GARDEZ L\'APPLI OUVERTE</string>
+    <string name="low_power_dim_body">La diffusion continue à l\'écran tamisé — ne fermez pas Dish.</string>
 
     <!-- Lien Politique de confidentialité (dans Paramètres) et message d\'erreur partagé. -->
     <string name="menu_privacy_policy">Politique de confidentialité</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -248,6 +248,8 @@
         <item quantity="many">Vinculados · %1$d controles</item>
         <item quantity="other">Vinculados · %1$d controles</item>
     </plurals>
+    <string name="low_power_streaming_hint">TRANSMITINDO · MANTENHA O APP ABERTO</string>
+    <string name="low_power_dim_body">A transmissão continua com a tela esmaecida — não feche o Dish.</string>
 
     <!-- Link da Política de Privacidade (em Configurações) e mensagem de erro compartilhada. -->
     <string name="menu_privacy_policy">Política de privacidade</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -297,6 +297,8 @@
         <item quantity="one">Bound · %1$d controller</item>
         <item quantity="other">Bound · %1$d controllers</item>
     </plurals>
+    <string name="low_power_streaming_hint">STREAMING · KEEP APP OPEN</string>
+    <string name="low_power_dim_body">Streaming continues while dimmed — don\'t close Dish.</string>
 
     <!-- Numeric placeholders rendered before the runtime value lands. Kept as
          resources (translatable=false) so layout previews and lint pass, but

--- a/app/src/test/java/com/tinkernorth/dish/source/lowpower/LowPowerManagerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/lowpower/LowPowerManagerTest.kt
@@ -26,6 +26,7 @@ import org.junit.Test
 class LowPowerManagerTest {
     private lateinit var window: Window
     private lateinit var statusView: TextView
+    private lateinit var streamingHint: LinearLayout
     private lateinit var lpm: LowPowerManager
 
     @Before
@@ -55,6 +56,7 @@ class LowPowerManagerTest {
         val countdownSeconds = mockk<TextView>(relaxed = true)
         val overlay = mockk<FrameLayout>(relaxed = true)
         val timeView = mockk<TextView>(relaxed = true)
+        streamingHint = mockk(relaxed = true)
 
         lpm = LowPowerManager(window)
         lpm.views =
@@ -64,6 +66,7 @@ class LowPowerManagerTest {
                 flLowPowerOverlay = overlay,
                 tvLowPowerTime = timeView,
                 tvLowPowerStatus = statusView,
+                llStreamingHint = streamingHint,
             )
     }
 
@@ -230,5 +233,55 @@ class LowPowerManagerTest {
 
         assertEquals(LowPowerManager.State.IDLE, lpm.state.value)
         verify { inactivityHandler.postDelayed(any(), 15_000L) }
+    }
+
+    @Test
+    fun `streaming hint shows when wake state goes active while idle`() {
+        val inactivityHandler = mockk<Handler>(relaxed = true)
+        setPrivateField("inactivityHandler", inactivityHandler)
+
+        lpm.onLockStateChanged(active = true)
+
+        verify { streamingHint.visibility = View.VISIBLE }
+    }
+
+    @Test
+    fun `streaming hint hides when wake state clears`() {
+        val inactivityHandler = mockk<Handler>(relaxed = true)
+        setPrivateField("inactivityHandler", inactivityHandler)
+        lpm.onLockStateChanged(active = true)
+
+        lpm.onLockStateChanged(active = false)
+
+        val captured = mutableListOf<Int>()
+        verify(atLeast = 1) { streamingHint.visibility = capture(captured) }
+        assertEquals(View.GONE, captured.last())
+    }
+
+    @Test
+    fun `streaming hint stays hidden while countdown banner is showing`() {
+        val inactivityHandler = mockk<Handler>(relaxed = true)
+        setPrivateField("inactivityHandler", inactivityHandler)
+        setStateDirect(LowPowerManager.State.COUNTDOWN)
+
+        lpm.onLockStateChanged(active = true)
+
+        verify { streamingHint.visibility = View.GONE }
+    }
+
+    @Test
+    fun `streaming hint reappears after user wakes from dim while still streaming`() {
+        val inactivityHandler = mockk<Handler>(relaxed = true)
+        val clockHandler = mockk<Handler>(relaxed = true)
+        setPrivateField("inactivityHandler", inactivityHandler)
+        setPrivateField("clockHandler", clockHandler)
+        lpm.onLockStateChanged(active = true)
+        setStateDirect(LowPowerManager.State.ACTIVE)
+
+        lpm.onUserInteraction()
+
+        val captured = mutableListOf<Int>()
+        verify(atLeast = 1) { streamingHint.visibility = capture(captured) }
+        assertEquals(View.VISIBLE, captured.last())
     }
 }


### PR DESCRIPTION
## Summary
- New persistent **STREAMING · KEEP APP OPEN** pill (bottom-center, `bg_pill` + cyan-tinted link glyph + `Label.Accent`) appears whenever a slot is bound + connected — the same `WakeStateController.shouldKeepScreenOn` signal that already raises `FLAG_KEEP_SCREEN_ON`. So users now have a continuous visual cue that closing the app or locking the screen ends the session.
- Inside the low-power dim overlay, a new body line ("Streaming continues while dimmed — don't close Dish.") sits between the status row and TAP TO WAKE so the dim screen itself answers "why is my phone dimmed?".
- Both views live in `overlay_low_power.xml` so the dashboard, gamepad, and touchpad overlays inherit them via the existing `<include>`. Visibility is gated entirely in `LowPowerManager` — the hint hides during COUNTDOWN/ACTIVE so it never collides with the countdown banner or the dim HUD.
- Strings localised in en, fr, de, es, bs, pt-BR.

## Test plan
- [x] `./gradlew ktlintCheck detekt lint testDebugUnitTest assembleDebug` (all green locally)
- [x] New `LowPowerManagerTest` cases cover the visibility transitions (IDLE↔streaming, COUNTDOWN suppress, ACTIVE→IDLE wake)
- [ ] Manual smoke on a phone: bind a Bluetooth controller, confirm the hint pill appears on dashboard + overlays; idle to trigger countdown and dim, confirm hint hides during countdown/dim and the dim copy is legible