### PR TITLE
feat(onboarding): welcome flow, setup wizard, and Help & FAQ

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,6 +132,7 @@ android {
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.core.splashscreen)
+    implementation(libs.androidx.viewpager2)
     implementation(libs.androidx.window)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -96,6 +96,32 @@
             android:parentActivityName=".ui.main.MainActivity"
             tools:targetApi="p" />
 
+        <activity
+            android:name=".ui.onboarding.WelcomeActivity"
+            android:exported="false"
+            android:resizeableActivity="true"
+            android:theme="@style/Theme.Dish"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden"
+            tools:targetApi="p" />
+
+        <activity
+            android:name=".ui.onboarding.SetupWizardActivity"
+            android:exported="false"
+            android:resizeableActivity="true"
+            android:theme="@style/Theme.Dish"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden"
+            android:parentActivityName=".ui.main.MainActivity"
+            tools:targetApi="p" />
+
+        <activity
+            android:name=".ui.onboarding.HelpActivity"
+            android:exported="false"
+            android:resizeableActivity="true"
+            android:theme="@style/Theme.Dish"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden"
+            android:parentActivityName=".ui.settings.SettingsActivity"
+            tools:targetApi="p" />
+
         <service
             android:name=".composer.StreamingService"
             android:exported="false"

--- a/app/src/main/java/com/tinkernorth/dish/source/store/OnboardingPreferenceStore.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/store/OnboardingPreferenceStore.kt
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.store
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.tinkernorth.dish.architecture.abstracts.AbstractStateSource
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+data class OnboardingState(
+    val welcomeCompleted: Boolean,
+    val dashboardHintDismissed: Boolean,
+)
+
+@Singleton
+class OnboardingPreferenceStore
+    @Inject
+    constructor(
+        @ApplicationContext context: Context,
+    ) : AbstractStateSource<OnboardingState>(
+            initialState = readInitial(context),
+        ) {
+        private val prefs: SharedPreferences =
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+        fun markWelcomeCompleted() {
+            prefs.edit { putBoolean(KEY_WELCOME_COMPLETED, true) }
+            setState(state.value.copy(welcomeCompleted = true))
+        }
+
+        fun dismissDashboardHint() {
+            prefs.edit { putBoolean(KEY_DASHBOARD_HINT_DISMISSED, true) }
+            setState(state.value.copy(dashboardHintDismissed = true))
+        }
+
+        fun resetWelcome() {
+            prefs.edit {
+                putBoolean(KEY_WELCOME_COMPLETED, false)
+                putBoolean(KEY_DASHBOARD_HINT_DISMISSED, false)
+            }
+            setState(OnboardingState(welcomeCompleted = false, dashboardHintDismissed = false))
+        }
+
+        companion object {
+            const val PREFS_NAME = "user_preferences"
+            const val KEY_WELCOME_COMPLETED = "onboarding_welcome_completed"
+            const val KEY_DASHBOARD_HINT_DISMISSED = "onboarding_dashboard_hint_dismissed"
+
+            private fun readInitial(context: Context): OnboardingState {
+                val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                return OnboardingState(
+                    welcomeCompleted = prefs.getBoolean(KEY_WELCOME_COMPLETED, false),
+                    dashboardHintDismissed = prefs.getBoolean(KEY_DASHBOARD_HINT_DISMISSED, false),
+                )
+            }
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/ui/common/DishNavigator.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/DishNavigator.kt
@@ -34,6 +34,18 @@ class DishNavigator(
         controller.navigate(R.id.settingsActivity)
     }
 
+    fun toWelcome() {
+        controller.navigate(R.id.welcomeActivity)
+    }
+
+    fun toSetupWizard() {
+        controller.navigate(R.id.setupWizardActivity)
+    }
+
+    fun toHelp() {
+        controller.navigate(R.id.helpActivity)
+    }
+
     fun toTouchpad(
         connectionId: String,
         touchpadMode: String,

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
@@ -7,6 +7,7 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import androidx.activity.viewModels
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -22,6 +23,8 @@ import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.hotpath.overlay.GamepadActivityHost
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.notification.DishNotifications
+import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
+import com.tinkernorth.dish.source.store.OnboardingState
 import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
@@ -47,6 +50,8 @@ class MainActivity :
     @Inject lateinit var gamepadRegistry: PhysicalGamepadRegistry
 
     @Inject lateinit var notifications: DishNotifications
+
+    @Inject lateinit var onboarding: OnboardingPreferenceStore
 
     private lateinit var gamepadHost: GamepadActivityHost
 
@@ -77,6 +82,12 @@ class MainActivity :
             finish()
             return
         }
+        if (!onboarding.state.value.welcomeCompleted) {
+            splashHoldUntilFirstRender = false
+            nav.toWelcome()
+            finish()
+            return
+        }
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
         gamepadHost = attachGamepadHost(binding.root, wakeState, gamepadRegistry, notifications)
@@ -100,6 +111,12 @@ class MainActivity :
         binding.rvControllers.adapter = controllerAdapter
         binding.btnManageConnections.setOnClickListener { nav.toConnections() }
         binding.btnSettings.setOnClickListener { nav.toSettings() }
+        binding.cardDashboardHintInclude.btnDashboardHintOpen.setOnClickListener {
+            nav.toSetupWizard()
+        }
+        binding.cardDashboardHintInclude.btnDashboardHintDismiss.setOnClickListener {
+            onboarding.dismissDashboardHint()
+        }
     }
 
     private fun observeViewModel() {
@@ -109,6 +126,22 @@ class MainActivity :
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) { viewModel.events.collect { handleEvent(it) } }
         }
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                onboarding.state.collect { refreshDashboardHint(it, viewModel.uiState.value) }
+            }
+        }
+    }
+
+    private fun refreshDashboardHint(
+        onboardingState: OnboardingState,
+        ui: MainUiState,
+    ) {
+        val shouldShow =
+            onboardingState.welcomeCompleted &&
+                !onboardingState.dashboardHintDismissed &&
+                ui.connections.isEmpty()
+        binding.cardDashboardHintInclude.cardDashboardHint.isVisible = shouldShow
     }
 
     private fun updateUI(s: MainUiState) {
@@ -132,6 +165,7 @@ class MainActivity :
             s.motionCapabilities,
             s.touchpadModesBySatellite,
         )
