### PR TITLE
feat(settings): open-source licenses screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -228,16 +228,9 @@ tasks.withType<Test>().configureEach {
     maxHeapSize = "2g"
 }
 
-// ─── Open-source license manifest ─────────────────────────────────────────────
-// AGP 9 dropped applicationVariants, which broke the official
-// play-services-oss-licenses plugin and AboutLibraries. We resolve POMs from
-// releaseRuntimeClasspath directly and emit a manifest the in-app screen reads.
 val licensesOutputFile =
     layout.projectDirectory.file("src/main/assets/licenses/licenses.json")
 
-// Hand-curated fallbacks for artifacts that publish empty <licenses> blocks.
-// Guava's listenablefuture-1.0 is a stub published by Google; the code itself
-// is Apache 2.0 (it's pulled in by Firebase transitively, never used directly).
 val knownLicenseOverrides: Map<String, List<Map<String, String?>>> =
     mapOf(
         "com.google.guava:listenablefuture" to

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -227,3 +227,218 @@ tasks.named("check") {
 tasks.withType<Test>().configureEach {
     maxHeapSize = "2g"
 }
+
+// ─── Open-source license manifest ─────────────────────────────────────────────
+// AGP 9 dropped applicationVariants, which broke the official
+// play-services-oss-licenses plugin and AboutLibraries. We resolve POMs from
+// releaseRuntimeClasspath directly and emit a manifest the in-app screen reads.
+val licensesOutputFile =
+    layout.projectDirectory.file("src/main/assets/licenses/licenses.json")
+
+// Hand-curated fallbacks for artifacts that publish empty <licenses> blocks.
+// Guava's listenablefuture-1.0 is a stub published by Google; the code itself
+// is Apache 2.0 (it's pulled in by Firebase transitively, never used directly).
+val knownLicenseOverrides: Map<String, List<Map<String, String?>>> =
+    mapOf(
+        "com.google.guava:listenablefuture" to
+            listOf(
+                mapOf(
+                    "name" to "Apache License 2.0",
+                    "url" to "http://www.apache.org/licenses/LICENSE-2.0.txt",
+                ),
+            ),
+    )
+
+tasks.register("generateLicenseManifest") {
+    group = "build"
+    description =
+        "Generate src/main/assets/licenses/licenses.json from the release runtime classpath POMs."
+
+    outputs.file(licensesOutputFile)
+
+    doLast {
+        val moduleIds =
+            configurations
+                .getByName("releaseRuntimeClasspath")
+                .incoming
+                .resolutionResult
+                .allComponents
+                .mapNotNull { it.id as? org.gradle.api.artifacts.component.ModuleComponentIdentifier }
+                .distinctBy { "${it.group}:${it.module}:${it.version}" }
+                .sortedBy { "${it.group}:${it.module}:${it.version}" }
+
+        val pomDeps =
+            moduleIds.map { id ->
+                dependencies.create("${id.group}:${id.module}:${id.version}@pom")
+            }
+        val pomConfig =
+            configurations.detachedConfiguration(*pomDeps.toTypedArray()).apply {
+                isTransitive = false
+            }
+
+        val entries =
+            pomConfig
+                .resolve()
+                .mapNotNull { parsePomFile(it) }
+                .map { entry ->
+                    val licenses = entry["licenses"] as? List<*>
+                    if (licenses.isNullOrEmpty()) {
+                        val key = "${entry["group"]}:${entry["artifact"]}"
+                        knownLicenseOverrides[key]?.let { entry + ("licenses" to it) } ?: entry
+                    } else {
+                        entry
+                    }
+                }.sortedBy { "${it["group"]}:${it["artifact"]}" }
+
+        val payload =
+            mapOf(
+                "generatedBy" to "generateLicenseManifest",
+                "libraries" to entries,
+            )
+
+        val outFile = licensesOutputFile.asFile
+        outFile.parentFile.mkdirs()
+        outFile.writeText(renderJson(payload))
+    }
+}
+
+tasks.named("preBuild") { dependsOn("generateLicenseManifest") }
+
+fun parsePomFile(pomFile: java.io.File): Map<String, Any?>? {
+    return try {
+        val factory =
+            javax.xml.parsers.DocumentBuilderFactory.newInstance().apply {
+                isNamespaceAware = false
+                setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+            }
+        val doc = factory.newDocumentBuilder().parse(pomFile)
+        val root: org.w3c.dom.Element = doc.documentElement
+
+        fun directChild(
+            parent: org.w3c.dom.Element,
+            tag: String,
+        ): org.w3c.dom.Element? {
+            val children = parent.childNodes
+            for (i in 0 until children.length) {
+                val node = children.item(i)
+                if (node is org.w3c.dom.Element && node.tagName == tag) return node
+            }
+            return null
+        }
+
+        val parent = directChild(root, "parent")
+        val group =
+            directChild(root, "groupId")?.textContent
+                ?: parent?.let { directChild(it, "groupId") }?.textContent
+        val artifact = directChild(root, "artifactId")?.textContent
+        val version =
+            directChild(root, "version")?.textContent
+                ?: parent?.let { directChild(it, "version") }?.textContent
+        val displayName =
+            directChild(root, "name")?.textContent?.takeIf { it.isNotBlank() }
+                ?: "$group:$artifact"
+        val url = directChild(root, "url")?.textContent
+
+        val licensesEl = directChild(root, "licenses")
+        val licenses: List<Map<String, String?>> =
+            if (licensesEl != null) {
+                val list = mutableListOf<Map<String, String?>>()
+                val kids = licensesEl.childNodes
+                for (i in 0 until kids.length) {
+                    val node = kids.item(i)
+                    if (node is org.w3c.dom.Element && node.tagName == "license") {
+                        list.add(
+                            mapOf(
+                                "name" to directChild(node, "name")?.textContent,
+                                "url" to directChild(node, "url")?.textContent,
+                            ),
+                        )
+                    }
+                }
+                list
+            } else {
+                emptyList()
+            }
+
+        mapOf(
+            "group" to group,
+            "artifact" to artifact,
+            "version" to version,
+            "name" to displayName,
+            "url" to url,
+            "licenses" to licenses,
+        )
+    } catch (e: Exception) {
+        logger.warn("generateLicenseManifest: failed to parse ${pomFile.name}: ${e.message}")
+        null
+    }
+}
+
+fun renderJson(value: Any?): String = StringBuilder().also { renderJsonTo(it, value, 0) }.append('\n').toString()
+
+fun renderJsonTo(
+    sb: StringBuilder,
+    value: Any?,
+    indent: Int,
+) {
+    when (value) {
+        null -> sb.append("null")
+        is Boolean -> sb.append(value.toString())
+        is Number -> sb.append(value.toString())
+        is String -> appendJsonString(sb, value)
+        is Map<*, *> -> {
+            if (value.isEmpty()) {
+                sb.append("{}")
+                return
+            }
+            sb.append("{\n")
+            val entries = value.entries.toList()
+            for ((i, e) in entries.withIndex()) {
+                repeat(indent + 1) { sb.append("  ") }
+                appendJsonString(sb, e.key.toString())
+                sb.append(": ")
+                renderJsonTo(sb, e.value, indent + 1)
+                if (i < entries.size - 1) sb.append(',')
+                sb.append('\n')
+            }
+            repeat(indent) { sb.append("  ") }
+            sb.append('}')
+        }
+        is Iterable<*> -> {
+            val list = value.toList()
+            if (list.isEmpty()) {
+                sb.append("[]")
+                return
+            }
+            sb.append("[\n")
+            for ((i, item) in list.withIndex()) {
+                repeat(indent + 1) { sb.append("  ") }
+                renderJsonTo(sb, item, indent + 1)
+                if (i < list.size - 1) sb.append(',')
+                sb.append('\n')
+            }
+            repeat(indent) { sb.append("  ") }
+            sb.append(']')
+        }
+        else -> appendJsonString(sb, value.toString())
+    }
+}
+
+fun appendJsonString(
+    sb: StringBuilder,
+    s: String,
+) {
+    sb.append('"')
+    for (c in s) {
+        when {
+            c == '"' -> sb.append("\\\"")
+            c == '\\' -> sb.append("\\\\")
+            c == '\n' -> sb.append("\\n")
+            c == '\r' -> sb.append("\\r")
+            c == '\t' -> sb.append("\\t")
+            c < ' ' -> sb.append("\\u%04x".format(c.code))
+            else -> sb.append(c)
+        }
+    }
+    sb.append('"')
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -97,6 +97,15 @@
             tools:targetApi="p" />
 
         <activity
+            android:name=".ui.settings.LicensesActivity"
+            android:exported="false"
+            android:resizeableActivity="true"
+            android:theme="@style/Theme.Dish"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden"
+            android:parentActivityName=".ui.settings.SettingsActivity"
+            tools:targetApi="p" />
+
+        <activity
             android:name=".ui.onboarding.WelcomeActivity"
             android:exported="false"
             android:resizeableActivity="true"

--- a/app/src/main/assets/licenses/licenses.json
+++ b/app/src/main/assets/licenses/licenses.json
@@ -1,0 +1,1773 @@
+{
+  "generatedBy": "generateLicenseManifest",
+  "libraries": [
+    {
+      "group": "androidx.activity",
+      "artifact": "activity",
+      "version": "1.13.0",
+      "name": "Activity",
+      "url": "https://developer.android.com/jetpack/androidx/releases/activity#1.13.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.activity",
+      "artifact": "activity-ktx",
+      "version": "1.13.0",
+      "name": "Activity Kotlin Extensions",
+      "url": "https://developer.android.com/jetpack/androidx/releases/activity#1.13.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.annotation",
+      "artifact": "annotation",
+      "version": "1.9.1",
+      "name": "Annotation",
+      "url": "https://developer.android.com/jetpack/androidx/releases/annotation#1.9.1",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.annotation",
+      "artifact": "annotation-experimental",
+      "version": "1.4.1",
+      "name": "Experimental annotation",
+      "url": "https://developer.android.com/jetpack/androidx/releases/annotation#1.4.1",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.annotation",
+      "artifact": "annotation-jvm",
+      "version": "1.9.1",
+      "name": "Annotation",
+      "url": "https://developer.android.com/jetpack/androidx/releases/annotation#1.9.1",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.appcompat",
+      "artifact": "appcompat",
+      "version": "1.7.1",
+      "name": "AppCompat",
+      "url": "https://developer.android.com/jetpack/androidx/releases/appcompat#1.7.1",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.appcompat",
+      "artifact": "appcompat-resources",
+      "version": "1.7.1",
+      "name": "AppCompat Resources",
+      "url": "https://developer.android.com/jetpack/androidx/releases/appcompat#1.7.1",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.arch.core",
+      "artifact": "core-common",
+      "version": "2.2.0",
+      "name": "Android Arch-Common",
+      "url": "https://developer.android.com/jetpack/androidx/releases/arch-core#2.2.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.arch.core",
+      "artifact": "core-runtime",
+      "version": "2.2.0",
+      "name": "Android Arch-Runtime",
+      "url": "https://developer.android.com/jetpack/androidx/releases/arch-core#2.2.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.cardview",
+      "artifact": "cardview",
+      "version": "1.0.0",
+      "name": "Android Support CardView v7",
+      "url": "http://developer.android.com/tools/extras/support-library.html",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.collection",
+      "artifact": "collection",
+      "version": "1.4.2",
+      "name": "collections",
+      "url": "https://developer.android.com/jetpack/androidx/releases/collection#1.4.2",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.collection",
+      "artifact": "collection-jvm",
+      "version": "1.4.2",
+      "name": "collections",
+      "url": "https://developer.android.com/jetpack/androidx/releases/collection#1.4.2",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.compose.runtime",
+      "artifact": "runtime-annotation",
+      "version": "1.9.0",
+      "name": "Compose Runtime Annotation",
+      "url": "https://developer.android.com/jetpack/androidx/releases/compose-runtime#1.9.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.compose.runtime",
+      "artifact": "runtime-annotation-android",
+      "version": "1.9.0",
+      "name": "Compose Runtime Annotation",
+      "url": "https://developer.android.com/jetpack/androidx/releases/compose-runtime#1.9.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.concurrent",
+      "artifact": "concurrent-futures",
+      "version": "1.1.0",
+      "name": "AndroidX Futures",
+      "url": "https://developer.android.com/topic/libraries/architecture/index.html",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.constraintlayout",
+      "artifact": "constraintlayout",
+      "version": "2.2.1",
+      "name": "ConstraintLayout",
+      "url": "https://developer.android.com/jetpack/androidx/releases/constraintlayout#2.2.1",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.constraintlayout",
+      "artifact": "constraintlayout-core",
+      "version": "1.1.1",
+      "name": "ConstraintLayout Core",
+      "url": "https://developer.android.com/jetpack/androidx/releases/constraintlayout#1.1.1",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.coordinatorlayout",
+      "artifact": "coordinatorlayout",
+      "version": "1.1.0",
+      "name": "Android Support Library Coordinator Layout",
+      "url": "https://developer.android.com/jetpack/androidx",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.core",
+      "artifact": "core",
+      "version": "1.18.0",
+      "name": "Core",
+      "url": "https://developer.android.com/jetpack/androidx/releases/core#1.18.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.core",
+      "artifact": "core-ktx",
+      "version": "1.18.0",
+      "name": "Core Kotlin Extensions",
+      "url": "https://developer.android.com/jetpack/androidx/releases/core#1.18.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.core",
+      "artifact": "core-splashscreen",
+      "version": "1.0.1",
+      "name": "SplashScreen",
+      "url": "https://developer.android.com/jetpack/androidx/releases/core#1.0.1",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.core",
+      "artifact": "core-viewtree",
+      "version": "1.0.0",
+      "name": "androidx.core:core-viewtree",
+      "url": "https://developer.android.com/jetpack/androidx/releases/core#1.0.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.cursoradapter",
+      "artifact": "cursoradapter",
+      "version": "1.0.0",
+      "name": "Android Support Library Cursor Adapter",
+      "url": "http://developer.android.com/tools/extras/support-library.html",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.customview",
+      "artifact": "customview",
+      "version": "1.2.0",
+      "name": "Custom View",
+      "url": "https://developer.android.com/jetpack/androidx/releases/customview#1.2.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.customview",
+      "artifact": "customview-poolingcontainer",
+      "version": "1.0.0",
+      "name": "androidx.customview:poolingcontainer",
+      "url": "https://developer.android.com/jetpack/androidx/releases/customview#1.0.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.databinding",
+      "artifact": "viewbinding",
+      "version": "9.2.1",
+      "name": "androidx.databinding:viewbinding",
+      "url": null,
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.datastore",
+      "artifact": "datastore",
+      "version": "1.1.7",
+      "name": "DataStore",
+      "url": "https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.datastore",
+      "artifact": "datastore-android",
+      "version": "1.1.7",
+      "name": "DataStore",
+      "url": "https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.datastore",
+      "artifact": "datastore-core",
+      "version": "1.1.7",
+      "name": "DataStore Core",
+      "url": "https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.datastore",
+      "artifact": "datastore-core-android",
+      "version": "1.1.7",
+      "name": "DataStore Core",
+      "url": "https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.datastore",
+      "artifact": "datastore-core-okio",
+      "version": "1.1.7",
+      "name": "DataStore Core Okio",
+      "url": "https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.datastore",
+      "artifact": "datastore-core-okio-jvm",
+      "version": "1.1.7",
+      "name": "DataStore Core Okio",
+      "url": "https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.datastore",
+      "artifact": "datastore-preferences",
+      "version": "1.1.7",
+      "name": "Preferences DataStore",
+      "url": "https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.datastore",
+      "artifact": "datastore-preferences-android",
+      "version": "1.1.7",
+      "name": "Preferences DataStore",
+      "url": "https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.datastore",
+      "artifact": "datastore-preferences-core",
+      "version": "1.1.7",
+      "name": "Preferences DataStore Core",
+      "url": "https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.datastore",
+      "artifact": "datastore-preferences-core-android",
+      "version": "1.1.7",
+      "name": "Preferences DataStore Core",
+      "url": "https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.datastore",
+      "artifact": "datastore-preferences-external-protobuf",
+      "version": "1.1.7",
+      "name": "Preferences External Protobuf",
+      "url": "https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7",
+      "licenses": [
+        {
+          "name": "BSD-3-Clause",
+          "url": "https://opensource.org/licenses/BSD-3-Clause"
+        }
+      ]
+    },
+    {
+      "group": "androidx.datastore",
+      "artifact": "datastore-preferences-proto",
+      "version": "1.1.7",
+      "name": "Preferences DataStore Proto",
+      "url": "https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.drawerlayout",
+      "artifact": "drawerlayout",
+      "version": "1.1.1",
+      "name": "Android Support Library Drawer Layout",
+      "url": "https://developer.android.com/jetpack/androidx",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.dynamicanimation",
+      "artifact": "dynamicanimation",
+      "version": "1.1.0",
+      "name": "DynamicAnimation",
+      "url": "https://developer.android.com/jetpack/androidx/releases/dynamicanimation#1.1.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.emoji2",
+      "artifact": "emoji2",
+      "version": "1.3.0",
+      "name": "Android Emoji2 Compat",
+      "url": "https://developer.android.com/jetpack/androidx/releases/emoji2#1.3.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.emoji2",
+      "artifact": "emoji2-views-helper",
+      "version": "1.3.0",
+      "name": "Android Emoji2 Compat view helpers",
+      "url": "https://developer.android.com/jetpack/androidx/releases/emoji2#1.3.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.fragment",
+      "artifact": "fragment",
+      "version": "1.5.4",
+      "name": "Android Support Library fragment",
+      "url": "https://developer.android.com/jetpack/androidx/releases/fragment#1.5.4",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.games",
+      "artifact": "games-activity",
+      "version": "4.4.2",
+      "name": "androidx.games:games-activity",
+      "url": null,
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.graphics",
+      "artifact": "graphics-shapes",
+      "version": "1.0.1",
+      "name": "Graphics Shapes",
+      "url": "https://developer.android.com/jetpack/androidx/releases/graphics#1.0.1",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.graphics",
+      "artifact": "graphics-shapes-android",
+      "version": "1.0.1",
+      "name": "Graphics Shapes",
+      "url": "https://developer.android.com/jetpack/androidx/releases/graphics#1.0.1",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.interpolator",
+      "artifact": "interpolator",
+      "version": "1.0.0",
+      "name": "Android Support Library Interpolators",
+      "url": "http://developer.android.com/tools/extras/support-library.html",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.lifecycle",
+      "artifact": "lifecycle-common",
+      "version": "2.10.0",
+      "name": "Lifecycle-Common",
+      "url": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.lifecycle",
+      "artifact": "lifecycle-common-jvm",
+      "version": "2.10.0",
+      "name": "Lifecycle-Common",
+      "url": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.lifecycle",
+      "artifact": "lifecycle-livedata",
+      "version": "2.10.0",
+      "name": "Lifecycle LiveData",
+      "url": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.lifecycle",
+      "artifact": "lifecycle-livedata-core",
+      "version": "2.10.0",
+      "name": "Lifecycle LiveData Core",
+      "url": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.lifecycle",
+      "artifact": "lifecycle-livedata-core-ktx",
+      "version": "2.10.0",
+      "name": "LiveData Core Kotlin Extensions",
+      "url": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.lifecycle",
+      "artifact": "lifecycle-process",
+      "version": "2.10.0",
+      "name": "Lifecycle Process",
+      "url": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.lifecycle",
+      "artifact": "lifecycle-runtime",
+      "version": "2.10.0",
+      "name": "Lifecycle Runtime",
+      "url": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.lifecycle",
+      "artifact": "lifecycle-runtime-android",
+      "version": "2.10.0",
+      "name": "Lifecycle Runtime",
+      "url": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.lifecycle",
+      "artifact": "lifecycle-runtime-ktx",
+      "version": "2.10.0",
+      "name": "Lifecycle Kotlin Extensions",
+      "url": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.lifecycle",
+      "artifact": "lifecycle-runtime-ktx-android",
+      "version": "2.10.0",
+      "name": "Lifecycle Kotlin Extensions",
+      "url": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.lifecycle",
+      "artifact": "lifecycle-viewmodel",
+      "version": "2.10.0",
+      "name": "Lifecycle ViewModel",
+      "url": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.lifecycle",
+      "artifact": "lifecycle-viewmodel-android",
+      "version": "2.10.0",
+      "name": "Lifecycle ViewModel",
+      "url": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.lifecycle",
+      "artifact": "lifecycle-viewmodel-ktx",
+      "version": "2.10.0",
+      "name": "Lifecycle ViewModel Kotlin Extensions",
+      "url": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.lifecycle",
+      "artifact": "lifecycle-viewmodel-savedstate",
+      "version": "2.10.0",
+      "name": "Lifecycle ViewModel with SavedState",
+      "url": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.lifecycle",
+      "artifact": "lifecycle-viewmodel-savedstate-android",
+      "version": "2.10.0",
+      "name": "Lifecycle ViewModel with SavedState",
+      "url": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.loader",
+      "artifact": "loader",
+      "version": "1.0.0",
+      "name": "Android Support Library loader",
+      "url": "http://developer.android.com/tools/extras/support-library.html",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.navigation",
+      "artifact": "navigation-common",
+      "version": "2.9.8",
+      "name": "Navigation Common",
+      "url": "https://developer.android.com/jetpack/androidx/releases/navigation#2.9.8",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.navigation",
+      "artifact": "navigation-common-android",
+      "version": "2.9.8",
+      "name": "Navigation Common",
+      "url": "https://developer.android.com/jetpack/androidx/releases/navigation#2.9.8",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.navigation",
+      "artifact": "navigation-runtime",
+      "version": "2.9.8",
+      "name": "Navigation Runtime",
+      "url": "https://developer.android.com/jetpack/androidx/releases/navigation#2.9.8",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.navigation",
+      "artifact": "navigation-runtime-android",
+      "version": "2.9.8",
+      "name": "Navigation Runtime",
+      "url": "https://developer.android.com/jetpack/androidx/releases/navigation#2.9.8",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.navigation",
+      "artifact": "navigation-runtime-ktx",
+      "version": "2.9.8",
+      "name": "Navigation Runtime Kotlin Extensions",
+      "url": "https://developer.android.com/jetpack/androidx/releases/navigation#2.9.8",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.navigationevent",
+      "artifact": "navigationevent",
+      "version": "1.0.0",
+      "name": "Navigation Event",
+      "url": "https://developer.android.com/jetpack/androidx/releases/navigationevent#1.0.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.navigationevent",
+      "artifact": "navigationevent-android",
+      "version": "1.0.0",
+      "name": "Navigation Event",
+      "url": "https://developer.android.com/jetpack/androidx/releases/navigationevent#1.0.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.profileinstaller",
+      "artifact": "profileinstaller",
+      "version": "1.4.0",
+      "name": "Profile Installer",
+      "url": "https://developer.android.com/jetpack/androidx/releases/profileinstaller#1.4.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.recyclerview",
+      "artifact": "recyclerview",
+      "version": "1.3.1",
+      "name": "Android Support RecyclerView",
+      "url": "https://developer.android.com/jetpack/androidx/releases/recyclerview#1.3.1",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.resourceinspection",
+      "artifact": "resourceinspection-annotation",
+      "version": "1.0.1",
+      "name": "Android Resource Inspection - Annotations",
+      "url": "https://developer.android.com/jetpack/androidx/releases/resourceinspection#1.0.1",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.savedstate",
+      "artifact": "savedstate",
+      "version": "1.4.0",
+      "name": "Saved State",
+      "url": "https://developer.android.com/jetpack/androidx/releases/savedstate#1.4.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.savedstate",
+      "artifact": "savedstate-android",
+      "version": "1.4.0",
+      "name": "Saved State",
+      "url": "https://developer.android.com/jetpack/androidx/releases/savedstate#1.4.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.savedstate",
+      "artifact": "savedstate-ktx",
+      "version": "1.4.0",
+      "name": "SavedState Kotlin Extensions",
+      "url": "https://developer.android.com/jetpack/androidx/releases/savedstate#1.4.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.startup",
+      "artifact": "startup-runtime",
+      "version": "1.1.1",
+      "name": "Android App Startup Runtime",
+      "url": "https://developer.android.com/jetpack/androidx/releases/startup#1.1.1",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.tracing",
+      "artifact": "tracing",
+      "version": "1.2.0",
+      "name": "Android Tracing",
+      "url": "https://developer.android.com/jetpack/androidx/releases/tracing#1.2.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.transition",
+      "artifact": "transition",
+      "version": "1.5.0",
+      "name": "Transition",
+      "url": "https://developer.android.com/jetpack/androidx/releases/transition#1.5.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.vectordrawable",
+      "artifact": "vectordrawable",
+      "version": "1.1.0",
+      "name": "Android Support VectorDrawable",
+      "url": "https://developer.android.com/jetpack/androidx",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.vectordrawable",
+      "artifact": "vectordrawable-animated",
+      "version": "1.1.0",
+      "name": "Android Support AnimatedVectorDrawable",
+      "url": "https://developer.android.com/jetpack/androidx",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.versionedparcelable",
+      "artifact": "versionedparcelable",
+      "version": "1.1.1",
+      "name": "VersionedParcelable",
+      "url": "http://developer.android.com/tools/extras/support-library.html",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.viewpager2",
+      "artifact": "viewpager2",
+      "version": "1.1.0",
+      "name": "ViewPager2",
+      "url": "https://developer.android.com/jetpack/androidx/releases/viewpager2#1.1.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.viewpager",
+      "artifact": "viewpager",
+      "version": "1.0.0",
+      "name": "Android Support Library View Pager",
+      "url": "http://developer.android.com/tools/extras/support-library.html",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.window",
+      "artifact": "window",
+      "version": "1.4.0",
+      "name": "WindowManager",
+      "url": "https://developer.android.com/jetpack/androidx/releases/window#1.4.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.window",
+      "artifact": "window-core",
+      "version": "1.4.0",
+      "name": "WindowManager Core",
+      "url": "https://developer.android.com/jetpack/androidx/releases/window#1.4.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "androidx.window",
+      "artifact": "window-core-android",
+      "version": "1.4.0",
+      "name": "WindowManager Core",
+      "url": "https://developer.android.com/jetpack/androidx/releases/window#1.4.0",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.android.datatransport",
+      "artifact": "transport-api",
+      "version": "3.2.0",
+      "name": "com.google.android.datatransport:transport-api",
+      "url": null,
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.android.datatransport",
+      "artifact": "transport-backend-cct",
+      "version": "3.3.0",
+      "name": "com.google.android.datatransport:transport-backend-cct",
+      "url": null,
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.android.datatransport",
+      "artifact": "transport-runtime",
+      "version": "3.3.0",
+      "name": "com.google.android.datatransport:transport-runtime",
+      "url": null,
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.android.gms",
+      "artifact": "play-services-basement",
+      "version": "18.8.0",
+      "name": "play-services-basement",
+      "url": null,
+      "licenses": [
+        {
+          "name": "Android Software Development Kit License",
+          "url": "https://developer.android.com/studio/terms.html"
+        }
+      ]
+    },
+    {
+      "group": "com.google.android.gms",
+      "artifact": "play-services-tasks",
+      "version": "18.4.0",
+      "name": "play-services-tasks",
+      "url": null,
+      "licenses": [
+        {
+          "name": "Android Software Development Kit License",
+          "url": "https://developer.android.com/studio/terms.html"
+        }
+      ]
+    },
+    {
+      "group": "com.google.android.material",
+      "artifact": "material",
+      "version": "1.14.0",
+      "name": "Material Components for Android",
+      "url": "https://github.com/material-components/material-components-android",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.code.findbugs",
+      "artifact": "jsr305",
+      "version": "3.0.2",
+      "name": "FindBugs-jsr305",
+      "url": "http://findbugs.sourceforge.net/",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.dagger",
+      "artifact": "dagger",
+      "version": "2.59.2",
+      "name": "Dagger",
+      "url": "https://github.com/google/dagger",
+      "licenses": [
+        {
+          "name": "Apache 2.0",
+          "url": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.dagger",
+      "artifact": "dagger-lint-aar",
+      "version": "2.59.2",
+      "name": "Dagger Lint Rules AAR Distribution",
+      "url": "https://github.com/google/dagger",
+      "licenses": [
+        {
+          "name": "Apache 2.0",
+          "url": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.dagger",
+      "artifact": "hilt-android",
+      "version": "2.59.2",
+      "name": "Hilt Android",
+      "url": "https://github.com/google/dagger",
+      "licenses": [
+        {
+          "name": "Apache 2.0",
+          "url": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.dagger",
+      "artifact": "hilt-core",
+      "version": "2.59.2",
+      "name": "Hilt Core",
+      "url": "https://github.com/google/dagger",
+      "licenses": [
+        {
+          "name": "Apache 2.0",
+          "url": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.errorprone",
+      "artifact": "error_prone_annotations",
+      "version": "2.26.0",
+      "name": "error-prone annotations",
+      "url": null,
+      "licenses": [
+        {
+          "name": "Apache 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.firebase",
+      "artifact": "firebase-annotations",
+      "version": "17.0.0",
+      "name": "com.google.firebase:firebase-annotations",
+      "url": null,
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.firebase",
+      "artifact": "firebase-bom",
+      "version": "34.13.0",
+      "name": "com.google.firebase:firebase-bom",
+      "url": null,
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.firebase",
+      "artifact": "firebase-common",
+      "version": "22.0.1",
+      "name": "com.google.firebase:firebase-common",
+      "url": null,
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.firebase",
+      "artifact": "firebase-components",
+      "version": "19.0.0",
+      "name": "com.google.firebase:firebase-components",
+      "url": null,
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.firebase",
+      "artifact": "firebase-config-interop",
+      "version": "16.0.1",
+      "name": "com.google.firebase:firebase-config-interop",
+      "url": null,
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.firebase",
+      "artifact": "firebase-crashlytics",
+      "version": "20.0.6",
+      "name": "com.google.firebase:firebase-crashlytics",
+      "url": null,
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.firebase",
+      "artifact": "firebase-datatransport",
+      "version": "19.0.0",
+      "name": "com.google.firebase:firebase-datatransport",
+      "url": null,
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.firebase",
+      "artifact": "firebase-encoders",
+      "version": "17.0.0",
+      "name": "firebase-encoders",
+      "url": null,
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.firebase",
+      "artifact": "firebase-encoders-json",
+      "version": "18.0.1",
+      "name": "com.google.firebase:firebase-encoders-json",
+      "url": null,
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.firebase",
+      "artifact": "firebase-encoders-proto",
+      "version": "16.0.0",
+      "name": "firebase-encoders-proto",
+      "url": null,
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.firebase",
+      "artifact": "firebase-installations",
+      "version": "19.1.0",
+      "name": "com.google.firebase:firebase-installations",
+      "url": null,
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.firebase",
+      "artifact": "firebase-installations-interop",
+      "version": "17.3.0",
+      "name": "com.google.firebase:firebase-installations-interop",
+      "url": null,
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.firebase",
+      "artifact": "firebase-measurement-connector",
+      "version": "20.0.1",
+      "name": "firebase-measurement-connector",
+      "url": null,
+      "licenses": [
+        {
+          "name": "Android Software Development Kit License",
+          "url": "https://developer.android.com/studio/terms.html"
+        }
+      ]
+    },
+    {
+      "group": "com.google.firebase",
+      "artifact": "firebase-sessions",
+      "version": "3.0.6",
+      "name": "com.google.firebase:firebase-sessions",
+      "url": null,
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.google.guava",
+      "artifact": "listenablefuture",
+      "version": "1.0",
+      "name": "Guava ListenableFuture only",
+      "url": null,
+      "licenses": [
+        {
+          "name": "Apache License 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.squareup.okio",
+      "artifact": "okio",
+      "version": "3.4.0",
+      "name": "okio",
+      "url": "https://github.com/square/okio/",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "com.squareup.okio",
+      "artifact": "okio-jvm",
+      "version": "3.4.0",
+      "name": "okio",
+      "url": "https://github.com/square/okio/",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "jakarta.inject",
+      "artifact": "jakarta.inject-api",
+      "version": "2.0.1",
+      "name": "Jakarta Dependency Injection",
+      "url": "https://github.com/eclipse-ee4j/injection-api",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "javax.inject",
+      "artifact": "javax.inject",
+      "version": "1",
+      "name": "javax.inject",
+      "url": "http://code.google.com/p/atinject/",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "org.jetbrains.kotlin",
+      "artifact": "kotlin-android-extensions-runtime",
+      "version": "1.9.22",
+      "name": "Kotlin Android Extensions Runtime",
+      "url": "https://kotlinlang.org/",
+      "licenses": [
+        {
+          "name": "The Apache License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "org.jetbrains.kotlin",
+      "artifact": "kotlin-bom",
+      "version": "1.8.22",
+      "name": "Kotlin Libraries bill-of-materials",
+      "url": "https://kotlinlang.org/",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "org.jetbrains.kotlin",
+      "artifact": "kotlin-parcelize-runtime",
+      "version": "1.9.22",
+      "name": "Parcelize Runtime",
+      "url": "https://kotlinlang.org/",
+      "licenses": [
+        {
+          "name": "The Apache License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "org.jetbrains.kotlin",
+      "artifact": "kotlin-stdlib",
+      "version": "2.3.21",
+      "name": "Kotlin Stdlib",
+      "url": "https://kotlinlang.org/",
+      "licenses": [
+        {
+          "name": "Apache-2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "org.jetbrains.kotlin",
+      "artifact": "kotlin-stdlib-jdk7",
+      "version": "1.8.22",
+      "name": "Kotlin Stdlib Jdk7",
+      "url": "https://kotlinlang.org/",
+      "licenses": [
+        {
+          "name": "The Apache License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "org.jetbrains.kotlin",
+      "artifact": "kotlin-stdlib-jdk8",
+      "version": "1.8.22",
+      "name": "Kotlin Stdlib Jdk8",
+      "url": "https://kotlinlang.org/",
+      "licenses": [
+        {
+          "name": "The Apache License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "org.jetbrains.kotlinx",
+      "artifact": "kotlinx-coroutines-android",
+      "version": "1.11.0",
+      "name": "kotlinx-coroutines-android",
+      "url": "https://github.com/Kotlin/kotlinx.coroutines",
+      "licenses": [
+        {
+          "name": "Apache-2.0",
+          "url": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "org.jetbrains.kotlinx",
+      "artifact": "kotlinx-coroutines-bom",
+      "version": "1.11.0",
+      "name": "kotlinx-coroutines-bom",
+      "url": "https://github.com/Kotlin/kotlinx.coroutines",
+      "licenses": [
+        {
+          "name": "Apache-2.0",
+          "url": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "org.jetbrains.kotlinx",
+      "artifact": "kotlinx-coroutines-core",
+      "version": "1.11.0",
+      "name": "kotlinx-coroutines-core",
+      "url": "https://github.com/Kotlin/kotlinx.coroutines",
+      "licenses": [
+        {
+          "name": "Apache-2.0",
+          "url": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "org.jetbrains.kotlinx",
+      "artifact": "kotlinx-coroutines-core-jvm",
+      "version": "1.11.0",
+      "name": "kotlinx-coroutines-core",
+      "url": "https://github.com/Kotlin/kotlinx.coroutines",
+      "licenses": [
+        {
+          "name": "Apache-2.0",
+          "url": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "org.jetbrains.kotlinx",
+      "artifact": "kotlinx-coroutines-play-services",
+      "version": "1.11.0",
+      "name": "kotlinx-coroutines-play-services",
+      "url": "https://github.com/Kotlin/kotlinx.coroutines",
+      "licenses": [
+        {
+          "name": "Apache-2.0",
+          "url": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "org.jetbrains.kotlinx",
+      "artifact": "kotlinx-serialization-bom",
+      "version": "1.11.0",
+      "name": "kotlinx-serialization-bom",
+      "url": "https://github.com/Kotlin/kotlinx.serialization",
+      "licenses": [
+        {
+          "name": "Apache-2.0",
+          "url": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "org.jetbrains.kotlinx",
+      "artifact": "kotlinx-serialization-core",
+      "version": "1.11.0",
+      "name": "kotlinx-serialization-core",
+      "url": "https://github.com/Kotlin/kotlinx.serialization",
+      "licenses": [
+        {
+          "name": "Apache-2.0",
+          "url": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "org.jetbrains.kotlinx",
+      "artifact": "kotlinx-serialization-core-jvm",
+      "version": "1.11.0",
+      "name": "kotlinx-serialization-core",
+      "url": "https://github.com/Kotlin/kotlinx.serialization",
+      "licenses": [
+        {
+          "name": "Apache-2.0",
+          "url": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "org.jetbrains.kotlinx",
+      "artifact": "kotlinx-serialization-json",
+      "version": "1.11.0",
+      "name": "kotlinx-serialization-json",
+      "url": "https://github.com/Kotlin/kotlinx.serialization",
+      "licenses": [
+        {
+          "name": "Apache-2.0",
+          "url": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "org.jetbrains.kotlinx",
+      "artifact": "kotlinx-serialization-json-jvm",
+      "version": "1.11.0",
+      "name": "kotlinx-serialization-json",
+      "url": "https://github.com/Kotlin/kotlinx.serialization",
+      "licenses": [
+        {
+          "name": "Apache-2.0",
+          "url": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "org.jetbrains",
+      "artifact": "annotations",
+      "version": "23.0.0",
+      "name": "JetBrains Java Annotations",
+      "url": "https://github.com/JetBrains/java-annotations",
+      "licenses": [
+        {
+          "name": "The Apache Software License, Version 2.0",
+          "url": "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    },
+    {
+      "group": "org.jspecify",
+      "artifact": "jspecify",
+      "version": "1.0.0",
+      "name": "JSpecify annotations",
+      "url": "http://jspecify.org/",
+      "licenses": [
+        {
+          "name": "The Apache License, Version 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      ]
+    }
+  ]
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/settings/LicenseManifest.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/settings/LicenseManifest.kt
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.settings
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LicenseManifest(
+    val generatedBy: String? = null,
+    val libraries: List<LicenseEntry> = emptyList(),
+)
+
+@Serializable
+data class LicenseEntry(
+    val group: String? = null,
+    val artifact: String? = null,
+    val version: String? = null,
+    val name: String? = null,
+    val url: String? = null,
+    val licenses: List<LicenseInfo> = emptyList(),
+)
+
+@Serializable
+data class LicenseInfo(
+    val name: String? = null,
+    val url: String? = null,
+)

--- a/app/src/main/java/com/tinkernorth/dish/ui/settings/LicensesActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/settings/LicensesActivity.kt
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.settings
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.net.toUri
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.tinkernorth.dish.R
+import com.tinkernorth.dish.databinding.ActivityLicensesBinding
+import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
+import com.tinkernorth.dish.ui.common.applyDishSystemBars
+import com.tinkernorth.dish.ui.common.setupDishToolbar
+import kotlinx.serialization.json.Json
+
+class LicensesActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityLicensesBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityLicensesBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        setupDishToolbar(binding.toolbar)
+        applyDishSystemBars(binding.root)
+        applyDishActivityTransitions()
+
+        binding.toolbar.title = getString(R.string.settings_open_source_licenses_title)
+
+        val manifest = loadManifest()
+        binding.recyclerLicenses.layoutManager = LinearLayoutManager(this)
+        binding.recyclerLicenses.adapter =
+            LicensesAdapter(manifest.libraries) { entry -> openLicenseUrl(entry) }
+    }
+
+    private fun loadManifest(): LicenseManifest =
+        assets.open("licenses/licenses.json").bufferedReader().use { reader ->
+            JSON.decodeFromString<LicenseManifest>(reader.readText())
+        }
+
+    private fun openLicenseUrl(entry: LicenseEntry) {
+        val url = entry.licenses.firstOrNull()?.url ?: entry.url ?: return
+        val intent =
+            Intent(Intent.ACTION_VIEW, url.toUri())
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        runCatching { startActivity(intent) }
+    }
+
+    companion object {
+        private val JSON = Json { ignoreUnknownKeys = true }
+    }
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/settings/LicensesAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/settings/LicensesAdapter.kt
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.settings
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.tinkernorth.dish.R
+import com.tinkernorth.dish.databinding.ItemLicenseBinding
+
+class LicensesAdapter(
+    private val items: List<LicenseEntry>,
+    private val onClick: (LicenseEntry) -> Unit,
+) : RecyclerView.Adapter<LicensesAdapter.VH>() {
+    class VH(
+        val binding: ItemLicenseBinding,
+    ) : RecyclerView.ViewHolder(binding.root)
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): VH {
+        val binding = ItemLicenseBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return VH(binding)
+    }
+
+    override fun onBindViewHolder(
+        holder: VH,
+        position: Int,
+    ) {
+        val entry = items[position]
+        val ctx = holder.itemView.context
+        holder.binding.tvLibraryName.text =
+            entry.name?.takeIf { it.isNotBlank() }
+                ?: listOfNotNull(entry.group, entry.artifact).joinToString(":")
+        holder.binding.tvLibraryVersion.text = entry.version.orEmpty()
+
+        val licenseName =
+            entry.licenses
+                .firstOrNull()
+                ?.name
+                ?.takeIf { it.isNotBlank() }
+        if (licenseName != null) {
+            holder.binding.tvLicense.visibility = View.VISIBLE
+            holder.binding.tvLicense.text = licenseName
+        } else {
+            holder.binding.tvLicense.visibility = View.GONE
+        }
+
+        val clickUrl = entry.licenses.firstOrNull()?.url ?: entry.url
+        if (!clickUrl.isNullOrBlank()) {
+            holder.itemView.isClickable = true
+            holder.itemView.isFocusable = true
+            holder.itemView.contentDescription =
+                ctx.getString(R.string.licenses_open_external, holder.binding.tvLibraryName.text)
+            holder.itemView.setOnClickListener { onClick(entry) }
+        } else {
+            holder.itemView.isClickable = false
+            holder.itemView.isFocusable = false
+            holder.itemView.setOnClickListener(null)
+        }
+    }
+
+    override fun getItemCount(): Int = items.size
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/settings/SettingsActivity.kt
@@ -90,6 +90,13 @@ class SettingsActivity : AppCompatActivity() {
             ellipsize = TextUtils.TruncateAt.END
         }
 
+        binding.cardRowOpenSourceLicenses.cardRowIcon.setImageResource(R.drawable.ic_license)
+        binding.cardRowOpenSourceLicenses.cardRowTitle.setText(R.string.settings_open_source_licenses_title)
+        binding.cardRowOpenSourceLicenses.cardRowSubtitle.setText(R.string.settings_open_source_licenses_body)
+        binding.cardOpenSourceLicenses.setOnClickListener {
+            startActivity(Intent(this, LicensesActivity::class.java))
+        }
+
         // Observe-then-bind: opposite order would re-write the persisted preference on the first frame.
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {

--- a/app/src/main/res/drawable/ic_license.xml
+++ b/app/src/main/res/drawable/ic_license.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M14,2 L6,2 L4,4 L4,20 L6,22 L18,22 L20,20 L20,8 Z" />
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M14,2 L14,8 L20,8" />
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M8,13 L16,13" />
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M8,17 L14,17" />
+</vector>

--- a/app/src/main/res/layout-sw600dp/activity_settings.xml
+++ b/app/src/main/res/layout-sw600dp/activity_settings.xml
@@ -230,6 +230,36 @@
                     </com.google.android.material.card.MaterialCardView>
 
                     <com.google.android.material.card.MaterialCardView
+                        android:id="@+id/cardOpenSourceLicenses"
+                        style="@style/Widget.Dish.Card"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/card_margin_bottom"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:foreground="?attr/selectableItemBackground">
+
+                        <LinearLayout
+                            style="@style/Widget.Dish.Card.RowContainer"
+                            android:gravity="center_vertical">
+
+                            <include
+                                android:id="@+id/cardRowOpenSourceLicenses"
+                                layout="@layout/card_row_icon_label_value"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1" />
+
+                            <ImageView
+                                android:layout_width="@dimen/icon_card_glyph"
+                                android:layout_height="@dimen/icon_card_glyph"
+                                android:layout_marginStart="@dimen/spacing_xl"
+                                android:src="@drawable/ic_chevron_right"
+                                android:importantForAccessibility="no" />
+                        </LinearLayout>
+                    </com.google.android.material.card.MaterialCardView>
+
+                    <com.google.android.material.card.MaterialCardView
                         style="@style/Widget.Dish.Card"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_licenses.xml
+++ b/app/src/main/res/layout/activity_licenses.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            style="@style/Widget.Dish.Toolbar"
+            android:layout_width="match_parent"
+            app:title="@string/settings_open_source_licenses_title" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerLicenses"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:clipToPadding="false"
+            android:paddingHorizontal="@dimen/spacing_5xl"
+            android:paddingTop="@dimen/spacing_md"
+            android:paddingBottom="@dimen/spacing_6xl"
+            android:scrollbars="vertical" />
+    </LinearLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -295,9 +295,36 @@
                     </LinearLayout>
                 </com.google.android.material.card.MaterialCardView>
 
-                <!-- Version row. Wrapped in its own card so future "About" rows
-                     (license, attributions) can stack inside the same card with
-                     hairline dividers, matching the design's MetaRow pattern. -->
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardOpenSourceLicenses"
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/card_margin_bottom"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
+
+                    <LinearLayout
+                        style="@style/Widget.Dish.Card.RowContainer"
+                        android:gravity="center_vertical">
+
+                        <include
+                            android:id="@+id/cardRowOpenSourceLicenses"
+                            layout="@layout/card_row_icon_label_value"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1" />
+
+                        <ImageView
+                            android:layout_width="@dimen/icon_card_glyph"
+                            android:layout_height="@dimen/icon_card_glyph"
+                            android:layout_marginStart="@dimen/spacing_xl"
+                            android:src="@drawable/ic_chevron_right"
+                            android:importantForAccessibility="no" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
                 <com.google.android.material.card.MaterialCardView
                     style="@style/Widget.Dish.Card"
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/item_license.xml
+++ b/app/src/main/res/layout/item_license.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/Widget.Dish.Card"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/card_margin_bottom"
+    android:foreground="?attr/selectableItemBackground">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="@dimen/card_padding">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:baselineAligned="false">
+
+            <TextView
+                android:id="@+id/tvLibraryName"
+                style="@style/TextAppearance.Dish.Title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                tools:text="AndroidX AppCompat" />
+
+            <TextView
+                android:id="@+id/tvLibraryVersion"
+                style="@style/TextAppearance.Dish.Body.Mono"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/spacing_md"
+                android:gravity="end"
+                tools:text="1.7.1" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/tvLicense"
+            style="@style/TextAppearance.Dish.Body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacing_xs"
+            tools:text="Apache License 2.0" />
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -267,5 +267,8 @@
     <string name="settings_appearance_dark">Tamno</string>
     <string name="settings_crash_reporting_title">Podijeli izvještaje o padovima</string>
     <string name="settings_crash_reporting_body">Podijelite anonimne dnevnike padova i stack trace s TinkerNorthom kako biste pomogli u ispravljanju grešaka. Igra ni unos kontrolera nisu uključeni.</string>
+    <string name="settings_open_source_licenses_title">Licence otvorenog koda</string>
+    <string name="settings_open_source_licenses_body">Napomene za biblioteke na kojima je Dish izgrađen.</string>
+    <string name="licenses_open_external">Otvori licencu za %1$s</string>
     <string name="settings_version_label">VERZIJA</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -264,5 +264,8 @@
     <string name="settings_appearance_dark">Dunkel</string>
     <string name="settings_crash_reporting_title">Absturzberichte teilen</string>
     <string name="settings_crash_reporting_body">Teile anonymisierte Absturzprotokolle und Stack-Traces mit TinkerNorth, um Bugs zu beheben. Spielgeschehen und Controller-Eingaben sind nicht enthalten.</string>
+    <string name="settings_open_source_licenses_title">Open-Source-Lizenzen</string>
+    <string name="settings_open_source_licenses_body">Hinweise zu den Bibliotheken, auf denen Dish aufbaut.</string>
+    <string name="licenses_open_external">Lizenz für %1$s öffnen</string>
     <string name="settings_version_label">VERSION</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -268,5 +268,8 @@
     <string name="settings_appearance_dark">Oscuro</string>
     <string name="settings_crash_reporting_title">Compartir informes de fallos</string>
     <string name="settings_crash_reporting_body">Comparte registros de fallos anonimizados y rastreos de pila con TinkerNorth para ayudar a corregir errores. No se incluyen partidas ni entradas del mando.</string>
+    <string name="settings_open_source_licenses_title">Licencias de código abierto</string>
+    <string name="settings_open_source_licenses_body">Avisos de las bibliotecas sobre las que se construye Dish.</string>
+    <string name="licenses_open_external">Abrir licencia de %1$s</string>
     <string name="settings_version_label">VERSIÓN</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -267,5 +267,8 @@
     <string name="settings_appearance_dark">Sombre</string>
     <string name="settings_crash_reporting_title">Partager les rapports de plantage</string>
     <string name="settings_crash_reporting_body">Partagez avec TinkerNorth des journaux de plantage anonymisés et des traces de pile pour aider à corriger les bugs. Aucune partie ni entrée de manette n\'est incluse.</string>
+    <string name="settings_open_source_licenses_title">Licences open source</string>
+    <string name="settings_open_source_licenses_body">Mentions pour les bibliothèques sur lesquelles Dish s\'appuie.</string>
+    <string name="licenses_open_external">Ouvrir la licence de %1$s</string>
     <string name="settings_version_label">VERSION</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -268,5 +268,8 @@
     <string name="settings_appearance_dark">Escuro</string>
     <string name="settings_crash_reporting_title">Compartilhar relatórios de falhas</string>
     <string name="settings_crash_reporting_body">Compartilhe logs de falhas anonimizados e stack traces com a TinkerNorth para ajudar a corrigir bugs. Nenhum jogo ou entrada de controle é incluído.</string>
+    <string name="settings_open_source_licenses_title">Licenças de código aberto</string>
+    <string name="settings_open_source_licenses_body">Créditos das bibliotecas em que o Dish é construído.</string>
+    <string name="licenses_open_external">Abrir licença de %1$s</string>
     <string name="settings_version_label">VERSÃO</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -327,6 +327,9 @@
     <string name="settings_appearance_dark">Dark</string>
     <string name="settings_crash_reporting_title">Share crash reports</string>
     <string name="settings_crash_reporting_body">Share anonymized crash logs and stack traces with TinkerNorth to help fix bugs. No gameplay or controller input is included.</string>
+    <string name="settings_open_source_licenses_title">Open source licenses</string>
+    <string name="settings_open_source_licenses_body">Acknowledgements for the libraries Dish is built on.</string>
+    <string name="licenses_open_external">Open license for %1$s</string>
     <string name="settings_version_label">VERSION</string>
     <!-- Brand wordmark in the footer. Not translated — stylistic constant
          across all locales, matching the rest of TinkerNorth's brand usage. -->


### PR DESCRIPTION
## Summary
- New **Settings → About → Open source licenses** entry that lists every library shipped in the release runtime classpath with its license and a tap-through to the canonical license URL.
- Build-time `:app:generateLicenseManifest` Gradle task resolves POMs via a detached `@pom` configuration and emits `app/src/main/assets/licenses/licenses.json` (wired as a `preBuild` dependency).
- `LicensesActivity` + `LicensesAdapter` render the manifest from assets at runtime; ~136 libraries covered.

## Why not a plugin?
The official `play-services-oss-licenses` plugin (0.10.6, last updated 2022) and AboutLibraries both read AGP's removed `applicationVariants` API and won't apply on AGP 9.2.1. AboutLibraries has an [open issue](https://github.com/mikepenz/AboutLibraries/issues/1265) tracking this. Once either ships an AGP-9 fix we can revisit, but for v1.0.0 launch the hand-rolled task is self-contained, requires no extra runtime dep, and is fully offline (uses the Gradle dep cache).

## Edge cases
- `com.google.guava:listenablefuture:1.0` publishes a stub POM with no `<licenses>` block (it's a transitively-pulled marker; the actual code is Apache 2.0). Handled via a hand-curated override map in the task.
- License URLs sometimes 404; `runCatching` around `startActivity` swallows transient browser launch failures.
- `verification-metadata.xml` is `.gitignore`d — local devs may need `./gradlew :app:generateLicenseManifest --write-verification-metadata sha256` once on first build to pick up POM checksums for the detached config.

## Test plan
- [x] `./gradlew :app:assembleDebug` — clean build
- [x] `./gradlew :app:ktlintCheck :app:detekt :app:lintDebug` — passes (lint enforces MissingTranslation, all 5 locales updated)
- [x] Installed on emulator, verified flow: Main → gear → Settings → "Open source licenses" → list renders → tap row → browser opens to Apache 2.0 URL
- [x] Verified card icon + layout match the existing Settings card style (chevron trailing, same Widget.Dish.Card)
- [x] Verified sw600dp tablet layout also has the new card