+        refreshDashboardHint(onboarding.state.value, s)
     }
 
     private fun handleEvent(event: MainEvent) {

--- a/app/src/main/java/com/tinkernorth/dish/ui/onboarding/HelpActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/onboarding/HelpActivity.kt
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.onboarding
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.net.toUri
+import androidx.core.view.isVisible
+import com.tinkernorth.dish.R
+import com.tinkernorth.dish.databinding.ActivityHelpBinding
+import com.tinkernorth.dish.databinding.HelpFaqRowBinding
+import com.tinkernorth.dish.source.notification.DishNotifications
+import com.tinkernorth.dish.ui.common.DishNavigator
+import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
+import com.tinkernorth.dish.ui.common.applyDishSystemBars
+import com.tinkernorth.dish.ui.common.setupDishToolbar
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class HelpActivity : AppCompatActivity() {
+    @Inject lateinit var notifications: DishNotifications
+
+    private lateinit var binding: ActivityHelpBinding
+    private val nav by lazy { DishNavigator(this) }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityHelpBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        setupDishToolbar(binding.toolbar)
+        applyDishSystemBars(binding.root)
+        applyDishActivityTransitions()
+
+        bindRunSetupCard()
+        bindSectionLabels()
+        bindFaqRows()
+        bindLinkCards()
+    }
+
+    private fun bindRunSetupCard() {
+        binding.cardRowRunSetup.cardRowIcon.setImageResource(R.drawable.ic_route)
+        binding.cardRowRunSetup.cardRowTitle.setText(R.string.help_run_setup_title)
+        binding.cardRowRunSetup.cardRowSubtitle.setText(R.string.help_run_setup_body)
+        binding.cardRunSetup.setOnClickListener { nav.toSetupWizard() }
+    }
+
+    private fun bindSectionLabels() {
+        binding.sectionConcepts.labelSection.setText(R.string.help_section_concepts)
+        binding.sectionPerformance.labelSection.setText(R.string.help_section_performance)
+        binding.sectionTrouble.labelSection.setText(R.string.help_section_troubleshooting)
+        binding.sectionAbout.labelSection.setText(R.string.help_section_about)
+    }
+
+    private fun bindFaqRows() {
+        bindFaq(binding.faqWhatIsDish, R.string.help_q_what_is_dish, R.string.help_a_what_is_dish)
+        bindFaq(binding.faqWhatIsSatellite, R.string.help_q_what_is_satellite, R.string.help_a_what_is_satellite)
+        bindFaq(binding.faqLanVsBluetooth, R.string.help_q_lan_vs_bluetooth, R.string.help_a_lan_vs_bluetooth)
+        bindFaq(binding.faqControllerModes, R.string.help_q_controller_modes, R.string.help_a_controller_modes)
+        bindFaq(binding.faqMotionTouchpad, R.string.help_q_motion_touchpad, R.string.help_a_motion_touchpad)
+
+        bindFaq(binding.faqBestSetup, R.string.help_q_best_setup, R.string.help_a_best_setup)
+        bindFaq(binding.faqWhyLanLower, R.string.help_q_why_lan_lower, R.string.help_a_why_lan_lower)
+        bindFaq(binding.faqWiredBetter, R.string.help_q_wired_better, R.string.help_a_wired_better)
+
+        bindFaq(binding.faqNoSatellites, R.string.help_q_no_satellites, R.string.help_a_no_satellites)
+        bindFaq(binding.faqPinRejected, R.string.help_q_pin_rejected, R.string.help_a_pin_rejected)
+        bindFaq(binding.faqDisconnects, R.string.help_q_disconnects, R.string.help_a_disconnects)
+        bindFaq(binding.faqNoMotion, R.string.help_q_no_motion, R.string.help_a_no_motion)
+        bindFaq(binding.faqBatteryDrain, R.string.help_q_battery_drain, R.string.help_a_battery_drain)
+
+        bindFaq(binding.faqOpenSource, R.string.help_q_open_source, R.string.help_a_open_source)
+        bindFaq(binding.faqPrivacy, R.string.help_q_privacy, R.string.help_a_privacy)
+    }
+
+    private fun bindFaq(
+        row: HelpFaqRowBinding,
+        @StringRes question: Int,
+        @StringRes answer: Int,
+    ) {
+        row.faqQuestion.setText(question)
+        row.faqAnswer.setText(answer)
+        row.faqRowRoot.setOnClickListener { toggleFaq(row) }
+    }
+
+    private fun toggleFaq(row: HelpFaqRowBinding) {
+        val expanding = !row.faqAnswer.isVisible
+        row.faqAnswer.isVisible = expanding
+        val rotation = if (expanding) 180f else 0f
+        val duration = resources.getInteger(R.integer.motion_duration_medium).toLong() / 2L
+        row.faqChevron
+            .animate()
+            .rotation(rotation)
+            .setDuration(duration)
+            .start()
+    }
+
+    private fun bindLinkCards() {
+        binding.cardRowHelpPrivacy.cardRowIcon.setImageResource(R.drawable.ic_shield)
+        binding.cardRowHelpPrivacy.cardRowTitle.setText(R.string.help_view_privacy_policy)
+        binding.cardRowHelpPrivacy.cardRowSubtitle.text =
+            getString(R.string.url_privacy_policy)
+                .removePrefix("https://")
+                .removePrefix("http://")
+                .removeSuffix("/")
+        binding.cardHelpPrivacy.setOnClickListener {
+            openExternalUrl(getString(R.string.url_privacy_policy))
+        }
+
+        binding.cardRowHelpGithub.cardRowIcon.setImageResource(R.drawable.ic_open_in_new)
+        binding.cardRowHelpGithub.cardRowTitle.setText(R.string.help_view_github)
+        binding.cardRowHelpGithub.cardRowSubtitle.text =
+            getString(R.string.url_github)
+                .removePrefix("https://")
+                .removePrefix("http://")
+                .removeSuffix("/")
+        binding.cardHelpGithub.setOnClickListener {
+            openExternalUrl(getString(R.string.url_github))
+        }
+    }
+
+    private fun openExternalUrl(url: String) {
+        val intent =
+            Intent(Intent.ACTION_VIEW, url.toUri())
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        runCatching { startActivity(intent) }
+            .onFailure {
+                notifications.warn(
+                    title = getString(R.string.error_open_url),
+                    body = url,
+                    key = "external-url-failed",
+                )
+            }
+    }
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/onboarding/SetupWizardActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/onboarding/SetupWizardActivity.kt
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.onboarding
+
+import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.core.view.isVisible
+import com.google.android.material.card.MaterialCardView
+import com.tinkernorth.dish.R
+import com.tinkernorth.dish.databinding.ActivitySetupWizardBinding
+import com.tinkernorth.dish.databinding.WizardOptionCardBinding
+import com.tinkernorth.dish.ui.common.DishNavigator
+import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
+import com.tinkernorth.dish.ui.common.applyDishSystemBars
+import com.tinkernorth.dish.ui.common.setupDishToolbar
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class SetupWizardActivity : AppCompatActivity() {
+    private lateinit var binding: ActivitySetupWizardBinding
+    private val nav by lazy { DishNavigator(this) }
+
+    private enum class WizardConnection { LAN, BT }
+
+    private enum class WizardController { VIRTUAL, USB, PHYSICAL_BT }
+
+    private var step: Int = 1
+    private var pickedConnection: WizardConnection? = null
+    private var pickedController: WizardController? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivitySetupWizardBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        setupDishToolbar(binding.toolbar)
+        applyDishSystemBars(binding.root)
+        applyDishActivityTransitions()
+
+        savedInstanceState?.let {
+            step = it.getInt(STATE_STEP, 1).coerceIn(1, MAX_STEPS)
+            pickedConnection = it.getString(STATE_CONNECTION)?.let(WizardConnection::valueOf)
+            pickedController = it.getString(STATE_CONTROLLER)?.let(WizardController::valueOf)
+        }
+
+        bindStep1OptionCards()
+        bindStep2OptionCards()
+        bindNavButtons()
+        applyStep(step)
+
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    if (step > 1) {
+                        applyStep(step - 1)
+                    } else {
+                        isEnabled = false
+                        onBackPressedDispatcher.onBackPressed()
+                    }
+                }
+            },
+        )
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putInt(STATE_STEP, step)
+        pickedConnection?.let { outState.putString(STATE_CONNECTION, it.name) }
+        pickedController?.let { outState.putString(STATE_CONTROLLER, it.name) }
+    }
+
+    private fun bindStep1OptionCards() {
+        setOption(
+            binding.optionLan,
+            icon = R.drawable.ic_wifi,
+            title = R.string.wizard_option_lan_title,
+            body = R.string.wizard_option_lan_body,
+            recommendedLabel = R.string.wizard_option_lan_pill_recommended,
+        ) { selectConnection(WizardConnection.LAN) }
+
+        setOption(
+            binding.optionBt,
+            icon = R.drawable.ic_bluetooth,
+            title = R.string.wizard_option_bt_title,
+            body = R.string.wizard_option_bt_body,
+            recommendedLabel = null,
+        ) { selectConnection(WizardConnection.BT) }
+    }
+
+    private fun bindStep2OptionCards() {
+        setOption(
+            binding.optionVirtual,
+            icon = R.drawable.ic_phone,
+            title = R.string.wizard_option_virtual_title,
+            body = R.string.wizard_option_virtual_body,
+            recommendedLabel = null,
+        ) { selectController(WizardController.VIRTUAL) }
+
+        setOption(
+            binding.optionUsb,
+            icon = R.drawable.ic_usb,
+            title = R.string.wizard_option_usb_title,
+            body = R.string.wizard_option_usb_body,
+            recommendedLabel = R.string.wizard_option_usb_pill_recommended,
+        ) { selectController(WizardController.USB) }
+
+        setOption(
+            binding.optionPhysBt,
+            icon = R.drawable.ic_gamepad,
+            title = R.string.wizard_option_phys_bt_title,
+            body = R.string.wizard_option_phys_bt_body,
+            recommendedLabel = null,
+        ) { selectController(WizardController.PHYSICAL_BT) }
+    }
+
+    private fun setOption(
+        binding: WizardOptionCardBinding,
+        @DrawableRes icon: Int,
+        @StringRes title: Int,
+        @StringRes body: Int,
+        @StringRes recommendedLabel: Int?,
+        onClick: () -> Unit,
+    ) {
+        binding.optionIcon.setImageResource(icon)
+        binding.optionTitle.setText(title)
+        binding.optionBody.setText(body)
+        if (recommendedLabel != null) {
+            binding.optionRecommendedPill.setText(recommendedLabel)
+            binding.optionRecommendedPill.isVisible = true
+        } else {
+            binding.optionRecommendedPill.isVisible = false
+        }
+        binding.cardWizardOptionRoot.setOnClickListener { onClick() }
+    }
+
+    private fun bindNavButtons() {
+        binding.btnWizardBack.setOnClickListener {
+            if (step > 1) applyStep(step - 1) else finish()
+        }
+        binding.btnWizardNext.setOnClickListener { onPrimaryAction() }
+    }
+
+    private fun selectConnection(connection: WizardConnection) {
+        pickedConnection = connection
+        applySelectionStrokes()
+        refreshPrimaryAction()
+    }
+
+    private fun selectController(controller: WizardController) {
+        pickedController = controller
+        applySelectionStrokes()
+        refreshPrimaryAction()
+    }
+
+    private fun applySelectionStrokes() {
+        applyStroke(binding.optionLan.cardWizardOptionRoot, pickedConnection == WizardConnection.LAN)
+        applyStroke(binding.optionBt.cardWizardOptionRoot, pickedConnection == WizardConnection.BT)
+        applyStroke(binding.optionVirtual.cardWizardOptionRoot, pickedController == WizardController.VIRTUAL)
+        applyStroke(binding.optionUsb.cardWizardOptionRoot, pickedController == WizardController.USB)
+        applyStroke(binding.optionPhysBt.cardWizardOptionRoot, pickedController == WizardController.PHYSICAL_BT)
+    }
+
+    private fun applyStroke(
+        card: MaterialCardView,
+        selected: Boolean,
+    ) {
+        val color =
+            if (selected) {
+                ContextCompat.getColor(this, R.color.colorPrimary)
+            } else {
+                ContextCompat.getColor(this, R.color.colorCardStroke)
+            }
+        val width =
+            resources.getDimensionPixelSize(
+                if (selected) R.dimen.wizard_option_stroke_selected else R.dimen.border_thin,
+            )
+        card.strokeColor = color
+        card.strokeWidth = width
+    }
+
+    private fun applyStep(target: Int) {
+        step = target.coerceIn(1, MAX_STEPS)
+
+        binding.tvWizardProgress.text = getString(R.string.wizard_step_progress, step, MAX_STEPS)
+
+        binding.step1Body.isVisible = step == 1
+        binding.step2Body.isVisible = step == 2
+        binding.step3Body.isVisible = step == 3
+
+        when (step) {
+            1 -> {
+                binding.tvWizardEyebrow.setText(R.string.wizard_step1_eyebrow)
+                binding.tvWizardTitle.setText(R.string.wizard_step1_title)
+                binding.tvWizardBody.setText(R.string.wizard_step1_body)
+            }
+            2 -> {
+                binding.tvWizardEyebrow.setText(R.string.wizard_step2_eyebrow)
+                binding.tvWizardTitle.setText(R.string.wizard_step2_title)
+                binding.tvWizardBody.setText(R.string.wizard_step2_body)
+            }
+            3 -> {
+                binding.tvWizardEyebrow.setText(R.string.wizard_step3_eyebrow)
+                binding.tvWizardTitle.setText(R.string.wizard_step3_title)
+                binding.tvWizardBody.text = ""
+                renderSummary()
+            }
+        }
+
+        applySelectionStrokes()
+        refreshPrimaryAction()
+    }
+
+    private fun renderSummary() {
+        binding.tvSummaryConnection.text =
+            when (pickedConnection) {
+                WizardConnection.LAN -> getString(R.string.wizard_option_lan_title)
+                WizardConnection.BT -> getString(R.string.wizard_option_bt_title)
+                null -> ""
+            }
+        binding.tvSummaryController.text =
+            when (pickedController) {
+                WizardController.VIRTUAL -> getString(R.string.wizard_option_virtual_title)
+                WizardController.USB -> getString(R.string.wizard_option_usb_title)
+                WizardController.PHYSICAL_BT -> getString(R.string.wizard_option_phys_bt_title)
+                null -> ""
+            }
+        binding.tvWizardNextSteps.setText(nextStepsCopy())
+    }
+
+    @StringRes
+    private fun nextStepsCopy(): Int =
+        when {
+            pickedConnection == WizardConnection.LAN && pickedController == WizardController.VIRTUAL ->
+                R.string.wizard_next_lan_virtual
+            pickedConnection == WizardConnection.LAN && pickedController == WizardController.USB ->
+                R.string.wizard_next_lan_usb
+            pickedConnection == WizardConnection.LAN && pickedController == WizardController.PHYSICAL_BT ->
+                R.string.wizard_next_lan_phys_bt
+            pickedConnection == WizardConnection.BT && pickedController == WizardController.VIRTUAL ->
+                R.string.wizard_next_bt_virtual
+            pickedConnection == WizardConnection.BT && pickedController == WizardController.USB ->
+                R.string.wizard_next_bt_usb
+            pickedConnection == WizardConnection.BT && pickedController == WizardController.PHYSICAL_BT ->
+                R.string.wizard_next_bt_phys_bt
+            else -> R.string.wizard_step3_title
+        }
+
+    private fun isCombinationViable(): Boolean =
+        pickedConnection != WizardConnection.BT ||
+            pickedController == WizardController.VIRTUAL
+
+    private fun refreshPrimaryAction() {
+        when (step) {
+            1 -> {
+                binding.btnWizardNext.isEnabled = pickedConnection != null
+                binding.btnWizardNext.setText(R.string.wizard_action_next)
+                binding.btnWizardBack.isVisible = false
+            }
+            2 -> {
+                binding.btnWizardNext.isEnabled = pickedController != null
+                binding.btnWizardNext.setText(R.string.wizard_action_next)
+                binding.btnWizardBack.isVisible = true
+            }
+            3 -> {
+                binding.btnWizardNext.isEnabled = true
+                binding.btnWizardNext.setText(
+                    if (isCombinationViable()) {
+                        R.string.wizard_action_finish
+                    } else {
+                        R.string.wizard_finish_review
+                    },
+                )
+                binding.btnWizardBack.isVisible = true
+            }
+        }
+    }
+
+    private fun onPrimaryAction() {
+        when (step) {
+            1 -> if (pickedConnection != null) applyStep(2)
+            2 -> if (pickedController != null) applyStep(3)
+            3 -> {
+                if (isCombinationViable()) {
+                    nav.toConnections()
+                    finish()
+                } else {
+                    applyStep(1)
+                }
+            }
+        }
+    }
+
+    private companion object {
+        const val MAX_STEPS = 3
+        const val STATE_STEP = "wizard_current_step"
+        const val STATE_CONNECTION = "wizard_picked_connection"
+        const val STATE_CONTROLLER = "wizard_picked_controller"
+    }
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/onboarding/WelcomeActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/onboarding/WelcomeActivity.kt
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.onboarding
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.LinearLayout
+import androidx.activity.OnBackPressedCallback
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
+import androidx.viewpager2.widget.ViewPager2
+import com.tinkernorth.dish.R
+import com.tinkernorth.dish.databinding.ActivityWelcomeBinding
+import com.tinkernorth.dish.source.notification.DishNotifications
+import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
+import com.tinkernorth.dish.ui.common.DishNavigator
+import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
+import com.tinkernorth.dish.ui.common.applyDishSystemBars
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class WelcomeActivity : AppCompatActivity() {
+    @Inject lateinit var onboardingStore: OnboardingPreferenceStore
+
+    @Inject lateinit var notifications: DishNotifications
+
+    private lateinit var binding: ActivityWelcomeBinding
+    private val nav by lazy { DishNavigator(this) }
+
+    private val stepIndicatorDots: MutableList<View> = mutableListOf()
+
+    private val pages: List<WelcomePage> by lazy {
+        listOf(
+            WelcomePage(
+                hero = R.drawable.ic_dish_connected,
+                eyebrow = R.string.welcome_step1_eyebrow,
+                title = R.string.welcome_step1_title,
+                body = R.string.welcome_step1_body,
+                heroContentDescription = R.string.welcome_step1_hero_desc,
+            ),
+            WelcomePage(
+                hero = R.drawable.ic_phone_link,
+                eyebrow = R.string.welcome_step2_eyebrow,
+                title = R.string.welcome_step2_title,
+                body = R.string.welcome_step2_body,
+                heroContentDescription = R.string.welcome_step2_hero_desc,
+            ),
+            WelcomePage(
+                hero = R.drawable.ic_pc_monitor,
+                eyebrow = R.string.welcome_step3_eyebrow,
+                title = R.string.welcome_step3_title,
+                body = R.string.welcome_step3_body,
+                heroContentDescription = R.string.welcome_step3_hero_desc,
+                extraCtaLabel = R.string.welcome_step3_satellite_link_label,
+                extraCtaTag = CTA_OPEN_SATELLITE,
+            ),
+            WelcomePage(
+                hero = R.drawable.ic_check_circle,
+                eyebrow = R.string.welcome_step4_eyebrow,
+                title = R.string.welcome_step4_title,
+                body = R.string.welcome_step4_body,
+                heroContentDescription = R.string.welcome_step4_hero_desc,
+                extraCtaLabel = R.string.welcome_step4_launch_wizard,
+                extraCtaTag = CTA_LAUNCH_WIZARD,
+            ),
+        )
+    }
+
+    private val pageChangeCallback =
+        object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                updateStepIndicator(position)
+                updateNavButtons(position)
+            }
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityWelcomeBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        applyDishSystemBars(binding.root)
+        applyDishActivityTransitions()
+
+        buildStepIndicator()
+        binding.welcomePager.adapter =
+            WelcomePagerAdapter(pages) { page -> handleExtraCta(page) }
+        binding.welcomePager.registerOnPageChangeCallback(pageChangeCallback)
+
+        val initial = savedInstanceState?.getInt(STATE_STEP, 0)?.coerceIn(0, pages.lastIndex) ?: 0
+        binding.welcomePager.setCurrentItem(initial, false)
+        updateStepIndicator(initial)
+        updateNavButtons(initial)
+
+        binding.btnWelcomeSkip.setOnClickListener { completeAndLaunch(launchWizardAfter = false) }
+        binding.btnWelcomeBack.setOnClickListener {
+            val current = binding.welcomePager.currentItem
+            if (current > 0) binding.welcomePager.setCurrentItem(current - 1, true)
+        }
+        binding.btnWelcomeNext.setOnClickListener {
+            val current = binding.welcomePager.currentItem
+            if (current < pages.lastIndex) {
+                binding.welcomePager.setCurrentItem(current + 1, true)
+            } else {
+                completeAndLaunch(launchWizardAfter = false)
+            }
+        }
+
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    val current = binding.welcomePager.currentItem
+                    if (current > 0) {
+                        binding.welcomePager.setCurrentItem(current - 1, true)
+                    } else {
+                        isEnabled = false
+                        onBackPressedDispatcher.onBackPressed()
+                    }
+                }
+            },
+        )
+    }
+
+    override fun onDestroy() {
+        binding.welcomePager.unregisterOnPageChangeCallback(pageChangeCallback)
+        super.onDestroy()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putInt(STATE_STEP, binding.welcomePager.currentItem)
+    }
+
+    private fun buildStepIndicator() {
+        val container = binding.welcomeStepIndicator
+        container.removeAllViews()
+        stepIndicatorDots.clear()
+        val mutedColor = ContextCompat.getColor(this, R.color.colorMuted)
+        val heightPx = resources.getDimensionPixelSize(R.dimen.step_indicator_height)
+        val inactivePx = resources.getDimensionPixelSize(R.dimen.step_indicator_dot_width)
+        val marginPx = resources.getDimensionPixelSize(R.dimen.spacing_xs)
+        pages.indices.forEach { _ ->
+            val dot =
+                View(this).apply {
+                    background = ContextCompat.getDrawable(this@WelcomeActivity, R.drawable.bg_step_indicator)
+                    background.setTint(mutedColor)
+                }
+            val lp =
+                LinearLayout.LayoutParams(inactivePx, heightPx).apply {
+                    marginStart = marginPx
+                    marginEnd = marginPx
+                }
+            container.addView(dot, lp)
+            stepIndicatorDots += dot
+        }
+    }
+
+    private fun updateStepIndicator(activeIndex: Int) {
+        val activeColor = ContextCompat.getColor(this, R.color.colorPrimary)
+        val mutedColor = ContextCompat.getColor(this, R.color.colorMuted)
+        val activePx = resources.getDimensionPixelSize(R.dimen.step_indicator_dot_width_active)
+        val inactivePx = resources.getDimensionPixelSize(R.dimen.step_indicator_dot_width)
+        stepIndicatorDots.forEachIndexed { index, view ->
+            val active = index == activeIndex
+            view.background.setTint(if (active) activeColor else mutedColor)
+            val lp = view.layoutParams
+            lp.width = if (active) activePx else inactivePx
+            view.layoutParams = lp
+            view.contentDescription = getString(R.string.welcome_step_indicator_desc, index + 1, pages.size)
+        }
+    }
+
+    private fun updateNavButtons(position: Int) {
+        binding.btnWelcomeBack.visibility = if (position == 0) View.INVISIBLE else View.VISIBLE
+        val isFinalPage = position == pages.lastIndex
+        binding.btnWelcomeNext.setText(
+            if (isFinalPage) R.string.welcome_get_started else R.string.welcome_next,
+        )
+        binding.btnWelcomeSkip.visibility = if (isFinalPage) View.INVISIBLE else View.VISIBLE
+    }
+
+    private fun handleExtraCta(page: WelcomePage) {
+        when (page.extraCtaTag) {
+            CTA_OPEN_SATELLITE -> openExternalUrl(getString(R.string.url_satellite))
+            CTA_LAUNCH_WIZARD -> completeAndLaunch(launchWizardAfter = true)
+        }
+    }
+
+    private fun completeAndLaunch(launchWizardAfter: Boolean) {
+        onboardingStore.markWelcomeCompleted()
+        if (launchWizardAfter) {
+            nav.toSetupWizard()
+        } else {
+            val intent =
+                Intent(this, com.tinkernorth.dish.ui.main.MainActivity::class.java).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                }
+            startActivity(intent)
+        }
+        finish()
+    }
+
+    private fun openExternalUrl(url: String) {
+        val intent =
+            Intent(Intent.ACTION_VIEW, url.toUri())
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        runCatching { startActivity(intent) }
+            .onFailure {
+                notifications.warn(
+                    title = getString(R.string.error_open_url),
+                    body = url,
+                    key = "external-url-failed",
+                )
+            }
+    }
+
+    private companion object {
+        const val STATE_STEP = "welcome_current_step"
+        const val CTA_OPEN_SATELLITE = "open_satellite"
+        const val CTA_LAUNCH_WIZARD = "launch_wizard"
+    }
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/onboarding/WelcomePagerAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/onboarding/WelcomePagerAdapter.kt
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.onboarding
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.RecyclerView
+import com.tinkernorth.dish.databinding.WelcomePageBinding
+
+data class WelcomePage(
+    @DrawableRes val hero: Int,
+    @StringRes val eyebrow: Int,
+    @StringRes val title: Int,
+    @StringRes val body: Int,
+    @StringRes val heroContentDescription: Int,
+    @StringRes val extraCtaLabel: Int? = null,
+    val extraCtaTag: String? = null,
+)
+
+class WelcomePagerAdapter(
+    private val pages: List<WelcomePage>,
+    private val onExtraCta: (WelcomePage) -> Unit,
+) : RecyclerView.Adapter<WelcomePagerAdapter.PageViewHolder>() {
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): PageViewHolder {
+        val binding =
+            WelcomePageBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false,
+            )
+        return PageViewHolder(binding, onExtraCta)
+    }
+
+    override fun onBindViewHolder(
+        holder: PageViewHolder,
+        position: Int,
+    ) {
+        holder.bind(pages[position])
+    }
+
+    override fun getItemCount(): Int = pages.size
+
+    class PageViewHolder(
+        private val binding: WelcomePageBinding,
+        private val onExtraCta: (WelcomePage) -> Unit,
+    ) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(page: WelcomePage) {
+            val context = binding.root.context
+            binding.ivWelcomePageHero.setImageResource(page.hero)
+            binding.ivWelcomePageHero.contentDescription = context.getString(page.heroContentDescription)
+            binding.tvWelcomePageEyebrow.setText(page.eyebrow)
+            binding.tvWelcomePageTitle.setText(page.title)
+            binding.tvWelcomePageBody.setText(page.body)
+
+            val ctaLabel = page.extraCtaLabel
+            if (ctaLabel != null) {
+                binding.btnWelcomePageExtra.setText(ctaLabel)
+                binding.btnWelcomePageExtra.isVisible = true
+                binding.btnWelcomePageExtra.setOnClickListener { onExtraCta(page) }
+            } else {
+                binding.btnWelcomePageExtra.isVisible = false
+                binding.btnWelcomePageExtra.setOnClickListener(null)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/settings/SettingsActivity.kt
@@ -17,6 +17,7 @@ import com.tinkernorth.dish.source.notification.DishNotifications
 import com.tinkernorth.dish.source.store.CrashReportingStore
 import com.tinkernorth.dish.source.store.ThemeMode
 import com.tinkernorth.dish.source.store.ThemePreferenceStore
+import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.setupDishToolbar
@@ -33,6 +34,7 @@ class SettingsActivity : AppCompatActivity() {
     @Inject lateinit var notifications: DishNotifications
 
     private lateinit var binding: ActivitySettingsBinding
+    private val nav by lazy { DishNavigator(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -42,9 +44,20 @@ class SettingsActivity : AppCompatActivity() {
         applyDishSystemBars(binding.root)
         applyDishActivityTransitions()
 
+        binding.sectionSetup.labelSection.setText(R.string.settings_section_setup)
         binding.sectionAppearance.labelSection.setText(R.string.settings_section_appearance)
         binding.sectionDiagnostics.labelSection.setText(R.string.settings_section_diagnostics)
         binding.sectionAbout.labelSection.setText(R.string.settings_section_about)
+
+        binding.cardRowSetupWizard.cardRowIcon.setImageResource(R.drawable.ic_route)
+        binding.cardRowSetupWizard.cardRowTitle.setText(R.string.settings_setup_wizard_title)
+        binding.cardRowSetupWizard.cardRowSubtitle.setText(R.string.settings_setup_wizard_body)
+        binding.cardSetupWizard.setOnClickListener { nav.toSetupWizard() }
+
+        binding.cardRowHelp.cardRowIcon.setImageResource(R.drawable.ic_help)
+        binding.cardRowHelp.cardRowTitle.setText(R.string.settings_help_title)
+        binding.cardRowHelp.cardRowSubtitle.setText(R.string.settings_help_body)
+        binding.cardHelp.setOnClickListener { nav.toHelp() }
 
         binding.cardRowAppearance.cardRowIcon.setImageResource(R.drawable.ic_contrast)
         binding.cardRowAppearance.cardRowTitle.setText(R.string.settings_appearance_title)

--- a/app/src/main/res/drawable/bg_recommended_pill.xml
+++ b/app/src/main/res/drawable/bg_recommended_pill.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/colorPrimaryDark" />
+    <corners android:radius="@dimen/corner_pill" />
+</shape>

--- a/app/src/main/res/drawable/bg_step_indicator.xml
+++ b/app/src/main/res/drawable/bg_step_indicator.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/colorMuted" />
+    <corners android:radius="@dimen/size_3" />
+</shape>

--- a/app/src/main/res/drawable/ic_check_circle.xml
+++ b/app/src/main/res/drawable/ic_check_circle.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="64"
+    android:viewportHeight="64">
+    <path
+        android:fillColor="#8FCFE3"
+        android:pathData="M4,32 A28,28 0 1 0 60,32 A28,28 0 1 0 4,32 Z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.18"
+        android:pathData="M10,28 A22,22 0 1 0 54,28 A22,22 0 1 0 10,28 Z" />
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="5"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M20,33 L29,42 L46,24" />
+</vector>

--- a/app/src/main/res/drawable/ic_chevron_right.xml
+++ b/app/src/main/res/drawable/ic_chevron_right.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="64"
+    android:viewportHeight="64"
+    android:autoMirrored="true">
+    <path
+        android:strokeColor="#8FCFE3"
+        android:strokeWidth="4"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M24,12 L42,32 L24,52" />
+</vector>

--- a/app/src/main/res/drawable/ic_help.xml
+++ b/app/src/main/res/drawable/ic_help.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M12,22 A10,10 0 1 0 12,2 A10,10 0 1 0 12,22 Z" />
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M9.09,9 A3,3 0 0 1 14.94,10 C14.94,12 12,13 12,13" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M11,16.5 A1,1 0 1 0 13,16.5 A1,1 0 1 0 11,16.5 Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_lightning.xml
+++ b/app/src/main/res/drawable/ic_lightning.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M13,3 L4,14 H11 L11,21 L20,10 H13 Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_pc_monitor.xml
+++ b/app/src/main/res/drawable/ic_pc_monitor.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="64"
+    android:viewportHeight="64">
+    <path
+        android:fillColor="#8FCFE3"
+        android:pathData="M8,12 H56 A2,2 0 0 1 58,14 V42 A2,2 0 0 1 56,44 H8 A2,2 0 0 1 6,42 V14 A2,2 0 0 1 8,12 Z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.18"
+        android:pathData="M11,15 H53 A1,1 0 0 1 54,16 V40 A1,1 0 0 1 53,41 H11 A1,1 0 0 1 10,40 V16 A1,1 0 0 1 11,15 Z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M48,19 A2,2 0 1 0 52,19 A2,2 0 1 0 48,19 Z" />
+    <path
+        android:fillColor="#8FCFE3"
+        android:pathData="M28,44 H36 V52 H28 Z" />
+    <path
+        android:fillColor="#8FCFE3"
+        android:pathData="M18,52 H46 A1,1 0 0 1 47,53 V55 A1,1 0 0 1 46,56 H18 A1,1 0 0 1 17,55 V53 A1,1 0 0 1 18,52 Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_phone.xml
+++ b/app/src/main/res/drawable/ic_phone.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M7,2 H17 A2,2 0 0 1 19,4 V20 A2,2 0 0 1 17,22 H7 A2,2 0 0 1 5,20 V4 A2,2 0 0 1 7,2 Z" />
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:pathData="M11,18 L13,18" />
+</vector>

--- a/app/src/main/res/drawable/ic_phone_link.xml
+++ b/app/src/main/res/drawable/ic_phone_link.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="64"
+    android:viewportHeight="64">
+    <path
+        android:fillColor="#8FCFE3"
+        android:pathData="M16,8 H32 A2,2 0 0 1 34,10 V54 A2,2 0 0 1 32,56 H16 A2,2 0 0 1 14,54 V10 A2,2 0 0 1 16,8 Z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.22"
+        android:pathData="M18,12 H30 V48 H18 Z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.55"
+        android:pathData="M22,51 H26 V53 H22 Z" />
+    <path
+        android:strokeColor="#8FCFE3"
+        android:strokeWidth="3"
+        android:strokeLineCap="round"
+        android:fillColor="#00000000"
+        android:pathData="M40,26 Q44,32 40,38" />
+    <path
+        android:strokeColor="#8FCFE3"
+        android:strokeWidth="3"
+        android:strokeLineCap="round"
+        android:fillColor="#00000000"
+        android:pathData="M46,22 Q52,32 46,42" />
+    <path
+        android:strokeColor="#8FCFE3"
+        android:strokeWidth="3"
+        android:strokeLineCap="round"
+        android:fillColor="#00000000"
+        android:pathData="M52,18 Q60,32 52,46" />
+</vector>

--- a/app/src/main/res/drawable/ic_route.xml
+++ b/app/src/main/res/drawable/ic_route.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M6,3 A2,2 0 1 0 6,7 A2,2 0 1 0 6,3 Z" />
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M18,17 A2,2 0 1 0 18,21 A2,2 0 1 0 18,17 Z" />
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M6,9 L6,13 A3,3 0 0 0 9,16 L15,16 A3,3 0 0 0 18,13 L18,15" />
+</vector>

--- a/app/src/main/res/drawable/ic_usb.xml
+++ b/app/src/main/res/drawable/ic_usb.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="64"
+    android:viewportHeight="64">
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="3.5"
+        android:fillColor="#00000000"
+        android:pathData="M28,6 A4,4 0 1 0 36,6 A4,4 0 1 0 28,6 Z" />
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="3.5"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M32,10 L32,52" />
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="3.5"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#FFFFFF"
+        android:pathData="M26,52 L32,58 L38,52 Z" />
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="3.5"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M32,28 L22,38" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M19,35 H25 V41 H19 Z" />
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="3.5"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M32,22 L42,32" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M39,28 A3,3 0 1 0 45,28 A3,3 0 1 0 39,28 Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_wifi.xml
+++ b/app/src/main/res/drawable/ic_wifi.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="64"
+    android:viewportHeight="64">
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="4"
+        android:strokeLineCap="round"
+        android:fillColor="#00000000"
+        android:pathData="M10,22 Q32,4 54,22" />
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="4"
+        android:strokeLineCap="round"
+        android:fillColor="#00000000"
+        android:pathData="M18,32 Q32,18 46,32" />
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="4"
+        android:strokeLineCap="round"
+        android:fillColor="#00000000"
+        android:pathData="M26,42 Q32,34 38,42" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M29,50 A3,3 0 1 0 35,50 A3,3 0 1 0 29,50 Z" />
+</vector>

--- a/app/src/main/res/layout-sw600dp/activity_help.xml
+++ b/app/src/main/res/layout-sw600dp/activity_help.xml
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            style="@style/Widget.Dish.Toolbar"
+            android:layout_width="match_parent"
+            app:title="@string/help_title" />
+
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:paddingTop="@dimen/spacing_md"
+            android:paddingBottom="@dimen/spacing_6xl">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:gravity="center_horizontal">
+
+                <LinearLayout
+                    android:layout_width="@dimen/welcome_content_max_width"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <com.google.android.material.card.MaterialCardView
+                        android:id="@+id/cardRunSetup"
+                        style="@style/Widget.Dish.Card"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:foreground="?attr/selectableItemBackground">
+
+                        <LinearLayout
+                            style="@style/Widget.Dish.Card.RowContainer"
+                            android:gravity="center_vertical">
+
+                            <include
+                                android:id="@+id/cardRowRunSetup"
+                                layout="@layout/card_row_icon_label_value"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1" />
+
+                            <ImageView
+                                android:layout_width="@dimen/icon_card_glyph"
+                                android:layout_height="@dimen/icon_card_glyph"
+                                android:layout_marginStart="@dimen/spacing_xl"
+                                android:src="@drawable/ic_chevron_right"
+                                android:importantForAccessibility="no" />
+                        </LinearLayout>
+                    </com.google.android.material.card.MaterialCardView>
+
+                    <include
+                        android:id="@+id/sectionConcepts"
+                        layout="@layout/section_header"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/section_header_gap_above"
+                        android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+                    <include
+                        android:id="@+id/faqWhatIsDish"
+                        layout="@layout/help_faq_row" />
+                    <include
+                        android:id="@+id/faqWhatIsSatellite"
+                        layout="@layout/help_faq_row" />
+                    <include
+                        android:id="@+id/faqLanVsBluetooth"
+                        layout="@layout/help_faq_row" />
+                    <include
+                        android:id="@+id/faqControllerModes"
+                        layout="@layout/help_faq_row" />
+                    <include
+                        android:id="@+id/faqMotionTouchpad"
+                        layout="@layout/help_faq_row" />
+
+                    <include
+                        android:id="@+id/sectionPerformance"
+                        layout="@layout/section_header"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/section_header_gap_above"
+                        android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+                    <include
+                        android:id="@+id/faqBestSetup"
+                        layout="@layout/help_faq_row" />
+                    <include
+                        android:id="@+id/faqWhyLanLower"
+                        layout="@layout/help_faq_row" />
+                    <include
+                        android:id="@+id/faqWiredBetter"
+                        layout="@layout/help_faq_row" />
+
+                    <include
+                        android:id="@+id/sectionTrouble"
+                        layout="@layout/section_header"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/section_header_gap_above"
+                        android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+                    <include
+                        android:id="@+id/faqNoSatellites"
+                        layout="@layout/help_faq_row" />
+                    <include
+                        android:id="@+id/faqPinRejected"
+                        layout="@layout/help_faq_row" />
+                    <include
+                        android:id="@+id/faqDisconnects"
+                        layout="@layout/help_faq_row" />
+                    <include
+                        android:id="@+id/faqNoMotion"
+                        layout="@layout/help_faq_row" />
+                    <include
+                        android:id="@+id/faqBatteryDrain"
+                        layout="@layout/help_faq_row" />
+
+                    <include
+                        android:id="@+id/sectionAbout"
+                        layout="@layout/section_header"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/section_header_gap_above"
+                        android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+                    <include
+                        android:id="@+id/faqOpenSource"
+                        layout="@layout/help_faq_row" />
+                    <include
+                        android:id="@+id/faqPrivacy"
+                        layout="@layout/help_faq_row" />
+
+                    <com.google.android.material.card.MaterialCardView
+                        android:id="@+id/cardHelpPrivacy"
+                        style="@style/Widget.Dish.Card"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/card_margin_bottom"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:foreground="?attr/selectableItemBackground">
+
+                        <LinearLayout
+                            style="@style/Widget.Dish.Card.RowContainer"
+                            android:gravity="center_vertical">
+
+                            <include
+                                android:id="@+id/cardRowHelpPrivacy"
+                                layout="@layout/card_row_icon_label_value"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1" />
+
+                            <ImageView
+                                android:layout_width="@dimen/icon_card_glyph"
+                                android:layout_height="@dimen/icon_card_glyph"
+                                android:layout_marginStart="@dimen/spacing_xl"
+                                android:src="@drawable/ic_open_in_new"
+                                android:importantForAccessibility="no" />
+                        </LinearLayout>
+                    </com.google.android.material.card.MaterialCardView>
+
+                    <com.google.android.material.card.MaterialCardView
+                        android:id="@+id/cardHelpGithub"
+                        style="@style/Widget.Dish.Card"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/card_margin_bottom"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:foreground="?attr/selectableItemBackground">
+
+                        <LinearLayout
+                            style="@style/Widget.Dish.Card.RowContainer"
+                            android:gravity="center_vertical">
+
+                            <include
+                                android:id="@+id/cardRowHelpGithub"
+                                layout="@layout/card_row_icon_label_value"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1" />
+
+                            <ImageView
+                                android:layout_width="@dimen/icon_card_glyph"
+                                android:layout_height="@dimen/icon_card_glyph"
+                                android:layout_marginStart="@dimen/spacing_xl"
+                                android:src="@drawable/ic_open_in_new"
+                                android:importantForAccessibility="no" />
+                        </LinearLayout>
+                    </com.google.android.material.card.MaterialCardView>
+                </LinearLayout>
+            </LinearLayout>
+        </androidx.core.widget.NestedScrollView>
+    </LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout-sw600dp/activity_main.xml
+++ b/app/src/main/res/layout-sw600dp/activity_main.xml
@@ -124,6 +124,13 @@
                             android:text="@string/action_manage" />
                     </LinearLayout>
                 </com.google.android.material.card.MaterialCardView>
+
+                <include
+                    android:id="@+id/cardDashboardHintInclude"
+                    layout="@layout/dashboard_hint_card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/card_margin_bottom" />
             </LinearLayout>
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout-sw600dp/activity_settings.xml
+++ b/app/src/main/res/layout-sw600dp/activity_settings.xml
@@ -34,10 +34,77 @@
                     android:orientation="vertical">
 
                     <include
+                        android:id="@+id/sectionSetup"
+                        layout="@layout/section_header"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+                    <com.google.android.material.card.MaterialCardView
+                        android:id="@+id/cardSetupWizard"
+                        style="@style/Widget.Dish.Card"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:foreground="?attr/selectableItemBackground">
+
+                        <LinearLayout
+                            style="@style/Widget.Dish.Card.RowContainer"
+                            android:gravity="center_vertical">
+
+                            <include
+                                android:id="@+id/cardRowSetupWizard"
+                                layout="@layout/card_row_icon_label_value"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1" />
+
+                            <ImageView
+                                android:layout_width="@dimen/icon_card_glyph"
+                                android:layout_height="@dimen/icon_card_glyph"
+                                android:layout_marginStart="@dimen/spacing_xl"
+                                android:src="@drawable/ic_chevron_right"
+                                android:importantForAccessibility="no" />
+                        </LinearLayout>
+                    </com.google.android.material.card.MaterialCardView>
+
+                    <com.google.android.material.card.MaterialCardView
+                        android:id="@+id/cardHelp"
+                        style="@style/Widget.Dish.Card"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/card_margin_bottom"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:foreground="?attr/selectableItemBackground">
+
+                        <LinearLayout
+                            style="@style/Widget.Dish.Card.RowContainer"
+                            android:gravity="center_vertical">
+
+                            <include
+                                android:id="@+id/cardRowHelp"
+                                layout="@layout/card_row_icon_label_value"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1" />
+
+                            <ImageView
+                                android:layout_width="@dimen/icon_card_glyph"
+                                android:layout_height="@dimen/icon_card_glyph"
+                                android:layout_marginStart="@dimen/spacing_xl"
+                                android:src="@drawable/ic_chevron_right"
+                                android:importantForAccessibility="no" />
+                        </LinearLayout>
+                    </com.google.android.material.card.MaterialCardView>
+
+                    <include
                         android:id="@+id/sectionAppearance"
                         layout="@layout/section_header"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/section_header_gap_above"
                         android:layout_marginBottom="@dimen/section_header_gap_below" />
 
                     <com.google.android.material.card.MaterialCardView

--- a/app/src/main/res/layout-sw600dp/activity_setup_wizard.xml
+++ b/app/src/main/res/layout-sw600dp/activity_setup_wizard.xml
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            style="@style/Widget.Dish.Toolbar"
+            android:layout_width="match_parent"
+            app:title="@string/wizard_title" />
+
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:paddingTop="@dimen/spacing_md"
+            android:paddingBottom="@dimen/spacing_5xl">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:gravity="center_horizontal">
+
+                <LinearLayout
+                    android:layout_width="@dimen/welcome_content_max_width"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/tvWizardProgress"
+                        style="@style/TextAppearance.Dish.Caption"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textAllCaps="true"
+                        tools:text="STEP 1 OF 3" />
+
+                    <TextView
+                        android:id="@+id/tvWizardEyebrow"
+                        style="@style/TextAppearance.Dish.Label.Accent"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_md"
+                        tools:text="STEP 1 · CONNECTION" />
+
+                    <TextView
+                        android:id="@+id/tvWizardTitle"
+                        style="@style/TextAppearance.Dish.Title.Large"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_md"
+                        tools:text="How will you reach your PC?" />
+
+                    <TextView
+                        android:id="@+id/tvWizardBody"
+                        style="@style/TextAppearance.Dish.Body"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_xl"
+                        tools:text="Two ways to send your input to a PC." />
+
+                    <LinearLayout
+                        android:id="@+id/step1Body"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_md"
+                        android:orientation="vertical">
+
+                        <include
+                            android:id="@+id/optionLan"
+                            layout="@layout/wizard_option_card" />
+
+                        <include
+                            android:id="@+id/optionBt"
+                            layout="@layout/wizard_option_card" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/step2Body"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_md"
+                        android:orientation="vertical"
+                        android:visibility="gone"
+                        tools:visibility="gone">
+
+                        <include
+                            android:id="@+id/optionVirtual"
+                            layout="@layout/wizard_option_card" />
+
+                        <include
+                            android:id="@+id/optionUsb"
+                            layout="@layout/wizard_option_card" />
+
+                        <include
+                            android:id="@+id/optionPhysBt"
+                            layout="@layout/wizard_option_card" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/step3Body"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_md"
+                        android:orientation="vertical"
+                        android:visibility="gone"
+                        tools:visibility="gone">
+
+                        <com.google.android.material.card.MaterialCardView
+                            style="@style/Widget.Dish.Card"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content">
+
+                            <LinearLayout
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:orientation="vertical"
+                                android:padding="@dimen/card_padding">
+
+                                <LinearLayout
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:orientation="horizontal"
+                                    android:gravity="center_vertical">
+
+                                    <TextView
+                                        style="@style/TextAppearance.Dish.Label"
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:text="@string/wizard_summary_connection_label"
+                                        android:textAllCaps="true" />
+
+                                    <TextView
+                                        android:id="@+id/tvSummaryConnection"
+                                        style="@style/TextAppearance.Dish.Body.Mono"
+                                        android:layout_width="0dp"
+                                        android:layout_height="wrap_content"
+                                        android:layout_weight="1"
+                                        android:layout_marginStart="@dimen/spacing_xl"
+                                        android:gravity="end"
+                                        tools:text="Wi-Fi to Satellite" />
+                                </LinearLayout>
+
+                                <LinearLayout
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:orientation="horizontal"
+                                    android:layout_marginTop="@dimen/spacing_md"
+                                    android:gravity="center_vertical">
+
+                                    <TextView
+                                        style="@style/TextAppearance.Dish.Label"
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:text="@string/wizard_summary_controller_label"
+                                        android:textAllCaps="true" />
+
+                                    <TextView
+                                        android:id="@+id/tvSummaryController"
+                                        style="@style/TextAppearance.Dish.Body.Mono"
+                                        android:layout_width="0dp"
+                                        android:layout_height="wrap_content"
+                                        android:layout_weight="1"
+                                        android:layout_marginStart="@dimen/spacing_xl"
+                                        android:gravity="end"
+                                        tools:text="USB controller into phone" />
+                                </LinearLayout>
+                            </LinearLayout>
+                        </com.google.android.material.card.MaterialCardView>
+
+                        <TextView
+                            android:id="@+id/tvWizardNextSteps"
+                            style="@style/TextAppearance.Dish.Body"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_5xl"
+                            tools:text="Tap Finish to open Connections." />
+                    </LinearLayout>
+                </LinearLayout>
+            </LinearLayout>
+        </androidx.core.widget.NestedScrollView>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_horizontal"
+            android:paddingVertical="@dimen/spacing_xl">
+
+            <LinearLayout
+                android:layout_width="@dimen/welcome_content_max_width"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnWizardBack"
+                    style="@style/Widget.Dish.Button.Outlined"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/wizard_action_back" />
+
+                <Space
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnWizardNext"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/wizard_action_next" />
+            </LinearLayout>
+        </LinearLayout>
+    </LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout-sw600dp/activity_welcome.xml
+++ b/app/src/main/res/layout-sw600dp/activity_welcome.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:gravity="center_horizontal">
+
+        <LinearLayout
+            android:id="@+id/welcomeRoot"
+            android:layout_width="@dimen/welcome_content_max_width"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:paddingHorizontal="@dimen/spacing_5xl"
+                android:paddingTop="@dimen/spacing_md">
+
+                <TextView
+                    style="@style/TextAppearance.Dish.Display.Large"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/brand_name" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnWelcomeSkip"
+                    style="@style/Widget.Dish.Button.Outlined"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/welcome_skip" />
+            </LinearLayout>
+
+            <androidx.viewpager2.widget.ViewPager2
+                android:id="@+id/welcomePager"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+            <LinearLayout
+                android:id="@+id/welcomeStepIndicator"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="@dimen/spacing_5xl"
+                android:orientation="horizontal"
+                android:gravity="center_vertical" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:paddingHorizontal="@dimen/spacing_5xl"
+                android:paddingTop="@dimen/spacing_5xl"
+                android:paddingBottom="@dimen/spacing_5xl">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnWelcomeBack"
+                    style="@style/Widget.Dish.Button.Outlined"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/welcome_back"
+                    android:visibility="invisible"
+                    tools:visibility="visible" />
+
+                <Space
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnWelcomeNext"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/welcome_next" />
+            </LinearLayout>
+        </LinearLayout>
+    </LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_help.xml
+++ b/app/src/main/res/layout/activity_help.xml
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            style="@style/Widget.Dish.Toolbar"
+            android:layout_width="match_parent"
+            app:title="@string/help_title" />
+
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:paddingHorizontal="@dimen/spacing_5xl"
+            android:paddingTop="@dimen/spacing_md"
+            android:paddingBottom="@dimen/spacing_6xl">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardRunSetup"
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
+
+                    <LinearLayout
+                        style="@style/Widget.Dish.Card.RowContainer"
+                        android:gravity="center_vertical">
+
+                        <include
+                            android:id="@+id/cardRowRunSetup"
+                            layout="@layout/card_row_icon_label_value"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1" />
+
+                        <ImageView
+                            android:layout_width="@dimen/icon_card_glyph"
+                            android:layout_height="@dimen/icon_card_glyph"
+                            android:layout_marginStart="@dimen/spacing_xl"
+                            android:src="@drawable/ic_chevron_right"
+                            android:importantForAccessibility="no" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <include
+                    android:id="@+id/sectionConcepts"
+                    layout="@layout/section_header"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/section_header_gap_above"
+                    android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+                <include
+                    android:id="@+id/faqWhatIsDish"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqWhatIsSatellite"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqLanVsBluetooth"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqControllerModes"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqMotionTouchpad"
+                    layout="@layout/help_faq_row" />
+
+                <include
+                    android:id="@+id/sectionPerformance"
+                    layout="@layout/section_header"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/section_header_gap_above"
+                    android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+                <include
+                    android:id="@+id/faqBestSetup"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqWhyLanLower"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqWiredBetter"
+                    layout="@layout/help_faq_row" />
+
+                <include
+                    android:id="@+id/sectionTrouble"
+                    layout="@layout/section_header"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/section_header_gap_above"
+                    android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+                <include
+                    android:id="@+id/faqNoSatellites"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqPinRejected"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqDisconnects"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqNoMotion"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqBatteryDrain"
+                    layout="@layout/help_faq_row" />
+
+                <include
+                    android:id="@+id/sectionAbout"
+                    layout="@layout/section_header"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/section_header_gap_above"
+                    android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+                <include
+                    android:id="@+id/faqOpenSource"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqPrivacy"
+                    layout="@layout/help_faq_row" />
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardHelpPrivacy"
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/card_margin_bottom"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
+
+                    <LinearLayout
+                        style="@style/Widget.Dish.Card.RowContainer"
+                        android:gravity="center_vertical">
+
+                        <include
+                            android:id="@+id/cardRowHelpPrivacy"
+                            layout="@layout/card_row_icon_label_value"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1" />
+
+                        <ImageView
+                            android:layout_width="@dimen/icon_card_glyph"
+                            android:layout_height="@dimen/icon_card_glyph"
+                            android:layout_marginStart="@dimen/spacing_xl"
+                            android:src="@drawable/ic_open_in_new"
+                            android:importantForAccessibility="no" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardHelpGithub"
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/card_margin_bottom"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
+
+                    <LinearLayout
+                        style="@style/Widget.Dish.Card.RowContainer"
+                        android:gravity="center_vertical">
+
+                        <include
+                            android:id="@+id/cardRowHelpGithub"
+                            layout="@layout/card_row_icon_label_value"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1" />
+
+                        <ImageView
+                            android:layout_width="@dimen/icon_card_glyph"
+                            android:layout_height="@dimen/icon_card_glyph"
+                            android:layout_marginStart="@dimen/spacing_xl"
+                            android:src="@drawable/ic_open_in_new"
+                            android:importantForAccessibility="no" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+            </LinearLayout>
+        </androidx.core.widget.NestedScrollView>
+    </LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -49,6 +49,13 @@
             </LinearLayout>
 
             <include
+                android:id="@+id/cardDashboardHintInclude"
+                layout="@layout/dashboard_hint_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/card_margin_bottom" />
+
+            <include
                 android:id="@+id/sectionConnections"
                 layout="@layout/section_header"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -53,17 +53,81 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
 
+                <include
+                    android:id="@+id/sectionSetup"
+                    layout="@layout/section_header"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardSetupWizard"
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
+
+                    <LinearLayout
+                        style="@style/Widget.Dish.Card.RowContainer"
+                        android:gravity="center_vertical">
+
+                        <include
+                            android:id="@+id/cardRowSetupWizard"
+                            layout="@layout/card_row_icon_label_value"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1" />
+
+                        <ImageView
+                            android:layout_width="@dimen/icon_card_glyph"
+                            android:layout_height="@dimen/icon_card_glyph"
+                            android:layout_marginStart="@dimen/spacing_xl"
+                            android:src="@drawable/ic_chevron_right"
+                            android:importantForAccessibility="no" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardHelp"
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/card_margin_bottom"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
+
+                    <LinearLayout
+                        style="@style/Widget.Dish.Card.RowContainer"
+                        android:gravity="center_vertical">
+
+                        <include
+                            android:id="@+id/cardRowHelp"
+                            layout="@layout/card_row_icon_label_value"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1" />
+
+                        <ImageView
+                            android:layout_width="@dimen/icon_card_glyph"
+                            android:layout_height="@dimen/icon_card_glyph"
+                            android:layout_marginStart="@dimen/spacing_xl"
+                            android:src="@drawable/ic_chevron_right"
+                            android:importantForAccessibility="no" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
                 <!-- ═══ APPEARANCE ═════════════════════════════════════════
                      Eyebrow uses the canonical `section_header.xml` include
-                     (label only); SettingsActivity.onCreate sets the text.
-                     First section on the screen — no gap_above on the
-                     include because the NestedScrollView's `paddingTop`
-                     (spacing_md) already supplies the breathing room. -->
+                     (label only); SettingsActivity.onCreate sets the text. -->
                 <include
                     android:id="@+id/sectionAppearance"
                     layout="@layout/section_header"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/section_header_gap_above"
                     android:layout_marginBottom="@dimen/section_header_gap_below" />
 
                 <!-- Theme card. Vertical orientation deviates from the other

--- a/app/src/main/res/layout/activity_setup_wizard.xml
+++ b/app/src/main/res/layout/activity_setup_wizard.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            style="@style/Widget.Dish.Toolbar"
+            android:layout_width="match_parent"
+            app:title="@string/wizard_title" />
+
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:paddingHorizontal="@dimen/spacing_5xl"
+            android:paddingTop="@dimen/spacing_md"
+            android:paddingBottom="@dimen/spacing_5xl">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/tvWizardProgress"
+                    style="@style/TextAppearance.Dish.Caption"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textAllCaps="true"
+                    tools:text="STEP 1 OF 3" />
+
+                <TextView
+                    android:id="@+id/tvWizardEyebrow"
+                    style="@style/TextAppearance.Dish.Label.Accent"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_md"
+                    tools:text="STEP 1 · CONNECTION" />
+
+                <TextView
+                    android:id="@+id/tvWizardTitle"
+                    style="@style/TextAppearance.Dish.Title.Large"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_md"
+                    tools:text="How will you reach your PC?" />
+
+                <TextView
+                    android:id="@+id/tvWizardBody"
+                    style="@style/TextAppearance.Dish.Body"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_xl"
+                    tools:text="Two ways to send your input to a PC. Wi-Fi is the lowest-latency path..." />
+
+                <LinearLayout
+                    android:id="@+id/step1Body"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_md"
+                    android:orientation="vertical">
+
+                    <include
+                        android:id="@+id/optionLan"
+                        layout="@layout/wizard_option_card" />
+
+                    <include
+                        android:id="@+id/optionBt"
+                        layout="@layout/wizard_option_card" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/step2Body"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_md"
+                    android:orientation="vertical"
+                    android:visibility="gone"
+                    tools:visibility="gone">
+
+                    <include
+                        android:id="@+id/optionVirtual"
+                        layout="@layout/wizard_option_card" />
+
+                    <include
+                        android:id="@+id/optionUsb"
+                        layout="@layout/wizard_option_card" />
+
+                    <include
+                        android:id="@+id/optionPhysBt"
+                        layout="@layout/wizard_option_card" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/step3Body"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_md"
+                    android:orientation="vertical"
+                    android:visibility="gone"
+                    tools:visibility="gone">
+
+                    <com.google.android.material.card.MaterialCardView
+                        style="@style/Widget.Dish.Card"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content">
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical"
+                            android:padding="@dimen/card_padding">
+
+                            <LinearLayout
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:orientation="horizontal"
+                                android:gravity="center_vertical">
+
+                                <TextView
+                                    style="@style/TextAppearance.Dish.Label"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/wizard_summary_connection_label"
+                                    android:textAllCaps="true" />
+
+                                <TextView
+                                    android:id="@+id/tvSummaryConnection"
+                                    style="@style/TextAppearance.Dish.Body.Mono"
+                                    android:layout_width="0dp"
+                                    android:layout_height="wrap_content"
+                                    android:layout_weight="1"
+                                    android:layout_marginStart="@dimen/spacing_xl"
+                                    android:gravity="end"
+                                    tools:text="Wi-Fi to Satellite" />
+                            </LinearLayout>
+
+                            <LinearLayout
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:orientation="horizontal"
+                                android:layout_marginTop="@dimen/spacing_md"
+                                android:gravity="center_vertical">
+
+                                <TextView
+                                    style="@style/TextAppearance.Dish.Label"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/wizard_summary_controller_label"
+                                    android:textAllCaps="true" />
+
+                                <TextView
+                                    android:id="@+id/tvSummaryController"
+                                    style="@style/TextAppearance.Dish.Body.Mono"
+                                    android:layout_width="0dp"
+                                    android:layout_height="wrap_content"
+                                    android:layout_weight="1"
+                                    android:layout_marginStart="@dimen/spacing_xl"
+                                    android:gravity="end"
+                                    tools:text="USB controller into phone" />
+                            </LinearLayout>
+                        </LinearLayout>
+                    </com.google.android.material.card.MaterialCardView>
+
+                    <TextView
+                        android:id="@+id/tvWizardNextSteps"
+                        style="@style/TextAppearance.Dish.Body"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_5xl"
+                        tools:text="Tap Finish to open Connections. Scan for your Satellite, pair it with the 4-digit PIN, then plug your USB controller into the phone." />
+                </LinearLayout>
+            </LinearLayout>
+        </androidx.core.widget.NestedScrollView>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingHorizontal="@dimen/spacing_5xl"
+            android:paddingVertical="@dimen/spacing_xl"
+            android:gravity="center_vertical">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnWizardBack"
+                style="@style/Widget.Dish.Button.Outlined"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/wizard_action_back" />
+
+            <Space
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnWizardNext"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/wizard_action_next" />
+        </LinearLayout>
+    </LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_welcome.xml
+++ b/app/src/main/res/layout/activity_welcome.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:id="@+id/welcomeRoot"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingHorizontal="@dimen/spacing_5xl"
+            android:paddingTop="@dimen/spacing_md">
+
+            <TextView
+                style="@style/TextAppearance.Dish.Display.Large"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/brand_name" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnWelcomeSkip"
+                style="@style/Widget.Dish.Button.Outlined"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/welcome_skip" />
+        </LinearLayout>
+
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/welcomePager"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+        <LinearLayout
+            android:id="@+id/welcomeStepIndicator"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="@dimen/spacing_5xl"
+            android:orientation="horizontal"
+            android:gravity="center_vertical" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingHorizontal="@dimen/spacing_5xl"
+            android:paddingTop="@dimen/spacing_5xl"
+            android:paddingBottom="@dimen/spacing_5xl">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnWelcomeBack"
+                style="@style/Widget.Dish.Button.Outlined"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/welcome_back"
+                android:visibility="invisible"
+                tools:visibility="visible" />
+
+            <Space
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnWelcomeNext"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/welcome_next" />
+        </LinearLayout>
+    </LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/dashboard_hint_card.xml
+++ b/app/src/main/res/layout/dashboard_hint_card.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/cardDashboardHint"
+    style="@style/Widget.Dish.Card"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:visibility="gone"
+    tools:visibility="visible">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="@dimen/card_padding">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="top">
+
+            <FrameLayout
+                android:layout_width="@dimen/icon_card_container"
+                android:layout_height="@dimen/icon_card_container"
+                android:background="@drawable/bg_icon_container">
+
+                <ImageView
+                    style="@style/Widget.Dish.Icon.Card"
+                    android:layout_gravity="center"
+                    android:src="@drawable/ic_route"
+                    android:importantForAccessibility="no" />
+            </FrameLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginStart="@dimen/spacing_2xl"
+                android:orientation="vertical">
+
+                <TextView
+                    style="@style/TextAppearance.Dish.Title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/dashboard_hint_title" />
+
+                <TextView
+                    style="@style/TextAppearance.Dish.Body"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_xs"
+                    android:text="@string/dashboard_hint_body" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginTop="@dimen/spacing_xl"
+            android:gravity="end">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnDashboardHintDismiss"
+                style="@style/Widget.Dish.Button.Outlined"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/spacing_md"
+                android:text="@string/dashboard_hint_action_dismiss" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnDashboardHintOpen"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/dashboard_hint_action_open" />
+        </LinearLayout>
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/help_faq_row.xml
+++ b/app/src/main/res/layout/help_faq_row.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/faqRowRoot"
+    style="@style/Widget.Dish.Card"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/card_margin_bottom"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?attr/selectableItemBackground">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="@dimen/card_padding">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <TextView
+                android:id="@+id/faqQuestion"
+                style="@style/TextAppearance.Dish.Title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                tools:text="What is Satellite?" />
+
+            <ImageView
+                android:id="@+id/faqChevron"
+                android:layout_width="@dimen/icon_chevron_lg"
+                android:layout_height="@dimen/icon_chevron_lg"
+                android:layout_marginStart="@dimen/spacing_xl"
+                android:src="@drawable/ic_chevron_down"
+                android:importantForAccessibility="no"
+                app:tint="@color/colorMuted" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/faqAnswer"
+            style="@style/TextAppearance.Dish.Body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacing_md"
+            android:visibility="gone"
+            tools:visibility="visible"
+            tools:text="Satellite is a small, free, open-source program that runs on your PC..." />
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/welcome_page.xml
+++ b/app/src/main/res/layout/welcome_page.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center_horizontal"
+    android:paddingHorizontal="@dimen/spacing_5xl">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <ImageView
+            android:id="@+id/ivWelcomePageHero"
+            android:layout_width="@dimen/welcome_hero_size"
+            android:layout_height="@dimen/welcome_hero_size"
+            android:layout_gravity="center"
+            android:adjustViewBounds="true"
+            android:scaleType="fitCenter"
+            tools:src="@drawable/ic_dish_connected" />
+    </FrameLayout>
+
+    <LinearLayout
+        android:id="@+id/welcomePageTextColumn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/tvWelcomePageEyebrow"
+            style="@style/TextAppearance.Dish.Label.Accent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            tools:text="WELCOME" />
+
+        <TextView
+            android:id="@+id/tvWelcomePageTitle"
+            style="@style/TextAppearance.Dish.Title.Large"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacing_md"
+            android:gravity="center_horizontal"
+            tools:text="Your phone, your gamepad" />
+
+        <TextView
+            android:id="@+id/tvWelcomePageBody"
+            style="@style/TextAppearance.Dish.Body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacing_xl"
+            android:gravity="center_horizontal"
+            tools:text="Dish turns your phone into a wireless controller for your PC." />
+    </LinearLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnWelcomePageExtra"
+        style="@style/Widget.Dish.Button.Outlined"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_5xl"
+        android:visibility="gone"
+        tools:text="Open setup guide"
+        tools:visibility="visible" />
+</LinearLayout>

--- a/app/src/main/res/layout/wizard_option_card.xml
+++ b/app/src/main/res/layout/wizard_option_card.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/cardWizardOptionRoot"
+    style="@style/Widget.Dish.Card"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/card_margin_bottom"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?attr/selectableItemBackground">
+
+    <LinearLayout
+        style="@style/Widget.Dish.Card.RowContainer"
+        android:gravity="top">
+
+        <FrameLayout
+            android:layout_width="@dimen/icon_card_container"
+            android:layout_height="@dimen/icon_card_container"
+            android:background="@drawable/bg_icon_container">
+
+            <ImageView
+                android:id="@+id/optionIcon"
+                style="@style/Widget.Dish.Icon.Card"
+                android:layout_gravity="center"
+                android:importantForAccessibility="no"
+                tools:src="@drawable/ic_wifi" />
+        </FrameLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="@dimen/spacing_2xl"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <TextView
+                    android:id="@+id/optionTitle"
+                    style="@style/TextAppearance.Dish.Title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    tools:text="Wi-Fi to Satellite" />
+
+                <TextView
+                    android:id="@+id/optionRecommendedPill"
+                    style="@style/TextAppearance.Dish.Caption"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/spacing_md"
+                    android:background="@drawable/bg_recommended_pill"
+                    android:paddingHorizontal="@dimen/spacing_md"
+                    android:paddingVertical="@dimen/recommended_pill_vertical_padding"
+                    android:textColor="@color/colorOnPrimary"
+                    android:textAllCaps="true"
+                    android:visibility="gone"
+                    tools:text="RECOMMENDED"
+                    tools:visibility="visible" />
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/optionBody"
+                style="@style/TextAppearance.Dish.Body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_xs"
+                tools:text="Phone and PC on the same Wi-Fi. Lowest latency, full feature set." />
+        </LinearLayout>
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -60,6 +60,21 @@
         android:name="com.tinkernorth.dish.ui.settings.SettingsActivity"
         android:label="@string/settings_title" />
 
+    <activity
+        android:id="@+id/welcomeActivity"
+        android:name="com.tinkernorth.dish.ui.onboarding.WelcomeActivity"
+        android:label="@string/welcome_step1_title" />
+
+    <activity
+        android:id="@+id/setupWizardActivity"
+        android:name="com.tinkernorth.dish.ui.onboarding.SetupWizardActivity"
+        android:label="@string/wizard_title" />
+
+    <activity
+        android:id="@+id/helpActivity"
+        android:name="com.tinkernorth.dish.ui.onboarding.HelpActivity"
+        android:label="@string/help_title" />
+
     <!-- ═══ INPUT OVERLAYS ════════════════════════════════════════════ -->
     <activity
         android:id="@+id/touchpadOverlayActivity"

--- a/app/src/main/res/values-bs/strings_onboarding.xml
+++ b/app/src/main/res/values-bs/strings_onboarding.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="welcome_skip">Preskoči</string>
+    <string name="welcome_back">Nazad</string>
+    <string name="welcome_next">Dalje</string>
+    <string name="welcome_get_started">Počni</string>
+
+    <string name="welcome_step1_eyebrow">DOBRO DOŠLI</string>
+    <string name="welcome_step1_title">Vaš telefon, vaš gamepad</string>
+    <string name="welcome_step1_body">Dish pretvara vaš telefon u bežični kontroler za vaš PC. Radi kao gamepad na dodir samostalno, ili kao bežični most za kontroler koji već imate.</string>
+
+    <string name="welcome_step2_eyebrow">KAKO FUNKCIONIŠE</string>
+    <string name="welcome_step2_title">Kratak skok preko Wi-Fi-ja</string>
+    <string name="welcome_step2_body">Vaš telefon šalje pritiske dugmadi, palice i pokret malom besplatnom pomagaču po imenu Satellite koji se izvršava na vašem PC-u. Satellite se vašim igrama prikazuje kao običan gamepad — bez dodatne konfiguracije po igri.</string>
+
+    <string name="welcome_step3_eyebrow">JOŠ JEDNA STVAR</string>
+    <string name="welcome_step3_title">Instalirajte Satellite na vaš PC</string>
+    <string name="welcome_step3_body">Satellite je besplatan i otvorenog koda. Preuzmite ga sa tinkernorth.com/satellite, pokrenite instalaciju, i Dish će ga automatski pronaći. Možete završiti ovaj uvod sada i instalirati Satellite kasnije.</string>
+    <string name="welcome_step3_satellite_link_label">Otvori stranicu za preuzimanje</string>
+
+    <string name="welcome_step4_eyebrow">SPREMNO</string>
+    <string name="welcome_step4_title">Kad god vi želite</string>
+    <string name="welcome_step4_body">Tapnite Počni za pokretanje. Otvorite Vodič za postavljanje u bilo kom trenutku iz Postavki ako želite vodič — ili krenite odmah i uparite sa Satellite-om na vašoj mreži.</string>
+    <string name="welcome_step4_launch_wizard">Otvori vodič za postavljanje</string>
+
+    <string name="welcome_step1_hero_desc">Logo Dish aplikacije</string>
+    <string name="welcome_step2_hero_desc">Telefon emituje bežični signal</string>
+    <string name="welcome_step3_hero_desc">Monitor sa pokrenutim Satellite-om</string>
+    <string name="welcome_step4_hero_desc">Postavljanje završeno</string>
+
+    <string name="welcome_step_indicator_desc">Korak %1$d od %2$d</string>
+
+    <string name="wizard_title">Vodič za postavljanje</string>
+    <string name="wizard_step_progress">Korak %1$d od %2$d</string>
+    <string name="wizard_action_back">Nazad</string>
+    <string name="wizard_action_next">Dalje</string>
+    <string name="wizard_action_finish">Završi</string>
+    <string name="wizard_recommended_label">Preporučeno</string>
+
+    <string name="wizard_step1_eyebrow">KORAK 1 · VEZA</string>
+    <string name="wizard_step1_title">Kako ćete doći do vašeg PC-a?</string>
+    <string name="wizard_step1_body">Dva načina za slanje unosa na PC. Wi-Fi ima najmanju latenciju i otključava pokret i touchpad. Bluetooth tretira ovaj telefon kao običan bežični gamepad — radi bez Satellite-a, ali sa malim troškom u latenciji.</string>
+
+    <string name="wizard_option_lan_title">Wi-Fi do Satellite-a</string>
+    <string name="wizard_option_lan_body">Telefon i PC na istoj Wi-Fi mreži. Najmanja latencija, kompletan skup funkcija (pokret, touchpad, vibracija).</string>
+    <string name="wizard_option_lan_pill_recommended">Preporučeno</string>
+
+    <string name="wizard_option_bt_title">Bluetooth gamepad</string>
+    <string name="wizard_option_bt_body">Uparite vaš telefon sa PC-om ili konzolom kao običan Bluetooth kontroler. Radi bez Satellite-a. Pokret i touchpad nisu dostupni na ovoj putanji.</string>
+
+    <string name="wizard_step2_eyebrow">KORAK 2 · KONTROLER</string>
+    <string name="wizard_step2_title">Sa čim ćete igrati?</string>
+    <string name="wizard_step2_body">Možete igrati sa padom na ekranu, ili priključiti pravi kontroler za prave palice i okidače. USB kontroler u telefon ima najmanju ulaznu latenciju — bez Bluetooth-a u lancu.</string>
+
+    <string name="wizard_option_virtual_title">Gamepad na ekranu</string>
+    <string name="wizard_option_virtual_body">Dodirujte dugmad na ekranu telefona. Sjajno za opuštene igre i isprobavanje — žiroskop vašeg telefona je dostupan za pomoć pri ciljanju.</string>
+
+    <string name="wizard_option_usb_title">USB kontroler u telefonu</string>
+    <string name="wizard_option_usb_body">Priključite žičani Xbox / PlayStation / generički gamepad u USB-C port telefona. Telefon prosljeđuje svaki pritisak vašem PC-u.</string>
+    <string name="wizard_option_usb_pill_recommended">Najmanja latencija</string>
+
+    <string name="wizard_option_phys_bt_title">Bluetooth kontroler uparen sa telefonom</string>
+    <string name="wizard_option_phys_bt_body">Koristite kontroler koji ste već uparili sa telefonom (Xbox Wireless, DualSense itd.). Jedan Bluetooth skok umjesto dva, u poređenju sa direktnim uparivanjem kontrolera sa PC-om.</string>
+
+    <string name="wizard_step3_eyebrow">KORAK 3 · IDEMO</string>
+    <string name="wizard_step3_title">Evo šta ćemo uraditi</string>
+
+    <string name="wizard_summary_connection_label">Veza</string>
+    <string name="wizard_summary_controller_label">Kontroler</string>
+
+    <string name="wizard_next_lan_virtual">Tapnite Završi za otvaranje Veza. Pretraga vašeg Satellite-a, uparite ga sa 4-cifrenim PIN-om, i otvorite gamepad na ekranu.</string>
+    <string name="wizard_next_lan_usb">Tapnite Završi za otvaranje Veza. Uparite vaš Satellite sa 4-cifrenim PIN-om, zatim priključite USB kontroler u telefon — pojaviće se kao novi slot spreman za povezivanje.</string>
+    <string name="wizard_next_lan_phys_bt">Tapnite Završi za otvaranje Veza. Uparite vaš Satellite sa 4-cifrenim PIN-om. Vaš već upareni Bluetooth kontroler će se pojaviti kao slot koji možete povezati sa Satellite-om.</string>
+    <string name="wizard_next_bt_virtual">Tapnite Završi za otvaranje Veza. Dodajte Bluetooth host, prihvatite uparivanje na PC-u, i otvorite gamepad na ekranu.</string>
+    <string name="wizard_next_bt_usb">Pažnja — Bluetooth host režim šalje stanje kontrolera telefona, ne odvojen USB pad. Koristite gamepad na ekranu na ovoj putanji, ili se vratite na Wi-Fi vezu u prethodnom koraku.</string>
+    <string name="wizard_next_bt_phys_bt">Pažnja — Bluetooth host režim šalje stanje kontrolera telefona, ne stanje vašeg već uparenog Bluetooth gamepada. Koristite gamepad na ekranu na ovoj putanji, ili se vratite na Wi-Fi vezu u prethodnom koraku.</string>
+
+    <string name="wizard_finish_review">Nazad</string>
+
+    <string name="help_title">Pomoć i FAQ</string>
+
+    <string name="help_section_concepts">KONCEPTI</string>
+    <string name="help_section_performance">NAJBOLJE PERFORMANSE</string>
+    <string name="help_section_troubleshooting">RJEŠAVANJE PROBLEMA</string>
+    <string name="help_section_about">O DISH-U</string>
+
+    <string name="help_run_setup_title">Provedi me kroz postavljanje</string>
+    <string name="help_run_setup_body">Otvori vodič za postavljanje. Odabire vašu vezu i kontroler, i vodi vas do odgovarajućeg ekrana.</string>
+
+    <string name="help_q_what_is_dish">Šta je Dish?</string>
+    <string name="help_a_what_is_dish">Dish pretvara vaš telefon u bežični gamepad. Može slati unos na PC preko Wi-Fi-ja (preko besplatnog Satellite pomagača) ili upariti sa PC-om / konzolom kao običan Bluetooth gamepad.</string>
+
+    <string name="help_q_what_is_satellite">Šta je Satellite?</string>
+    <string name="help_a_what_is_satellite">Satellite je mali, besplatan program otvorenog koda koji se izvršava na vašem PC-u. Prima unos od Dish-a preko Wi-Fi-ja i prikazuje se vašim igrama kao običan kontroler. Bez Satellite-a, igre ne mogu vidjeti vaš telefon — instalirajte ga sa tinkernorth.com/satellite.</string>
+
+    <string name="help_q_lan_vs_bluetooth">Wi-Fi ili Bluetooth — šta odabrati?</string>
+    <string name="help_a_lan_vs_bluetooth">Wi-Fi sa Satellite-om je bolji izbor za skoro sve. Manja latencija, podržava pokret (ciljanje žiroskopom) i otključava touchpad. Bluetooth host režim je pravi izbor kada ne želite instalirati ništa na PC, ili kada koristite konzolu / set-top box koji ne pokreće Satellite.</string>
+
+    <string name="help_q_controller_modes">Mogu li koristiti pravi kontroler sa Dish-om?</string>
+    <string name="help_a_controller_modes">Da. Priključite USB kontroler u USB-C port telefona, ili uparite Bluetooth kontroler (Xbox Wireless, DualSense, 8BitDo itd.) direktno sa telefonom. Kontroler će se pojaviti kao novi slot koji možete povezati sa Satellite-om.</string>
+
+    <string name="help_q_motion_touchpad">Šta je pokret a šta touchpad?</string>
+    <string name="help_a_motion_touchpad">Pokret je žiroskop vašeg telefona koji se koristi kao pomoć pri ciljanju — pojavljuje se igrama kao žiroskop unutar PlayStation pada. Touchpad pretvara ekran telefona u trackpad na koji se može kliknuti i koji možete koristiti za menije ili kao miš. Oba zahtijevaju Wi-Fi vezu (Satellite) — Bluetooth host režim ne može ih prenijeti.</string>
+
+    <string name="help_q_best_setup">Koja je najbolja postavka za malu latenciju?</string>
+    <string name="help_a_best_setup">USB kontroler u telefonu, telefon na Wi-Fi 5 GHz, PC na istom ruteru (poželjno žičnim Ethernetom). USB-do-telefona ne dodaje latenciju; Wi-Fi dodaje jedan kratak skok. Izbjegavajte Wi-Fi 2,4 GHz i mobilne podatke — Dish treba telefon i PC na istoj lokalnoj mreži.</string>
+
+    <string name="help_q_why_lan_lower">Zašto Wi-Fi ima manju latenciju od Bluetooth-a?</string>
+    <string name="help_a_why_lan_lower">Wi-Fi šalje unos kao male UDP pakete brzinom kojom vaš telefon polaže — obično brže nego što Bluetooth može. Bluetooth HID ima fiksni interval pollinga i duži pipeline, tako da sjedi između vas i igre sa malim ali stvarnim kašnjenjem.</string>
+
+    <string name="help_q_wired_better">Da li je žično bolje od bežičnog?</string>
+    <string name="help_a_wired_better">Za segment kontroler-do-telefona: da, USB je bolji od Bluetooth-uparenog-na-telefon. Za segment telefon-do-PC-a: Wi-Fi je jedina opcija — ne možete priključiti USB telefona u PC za prosljeđivanje unosa. Povežite vaš PC sa ruterom Ethernetom ako možete; strana telefona ostaje na Wi-Fi-ju.</string>
+
+    <string name="help_q_no_satellites">Dish ne nalazi nijedan Satellite — šta sada?</string>
+    <string name="help_a_no_satellites">Provjerite da li Satellite radi na PC-u (njegova ikona u sistemskoj traci bi trebala biti vidljiva). Potvrdite da su telefon i PC na istoj Wi-Fi mreži — gostujuće mreže i 2,4 GHz vs 5 GHz na istom ruteru se broje kao različite. Tapnite Skeniraj u Vezama za ponovni pokušaj.</string>
+
+    <string name="help_q_pin_rejected">Moj PIN se stalno odbija.</string>
+    <string name="help_a_pin_rejected">PIN prikazuje Satellite na vašem PC-u i mijenja se ako ga ponovo pokrenete. Provjerite cifre na PC-u neposredno prije nego što kucate — i osigurajte se da kucate u pravi Satellite ako se više njih prikazuje u listi.</string>
+
+    <string name="help_q_disconnects">Moj kontroler se prekida usred igre.</string>
+    <string name="help_a_disconnects">Većina prekida dolazi od toga da telefon ide na spavanje ili Wi-Fi prebacuje opsege. Priključite telefon na punjenje dok igrate, i fiksirajte Wi-Fi telefona na 5 GHz ako vam ruter to dozvoljava. Dish drži obavještenje u prvom planu tokom strimovanja — ostavite ga na mjestu, tako Android održava vezu živom.</string>
+
+    <string name="help_q_no_motion">Pokret (ciljanje žiroskopom) ne radi.</string>
+    <string name="help_a_no_motion">Pokretu trebaju tri stvari: Wi-Fi veza (Satellite) (Bluetooth host ne može prenijeti pokret), telefon sa žiroskopom (većina od 2018.) i kontroler u PlayStation stilu na strani hosta. Promijenite tip kontrolera u slotu na PlayStation da aktivirate kanal pokreta.</string>
+
+    <string name="help_q_battery_drain">Baterija se brzo prazni tokom strimovanja.</string>
+    <string name="help_a_battery_drain">Strimovanje stalno koristi radio vašeg telefona — to je cijena bivanja živim kontrolerom. Priključite na punjenje dok igrate. Dish ima i režim štednje energije (zatamnjeni ekran tokom igre) koji spušta ekran na minimalnu svjetlinu uz nastavak strimovanja — ostavite aplikaciju otvorenom i ne zaključavajte ekran.</string>
+
+    <string name="help_q_open_source">Da li je Dish otvorenog koda?</string>
+    <string name="help_a_open_source">Da. Dish (Android, Linux, Mac) i Satellite su svi objavljeni pod LGPL-3.0, izvorni kod na GitHub-u na github.com/TinkerNorth. Pull request-ovi su dobrodošli.</string>
+
+    <string name="help_q_privacy">Šta Dish prikuplja?</string>
+    <string name="help_a_privacy">Skoro ništa. Dish ne šalje sadržaj igre ni unos kontrolera nigdje — taj saobraćaj ostaje na vašoj lokalnoj mreži između telefona i PC-a. Anonimni izvještaji o padovima su opcionalni (Postavke → Dijagnostika). Za potpunu listu pogledajte politiku privatnosti.</string>
+
+    <string name="help_view_privacy_policy">Politika privatnosti</string>
+    <string name="help_view_github">Pogledaj izvorni kod na GitHub-u</string>
+
+    <string name="dashboard_hint_title">Trebate pomoć?</string>
+    <string name="dashboard_hint_body">Otvorite vodič za postavljanje da odaberete vašu vezu i kontroler — odvešćemo vas na odgovarajući ekran.</string>
+    <string name="dashboard_hint_action_open">Otvori vodič</string>
+    <string name="dashboard_hint_action_dismiss">Ne sada</string>
+
+    <string name="settings_section_setup">POSTAVLJANJE I POMOĆ</string>
+    <string name="settings_setup_wizard_title">Vodič za postavljanje</string>
+    <string name="settings_setup_wizard_body">Prođite kroz opcije veze i kontrolera. Možete ponoviti u bilo kom trenutku.</string>
+    <string name="settings_help_title">Pomoć i FAQ</string>
+    <string name="settings_help_body">Koncepti, savjeti za performanse i rješavanje problema.</string>
+</resources>

--- a/app/src/main/res/values-de/strings_onboarding.xml
+++ b/app/src/main/res/values-de/strings_onboarding.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="welcome_skip">Überspringen</string>
+    <string name="welcome_back">Zurück</string>
+    <string name="welcome_next">Weiter</string>
+    <string name="welcome_get_started">Loslegen</string>
+
+    <string name="welcome_step1_eyebrow">WILLKOMMEN</string>
+    <string name="welcome_step1_title">Dein Handy, dein Gamepad</string>
+    <string name="welcome_step1_body">Dish macht dein Handy zum kabellosen Controller für deinen PC. Es funktioniert eigenständig als Touch-Gamepad oder als kabellose Brücke für einen Controller, den du bereits besitzt.</string>
+
+    <string name="welcome_step2_eyebrow">SO FUNKTIONIERT\'S</string>
+    <string name="welcome_step2_title">Ein kurzer Sprung über WLAN</string>
+    <string name="welcome_step2_body">Dein Handy sendet Tastendrücke, Sticks und Bewegung an einen kleinen kostenlosen Helfer namens Satellite, der auf deinem PC läuft. Satellite erscheint deinen Spielen als regulärer Gamepad — keine zusätzliche Konfiguration pro Spiel.</string>
+
+    <string name="welcome_step3_eyebrow">NOCH EINE SACHE</string>
+    <string name="welcome_step3_title">Satellite auf dem PC installieren</string>
+    <string name="welcome_step3_body">Satellite ist kostenlos und Open Source. Hol es dir von tinkernorth.com/satellite, führe das Installationsprogramm aus, und Dish findet es automatisch. Du kannst diese Einführung jetzt beenden und Satellite später installieren.</string>
+    <string name="welcome_step3_satellite_link_label">Download-Seite öffnen</string>
+
+    <string name="welcome_step4_eyebrow">FERTIG</string>
+    <string name="welcome_step4_title">Bereit, wenn du es bist</string>
+    <string name="welcome_step4_body">Tippe Loslegen, um zu starten. Öffne den Einrichtungsassistenten jederzeit über Einstellungen, wenn du eine Anleitung möchtest — oder leg direkt los und koppele mit einem Satellite in deinem Netzwerk.</string>
+    <string name="welcome_step4_launch_wizard">Einrichtungsassistent öffnen</string>
+
+    <string name="welcome_step1_hero_desc">Dish-App-Logo</string>
+    <string name="welcome_step2_hero_desc">Handy, das ein Funksignal sendet</string>
+    <string name="welcome_step3_hero_desc">Desktop-Monitor mit laufendem Satellite</string>
+    <string name="welcome_step4_hero_desc">Einrichtung abgeschlossen</string>
+
+    <string name="welcome_step_indicator_desc">Schritt %1$d von %2$d</string>
+
+    <string name="wizard_title">Einrichtungsassistent</string>
+    <string name="wizard_step_progress">Schritt %1$d von %2$d</string>
+    <string name="wizard_action_back">Zurück</string>
+    <string name="wizard_action_next">Weiter</string>
+    <string name="wizard_action_finish">Fertigstellen</string>
+    <string name="wizard_recommended_label">Empfohlen</string>
+
+    <string name="wizard_step1_eyebrow">SCHRITT 1 · VERBINDUNG</string>
+    <string name="wizard_step1_title">Wie erreichst du deinen PC?</string>
+    <string name="wizard_step1_body">Zwei Wege, deine Eingaben an einen PC zu senden. WLAN hat die geringste Latenz und schaltet Bewegung und Touchpad frei. Bluetooth behandelt dieses Handy als regulären kabellosen Gamepad — funktioniert ohne Satellite, aber mit etwas mehr Latenz.</string>
+
+    <string name="wizard_option_lan_title">WLAN zu Satellite</string>
+    <string name="wizard_option_lan_body">Handy und PC im selben WLAN. Geringste Latenz, voller Funktionsumfang (Bewegung, Touchpad, Vibration).</string>
+    <string name="wizard_option_lan_pill_recommended">Empfohlen</string>
+
+    <string name="wizard_option_bt_title">Bluetooth-Gamepad</string>
+    <string name="wizard_option_bt_body">Koppele dein Handy mit deinem PC oder deiner Konsole als regulären Bluetooth-Controller. Funktioniert ohne Satellite. Bewegung und Touchpad sind auf diesem Weg nicht verfügbar.</string>
+
+    <string name="wizard_step2_eyebrow">SCHRITT 2 · CONTROLLER</string>
+    <string name="wizard_step2_title">Womit spielst du?</string>
+    <string name="wizard_step2_body">Du kannst mit dem Bildschirm-Pad spielen oder einen echten Controller anschließen für richtige Sticks und Trigger. Ein USB-Controller im Handy hat die geringste Eingabelatenz — kein Bluetooth im Pfad.</string>
+
+    <string name="wizard_option_virtual_title">Bildschirm-Gamepad</string>
+    <string name="wizard_option_virtual_body">Tippe die Tasten auf dem Handy-Bildschirm. Ideal für gemütliche Spiele und zum Ausprobieren — das Gyroskop deines Handys ist für Zielhilfe verfügbar.</string>
+
+    <string name="wizard_option_usb_title">USB-Controller am Handy</string>
+    <string name="wizard_option_usb_body">Schließe einen kabelgebundenen Xbox-/PlayStation-/generischen Gamepad an den USB-C-Anschluss deines Handys an. Das Handy leitet jeden Tastendruck an deinen PC weiter.</string>
+    <string name="wizard_option_usb_pill_recommended">Geringste Latenz</string>
+
+    <string name="wizard_option_phys_bt_title">Bluetooth-Controller am Handy gekoppelt</string>
+    <string name="wizard_option_phys_bt_body">Nutze einen Controller, den du bereits mit deinem Handy gekoppelt hast (Xbox Wireless, DualSense usw.). Ein Bluetooth-Sprung statt zwei, verglichen mit dem direkten Koppeln des Controllers an deinen PC.</string>
+
+    <string name="wizard_step3_eyebrow">SCHRITT 3 · LOS GEHT\'S</string>
+    <string name="wizard_step3_title">Das machen wir</string>
+
+    <string name="wizard_summary_connection_label">Verbindung</string>
+    <string name="wizard_summary_controller_label">Controller</string>
+
+    <string name="wizard_next_lan_virtual">Tippe Fertigstellen, um Verbindungen zu öffnen. Such nach deinem Satellite, koppele es mit der 4-stelligen PIN, dann öffne das Bildschirm-Gamepad.</string>
+    <string name="wizard_next_lan_usb">Tippe Fertigstellen, um Verbindungen zu öffnen. Koppele dein Satellite mit der 4-stelligen PIN, dann schließe deinen USB-Controller an das Handy an — er erscheint als neuer Slot, bereit zum Binden.</string>
+    <string name="wizard_next_lan_phys_bt">Tippe Fertigstellen, um Verbindungen zu öffnen. Koppele dein Satellite mit der 4-stelligen PIN. Dein bereits gekoppelter Bluetooth-Controller erscheint als Slot, den du an das Satellite binden kannst.</string>
+    <string name="wizard_next_bt_virtual">Tippe Fertigstellen, um Verbindungen zu öffnen. Füge einen Bluetooth-Host hinzu, akzeptiere die Kopplung auf deinem PC, dann öffne das Bildschirm-Gamepad.</string>
+    <string name="wizard_next_bt_usb">Hinweis — der Bluetooth-Host-Modus sendet den Controller-Zustand des Handys, nicht einen separaten USB-Pad. Nutze das Bildschirm-Gamepad auf diesem Weg, oder wechsle im vorigen Schritt zur WLAN-Verbindung.</string>
+    <string name="wizard_next_bt_phys_bt">Hinweis — der Bluetooth-Host-Modus sendet den Controller-Zustand des Handys, nicht den deines bereits gekoppelten Bluetooth-Gamepads. Nutze das Bildschirm-Gamepad auf diesem Weg, oder wechsle im vorigen Schritt zur WLAN-Verbindung.</string>
+
+    <string name="wizard_finish_review">Zurück</string>
+
+    <string name="help_title">Hilfe &amp; FAQ</string>
+
+    <string name="help_section_concepts">KONZEPTE</string>
+    <string name="help_section_performance">BESTE LEISTUNG</string>
+    <string name="help_section_troubleshooting">FEHLERBEHEBUNG</string>
+    <string name="help_section_about">ÜBER DISH</string>
+
+    <string name="help_run_setup_title">Setup-Anleitung öffnen</string>
+    <string name="help_run_setup_body">Öffne den Einrichtungsassistenten. Wählt deine Verbindung und deinen Controller, dann führt dich zur richtigen Stelle.</string>
+
+    <string name="help_q_what_is_dish">Was ist Dish?</string>
+    <string name="help_a_what_is_dish">Dish macht dein Handy zum kabellosen Gamepad. Es kann Eingaben über WLAN an einen PC senden (mit dem kostenlosen Satellite-Helfer) oder sich an einen PC / eine Konsole als regulärer Bluetooth-Gamepad koppeln.</string>
+
+    <string name="help_q_what_is_satellite">Was ist Satellite?</string>
+    <string name="help_a_what_is_satellite">Satellite ist ein kleines, kostenloses, quelloffenes Programm, das auf deinem PC läuft. Es empfängt Eingaben von Dish über WLAN und erscheint deinen Spielen als regulärer Controller. Ohne Satellite können Spiele dein Handy nicht sehen — installiere es von tinkernorth.com/satellite.</string>
+
+    <string name="help_q_lan_vs_bluetooth">WLAN oder Bluetooth — was soll ich wählen?</string>
+    <string name="help_a_lan_vs_bluetooth">WLAN mit Satellite ist für fast jeden der bessere Weg. Niedrigere Latenz, unterstützt Bewegung (Gyro-Zielen) und schaltet das Touchpad frei. Der Bluetooth-Host-Modus ist die richtige Wahl, wenn du nichts auf dem PC installieren willst oder eine Konsole / Set-Top-Box nutzt, die Satellite nicht ausführt.</string>
+
+    <string name="help_q_controller_modes">Kann ich einen echten Controller mit Dish nutzen?</string>
+    <string name="help_a_controller_modes">Ja. Schließe einen USB-Controller an den USB-C-Anschluss deines Handys an oder koppele einen Bluetooth-Controller (Xbox Wireless, DualSense, 8BitDo usw.) direkt mit deinem Handy. Der Controller erscheint als neuer Slot, den du an dein Satellite binden kannst.</string>
+
+    <string name="help_q_motion_touchpad">Was ist Bewegung und was ist das Touchpad?</string>
+    <string name="help_a_motion_touchpad">Bewegung ist das Gyroskop deines Handys, das als Zielhilfe verwendet wird — es erscheint Spielen als das Gyroskop eines PlayStation-Pads. Das Touchpad verwandelt den Handy-Bildschirm in ein klickbares Trackpad für Menüs oder als Maus. Beide benötigen eine WLAN-Verbindung (Satellite) — der Bluetooth-Host-Modus kann sie nicht übertragen.</string>
+
+    <string name="help_q_best_setup">Was ist die beste Einrichtung für geringe Latenz?</string>
+    <string name="help_a_best_setup">USB-Controller im Handy, Handy im 5-GHz-WLAN, PC am selben Router (am besten per Ethernet). USB-zum-Handy hat keine zusätzliche Latenz; WLAN fügt einen kurzen Sprung hinzu. Vermeide 2,4-GHz-WLAN und mobile Daten — Dish benötigt Handy und PC im selben lokalen Netzwerk.</string>
+
+    <string name="help_q_why_lan_lower">Warum hat WLAN eine geringere Latenz als Bluetooth?</string>
+    <string name="help_a_why_lan_lower">WLAN sendet Eingaben als kleine UDP-Pakete im Takt deines Handys — meist schneller, als Bluetooth es kann. Bluetooth HID hat ein festes Polling-Intervall und eine längere Pipeline und sitzt damit mit einer kleinen, aber realen Verzögerung zwischen dir und dem Spiel.</string>
+
+    <string name="help_q_wired_better">Ist kabelgebunden besser als kabellos?</string>
+    <string name="help_a_wired_better">Für die Strecke vom Controller zum Handy: ja, USB schlägt Bluetooth-am-Handy-gekoppelt. Für die Strecke vom Handy zum PC: WLAN ist die einzige Option — du kannst den USB deines Handys nicht an deinen PC für die Eingabeweiterleitung anschließen. Schließe deinen PC nach Möglichkeit per Ethernet an den Router an; das Handy bleibt im WLAN.</string>
+
+    <string name="help_q_no_satellites">Dish findet keine Satellites — was nun?</string>
+    <string name="help_a_no_satellites">Prüfe, ob Satellite auf dem PC läuft (das Tray-Symbol sollte sichtbar sein). Bestätige, dass Handy und PC im selben WLAN sind — Gastnetzwerke und 2,4 GHz vs. 5 GHz im selben Router zählen als unterschiedlich. Tippe Scan in Verbindungen, um erneut zu suchen.</string>
+
+    <string name="help_q_pin_rejected">Meine PIN wird immer wieder abgelehnt.</string>
+    <string name="help_a_pin_rejected">Die PIN wird von Satellite auf deinem PC angezeigt und ändert sich beim Neustart. Prüfe die Ziffern auf dem PC direkt vor der Eingabe — und stelle sicher, dass du in das richtige Satellite tippst, wenn mehrere in der Liste sind.</string>
+
+    <string name="help_q_disconnects">Mein Controller trennt sich mitten im Spiel.</string>
+    <string name="help_a_disconnects">Die meisten Trennungen kommen davon, dass dein Handy schlafen geht oder das WLAN die Bänder wechselt. Schließ das Handy zum Laden an, während du spielst, und fixiere das WLAN deines Handys auf 5 GHz, falls der Router es zulässt. Dish behält eine Vordergrundbenachrichtigung während des Streamings — lass sie an Ort und Stelle, so hält Android die Verbindung lebendig.</string>
+
+    <string name="help_q_no_motion">Bewegung (Gyro-Zielen) funktioniert nicht.</string>
+    <string name="help_a_no_motion">Bewegung braucht drei Dinge: eine WLAN-Verbindung (Satellite) (Bluetooth-Host kann Bewegung nicht übertragen), ein Handy mit Gyroskop (die meisten Handys seit 2018) und einen PlayStation-Stil-Controller auf der Host-Seite. Wechsle den Controller-Typ am Slot auf PlayStation, um den Bewegungskanal zu aktivieren.</string>
+
+    <string name="help_q_battery_drain">Der Akku entlädt sich schnell beim Streaming.</string>
+    <string name="help_a_battery_drain">Streaming nutzt das Funkmodul deines Handys ständig — das ist der Preis, ein Live-Controller zu sein. Schließ es zum Laden an, während du spielst. Dish hat auch einen Energiesparmodus (der dunkle Bildschirm während des Spiels), der die Anzeige auf ihre minimale Helligkeit reduziert, während weiter gestreamt wird — lass die App offen und sperre den Bildschirm nicht.</string>
+
+    <string name="help_q_open_source">Ist Dish Open Source?</string>
+    <string name="help_a_open_source">Ja. Dish (Android, Linux, Mac) und Satellite sind alle unter LGPL-3.0 veröffentlicht, Quellcode auf GitHub unter github.com/TinkerNorth. Pull Requests willkommen.</string>
+
+    <string name="help_q_privacy">Was sammelt Dish?</string>
+    <string name="help_a_privacy">Fast nichts. Dish sendet keine Spielinhalte oder Controller-Eingaben irgendwohin — dieser Verkehr bleibt in deinem lokalen Netzwerk zwischen Handy und PC. Anonyme Absturzberichte sind opt-in (Einstellungen → Diagnose). Die vollständige Liste findest du in der Datenschutzrichtlinie.</string>
+
+    <string name="help_view_privacy_policy">Datenschutzrichtlinie</string>
+    <string name="help_view_github">Quellcode auf GitHub ansehen</string>
+
+    <string name="dashboard_hint_title">Brauchst du Hilfe?</string>
+    <string name="dashboard_hint_body">Öffne den Einrichtungsassistenten, um deine Verbindung und deinen Controller zu wählen — wir bringen dich zur richtigen Stelle.</string>
+    <string name="dashboard_hint_action_open">Assistent öffnen</string>
+    <string name="dashboard_hint_action_dismiss">Nicht jetzt</string>
+
+    <string name="settings_section_setup">EINRICHTUNG &amp; HILFE</string>
+    <string name="settings_setup_wizard_title">Einrichtungsassistent</string>
+    <string name="settings_setup_wizard_body">Verbindung und Controller-Optionen durchgehen. Jederzeit erneut ausführbar.</string>
+    <string name="settings_help_title">Hilfe &amp; FAQ</string>
+    <string name="settings_help_body">Konzepte, Leistungstipps und Fehlerbehebung.</string>
+</resources>

--- a/app/src/main/res/values-es/strings_onboarding.xml
+++ b/app/src/main/res/values-es/strings_onboarding.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="welcome_skip">Omitir</string>
+    <string name="welcome_back">Atrás</string>
+    <string name="welcome_next">Siguiente</string>
+    <string name="welcome_get_started">Empezar</string>
+
+    <string name="welcome_step1_eyebrow">BIENVENIDO</string>
+    <string name="welcome_step1_title">Tu teléfono, tu gamepad</string>
+    <string name="welcome_step1_body">Dish convierte tu teléfono en un mando inalámbrico para tu PC. Funciona como gamepad táctil por sí solo, o como puente inalámbrico para un mando que ya tengas.</string>
+
+    <string name="welcome_step2_eyebrow">CÓMO FUNCIONA</string>
+    <string name="welcome_step2_title">Un salto corto por Wi-Fi</string>
+    <string name="welcome_step2_body">Tu teléfono envía pulsaciones, sticks y movimiento a un pequeño ayudante gratuito llamado Satellite que se ejecuta en tu PC. Satellite aparece ante tus juegos como un mando normal — sin configuración extra por juego.</string>
+
+    <string name="welcome_step3_eyebrow">UNA COSA MÁS</string>
+    <string name="welcome_step3_title">Instala Satellite en tu PC</string>
+    <string name="welcome_step3_body">Satellite es gratuito y de código abierto. Descárgalo desde tinkernorth.com/satellite, ejecuta el instalador y Dish lo encontrará automáticamente. Puedes terminar esta introducción ahora e instalar Satellite más tarde.</string>
+    <string name="welcome_step3_satellite_link_label">Abrir página de descarga</string>
+
+    <string name="welcome_step4_eyebrow">LISTO</string>
+    <string name="welcome_step4_title">Cuando tú quieras</string>
+    <string name="welcome_step4_body">Toca Empezar para comenzar. Abre la Guía de configuración cuando quieras desde Ajustes si necesitas instrucciones — o lánzate directamente y empareja con un Satellite en tu red.</string>
+    <string name="welcome_step4_launch_wizard">Abrir guía de configuración</string>
+
+    <string name="welcome_step1_hero_desc">Logo de la aplicación Dish</string>
+    <string name="welcome_step2_hero_desc">Teléfono emitiendo una señal inalámbrica</string>
+    <string name="welcome_step3_hero_desc">Monitor de escritorio mostrando Satellite en ejecución</string>
+    <string name="welcome_step4_hero_desc">Configuración completada</string>
+
+    <string name="welcome_step_indicator_desc">Paso %1$d de %2$d</string>
+
+    <string name="wizard_title">Guía de configuración</string>
+    <string name="wizard_step_progress">Paso %1$d de %2$d</string>
+    <string name="wizard_action_back">Atrás</string>
+    <string name="wizard_action_next">Siguiente</string>
+    <string name="wizard_action_finish">Finalizar</string>
+    <string name="wizard_recommended_label">Recomendado</string>
+
+    <string name="wizard_step1_eyebrow">PASO 1 · CONEXIÓN</string>
+    <string name="wizard_step1_title">¿Cómo llegarás a tu PC?</string>
+    <string name="wizard_step1_body">Dos formas de enviar tu entrada a un PC. Wi-Fi tiene la menor latencia y desbloquea el movimiento y el touchpad. Bluetooth trata este teléfono como un mando inalámbrico normal — funciona sin Satellite, pero con un pequeño coste de latencia.</string>
+
+    <string name="wizard_option_lan_title">Wi-Fi a Satellite</string>
+    <string name="wizard_option_lan_body">Teléfono y PC en el mismo Wi-Fi. Latencia mínima, conjunto completo de funciones (movimiento, touchpad, vibración).</string>
+    <string name="wizard_option_lan_pill_recommended">Recomendado</string>
+
+    <string name="wizard_option_bt_title">Mando Bluetooth</string>
+    <string name="wizard_option_bt_body">Empareja tu teléfono con tu PC o consola como un mando Bluetooth normal. Funciona sin Satellite. El movimiento y el touchpad no están disponibles por esta ruta.</string>
+
+    <string name="wizard_step2_eyebrow">PASO 2 · MANDO</string>
+    <string name="wizard_step2_title">¿Con qué vas a jugar?</string>
+    <string name="wizard_step2_body">Puedes jugar con el pad en pantalla, o conectar un mando real para tener sticks y gatillos de verdad. Un mando USB en tu teléfono tiene la menor latencia de entrada — sin Bluetooth en la cadena.</string>
+
+    <string name="wizard_option_virtual_title">Gamepad en pantalla</string>
+    <string name="wizard_option_virtual_body">Toca los botones en la pantalla del teléfono. Ideal para juegos casuales y para probar — el giroscopio de tu teléfono está disponible para ayuda de apuntado.</string>
+
+    <string name="wizard_option_usb_title">Mando USB en el teléfono</string>
+    <string name="wizard_option_usb_body">Conecta un mando Xbox / PlayStation / genérico con cable al puerto USB-C de tu teléfono. El teléfono reenvía cada pulsación a tu PC.</string>
+    <string name="wizard_option_usb_pill_recommended">Mínima latencia</string>
+
+    <string name="wizard_option_phys_bt_title">Mando Bluetooth emparejado al teléfono</string>
+    <string name="wizard_option_phys_bt_body">Usa un mando que ya hayas emparejado con tu teléfono (Xbox Wireless, DualSense, etc.). Un salto Bluetooth en lugar de dos, en comparación con emparejar el mando directamente con tu PC.</string>
+
+    <string name="wizard_step3_eyebrow">PASO 3 · ADELANTE</string>
+    <string name="wizard_step3_title">Esto es lo que haremos</string>
+
+    <string name="wizard_summary_connection_label">Conexión</string>
+    <string name="wizard_summary_controller_label">Mando</string>
+
+    <string name="wizard_next_lan_virtual">Toca Finalizar para abrir Conexiones. Busca tu Satellite, empareja con el PIN de 4 dígitos, y luego abre el gamepad en pantalla.</string>
+    <string name="wizard_next_lan_usb">Toca Finalizar para abrir Conexiones. Empareja tu Satellite con el PIN de 4 dígitos, y luego conecta tu mando USB al teléfono — aparecerá como un nuevo slot listo para vincular.</string>
+    <string name="wizard_next_lan_phys_bt">Toca Finalizar para abrir Conexiones. Empareja tu Satellite con el PIN de 4 dígitos. Tu mando Bluetooth ya emparejado aparecerá como un slot que podrás vincular al Satellite.</string>
+    <string name="wizard_next_bt_virtual">Toca Finalizar para abrir Conexiones. Añade un host Bluetooth, acepta el emparejamiento en tu PC, y luego abre el gamepad en pantalla.</string>
+    <string name="wizard_next_bt_usb">Aviso — el modo host Bluetooth envía el estado del mando del teléfono, no un pad USB separado. Usa el gamepad en pantalla por esta ruta, o cambia a la conexión Wi-Fi en el paso anterior.</string>
+    <string name="wizard_next_bt_phys_bt">Aviso — el modo host Bluetooth envía el estado del mando del teléfono, no el de tu gamepad Bluetooth ya emparejado. Usa el gamepad en pantalla por esta ruta, o cambia a la conexión Wi-Fi en el paso anterior.</string>
+
+    <string name="wizard_finish_review">Volver</string>
+
+    <string name="help_title">Ayuda y preguntas frecuentes</string>
+
+    <string name="help_section_concepts">CONCEPTOS</string>
+    <string name="help_section_performance">MEJOR RENDIMIENTO</string>
+    <string name="help_section_troubleshooting">SOLUCIÓN DE PROBLEMAS</string>
+    <string name="help_section_about">ACERCA DE DISH</string>
+
+    <string name="help_run_setup_title">Guíame paso a paso</string>
+    <string name="help_run_setup_body">Abre la guía de configuración. Selecciona tu conexión y mando, y te lleva a la pantalla adecuada.</string>
+
+    <string name="help_q_what_is_dish">¿Qué es Dish?</string>
+    <string name="help_a_what_is_dish">Dish convierte tu teléfono en un gamepad inalámbrico. Puede enviar entrada a un PC por Wi-Fi (con el ayudante gratuito Satellite) o emparejarse con un PC / consola como un mando Bluetooth normal.</string>
+
+    <string name="help_q_what_is_satellite">¿Qué es Satellite?</string>
+    <string name="help_a_what_is_satellite">Satellite es un programa pequeño, gratuito y de código abierto que se ejecuta en tu PC. Recibe entrada de Dish por Wi-Fi y se presenta a tus juegos como un mando normal. Sin Satellite, los juegos no pueden ver tu teléfono — instálalo desde tinkernorth.com/satellite.</string>
+
+    <string name="help_q_lan_vs_bluetooth">Wi-Fi o Bluetooth — ¿cuál elegir?</string>
+    <string name="help_a_lan_vs_bluetooth">Wi-Fi con Satellite es la mejor opción para casi todos. Menor latencia, soporta movimiento (giro para apuntar) y desbloquea el touchpad. El modo host Bluetooth es la opción adecuada cuando no quieres instalar nada en el PC, o cuando usas una consola / decodificador que no ejecuta Satellite.</string>
+
+    <string name="help_q_controller_modes">¿Puedo usar un mando real con Dish?</string>
+    <string name="help_a_controller_modes">Sí. Conecta un mando USB al puerto USB-C de tu teléfono, o empareja un mando Bluetooth (Xbox Wireless, DualSense, 8BitDo, etc.) directamente con tu teléfono. El mando aparecerá como un nuevo slot que podrás vincular a tu Satellite.</string>
+
+    <string name="help_q_motion_touchpad">¿Qué son el movimiento y el touchpad?</string>
+    <string name="help_a_motion_touchpad">El movimiento es el giroscopio de tu teléfono usado como ayuda de apuntado — aparece a los juegos como el giroscopio dentro de un mando de PlayStation. El touchpad convierte la pantalla del teléfono en un trackpad clicable que puedes usar para menús o como ratón. Ambos necesitan una conexión Wi-Fi (Satellite) — el modo host Bluetooth no puede transportarlos.</string>
+
+    <string name="help_q_best_setup">¿Cuál es la mejor configuración para baja latencia?</string>
+    <string name="help_a_best_setup">Mando USB en el teléfono, teléfono en Wi-Fi 5 GHz, PC en el mismo router (preferiblemente Ethernet con cable). USB-al-teléfono no añade latencia; Wi-Fi añade un salto corto. Evita Wi-Fi 2,4 GHz y datos móviles — Dish necesita el teléfono y el PC en la misma red local.</string>
+
+    <string name="help_q_why_lan_lower">¿Por qué Wi-Fi tiene menor latencia que Bluetooth?</string>
+    <string name="help_a_why_lan_lower">Wi-Fi envía la entrada como pequeños paquetes UDP al ritmo al que tu teléfono los polea — normalmente más rápido de lo que Bluetooth puede. Bluetooth HID tiene un intervalo de polling fijo y una tubería más larga, por lo que se sitúa entre tú y el juego con un retraso pequeño pero real.</string>
+
+    <string name="help_q_wired_better">¿Es mejor con cable que inalámbrico?</string>
+    <string name="help_a_wired_better">Para el tramo mando-a-teléfono: sí, USB supera a Bluetooth-emparejado-al-teléfono. Para el tramo teléfono-a-PC: Wi-Fi es la única opción — no puedes conectar el USB de tu teléfono a tu PC para reenviar entrada. Conecta tu PC al router por Ethernet si puedes; el lado del teléfono se queda en Wi-Fi.</string>
+
+    <string name="help_q_no_satellites">Dish no encuentra ningún Satellite — ¿y ahora qué?</string>
+    <string name="help_a_no_satellites">Verifica que Satellite esté ejecutándose en el PC (su icono en la bandeja debería estar visible). Confirma que el teléfono y el PC están en la misma red Wi-Fi — las redes de invitados y 2,4 GHz vs 5 GHz en el mismo router cuentan como diferentes. Toca Buscar en Conexiones para reintentar.</string>
+
+    <string name="help_q_pin_rejected">Mi PIN se rechaza siempre.</string>
+    <string name="help_a_pin_rejected">El PIN lo muestra Satellite en tu PC y cambia si lo reinicias. Revisa los dígitos en el PC justo antes de teclear — y asegúrate de estar escribiendo en el Satellite correcto si hay más de uno en la lista.</string>
+
+    <string name="help_q_disconnects">Mi mando se desconecta a mitad de partida.</string>
+    <string name="help_a_disconnects">La mayoría de desconexiones vienen de que tu teléfono entra en suspensión o el Wi-Fi cambia de banda. Conéctalo a la corriente mientras juegas, y fija el Wi-Fi de tu teléfono a 5 GHz si el router lo permite. Dish mantiene una notificación en primer plano mientras transmite — déjala en su sitio, así es como Android mantiene viva la conexión.</string>
+
+    <string name="help_q_no_motion">El movimiento (giro para apuntar) no funciona.</string>
+    <string name="help_a_no_motion">El movimiento necesita tres cosas: una conexión Wi-Fi (Satellite) (el host Bluetooth no puede transportar movimiento), un teléfono con giroscopio (la mayoría desde 2018) y un mando estilo PlayStation en el lado del host. Cambia el tipo de mando del slot a PlayStation para activar el canal de movimiento.</string>
+
+    <string name="help_q_battery_drain">La batería se agota rápido mientras transmito.</string>
+    <string name="help_a_battery_drain">Transmitir usa la radio de tu teléfono constantemente — es el coste de ser un mando en vivo. Conéctalo a la corriente mientras juegas. Dish también tiene un modo de bajo consumo (la pantalla atenuada durante el juego) que baja la pantalla a su brillo mínimo mientras sigue transmitiendo — deja la aplicación abierta y no bloquees la pantalla.</string>
+
+    <string name="help_q_open_source">¿Es Dish de código abierto?</string>
+    <string name="help_a_open_source">Sí. Dish (Android, Linux, Mac) y Satellite están publicados bajo LGPL-3.0, código fuente en GitHub en github.com/TinkerNorth. Se aceptan pull requests.</string>
+
+    <string name="help_q_privacy">¿Qué recopila Dish?</string>
+    <string name="help_a_privacy">Casi nada. Dish no envía contenido de juego ni entrada del mando a ningún sitio — ese tráfico se queda en tu red local entre teléfono y PC. Los informes anónimos de fallos son opcionales (Ajustes → Diagnóstico). Consulta la política de privacidad para la lista completa.</string>
+
+    <string name="help_view_privacy_policy">Política de privacidad</string>
+    <string name="help_view_github">Ver código fuente en GitHub</string>
+
+    <string name="dashboard_hint_title">¿Necesitas ayuda?</string>
+    <string name="dashboard_hint_body">Abre la guía de configuración para elegir tu conexión y mando — te llevamos a la pantalla adecuada.</string>
+    <string name="dashboard_hint_action_open">Abrir guía</string>
+    <string name="dashboard_hint_action_dismiss">Ahora no</string>
+
+    <string name="settings_section_setup">CONFIGURACIÓN Y AYUDA</string>
+    <string name="settings_setup_wizard_title">Guía de configuración</string>
+    <string name="settings_setup_wizard_body">Recorre las opciones de conexión y mando. Repítela cuando quieras.</string>
+    <string name="settings_help_title">Ayuda y preguntas frecuentes</string>
+    <string name="settings_help_body">Conceptos, consejos de rendimiento y solución de problemas.</string>
+</resources>

--- a/app/src/main/res/values-fr/strings_onboarding.xml
+++ b/app/src/main/res/values-fr/strings_onboarding.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="welcome_skip">Passer</string>
+    <string name="welcome_back">Retour</string>
+    <string name="welcome_next">Suivant</string>
+    <string name="welcome_get_started">Commencer</string>
+
+    <string name="welcome_step1_eyebrow">BIENVENUE</string>
+    <string name="welcome_step1_title">Votre téléphone, votre manette</string>
+    <string name="welcome_step1_body">Dish transforme votre téléphone en manette sans fil pour votre PC. Il fonctionne comme manette tactile à lui seul, ou comme passerelle sans fil pour une manette que vous possédez déjà.</string>
+
+    <string name="welcome_step2_eyebrow">COMMENT ÇA MARCHE</string>
+    <string name="welcome_step2_title">Un saut court par Wi-Fi</string>
+    <string name="welcome_step2_body">Votre téléphone envoie les appuis, les sticks et le mouvement à un petit assistant gratuit appelé Satellite qui s\'exécute sur votre PC. Satellite apparaît à vos jeux comme une manette normale — pas de configuration supplémentaire par jeu.</string>
+
+    <string name="welcome_step3_eyebrow">UNE CHOSE DE PLUS</string>
+    <string name="welcome_step3_title">Installez Satellite sur votre PC</string>
+    <string name="welcome_step3_body">Satellite est gratuit et open source. Téléchargez-le depuis tinkernorth.com/satellite, lancez l\'installateur, et Dish le trouvera automatiquement. Vous pouvez terminer cette introduction maintenant et installer Satellite plus tard.</string>
+    <string name="welcome_step3_satellite_link_label">Ouvrir la page de téléchargement</string>
+
+    <string name="welcome_step4_eyebrow">C\'EST PRÊT</string>
+    <string name="welcome_step4_title">Quand vous voulez</string>
+    <string name="welcome_step4_body">Appuyez sur Commencer pour démarrer. Ouvrez le Guide de configuration à tout moment depuis les Paramètres si vous voulez une visite guidée — ou lancez-vous et appairez avec un Satellite sur votre réseau.</string>
+    <string name="welcome_step4_launch_wizard">Ouvrir le guide de configuration</string>
+
+    <string name="welcome_step1_hero_desc">Logo de l\'application Dish</string>
+    <string name="welcome_step2_hero_desc">Téléphone émettant un signal sans fil</string>
+    <string name="welcome_step3_hero_desc">Écran d\'ordinateur affichant Satellite en cours d\'exécution</string>
+    <string name="welcome_step4_hero_desc">Configuration terminée</string>
+
+    <string name="welcome_step_indicator_desc">Étape %1$d sur %2$d</string>
+
+    <string name="wizard_title">Guide de configuration</string>
+    <string name="wizard_step_progress">Étape %1$d sur %2$d</string>
+    <string name="wizard_action_back">Retour</string>
+    <string name="wizard_action_next">Suivant</string>
+    <string name="wizard_action_finish">Terminer</string>
+    <string name="wizard_recommended_label">Recommandé</string>
+
+    <string name="wizard_step1_eyebrow">ÉTAPE 1 · CONNEXION</string>
+    <string name="wizard_step1_title">Comment allez-vous atteindre votre PC ?</string>
+    <string name="wizard_step1_body">Deux façons d\'envoyer votre entrée à un PC. Le Wi-Fi a la latence la plus faible et débloque le mouvement et le pavé tactile. Le Bluetooth traite ce téléphone comme une manette sans fil normale — fonctionne sans Satellite, mais avec un petit coût de latence.</string>
+
+    <string name="wizard_option_lan_title">Wi-Fi vers Satellite</string>
+    <string name="wizard_option_lan_body">Téléphone et PC sur le même Wi-Fi. Latence minimale, ensemble complet de fonctionnalités (mouvement, pavé tactile, vibration).</string>
+    <string name="wizard_option_lan_pill_recommended">Recommandé</string>
+
+    <string name="wizard_option_bt_title">Manette Bluetooth</string>
+    <string name="wizard_option_bt_body">Appairez votre téléphone avec votre PC ou console comme une manette Bluetooth normale. Fonctionne sans Satellite. Le mouvement et le pavé tactile ne sont pas disponibles par ce chemin.</string>
+
+    <string name="wizard_step2_eyebrow">ÉTAPE 2 · MANETTE</string>
+    <string name="wizard_step2_title">Avec quoi allez-vous jouer ?</string>
+    <string name="wizard_step2_body">Vous pouvez jouer avec le pad à l\'écran, ou brancher une vraie manette pour de vrais sticks et gâchettes. Une manette USB dans votre téléphone a la latence d\'entrée la plus faible — pas de Bluetooth dans la chaîne.</string>
+
+    <string name="wizard_option_virtual_title">Manette à l\'écran</string>
+    <string name="wizard_option_virtual_body">Touchez les boutons sur l\'écran du téléphone. Idéal pour les jeux décontractés et pour essayer — le gyroscope de votre téléphone est disponible pour l\'aide à la visée.</string>
+
+    <string name="wizard_option_usb_title">Manette USB dans le téléphone</string>
+    <string name="wizard_option_usb_body">Branchez une manette Xbox / PlayStation / générique filaire sur le port USB-C de votre téléphone. Le téléphone transmet chaque appui à votre PC.</string>
+    <string name="wizard_option_usb_pill_recommended">Latence minimale</string>
+
+    <string name="wizard_option_phys_bt_title">Manette Bluetooth appairée au téléphone</string>
+    <string name="wizard_option_phys_bt_body">Utilisez une manette que vous avez déjà appairée à votre téléphone (Xbox Wireless, DualSense, etc.). Un saut Bluetooth au lieu de deux, par rapport à l\'appairage de la manette directement avec votre PC.</string>
+
+    <string name="wizard_step3_eyebrow">ÉTAPE 3 · C\'EST PARTI</string>
+    <string name="wizard_step3_title">Voici ce que nous allons faire</string>
+
+    <string name="wizard_summary_connection_label">Connexion</string>
+    <string name="wizard_summary_controller_label">Manette</string>
+
+    <string name="wizard_next_lan_virtual">Appuyez sur Terminer pour ouvrir Connexions. Cherchez votre Satellite, appairez-le avec le PIN à 4 chiffres, puis ouvrez la manette à l\'écran.</string>
+    <string name="wizard_next_lan_usb">Appuyez sur Terminer pour ouvrir Connexions. Appairez votre Satellite avec le PIN à 4 chiffres, puis branchez votre manette USB sur le téléphone — elle apparaîtra comme un nouvel emplacement prêt à lier.</string>
+    <string name="wizard_next_lan_phys_bt">Appuyez sur Terminer pour ouvrir Connexions. Appairez votre Satellite avec le PIN à 4 chiffres. Votre manette Bluetooth déjà appairée apparaîtra comme un emplacement que vous pouvez lier au Satellite.</string>
+    <string name="wizard_next_bt_virtual">Appuyez sur Terminer pour ouvrir Connexions. Ajoutez un hôte Bluetooth, acceptez l\'appairage sur votre PC, puis ouvrez la manette à l\'écran.</string>
+    <string name="wizard_next_bt_usb">Attention — le mode hôte Bluetooth envoie l\'état de la manette du téléphone, pas un pad USB séparé. Utilisez la manette à l\'écran par ce chemin, ou passez à la connexion Wi-Fi à l\'étape précédente.</string>
+    <string name="wizard_next_bt_phys_bt">Attention — le mode hôte Bluetooth envoie l\'état de la manette du téléphone, pas celui de votre manette Bluetooth déjà appairée. Utilisez la manette à l\'écran par ce chemin, ou passez à la connexion Wi-Fi à l\'étape précédente.</string>
+
+    <string name="wizard_finish_review">Retour</string>
+
+    <string name="help_title">Aide et FAQ</string>
+
+    <string name="help_section_concepts">CONCEPTS</string>
+    <string name="help_section_performance">MEILLEURES PERFORMANCES</string>
+    <string name="help_section_troubleshooting">DÉPANNAGE</string>
+    <string name="help_section_about">À PROPOS DE DISH</string>
+
+    <string name="help_run_setup_title">Guidez-moi pour la configuration</string>
+    <string name="help_run_setup_body">Ouvre le guide de configuration. Choisit votre connexion et votre manette, puis vous emmène à l\'écran approprié.</string>
+
+    <string name="help_q_what_is_dish">Qu\'est-ce que Dish ?</string>
+    <string name="help_a_what_is_dish">Dish transforme votre téléphone en manette sans fil. Il peut envoyer l\'entrée à un PC par Wi-Fi (via l\'assistant gratuit Satellite) ou s\'appairer à un PC / une console comme une manette Bluetooth normale.</string>
+
+    <string name="help_q_what_is_satellite">Qu\'est-ce que Satellite ?</string>
+    <string name="help_a_what_is_satellite">Satellite est un petit programme gratuit et open source qui s\'exécute sur votre PC. Il reçoit l\'entrée de Dish par Wi-Fi et se présente à vos jeux comme une manette normale. Sans Satellite, les jeux ne peuvent pas voir votre téléphone — installez-le depuis tinkernorth.com/satellite.</string>
+
+    <string name="help_q_lan_vs_bluetooth">Wi-Fi ou Bluetooth — lequel choisir ?</string>
+    <string name="help_a_lan_vs_bluetooth">Wi-Fi avec Satellite est le meilleur choix pour presque tout le monde. Latence plus faible, prend en charge le mouvement (visée gyro) et débloque le pavé tactile. Le mode hôte Bluetooth est le bon choix lorsque vous ne voulez rien installer sur le PC, ou lorsque vous utilisez une console / un boîtier qui n\'exécute pas Satellite.</string>
+
+    <string name="help_q_controller_modes">Puis-je utiliser une vraie manette avec Dish ?</string>
+    <string name="help_a_controller_modes">Oui. Branchez une manette USB sur le port USB-C de votre téléphone, ou appairez une manette Bluetooth (Xbox Wireless, DualSense, 8BitDo, etc.) directement à votre téléphone. La manette apparaîtra comme un nouvel emplacement que vous pourrez lier à votre Satellite.</string>
+
+    <string name="help_q_motion_touchpad">C\'est quoi le mouvement et le pavé tactile ?</string>
+    <string name="help_a_motion_touchpad">Le mouvement est le gyroscope de votre téléphone utilisé comme aide à la visée — il apparaît aux jeux comme le gyroscope d\'une manette PlayStation. Le pavé tactile transforme l\'écran du téléphone en pavé tactile cliquable que vous pouvez utiliser pour les menus ou comme souris. Les deux ont besoin d\'une connexion Wi-Fi (Satellite) — le mode hôte Bluetooth ne peut pas les transporter.</string>
+
+    <string name="help_q_best_setup">Quelle est la meilleure configuration pour une faible latence ?</string>
+    <string name="help_a_best_setup">Manette USB dans le téléphone, téléphone en Wi-Fi 5 GHz, PC sur le même routeur (de préférence Ethernet filaire). USB-vers-téléphone n\'ajoute pas de latence ; le Wi-Fi ajoute un saut court. Évitez le Wi-Fi 2,4 GHz et les données mobiles — Dish a besoin du téléphone et du PC sur le même réseau local.</string>
+
+    <string name="help_q_why_lan_lower">Pourquoi le Wi-Fi a-t-il une latence plus faible que le Bluetooth ?</string>
+    <string name="help_a_why_lan_lower">Le Wi-Fi envoie l\'entrée sous forme de petits paquets UDP au rythme auquel votre téléphone interroge — généralement plus rapide que le Bluetooth ne le peut. Bluetooth HID a un intervalle de polling fixe et un pipeline plus long, donc il se trouve entre vous et le jeu avec un délai petit mais réel.</string>
+
+    <string name="help_q_wired_better">Filaire est-il meilleur que sans fil ?</string>
+    <string name="help_a_wired_better">Pour le tronçon manette-vers-téléphone : oui, USB bat Bluetooth-appairé-au-téléphone. Pour le tronçon téléphone-vers-PC : le Wi-Fi est la seule option — vous ne pouvez pas brancher l\'USB de votre téléphone sur votre PC pour transmettre l\'entrée. Connectez votre PC au routeur par Ethernet si possible ; le côté téléphone reste en Wi-Fi.</string>
+
+    <string name="help_q_no_satellites">Dish ne trouve aucun Satellite — que faire ?</string>
+    <string name="help_a_no_satellites">Vérifiez que Satellite s\'exécute sur le PC (son icône dans la barre des tâches devrait être visible). Confirmez que le téléphone et le PC sont sur le même réseau Wi-Fi — les réseaux invités et 2,4 GHz vs 5 GHz sur le même routeur comptent comme différents. Appuyez sur Scanner dans Connexions pour réessayer.</string>
+
+    <string name="help_q_pin_rejected">Mon PIN est sans cesse rejeté.</string>
+    <string name="help_a_pin_rejected">Le PIN est affiché par Satellite sur votre PC et change si vous le redémarrez. Vérifiez les chiffres sur le PC juste avant de taper — et assurez-vous de taper dans le bon Satellite si plusieurs s\'affichent dans la liste.</string>
+
+    <string name="help_q_disconnects">Ma manette se déconnecte en pleine partie.</string>
+    <string name="help_a_disconnects">La plupart des déconnexions viennent du téléphone qui se met en veille ou du Wi-Fi qui change de bande. Branchez le téléphone pour charger pendant que vous jouez, et fixez le Wi-Fi de votre téléphone à 5 GHz si le routeur le permet. Dish garde une notification de premier plan pendant le streaming — laissez-la en place, c\'est ainsi qu\'Android maintient la connexion en vie.</string>
+
+    <string name="help_q_no_motion">Le mouvement (visée gyro) ne fonctionne pas.</string>
+    <string name="help_a_no_motion">Le mouvement a besoin de trois choses : une connexion Wi-Fi (Satellite) (l\'hôte Bluetooth ne peut pas transporter le mouvement), un téléphone avec gyroscope (la plupart depuis 2018), et une manette de style PlayStation côté hôte. Changez le type de manette sur l\'emplacement en PlayStation pour activer le canal de mouvement.</string>
+
+    <string name="help_q_battery_drain">La batterie se vide vite pendant le streaming.</string>
+    <string name="help_a_battery_drain">Le streaming utilise la radio de votre téléphone en permanence — c\'est le coût d\'être une manette en direct. Branchez pour charger pendant que vous jouez. Dish a aussi un mode basse consommation (l\'écran atténué pendant le jeu) qui baisse l\'affichage à sa luminosité minimale tout en continuant à streamer — laissez l\'application ouverte et ne verrouillez pas l\'écran.</string>
+
+    <string name="help_q_open_source">Dish est-il open source ?</string>
+    <string name="help_a_open_source">Oui. Dish (Android, Linux, Mac) et Satellite sont tous publiés sous LGPL-3.0, code source sur GitHub à github.com/TinkerNorth. Les pull requests sont les bienvenues.</string>
+
+    <string name="help_q_privacy">Que collecte Dish ?</string>
+    <string name="help_a_privacy">Presque rien. Dish n\'envoie pas le contenu du jeu ni l\'entrée de la manette ailleurs — ce trafic reste sur votre réseau local entre le téléphone et le PC. Les rapports de plantage anonymes sont opt-in (Paramètres → Diagnostic). Voir la politique de confidentialité pour la liste complète.</string>
+
+    <string name="help_view_privacy_policy">Politique de confidentialité</string>
+    <string name="help_view_github">Voir le code source sur GitHub</string>
+
+    <string name="dashboard_hint_title">Besoin d\'aide ?</string>
+    <string name="dashboard_hint_body">Ouvrez le guide de configuration pour choisir votre connexion et votre manette — nous vous emmenons à l\'écran approprié.</string>
+    <string name="dashboard_hint_action_open">Ouvrir le guide</string>
+    <string name="dashboard_hint_action_dismiss">Pas maintenant</string>
+
+    <string name="settings_section_setup">CONFIGURATION ET AIDE</string>
+    <string name="settings_setup_wizard_title">Guide de configuration</string>
+    <string name="settings_setup_wizard_body">Parcourez les options de connexion et de manette. Relançable à tout moment.</string>
+    <string name="settings_help_title">Aide et FAQ</string>
+    <string name="settings_help_body">Concepts, conseils de performance et dépannage.</string>
+</resources>

--- a/app/src/main/res/values-pt-rBR/strings_onboarding.xml
+++ b/app/src/main/res/values-pt-rBR/strings_onboarding.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="welcome_skip">Pular</string>
+    <string name="welcome_back">Voltar</string>
+    <string name="welcome_next">Próximo</string>
+    <string name="welcome_get_started">Começar</string>
+
+    <string name="welcome_step1_eyebrow">BEM-VINDO</string>
+    <string name="welcome_step1_title">Seu celular, seu gamepad</string>
+    <string name="welcome_step1_body">O Dish transforma seu celular em um controle sem fio para seu PC. Funciona como gamepad por toque sozinho, ou como ponte sem fio para um controle que você já possui.</string>
+
+    <string name="welcome_step2_eyebrow">COMO FUNCIONA</string>
+    <string name="welcome_step2_title">Um pulo curto via Wi-Fi</string>
+    <string name="welcome_step2_body">Seu celular envia toques, sticks e movimento para um pequeno auxiliar gratuito chamado Satellite que roda no seu PC. O Satellite aparece para os jogos como um controle comum — sem configuração extra por jogo.</string>
+
+    <string name="welcome_step3_eyebrow">MAIS UMA COISA</string>
+    <string name="welcome_step3_title">Instale o Satellite no seu PC</string>
+    <string name="welcome_step3_body">O Satellite é gratuito e de código aberto. Baixe em tinkernorth.com/satellite, execute o instalador, e o Dish vai encontrá-lo automaticamente. Você pode terminar essa introdução agora e instalar o Satellite depois.</string>
+    <string name="welcome_step3_satellite_link_label">Abrir página de download</string>
+
+    <string name="welcome_step4_eyebrow">PRONTO</string>
+    <string name="welcome_step4_title">Quando você quiser</string>
+    <string name="welcome_step4_body">Toque Começar para iniciar. Abra o Guia de configuração a qualquer momento em Configurações se quiser um passo a passo — ou pule direto e pareie com um Satellite na sua rede.</string>
+    <string name="welcome_step4_launch_wizard">Abrir guia de configuração</string>
+
+    <string name="welcome_step1_hero_desc">Logo do app Dish</string>
+    <string name="welcome_step2_hero_desc">Celular emitindo um sinal sem fio</string>
+    <string name="welcome_step3_hero_desc">Monitor de desktop mostrando o Satellite em execução</string>
+    <string name="welcome_step4_hero_desc">Configuração concluída</string>
+
+    <string name="welcome_step_indicator_desc">Passo %1$d de %2$d</string>
+
+    <string name="wizard_title">Guia de configuração</string>
+    <string name="wizard_step_progress">Passo %1$d de %2$d</string>
+    <string name="wizard_action_back">Voltar</string>
+    <string name="wizard_action_next">Próximo</string>
+    <string name="wizard_action_finish">Concluir</string>
+    <string name="wizard_recommended_label">Recomendado</string>
+
+    <string name="wizard_step1_eyebrow">PASSO 1 · CONEXÃO</string>
+    <string name="wizard_step1_title">Como você vai chegar ao seu PC?</string>
+    <string name="wizard_step1_body">Duas formas de enviar a entrada a um PC. Wi-Fi tem a menor latência e libera movimento e touchpad. Bluetooth trata este celular como um controle sem fio comum — funciona sem o Satellite, mas com um pequeno custo de latência.</string>
+
+    <string name="wizard_option_lan_title">Wi-Fi para o Satellite</string>
+    <string name="wizard_option_lan_body">Celular e PC na mesma rede Wi-Fi. Latência mínima, conjunto completo de recursos (movimento, touchpad, vibração).</string>
+    <string name="wizard_option_lan_pill_recommended">Recomendado</string>
+
+    <string name="wizard_option_bt_title">Gamepad Bluetooth</string>
+    <string name="wizard_option_bt_body">Pareie seu celular ao seu PC ou console como um controle Bluetooth comum. Funciona sem o Satellite. Movimento e touchpad não estão disponíveis nesta rota.</string>
+
+    <string name="wizard_step2_eyebrow">PASSO 2 · CONTROLE</string>
+    <string name="wizard_step2_title">Com o que você vai jogar?</string>
+    <string name="wizard_step2_body">Você pode jogar com o pad na tela, ou plugar um controle de verdade para ter sticks e gatilhos reais. Um controle USB no celular tem a menor latência de entrada — sem Bluetooth no caminho.</string>
+
+    <string name="wizard_option_virtual_title">Gamepad na tela</string>
+    <string name="wizard_option_virtual_body">Toque os botões na tela do celular. Ótimo para jogos casuais e para experimentar — o giroscópio do seu celular fica disponível como auxílio de mira.</string>
+
+    <string name="wizard_option_usb_title">Controle USB no celular</string>
+    <string name="wizard_option_usb_body">Plugue um controle Xbox / PlayStation / genérico com fio na porta USB-C do seu celular. O celular repassa cada toque ao seu PC.</string>
+    <string name="wizard_option_usb_pill_recommended">Menor latência</string>
+
+    <string name="wizard_option_phys_bt_title">Controle Bluetooth pareado ao celular</string>
+    <string name="wizard_option_phys_bt_body">Use um controle que você já pareou ao celular (Xbox Wireless, DualSense, etc.). Um pulo Bluetooth em vez de dois, comparado a parear o controle direto no PC.</string>
+
+    <string name="wizard_step3_eyebrow">PASSO 3 · BORA</string>
+    <string name="wizard_step3_title">Aqui está o que vamos fazer</string>
+
+    <string name="wizard_summary_connection_label">Conexão</string>
+    <string name="wizard_summary_controller_label">Controle</string>
+
+    <string name="wizard_next_lan_virtual">Toque Concluir para abrir Conexões. Busque o seu Satellite, pareie com o PIN de 4 dígitos, e abra o gamepad na tela.</string>
+    <string name="wizard_next_lan_usb">Toque Concluir para abrir Conexões. Pareie o seu Satellite com o PIN de 4 dígitos, depois plugue o controle USB no celular — ele vai aparecer como um novo slot pronto para vincular.</string>
+    <string name="wizard_next_lan_phys_bt">Toque Concluir para abrir Conexões. Pareie o seu Satellite com o PIN de 4 dígitos. Seu controle Bluetooth já pareado vai aparecer como um slot que você pode vincular ao Satellite.</string>
+    <string name="wizard_next_bt_virtual">Toque Concluir para abrir Conexões. Adicione um host Bluetooth, aceite o pareamento no seu PC, e abra o gamepad na tela.</string>
+    <string name="wizard_next_bt_usb">Aviso — o modo host Bluetooth envia o estado do controle do celular, não um pad USB separado. Use o gamepad na tela por essa rota, ou troque para a conexão Wi-Fi no passo anterior.</string>
+    <string name="wizard_next_bt_phys_bt">Aviso — o modo host Bluetooth envia o estado do controle do celular, não o do seu gamepad Bluetooth já pareado. Use o gamepad na tela por essa rota, ou troque para a conexão Wi-Fi no passo anterior.</string>
+
+    <string name="wizard_finish_review">Voltar</string>
+
+    <string name="help_title">Ajuda e FAQ</string>
+
+    <string name="help_section_concepts">CONCEITOS</string>
+    <string name="help_section_performance">MELHOR DESEMPENHO</string>
+    <string name="help_section_troubleshooting">SOLUÇÃO DE PROBLEMAS</string>
+    <string name="help_section_about">SOBRE O DISH</string>
+
+    <string name="help_run_setup_title">Me guie pela configuração</string>
+    <string name="help_run_setup_body">Abre o guia de configuração. Escolhe sua conexão e controle, e te leva à tela certa.</string>
+
+    <string name="help_q_what_is_dish">O que é o Dish?</string>
+    <string name="help_a_what_is_dish">O Dish transforma seu celular em um gamepad sem fio. Pode enviar entrada para um PC por Wi-Fi (com o auxiliar gratuito Satellite) ou parear com um PC / console como um controle Bluetooth comum.</string>
+
+    <string name="help_q_what_is_satellite">O que é o Satellite?</string>
+    <string name="help_a_what_is_satellite">O Satellite é um programa pequeno, gratuito e de código aberto que roda no seu PC. Ele recebe entrada do Dish por Wi-Fi e se apresenta aos jogos como um controle comum. Sem o Satellite, os jogos não enxergam seu celular — instale em tinkernorth.com/satellite.</string>
+
+    <string name="help_q_lan_vs_bluetooth">Wi-Fi ou Bluetooth — qual escolher?</string>
+    <string name="help_a_lan_vs_bluetooth">Wi-Fi com Satellite é a melhor escolha para quase todo mundo. Latência menor, suporta movimento (mira por giroscópio) e libera o touchpad. O modo host Bluetooth é a escolha certa quando você não quer instalar nada no PC, ou quando está usando um console / set-top box que não roda o Satellite.</string>
+
+    <string name="help_q_controller_modes">Posso usar um controle de verdade com o Dish?</string>
+    <string name="help_a_controller_modes">Sim. Plugue um controle USB na porta USB-C do seu celular, ou pareie um controle Bluetooth (Xbox Wireless, DualSense, 8BitDo, etc.) direto no celular. O controle aparece como um novo slot que você pode vincular ao seu Satellite.</string>
+
+    <string name="help_q_motion_touchpad">O que é movimento e o que é o touchpad?</string>
+    <string name="help_a_motion_touchpad">Movimento é o giroscópio do seu celular usado como auxílio de mira — aparece para os jogos como o giroscópio dentro de um controle de PlayStation. O touchpad transforma a tela do celular em um trackpad clicável que você pode usar para menus ou como mouse. Os dois precisam de conexão Wi-Fi (Satellite) — o modo host Bluetooth não consegue carregar nenhum dos dois.</string>
+
+    <string name="help_q_best_setup">Qual é a melhor configuração para latência baixa?</string>
+    <string name="help_a_best_setup">Controle USB no celular, celular no Wi-Fi de 5 GHz, PC no mesmo roteador (de preferência por Ethernet com fio). USB-para-celular não adiciona latência; Wi-Fi adiciona um pulo curto. Evite Wi-Fi de 2,4 GHz e dados móveis — o Dish precisa do celular e do PC na mesma rede local.</string>
+
+    <string name="help_q_why_lan_lower">Por que o Wi-Fi tem latência menor que o Bluetooth?</string>
+    <string name="help_a_why_lan_lower">O Wi-Fi envia a entrada como pequenos pacotes UDP no ritmo em que seu celular faz polling — geralmente mais rápido que o Bluetooth consegue. Bluetooth HID tem intervalo de polling fixo e um pipeline mais longo, então fica entre você e o jogo com um atraso pequeno mas real.</string>
+
+    <string name="help_q_wired_better">Com fio é melhor que sem fio?</string>
+    <string name="help_a_wired_better">Para o trecho controle-para-celular: sim, USB ganha de Bluetooth-pareado-no-celular. Para o trecho celular-para-PC: Wi-Fi é a única opção — você não pode plugar o USB do celular no PC para encaminhar entrada. Conecte o PC ao roteador por Ethernet se possível; o lado do celular fica no Wi-Fi.</string>
+
+    <string name="help_q_no_satellites">O Dish não acha nenhum Satellite — e agora?</string>
+    <string name="help_a_no_satellites">Confira se o Satellite está rodando no PC (o ícone na bandeja deveria estar visível). Confirme que o celular e o PC estão na mesma rede Wi-Fi — redes de convidados e 2,4 GHz vs 5 GHz no mesmo roteador contam como diferentes. Toque Buscar em Conexões para tentar de novo.</string>
+
+    <string name="help_q_pin_rejected">Meu PIN continua sendo rejeitado.</string>
+    <string name="help_a_pin_rejected">O PIN é mostrado pelo Satellite no seu PC e muda se você reiniciar. Confira os dígitos no PC logo antes de digitar — e tenha certeza de estar digitando no Satellite certo se tiver mais de um na lista.</string>
+
+    <string name="help_q_disconnects">Meu controle desconecta no meio do jogo.</string>
+    <string name="help_a_disconnects">A maioria das desconexões vem do celular dormindo ou do Wi-Fi trocando de banda. Plugue o celular pra carregar enquanto joga, e fixe o Wi-Fi do seu celular em 5 GHz se o roteador deixar. O Dish mantém uma notificação em primeiro plano durante o streaming — deixe ela aí, é assim que o Android mantém a conexão viva.</string>
+
+    <string name="help_q_no_motion">O movimento (mira por giro) não funciona.</string>
+    <string name="help_a_no_motion">O movimento precisa de três coisas: conexão Wi-Fi (Satellite) (o host Bluetooth não carrega movimento), um celular com giroscópio (a maioria desde 2018) e um controle estilo PlayStation no lado do host. Troque o tipo de controle do slot para PlayStation para ativar o canal de movimento.</string>
+
+    <string name="help_q_battery_drain">A bateria descarrega rápido durante o streaming.</string>
+    <string name="help_a_battery_drain">O streaming usa o rádio do seu celular o tempo todo — esse é o custo de ser um controle ao vivo. Plugue pra carregar enquanto joga. O Dish também tem um modo de baixo consumo (a tela escurecida durante o jogo) que reduz o brilho da tela ao mínimo enquanto continua transmitindo — deixe o app aberto e não bloqueie a tela.</string>
+
+    <string name="help_q_open_source">O Dish é de código aberto?</string>
+    <string name="help_a_open_source">Sim. Dish (Android, Linux, Mac) e Satellite são todos publicados sob LGPL-3.0, código-fonte no GitHub em github.com/TinkerNorth. Pull requests são bem-vindas.</string>
+
+    <string name="help_q_privacy">O que o Dish coleta?</string>
+    <string name="help_a_privacy">Quase nada. O Dish não envia conteúdo de jogo nem entrada do controle pra lugar nenhum — esse tráfego fica na sua rede local entre celular e PC. Relatórios anônimos de falhas são opcionais (Configurações → Diagnóstico). Veja a política de privacidade para a lista completa.</string>
+
+    <string name="help_view_privacy_policy">Política de privacidade</string>
+    <string name="help_view_github">Ver código-fonte no GitHub</string>
+
+    <string name="dashboard_hint_title">Precisa de uma mão?</string>
+    <string name="dashboard_hint_body">Abra o guia de configuração para escolher sua conexão e controle — a gente te leva à tela certa.</string>
+    <string name="dashboard_hint_action_open">Abrir guia</string>
+    <string name="dashboard_hint_action_dismiss">Agora não</string>
+
+    <string name="settings_section_setup">CONFIGURAÇÃO E AJUDA</string>
+    <string name="settings_setup_wizard_title">Guia de configuração</string>
+    <string name="settings_setup_wizard_body">Veja as opções de conexão e controle. Pode rodar quantas vezes quiser.</string>
+    <string name="settings_help_title">Ajuda e FAQ</string>
+    <string name="settings_help_body">Conceitos, dicas de desempenho e solução de problemas.</string>
+</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -133,6 +133,17 @@
          ============================================================ -->
     <dimen name="settings_content_max_width">@dimen/size_600</dimen>
 
+    <dimen name="welcome_hero_size">@dimen/size_240</dimen>
+    <dimen name="welcome_content_max_width">@dimen/size_600</dimen>
+
+    <dimen name="step_indicator_height">@dimen/size_6</dimen>
+    <dimen name="step_indicator_dot_width">@dimen/size_8</dimen>
+    <dimen name="step_indicator_dot_width_active">@dimen/size_18</dimen>
+
+    <dimen name="wizard_option_stroke_selected">@dimen/size_2</dimen>
+
+    <dimen name="recommended_pill_vertical_padding">@dimen/size_2</dimen>
+
     <!-- ============================================================
          NOTIFICATION SNACKBAR (DishNotifications)
          ============================================================ -->

--- a/app/src/main/res/values/dimens_primitives.xml
+++ b/app/src/main/res/values/dimens_primitives.xml
@@ -39,6 +39,7 @@
     <dimen name="size_36">36dp</dimen>
     <dimen name="size_40">40dp</dimen>
     <dimen name="size_56">56dp</dimen>
+    <dimen name="size_240">240dp</dimen>
     <dimen name="size_600">600dp</dimen>
 
     <!-- ===== sp scale ===== -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -336,4 +336,5 @@
          the canonical TinkerNorth domain. The page covers all jurisdictions
          (GDPR, UK GDPR, CCPA/CPRA, LGPD) in sections inside the document. -->
     <string name="url_privacy_policy" translatable="false">https://dish.tinkernorth.com/privacy/dish-android/</string>
+
 </resources>

--- a/app/src/main/res/values/strings_onboarding.xml
+++ b/app/src/main/res/values/strings_onboarding.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="welcome_skip">Skip</string>
+    <string name="welcome_back">Back</string>
+    <string name="welcome_next">Next</string>
+    <string name="welcome_get_started">Get started</string>
+
+    <string name="welcome_step1_eyebrow">WELCOME</string>
+    <string name="welcome_step1_title">Your phone, your gamepad</string>
+    <string name="welcome_step1_body">Dish turns your phone into a wireless controller for your PC. It works as a touch gamepad on its own, or as a wireless bridge for a controller you already own.</string>
+
+    <string name="welcome_step2_eyebrow">HOW IT WORKS</string>
+    <string name="welcome_step2_title">A short hop over Wi-Fi</string>
+    <string name="welcome_step2_body">Your phone sends button presses, sticks, and motion to a small free helper called Satellite running on your PC. Satellite shows up to your games as a regular gamepad — no extra setup per game.</string>
+
+    <string name="welcome_step3_eyebrow">ONE MORE THING</string>
+    <string name="welcome_step3_title">Install Satellite on your PC</string>
+    <string name="welcome_step3_body">Satellite is free and open source. Grab it from tinkernorth.com/satellite, run the installer, and Dish will find it automatically. You can finish this intro now and install Satellite later.</string>
+    <string name="welcome_step3_satellite_link_label">Open download page</string>
+
+    <string name="welcome_step4_eyebrow">YOU\'RE SET</string>
+    <string name="welcome_step4_title">Ready when you are</string>
+    <string name="welcome_step4_body">Tap Get started to begin. Open Setup guide any time from Settings if you want a walkthrough — or jump straight in and pair with a Satellite on your network.</string>
+    <string name="welcome_step4_launch_wizard">Open setup guide</string>
+
+    <string name="welcome_step1_hero_desc">Dish app logo</string>
+    <string name="welcome_step2_hero_desc">Phone broadcasting a wireless signal</string>
+    <string name="welcome_step3_hero_desc">Desktop monitor showing Satellite running</string>
+    <string name="welcome_step4_hero_desc">Setup complete</string>
+
+    <string name="welcome_step_indicator_desc">Step %1$d of %2$d</string>
+
+    <string name="wizard_title">Setup guide</string>
+    <string name="wizard_step_progress">Step %1$d of %2$d</string>
+    <string name="wizard_action_back">Back</string>
+    <string name="wizard_action_next">Next</string>
+    <string name="wizard_action_finish">Finish</string>
+    <string name="wizard_recommended_label">Recommended</string>
+
+    <string name="wizard_step1_eyebrow">STEP 1 · CONNECTION</string>
+    <string name="wizard_step1_title">How will you reach your PC?</string>
+    <string name="wizard_step1_body">Two ways to send your input to a PC. Wi-Fi is the lowest-latency path and unlocks motion and the touchpad. Bluetooth treats this phone as a regular wireless gamepad — works without Satellite, but with a small latency cost.</string>
+
+    <string name="wizard_option_lan_title">Wi-Fi to Satellite</string>
+    <string name="wizard_option_lan_body">Phone and PC on the same Wi-Fi. Lowest latency, full feature set (motion, touchpad, rumble).</string>
+    <string name="wizard_option_lan_pill_recommended">Recommended</string>
+
+    <string name="wizard_option_bt_title">Bluetooth gamepad</string>
+    <string name="wizard_option_bt_body">Pair your phone to your PC or console as a regular Bluetooth controller. Works without Satellite. Motion and touchpad aren\'t available on this path.</string>
+
+    <string name="wizard_step2_eyebrow">STEP 2 · CONTROLLER</string>
+    <string name="wizard_step2_title">What will you play with?</string>
+    <string name="wizard_step2_body">You can play with the on-screen pad, or plug in a real controller for proper sticks and triggers. A USB controller into your phone has the lowest input latency — no Bluetooth in the chain.</string>
+
+    <string name="wizard_option_virtual_title">On-screen gamepad</string>
+    <string name="wizard_option_virtual_body">Touch the buttons on the phone screen. Great for couch games and trying things out — your phone\'s gyroscope is available for aim assist.</string>
+
+    <string name="wizard_option_usb_title">USB controller into phone</string>
+    <string name="wizard_option_usb_body">Plug a wired Xbox / PlayStation / generic gamepad into your phone\'s USB-C port. The phone forwards every press to your PC.</string>
+    <string name="wizard_option_usb_pill_recommended">Lowest latency</string>
+
+    <string name="wizard_option_phys_bt_title">Bluetooth controller paired to phone</string>
+    <string name="wizard_option_phys_bt_body">Use a controller you\'ve already paired to your phone (Xbox Wireless, DualSense, etc.). One Bluetooth hop instead of two compared with pairing the controller direct to your PC.</string>
+
+    <string name="wizard_step3_eyebrow">STEP 3 · LET\'S GO</string>
+    <string name="wizard_step3_title">Here\'s what we\'ll do</string>
+
+    <string name="wizard_summary_connection_label">Connection</string>
+    <string name="wizard_summary_controller_label">Controller</string>
+
+    <string name="wizard_next_lan_virtual">Tap Finish to open Connections. Scan for your Satellite, pair it with the 4-digit PIN, then open the on-screen gamepad.</string>
+    <string name="wizard_next_lan_usb">Tap Finish to open Connections. Pair your Satellite with the 4-digit PIN, then plug your USB controller into the phone — it\'ll appear as a new slot ready to bind.</string>
+    <string name="wizard_next_lan_phys_bt">Tap Finish to open Connections. Pair your Satellite with the 4-digit PIN. Your already-paired Bluetooth controller will appear as a slot you can bind to the Satellite.</string>
+    <string name="wizard_next_bt_virtual">Tap Finish to open Connections. Add a Bluetooth host, accept the pairing on your PC, then open the on-screen gamepad.</string>
+    <string name="wizard_next_bt_usb">Heads up — Bluetooth-host mode sends the phone\'s controller state, not a separate USB pad. Use the on-screen gamepad on this path, or switch to the Wi-Fi connection in the previous step.</string>
+    <string name="wizard_next_bt_phys_bt">Heads up — Bluetooth-host mode sends the phone\'s controller state, not your already-paired Bluetooth gamepad. Use the on-screen gamepad on this path, or switch to the Wi-Fi connection in the previous step.</string>
+
+    <string name="wizard_finish_review">Go back</string>
+
+    <string name="help_title">Help &amp; FAQ</string>
+
+    <string name="help_section_concepts">CONCEPTS</string>
+    <string name="help_section_performance">BEST PERFORMANCE</string>
+    <string name="help_section_troubleshooting">TROUBLESHOOTING</string>
+    <string name="help_section_about">ABOUT DISH</string>
+
+    <string name="help_run_setup_title">Walk me through setup</string>
+    <string name="help_run_setup_body">Open the setup guide. Picks your connection and controller, then takes you to the right screen.</string>
+
+    <string name="help_q_what_is_dish">What is Dish?</string>
+    <string name="help_a_what_is_dish">Dish turns your phone into a wireless gamepad. It can send input to a PC over Wi-Fi (via the free Satellite helper) or pair to a PC / console as a regular Bluetooth gamepad.</string>
+
+    <string name="help_q_what_is_satellite">What is Satellite?</string>
+    <string name="help_a_what_is_satellite">Satellite is a small, free, open-source program that runs on your PC. It receives input from Dish over Wi-Fi and presents itself to your games as a regular controller. Without Satellite, games can\'t see your phone — install it from tinkernorth.com/satellite.</string>
+
+    <string name="help_q_lan_vs_bluetooth">Wi-Fi or Bluetooth — which should I pick?</string>
+    <string name="help_a_lan_vs_bluetooth">Wi-Fi with Satellite is the better path for almost everyone. It\'s lower latency, supports motion (gyro aim), and unlocks the touchpad. Bluetooth-host mode is the right choice when you don\'t want to install anything on the PC, or when you\'re using a console / set-top box that doesn\'t run Satellite.</string>
+
+    <string name="help_q_controller_modes">Can I use a real controller with Dish?</string>
+    <string name="help_a_controller_modes">Yes. Plug a USB controller into your phone\'s USB-C port, or pair a Bluetooth controller (Xbox Wireless, DualSense, 8BitDo, etc.) directly to your phone. The controller shows up as a new slot you can bind to your Satellite.</string>
+
+    <string name="help_q_motion_touchpad">What\'s motion and what\'s the touchpad?</string>
+    <string name="help_a_motion_touchpad">Motion is your phone\'s gyroscope used as aim assist — it appears to games as the gyro inside a PlayStation pad. The touchpad turns the phone screen into a clickable trackpad you can use for menus or as a mouse. Both need a Wi-Fi (Satellite) connection — Bluetooth-host mode can\'t carry them.</string>
+
+    <string name="help_q_best_setup">What\'s the best setup for low latency?</string>
+    <string name="help_a_best_setup">USB controller into the phone, phone on 5 GHz Wi-Fi, PC on the same router (preferably wired Ethernet). USB-to-phone is zero added latency; Wi-Fi adds one short hop. Avoid 2.4 GHz Wi-Fi and avoid mobile data — Dish needs the phone and PC on the same local network.</string>
+
+    <string name="help_q_why_lan_lower">Why is Wi-Fi lower latency than Bluetooth?</string>
+    <string name="help_a_why_lan_lower">Wi-Fi sends input as small UDP packets at the pace your phone polls — usually faster than Bluetooth can. Bluetooth HID has a fixed polling interval and a longer pipeline, so it sits between you and the game with a small but real delay.</string>
+
+    <string name="help_q_wired_better">Is wired better than wireless?</string>
+    <string name="help_a_wired_better">For the controller-to-phone leg: yes, USB beats Bluetooth-paired-to-phone. For the phone-to-PC leg: Wi-Fi is the only option — you can\'t plug your phone\'s USB into your PC for input forwarding. Connect your PC to the router with Ethernet if you can; phone-side stays on Wi-Fi.</string>
+
+    <string name="help_q_no_satellites">Dish can\'t find any Satellites — what now?</string>
+    <string name="help_a_no_satellites">Check that Satellite is running on the PC (its tray icon should be visible). Confirm the phone and PC are on the same Wi-Fi network — guest networks and 2.4 GHz vs 5 GHz on the same router count as different. Tap Scan in Connections to retry.</string>
+
+    <string name="help_q_pin_rejected">My PIN keeps getting rejected.</string>
+    <string name="help_a_pin_rejected">The PIN is shown by Satellite on your PC and changes if you restart it. Check the digits on the PC right before you type — and make sure you\'re typing into the right Satellite if more than one is showing in the list.</string>
+
+    <string name="help_q_disconnects">My controller keeps disconnecting mid-game.</string>
+    <string name="help_a_disconnects">Most disconnects come from your phone going to sleep or Wi-Fi switching bands. Plug the phone in to charge while you play, and pin your phone\'s Wi-Fi to 5 GHz if the router lets you. Dish keeps a foreground notification while streaming — leave it dismissed in place, that\'s how Android keeps the link alive.</string>
+
+    <string name="help_q_no_motion">Motion (gyro aim) isn\'t working.</string>
+    <string name="help_a_no_motion">Motion needs three things: a Wi-Fi (Satellite) connection (Bluetooth-host can\'t carry motion), a phone with a gyroscope (most phones since 2018), and a PlayStation-style controller on the host side. Switch the controller type to PlayStation on the slot to enable the motion channel.</string>
+
+    <string name="help_q_battery_drain">Battery drains fast while streaming.</string>
+    <string name="help_a_battery_drain">Streaming uses your phone\'s radio constantly — that\'s the cost of being a live controller. Plug in to charge while playing. Dish also has a low-power mode (the dim screen during gameplay) that drops the display to its minimum brightness while still streaming — leave the app open and don\'t lock the screen.</string>
+
+    <string name="help_q_open_source">Is Dish open source?</string>
+    <string name="help_a_open_source">Yes. Dish (Android, Linux, Mac) and Satellite are all released under LGPL-3.0, source on GitHub at github.com/TinkerNorth. Pull requests welcome.</string>
+
+    <string name="help_q_privacy">What does Dish collect?</string>
+    <string name="help_a_privacy">Almost nothing. Dish doesn\'t send gameplay or controller input anywhere — that traffic stays on your local network between phone and PC. Anonymous crash reports are opt-in (Settings → Diagnostics). See the privacy policy for the full list.</string>
+
+    <string name="help_view_privacy_policy">Privacy policy</string>
+    <string name="help_view_github">View source on GitHub</string>
+
+    <string name="dashboard_hint_title">Need a hand?</string>
+    <string name="dashboard_hint_body">Open the setup guide to pick your connection and controller — we\'ll take you to the right screen.</string>
+    <string name="dashboard_hint_action_open">Open guide</string>
+    <string name="dashboard_hint_action_dismiss">Not now</string>
+
+    <string name="settings_section_setup">SETUP &amp; HELP</string>
+    <string name="settings_setup_wizard_title">Setup guide</string>
+    <string name="settings_setup_wizard_body">Walk through connection and controller options. Re-run any time.</string>
+    <string name="settings_help_title">Help &amp; FAQ</string>
+    <string name="settings_help_body">Concepts, performance tips, and troubleshooting.</string>
+
+    <string name="url_satellite" translatable="false">https://tinkernorth.com/satellite</string>
+    <string name="url_github" translatable="false">https://github.com/TinkerNorth</string>
+</resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,11 +28,13 @@ androidxTestCore = "1.7.0"
 androidxTestRunner = "1.7.0"
 androidxTestRules = "1.7.0"
 splashscreen = "1.0.1"
+viewpager2 = "1.1.0"
 window = "1.4.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }
+androidx-viewpager2 = { group = "androidx.viewpager2", name = "viewpager2", version.ref = "viewpager2" }
 androidx-window = { group = "androidx.window", name = "window", version.ref = "window" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }


### PR DESCRIPTION
## Summary
- First-launch welcome flow (`WelcomeActivity`) — 4-page swipeable ViewPager2 with brand intro, how-it-works, Satellite download prompt, ready-to-go. Step indicator pills + Skip / Back / Next / per-page extra CTAs.
- Re-runnable setup guide (`SetupWizardActivity`) — 3-step branching wizard (Connection → Controller → Summary). Selected option uses M3 outlined-card pattern; LAN + USB carry \"Recommended\" / \"Lowest latency\" pills. Hands off to Connections on Finish; flags unviable BT-host + physical-controller combos.
- Help & FAQ (`HelpActivity`) — accordion across Concepts / Best Performance / Troubleshooting / About; top CTA re-opens the wizard; trailing rows link Privacy Policy + GitHub source.
- Dashboard hint card surfaces above CONNECTIONS on phones / below the right-column summary on tablets, gated on welcome-completed + zero connections + not-dismissed.
- Settings → \"SETUP & HELP\" section above Appearance.

## Latency education thread
Wizard step 1 names Wi-Fi as the lowest-latency path with a \"Recommended\" pill on LAN. Step 2 names USB-into-phone as lowest input latency with a \"Lowest latency\" pill on USB. Three dedicated FAQ entries (best setup, why Wi-Fi beats Bluetooth, wired vs wireless) reinforce the story.

## Form factors
`layout-sw600dp/` variants for `activity_welcome`, `activity_setup_wizard`, `activity_help`. Existing tablet variants of `activity_main` + `activity_settings` updated to host the new includes.

## Localization
`strings_onboarding.xml` translated across all 6 locales (en + de + es + fr + pt-BR + bs).

## Design system
New semantic dimens: \`welcome_hero_size\`, \`welcome_content_max_width\`, \`step_indicator_*\`, \`wizard_option_stroke_selected\`, \`recommended_pill_vertical_padding\`. 11 new vector drawables + 2 shape drawables, all routed through \`colorPrimary\` / \`colorMuted\` / \`colorOnPrimary\` semantic tokens.

## Foundation
- \`OnboardingPreferenceStore\` (Hilt singleton, mirrors \`ThemePreferenceStore\`); cloud-backed via \`user_preferences\` so the welcome doesn't replay after reinstall.
- \`DishNavigator.toWelcome / toSetupWizard / toHelp\`; new nav-graph destinations; \`AndroidManifest.xml\` entries with proper \`parentActivityName\` so up-nav lands where the user expects.
- \`androidx.viewpager2:1.1.0\` added to the version catalog.

## Test plan
- [ ] Fresh install on phone → WelcomeActivity launches; swipe + Skip + Back + Next + per-page CTA all work
- [ ] Final page \"Get started\" lands on MainActivity; \"Open setup guide\" lands on SetupWizardActivity
- [ ] Step 3's \"Open download page\" opens Satellite URL in a browser
- [ ] After welcome completes, dashboard shows hint card above CONNECTIONS (phone) / below summary (tablet)
- [ ] Dismiss hint persists across relaunch; reset via reinstall
- [ ] Settings → Setup guide / Help & FAQ both reachable; Up returns correctly
- [ ] Setup wizard: each connection × controller path renders the right next-steps copy; BT-host + USB/Phys-BT downgrades primary to \"Go back\"
- [ ] Help accordion: tap toggles answer; chevron rotates; multiple expansions independent
- [ ] All 6 locales render onboarding strings without overflow on small screens
- [ ] Tablet/foldable: content column caps at 600dp on welcome/wizard/help
- [ ] Gamepad / D-pad navigation: focus rings visible on every focusable; pager left/right keys flip pages