### PR TITLE
Launch readiness: Baseline Profile, form-factor declarations, motion-toggle a11y

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,19 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Enable KVM (for Baseline Profile managed-device emulator)
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Generate Baseline Profile
+        env:
+          DISH_VERSION_CODE: ${{ steps.ver.outputs.code }}
+          DISH_VERSION_NAME: ${{ steps.ver.outputs.name }}
+        run: ./gradlew :app:generateBaselineProfile
+
       - name: Build release APK + AAB
         env:
           DISH_KEYSTORE_FILE: ${{ steps.keystore.outputs.path }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.hilt)
     alias(libs.plugins.ktlint)
     alias(libs.plugins.detekt)
+    alias(libs.plugins.androidx.baselineprofile)
 }
 
 // Firebase plugins only apply when google-services.json is present so local builds without Firebase still work.
@@ -132,6 +133,7 @@ android {
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.core.splashscreen)
+    implementation(libs.androidx.profileinstaller)
     implementation(libs.androidx.viewpager2)
     implementation(libs.androidx.window)
     implementation(libs.androidx.appcompat)
@@ -159,6 +161,7 @@ dependencies {
     androidTestImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.rules)
+    "baselineProfile"(project(":baselineprofile"))
 }
 
 ktlint {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,9 @@
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
     <uses-feature android:name="android.hardware.bluetooth" android:required="false" />
+    <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
+    <uses-feature android:name="android.hardware.faketouch" android:required="false" />
+    <uses-feature android:name="android.hardware.gamepad" android:required="false" />
 
     <!-- network_security_config denies cleartext as a belt-and-braces signal for Play's pre-launch checks. -->
     <application

--- a/app/src/main/assets/licenses/licenses.json
+++ b/app/src/main/assets/licenses/licenses.json
@@ -914,9 +914,9 @@
     {
       "group": "androidx.profileinstaller",
       "artifact": "profileinstaller",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "name": "Profile Installer",
-      "url": "https://developer.android.com/jetpack/androidx/releases/profileinstaller#1.4.0",
+      "url": "https://developer.android.com/jetpack/androidx/releases/profileinstaller#1.4.1",
       "licenses": [
         {
           "name": "The Apache Software License, Version 2.0",

--- a/app/src/main/res/layout/picker_motion_toggle.xml
+++ b/app/src/main/res/layout/picker_motion_toggle.xml
@@ -37,5 +37,6 @@
         style="@style/Widget.Dish.Switch"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical" />
+        android:layout_gravity="center_vertical"
+        android:contentDescription="@string/controller_motion_toggle_label" />
 </LinearLayout>

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -1,0 +1,53 @@
+plugins {
+    alias(libs.plugins.android.test)
+    alias(libs.plugins.androidx.baselineprofile)
+}
+
+android {
+    namespace = "com.tinkernorth.dish.baselineprofile"
+    compileSdk = 37
+
+    defaultConfig {
+        minSdk = 28
+        targetSdk = 37
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlin {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        }
+    }
+
+    targetProjectPath = ":app"
+    experimentalProperties["android.experimental.self-instrumenting"] = true
+
+    testOptions {
+        managedDevices {
+            localDevices {
+                create("pixel6Api34") {
+                    device = "Pixel 6"
+                    apiLevel = 34
+                    systemImageSource = "aosp"
+                }
+            }
+        }
+    }
+}
+
+baselineProfile {
+    managedDevices += "pixel6Api34"
+    useConnectedDevices = false
+}
+
+dependencies {
+    implementation(libs.androidx.benchmark.macro.junit4)
+    implementation(libs.androidx.test.core)
+    implementation(libs.androidx.test.runner)
+    implementation(libs.androidx.test.rules)
+    implementation(libs.androidx.junit)
+}

--- a/baselineprofile/src/main/AndroidManifest.xml
+++ b/baselineprofile/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/baselineprofile/src/main/java/com/tinkernorth/dish/baselineprofile/BaselineProfileGenerator.kt
+++ b/baselineprofile/src/main/java/com/tinkernorth/dish/baselineprofile/BaselineProfileGenerator.kt
@@ -1,0 +1,23 @@
+package com.tinkernorth.dish.baselineprofile
+
+import androidx.benchmark.macro.junit4.BaselineProfileRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BaselineProfileGenerator {
+    @get:Rule
+    val rule = BaselineProfileRule()
+
+    @Test
+    fun generate() =
+        rule.collect(
+            packageName = "com.tinkernorth.dish",
+            includeInStartupProfile = true,
+        ) {
+            pressHome()
+            startActivityAndWait()
+        }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.test) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false
@@ -8,6 +9,7 @@ plugins {
     alias(libs.plugins.dependency.check) apply false
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.firebase.crashlytics) apply false
+    alias(libs.plugins.androidx.baselineprofile) apply false
 }
 
 apply(plugin = "org.owasp.dependencycheck")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,8 @@ androidxTestRules = "1.7.0"
 splashscreen = "1.0.1"
 viewpager2 = "1.1.0"
 window = "1.4.0"
+benchmark = "1.5.0-alpha06"
+profileinstaller = "1.4.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -61,9 +63,12 @@ firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashly
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTestRunner" }
 androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidxTestRules" }
+androidx-benchmark-macro-junit4 = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "benchmark" }
+androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "profileinstaller" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
+android-test = { id = "com.android.test", version.ref = "agp" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
@@ -72,3 +77,4 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dependency-check = { id = "org.owasp.dependencycheck", version.ref = "dependency-check" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "crashlyticsPlugin" }
+androidx-baselineprofile = { id = "androidx.baselineprofile", version.ref = "benchmark" }

--- a/play/CONTENT_RATING.md
+++ b/play/CONTENT_RATING.md
@@ -4,7 +4,7 @@ Quick reference for filling out Play's IARC questionnaire. Dish is a utility-cla
 
 | Question category | Answer | Notes |
 |---|---|---|
-| Violence | NONE | Dish is a controller — what gets played through it is the host PC's content, not Dish's. |
+| Violence | NONE | Dish is a controller. What gets played through it is the host PC's content, not Dish's. |
 | Sexuality / nudity | NONE | |
 | Language / profanity | NONE | |
 | Controlled substances | NONE | |

--- a/play/CONTENT_RATING.md
+++ b/play/CONTENT_RATING.md
@@ -1,0 +1,18 @@
+# IARC content rating answers for Dish
+
+Quick reference for filling out Play's IARC questionnaire. Dish is a utility-class app (input forwarding); it has no game content of its own.
+
+| Question category | Answer | Notes |
+|---|---|---|
+| Violence | NONE | Dish is a controller — what gets played through it is the host PC's content, not Dish's. |
+| Sexuality / nudity | NONE | |
+| Language / profanity | NONE | |
+| Controlled substances | NONE | |
+| User-generated content | NONE | No social features, no user accounts. |
+| User-to-user communication | NONE | No chat, no comments, no messaging. |
+| Sharing user location | NONE | No location permissions. |
+| Personal info sharing | NONE | No personal data collected. |
+| Digital purchases | NONE | Free, open source. No IAP. |
+| Gambling references | NONE | |
+
+Expected rating across boards: **3+ / Everyone / PEGI 3 / Apple 4+ equivalent**.

--- a/play/DATA_SAFETY.md
+++ b/play/DATA_SAFETY.md
@@ -1,0 +1,50 @@
+# Data Safety form — answers for Google Play
+
+These map to the fields on the Data Safety form in Play Console. Cross-referenced against `PRIVACY.md` and the actual code.
+
+## Top-level summary
+
+| Question | Answer |
+|---|---|
+| Does your app collect or share any of the required user data types? | **YES** (Crash logs only) |
+| Is all of the user data collected by your app encrypted in transit? | **YES** — TLS to Firebase Crashlytics |
+| Do you provide a way for users to request that their data be deleted? | **YES** — uninstalling the app removes all stored data; crash reports are auto-deleted by Firebase after 90 days |
+| Does your app comply with Google Play Families Policy? | **YES** (general-audience; no data collection from children) |
+
+## Data types — what is collected
+
+### App activity > Crashes
+
+- **Collected?** YES
+- **Shared?** NO
+- **Purpose**: App functionality (crash diagnostics)
+- **Optional?** YES — user can opt out from Settings → "Share crash reports"
+- **Notes**: Sent to Firebase Crashlytics. Includes stack trace, device model and Android version, app version, Firebase Installation ID. Does NOT include controller input, satellite/host names, Wi-Fi SSID, IP, or any personally identifying information.
+
+### Everything else
+
+**NOT collected and NOT shared** — for all of the following categories:
+
+- Personal info (name, email, address, phone, age, etc.)
+- Financial info
+- Health and fitness
+- Messages
+- Photos and videos
+- Audio
+- Files and docs
+- Calendar
+- Contacts
+- App activity > Page views, app interactions, searches, installed apps
+- Web browsing history
+- App info and performance > other diagnostics (RAM/disk telemetry, network usage telemetry, etc.)
+- Device or other IDs (advertising ID, Android device ID, customer-set IDs, etc.)
+
+## Notable absences worth flagging in justification text
+
+- **No advertising ID (AD_ID)**: Firebase Analytics is deliberately omitted from the build (see `app/build.gradle.kts`). The `com.google.android.gms.permission.AD_ID` permission is NOT in the manifest.
+- **No location**: the app does not request or use location permissions at any API level.
+- **No contact / SMS / call log / camera / microphone permissions**: not requested.
+
+## Notes for Play reviewers
+
+The privacy policy hosted at `https://dish.tinkernorth.com/privacy/dish-android/` is the canonical version. The `PRIVACY.md` file at the repo root mirrors it.

--- a/play/DATA_SAFETY.md
+++ b/play/DATA_SAFETY.md
@@ -1,4 +1,4 @@
-# Data Safety form — answers for Google Play
+# Data Safety form: answers for Google Play
 
 These map to the fields on the Data Safety form in Play Console. Cross-referenced against `PRIVACY.md` and the actual code.
 
@@ -7,23 +7,23 @@ These map to the fields on the Data Safety form in Play Console. Cross-reference
 | Question | Answer |
 |---|---|
 | Does your app collect or share any of the required user data types? | **YES** (Crash logs only) |
-| Is all of the user data collected by your app encrypted in transit? | **YES** — TLS to Firebase Crashlytics |
-| Do you provide a way for users to request that their data be deleted? | **YES** — uninstalling the app removes all stored data; crash reports are auto-deleted by Firebase after 90 days |
+| Is all of the user data collected by your app encrypted in transit? | **YES**, TLS to Firebase Crashlytics |
+| Do you provide a way for users to request that their data be deleted? | **YES**. Uninstalling the app removes all stored data; crash reports are auto-deleted by Firebase after 90 days |
 | Does your app comply with Google Play Families Policy? | **YES** (general-audience; no data collection from children) |
 
-## Data types — what is collected
+## Data types collected
 
 ### App activity > Crashes
 
 - **Collected?** YES
 - **Shared?** NO
 - **Purpose**: App functionality (crash diagnostics)
-- **Optional?** YES — user can opt out from Settings → "Share crash reports"
+- **Optional?** YES. User can opt out from Settings → "Share crash reports"
 - **Notes**: Sent to Firebase Crashlytics. Includes stack trace, device model and Android version, app version, Firebase Installation ID. Does NOT include controller input, satellite/host names, Wi-Fi SSID, IP, or any personally identifying information.
 
 ### Everything else
 
-**NOT collected and NOT shared** — for all of the following categories:
+**NOT collected and NOT shared** for all of the following categories:
 
 - Personal info (name, email, address, phone, age, etc.)
 - Financial info

--- a/play/PERMISSIONS_JUSTIFICATION.md
+++ b/play/PERMISSIONS_JUSTIFICATION.md
@@ -1,0 +1,39 @@
+# Permission justifications for Play Console
+
+These are the user-facing explanations for the Play Console "Sensitive Permissions" form. Permissions that Play does not flag as sensitive are included for completeness so the full posture is in one place.
+
+## FOREGROUND_SERVICE / FOREGROUND_SERVICE_CONNECTED_DEVICE
+
+**Why we declare it**: Dish keeps a streaming controller session alive while the user has the app backgrounded — so input keeps flowing to the host PC without latency spikes from being killed by the OS. The `connectedDevice` service type is the correct match per Play policy: this is a user-initiated session to a paired physical device (the host PC or console).
+
+## BLUETOOTH_CONNECT (API 31+) / BLUETOOTH / BLUETOOTH_ADMIN (API ≤30 fallback)
+
+**Why we declare it**: For Bluetooth-host mode, Dish pairs with the user's PC, console, or set-top box and presents itself as a standard Bluetooth HID gamepad. The permission is requested at runtime, only when the user taps "Add Bluetooth host" in the Connections screen. Declining still lets the app run — Wi-Fi mode does not need Bluetooth.
+
+## POST_NOTIFICATIONS (API 33+)
+
+**Why we declare it**: We surface a sticky session notification while a controller is actively streaming, plus actionable error banners (satellite disconnected mid-game, discoverability expired, etc.). Declining is graceful — the app runs normally, just without the visible notification.
+
+## WAKE_LOCK
+
+**Why we declare it**: Prevents the CPU from sleeping while a controller is bound to a host. Input latency on a sleeping CPU spikes from ~10ms to multi-100ms during sleep-wake transitions, which is unplayable. The wake lock is held only while a session is active.
+
+## VIBRATE
+
+**Why we declare it**: In-game rumble events from the host (PlayStation-style force feedback) are routed to the phone's vibration motor via `MSG_RUMBLE` packets.
+
+## CHANGE_WIFI_MULTICAST_STATE
+
+**Why we declare it**: Required to receive mDNS / Bonjour service-discovery beacons from the Satellite running on the LAN. Without it, the phone cannot find Satellites announcing themselves on `_satellite._udp` over `224.0.0.251:5353`.
+
+## INTERNET / ACCESS_NETWORK_STATE / ACCESS_WIFI_STATE
+
+**Why we declare it**: Standard "we send and receive UDP packets on the local network" permissions. Dish makes no off-LAN internet connections except for crash diagnostics (opt-out). The HTTPS pairing handshake and the UDP gamepad stream both target the user's own LAN Satellite.
+
+## Permissions Dish does NOT request — deliberately
+
+Worth calling out in the listing copy / reviewer notes:
+
+- No location (any API level).
+- No advertising ID (`com.google.android.gms.permission.AD_ID`) — Firebase Analytics deliberately omitted from the build to avoid auto-injection.
+- No microphone, camera, contacts, calendar, SMS, call log, photos, or files.

--- a/play/PERMISSIONS_JUSTIFICATION.md
+++ b/play/PERMISSIONS_JUSTIFICATION.md
@@ -4,15 +4,15 @@ These are the user-facing explanations for the Play Console "Sensitive Permissio
 
 ## FOREGROUND_SERVICE / FOREGROUND_SERVICE_CONNECTED_DEVICE
 
-**Why we declare it**: Dish keeps a streaming controller session alive while the user has the app backgrounded — so input keeps flowing to the host PC without latency spikes from being killed by the OS. The `connectedDevice` service type is the correct match per Play policy: this is a user-initiated session to a paired physical device (the host PC or console).
+**Why we declare it**: Dish keeps a streaming controller session alive while the user has the app backgrounded, so input keeps flowing to the host PC without latency spikes from being killed by the OS. The `connectedDevice` service type is the correct match per Play policy: this is a user-initiated session to a paired physical device (the host PC or console).
 
 ## BLUETOOTH_CONNECT (API 31+) / BLUETOOTH / BLUETOOTH_ADMIN (API ≤30 fallback)
 
-**Why we declare it**: For Bluetooth-host mode, Dish pairs with the user's PC, console, or set-top box and presents itself as a standard Bluetooth HID gamepad. The permission is requested at runtime, only when the user taps "Add Bluetooth host" in the Connections screen. Declining still lets the app run — Wi-Fi mode does not need Bluetooth.
+**Why we declare it**: For Bluetooth-host mode, Dish pairs with the user's PC, console, or set-top box and presents itself as a standard Bluetooth HID gamepad. The permission is requested at runtime, only when the user taps "Add Bluetooth host" in the Connections screen. Declining still lets the app run, since Wi-Fi mode does not need Bluetooth.
 
 ## POST_NOTIFICATIONS (API 33+)
 
-**Why we declare it**: We surface a sticky session notification while a controller is actively streaming, plus actionable error banners (satellite disconnected mid-game, discoverability expired, etc.). Declining is graceful — the app runs normally, just without the visible notification.
+**Why we declare it**: We surface a sticky session notification while a controller is actively streaming, plus actionable error banners (satellite disconnected mid-game, discoverability expired, etc.). Declining is graceful: the app runs normally, just without the visible notification.
 
 ## WAKE_LOCK
 
@@ -30,10 +30,10 @@ These are the user-facing explanations for the Play Console "Sensitive Permissio
 
 **Why we declare it**: Standard "we send and receive UDP packets on the local network" permissions. Dish makes no off-LAN internet connections except for crash diagnostics (opt-out). The HTTPS pairing handshake and the UDP gamepad stream both target the user's own LAN Satellite.
 
-## Permissions Dish does NOT request — deliberately
+## Permissions Dish does NOT request (deliberate)
 
 Worth calling out in the listing copy / reviewer notes:
 
 - No location (any API level).
-- No advertising ID (`com.google.android.gms.permission.AD_ID`) — Firebase Analytics deliberately omitted from the build to avoid auto-injection.
+- No advertising ID (`com.google.android.gms.permission.AD_ID`). Firebase Analytics is deliberately omitted from the build to avoid auto-injection.
 - No microphone, camera, contacts, calendar, SMS, call log, photos, or files.

--- a/play/README.md
+++ b/play/README.md
@@ -1,0 +1,71 @@
+# Play Store assets
+
+This directory holds the metadata, copy, and (eventually) screenshots/graphics required to submit Dish to Google Play.
+
+## Structure
+
+```
+play/
+  README.md                          ← you are here
+  REVIEWER_NOTES.md                  ← test instructions for the Play reviewer (English only)
+  DATA_SAFETY.md                     ← form answers for the Data Safety section
+  PERMISSIONS_JUSTIFICATION.md       ← per-permission rationale for Play Console
+  CONTENT_RATING.md                  ← notes for the IARC content-rating questionnaire
+  metadata/
+    android/
+      en-US/                         ← English (US) — canonical listing locale
+        title.txt
+        short_description.txt
+        full_description.txt
+        video.txt
+        changelogs/
+          10000.txt                  ← versionCode → release notes
+      bs/                            ← Bosnian
+      de-DE/                         ← German
+      es-ES/                         ← Spanish (Spain)
+      fr-FR/                         ← French (France)
+      pt-BR/                         ← Brazilian Portuguese
+```
+
+## Tooling
+
+The directory layout follows the [Fastlane Supply](https://docs.fastlane.tools/actions/supply/) convention so it can be uploaded with one command once a Play Console API key is configured:
+
+```bash
+fastlane supply --aab path/to/dish-v1.0.0.aab --metadata_path play/metadata
+```
+
+Without Fastlane, the same files can be copy-pasted into the Play Console store-listing pages by hand.
+
+## What's missing (visual assets)
+
+These have to be designed and exported separately. None of them exist yet:
+
+| Asset | Spec |
+|---|---|
+| Store icon | 512×512 PNG, 32-bit, no alpha, ≤1 MB |
+| Feature graphic | 1024×500 PNG or JPG |
+| Phone screenshots | 2–8, 16:9 or 9:16, 320–3840 px short side |
+| 7-inch tablet screenshots | 16:9 or 9:16, recommended for tablet surfacing |
+| 10-inch tablet screenshots | 16:9 or 9:16, recommended for foldable/ChromeOS surfacing |
+| Promo video | YouTube URL, ≤30s landscape, optional but expected at Editor's Choice tier |
+
+When ready, Fastlane Supply expects them under `play/metadata/android/<locale>/images/`:
+
+```
+images/icon.png
+images/featureGraphic.png
+images/phoneScreenshots/01_dashboard.png
+images/sevenInchScreenshots/01_dashboard.png
+images/tenInchScreenshots/01_dashboard.png
+```
+
+## Locales
+
+This listing is localized into the same six languages the app itself supports (`values/`, `values-bs/`, `values-de/`, `values-es/`, `values-fr/`, `values-pt-rBR/`). If you add more in-app locales later, mirror them here.
+
+Note on Play Console locale codes: `pt-BR` matches Android's `pt-rBR`. German uses `de-DE`. Spanish uses `es-ES`; switch to `es-419` later if Latin-American Spanish coverage matters more than Iberian Spanish.
+
+## Privacy policy
+
+Hosted at `https://dish.tinkernorth.com/privacy/dish-android/`. The `PRIVACY.md` file at the repo root is the in-repo mirror. Paste the hosted URL into the Play Console "Privacy policy" field on the App content page.

--- a/play/README.md
+++ b/play/README.md
@@ -13,7 +13,7 @@ play/
   CONTENT_RATING.md                  ← notes for the IARC content-rating questionnaire
   metadata/
     android/
-      en-US/                         ← English (US) — canonical listing locale
+      en-US/                         ← English (US), canonical listing locale
         title.txt
         short_description.txt
         full_description.txt
@@ -45,7 +45,7 @@ These have to be designed and exported separately. None of them exist yet:
 |---|---|
 | Store icon | 512×512 PNG, 32-bit, no alpha, ≤1 MB |
 | Feature graphic | 1024×500 PNG or JPG |
-| Phone screenshots | 2–8, 16:9 or 9:16, 320–3840 px short side |
+| Phone screenshots | 2 to 8, 16:9 or 9:16, 320 to 3840 px short side |
 | 7-inch tablet screenshots | 16:9 or 9:16, recommended for tablet surfacing |
 | 10-inch tablet screenshots | 16:9 or 9:16, recommended for foldable/ChromeOS surfacing |
 | Promo video | YouTube URL, ≤30s landscape, optional but expected at Editor's Choice tier |

--- a/play/REVIEWER_NOTES.md
+++ b/play/REVIEWER_NOTES.md
@@ -1,0 +1,46 @@
+# Reviewer notes for Dish (Play Store review)
+
+## What Dish does
+
+Dish turns an Android phone into a wireless gamepad. It has two operating modes:
+
+1. **Wi-Fi mode (recommended)** — pairs over the LAN with a free helper called Satellite running on a Windows/macOS/Linux PC, then streams encrypted controller input via UDP.
+2. **Bluetooth HID mode** — pairs to any device that accepts a Bluetooth gamepad (PC, console, set-top box).
+
+## Fastest way to test (no extra software)
+
+**Bluetooth HID mode** needs nothing external. Pair to any nearby Bluetooth-capable device:
+
+1. Launch the app — complete the welcome flow or tap Skip.
+2. From the dashboard, tap "Manage" under Connections.
+3. Open "Bluetooth Hosts" → "Add" → pair to any Bluetooth-capable device (e.g., another phone, a Windows laptop, a console).
+4. From the dashboard, tap any controller slot → open the on-screen gamepad.
+5. Press buttons / sticks — the paired host will see them as a standard Xbox-compatible HID gamepad.
+
+## Testing Wi-Fi mode
+
+A demo Satellite is available from https://github.com/TinkerNorth/satellite/releases — installers for Windows, macOS, and Linux. The 4-digit pairing PIN is shown by Satellite when it starts.
+
+## Foreground service rationale
+
+The streaming session runs as a foreground service of type `connectedDevice` so a backgrounded session keeps inputs flowing to the host without latency spikes. This matches Play's guidance for user-initiated controller-pairing apps: a persistent connection to a user-attached or paired physical device is the exact use case `FOREGROUND_SERVICE_CONNECTED_DEVICE` exists for.
+
+## No login required
+
+The app has no user accounts. Pairing uses local-network PINs only. No reviewer credentials needed.
+
+## Privacy / data collection summary
+
+Detailed in `PRIVACY.md` (https://github.com/TinkerNorth/dish-android/blob/main/PRIVACY.md). Short version:
+
+- No advertising.
+- No analytics (Firebase Analytics is deliberately omitted from the build to avoid AD_ID auto-injection).
+- The only data leaving the device is optional Firebase Crashlytics crash reports — opt-out from Settings.
+- The hosted privacy URL is https://dish.tinkernorth.com/privacy/dish-android/.
+
+## Recommended test devices
+
+- **Phone**: any Android 7+ device (min SDK 24).
+- **Tablet (sw600dp)**: confirms adaptive layout.
+- **Foldable**: confirms WindowInfoTracker-driven fold-aware behavior.
+- **For Bluetooth mode testing**: any second Bluetooth-capable device.

--- a/play/REVIEWER_NOTES.md
+++ b/play/REVIEWER_NOTES.md
@@ -4,22 +4,22 @@
 
 Dish turns an Android phone into a wireless gamepad. It has two operating modes:
 
-1. **Wi-Fi mode (recommended)** — pairs over the LAN with a free helper called Satellite running on a Windows/macOS/Linux PC, then streams encrypted controller input via UDP.
-2. **Bluetooth HID mode** — pairs to any device that accepts a Bluetooth gamepad (PC, console, set-top box).
+1. **Wi-Fi mode (recommended)**: pairs over the LAN with a free helper called Satellite running on a Windows/macOS/Linux PC, then streams encrypted controller input via UDP.
+2. **Bluetooth HID mode**: pairs to any device that accepts a Bluetooth gamepad (PC, console, set-top box).
 
 ## Fastest way to test (no extra software)
 
 **Bluetooth HID mode** needs nothing external. Pair to any nearby Bluetooth-capable device:
 
-1. Launch the app — complete the welcome flow or tap Skip.
+1. Launch the app, then complete the welcome flow or tap Skip.
 2. From the dashboard, tap "Manage" under Connections.
-3. Open "Bluetooth Hosts" → "Add" → pair to any Bluetooth-capable device (e.g., another phone, a Windows laptop, a console).
+3. Open "Bluetooth Hosts" → "Add" → pair to any Bluetooth-capable device (for example, another phone, a Windows laptop, a console).
 4. From the dashboard, tap any controller slot → open the on-screen gamepad.
-5. Press buttons / sticks — the paired host will see them as a standard Xbox-compatible HID gamepad.
+5. Press buttons / sticks. The paired host will see them as a standard Xbox-compatible HID gamepad.
 
 ## Testing Wi-Fi mode
 
-A demo Satellite is available from https://github.com/TinkerNorth/satellite/releases — installers for Windows, macOS, and Linux. The 4-digit pairing PIN is shown by Satellite when it starts.
+A demo Satellite is available from https://github.com/TinkerNorth/satellite/releases (installers for Windows, macOS, and Linux). The 4-digit pairing PIN is shown by Satellite when it starts.
 
 ## Foreground service rationale
 
@@ -34,8 +34,8 @@ The app has no user accounts. Pairing uses local-network PINs only. No reviewer 
 Detailed in `PRIVACY.md` (https://github.com/TinkerNorth/dish-android/blob/main/PRIVACY.md). Short version:
 
 - No advertising.
-- No analytics (Firebase Analytics is deliberately omitted from the build to avoid AD_ID auto-injection).
-- The only data leaving the device is optional Firebase Crashlytics crash reports — opt-out from Settings.
+- No analytics. Firebase Analytics is deliberately omitted from the build to avoid AD_ID auto-injection.
+- The only data leaving the device is optional Firebase Crashlytics crash reports, with opt-out from Settings.
 - The hosted privacy URL is https://dish.tinkernorth.com/privacy/dish-android/.
 
 ## Recommended test devices

--- a/play/metadata/android/bs/changelogs/10000.txt
+++ b/play/metadata/android/bs/changelogs/10000.txt
@@ -1,0 +1,7 @@
+Prvo izdanje.
+
+• Pretvorite telefon u bežični gamepad za PC.
+• Dva režima: Wi-Fi sa Satellite-om, ili Bluetooth gamepad za bilo koji host.
+• Koristite gamepad na ekranu, ili priključite / uparite vlastiti kontroler.
+• Motion (žiroskop), touchpad i in-game rumble na Wi-Fi putu.
+• Open source pod LGPL-3.0.

--- a/play/metadata/android/bs/full_description.txt
+++ b/play/metadata/android/bs/full_description.txt
@@ -1,37 +1,32 @@
-Dish pretvara vaš Android telefon u bežični gamepad za vaš PC. Bilo da želite Wi-Fi vezu niske latencije sa motion-aim-om i touchpadom, ili jednostavnost uparivanja kao običan Bluetooth kontroler — Dish to može. Bez podešavanja po igri, bez mjesečnih pretplata, bez reklama.
+Dish pretvara bilo koji kontroler ili Android telefon u bežični gamepad niske latencije. Bilo da želite Wi-Fi vezu niske latencije sa motion-aim-om i touchpadom, ili jednostavnost uparivanja kao običnog Bluetooth kontrolera, Dish to može. Bez podešavanja po igri, bez mjesečnih pretplata, bez reklama.
 
 
 DVA NAČINA POVEZIVANJA
 
 • Wi-Fi (sa Satellite-om, besplatno): najbrži put. Najniža latencija unosa, motion (žiroskop) za pomoć pri ciljanju i klikabilan touchpad za menije i kontrolu miša.
 
-• Bluetooth: uparite telefon sa PC-jem, konzolom ili set-top boxom kao običan Bluetooth gamepad. Nije potreban PC softver — radi sa svime što prihvata Bluetooth kontroler.
+• Bluetooth: uparite telefon sa PC-jem, konzolom ili set-top boxom kao običan Bluetooth gamepad. Radi sa svime što prihvata Bluetooth kontroler.
 
 
 KORISTITE VLASTITI KONTROLER
 
-Priključite USB gamepad u USB-C port telefona za nultu dodatnu latenciju, ili uparite Bluetooth kontroler (Xbox, DualSense, 8BitDo i druge) direktno sa telefonom. Dish prosljeđuje svaki pritisak, osu i okidač na vaš PC.
+Priključite USB gamepad u USB port telefona za nultu dodatnu latenciju, ili uparite Bluetooth kontroler (Xbox, DualSense, 8BitDo i druge) direktno sa telefonom. Dish prosljeđuje svaki pritisak, osu i okidač na vaš host.
 
 
 NAPRAVLJEN ZA IGRANJE
 
-• Nativni input pipeline (C++/JNI), tako da unosi ne čekaju iza UI posla
-• ChaCha20-Poly1305 enkriptovan Wi-Fi stream preko UDP-a — brz i autentificiran
+• Optimizovan brzi put za najnižu latenciju
+• Enkriptovan Wi-Fi stream
 • Više satelita istovremeno: uparite više PC-ja i preusmjerite između njih po slotu
 • Motion i touchpad predstavljeni igrama kao standardan PlayStation pad
 • In-game rumble sa hosta vibrira vaš telefon
 
 
-PRIVATNOST KOJU MOŽETE PROVJERITI
-
-Dish je open source pod LGPL-3.0 licencom. Bez reklama. Bez analitike. Ne šaljemo nikakve podatke na TinkerNorth servere — jer ih ne posjedujemo. Jedino mrežno odredište je Satellite na vašoj vlastitoj LAN-i. Dijagnostika padova (Firebase Crashlytics) je uključena prema zadanim postavkama i možete je isključiti u svakom trenutku iz Postavki.
-
-
 PREUZMITE SATELLITE
 
-Besplatni Satellite pomoćnik dostupan je za Windows, macOS i Linux na tinkernorth.com/satellite. Bluetooth-host režim radi bez Satellite-a, ali Wi-Fi put pruža najbolje iskustvo.
+Besplatni Satellite pomoćnik dostupan je za Windows, macOS i Linux na https://dish.tinkernorth.com/downloads/satellite. Bluetooth-host režim radi bez Satellite-a, ali Wi-Fi put pruža najbolje iskustvo.
 
 
 ZA ENTUZIJASTE
 
-Izvorni kod, sigurnosna politika i dokumentacija žičanog formata javni su na GitHub-u na github.com/TinkerNorth/dish-android. Cijeli proizvod — telefonski klijent, Satellite server i platformske varijante — gradi se u otvorenom kodu.
+Izvorni kod, sigurnosna politika i dokumentacija žičanog formata javni su na GitHub-u na github.com/TinkerNorth/dish-android. Telefonski klijent, Satellite server i platformske varijante.

--- a/play/metadata/android/bs/full_description.txt
+++ b/play/metadata/android/bs/full_description.txt
@@ -1,0 +1,37 @@
+Dish pretvara vaš Android telefon u bežični gamepad za vaš PC. Bilo da želite Wi-Fi vezu niske latencije sa motion-aim-om i touchpadom, ili jednostavnost uparivanja kao običan Bluetooth kontroler — Dish to može. Bez podešavanja po igri, bez mjesečnih pretplata, bez reklama.
+
+
+DVA NAČINA POVEZIVANJA
+
+• Wi-Fi (sa Satellite-om, besplatno): najbrži put. Najniža latencija unosa, motion (žiroskop) za pomoć pri ciljanju i klikabilan touchpad za menije i kontrolu miša.
+
+• Bluetooth: uparite telefon sa PC-jem, konzolom ili set-top boxom kao običan Bluetooth gamepad. Nije potreban PC softver — radi sa svime što prihvata Bluetooth kontroler.
+
+
+KORISTITE VLASTITI KONTROLER
+
+Priključite USB gamepad u USB-C port telefona za nultu dodatnu latenciju, ili uparite Bluetooth kontroler (Xbox, DualSense, 8BitDo i druge) direktno sa telefonom. Dish prosljeđuje svaki pritisak, osu i okidač na vaš PC.
+
+
+NAPRAVLJEN ZA IGRANJE
+
+• Nativni input pipeline (C++/JNI), tako da unosi ne čekaju iza UI posla
+• ChaCha20-Poly1305 enkriptovan Wi-Fi stream preko UDP-a — brz i autentificiran
+• Više satelita istovremeno: uparite više PC-ja i preusmjerite između njih po slotu
+• Motion i touchpad predstavljeni igrama kao standardan PlayStation pad
+• In-game rumble sa hosta vibrira vaš telefon
+
+
+PRIVATNOST KOJU MOŽETE PROVJERITI
+
+Dish je open source pod LGPL-3.0 licencom. Bez reklama. Bez analitike. Ne šaljemo nikakve podatke na TinkerNorth servere — jer ih ne posjedujemo. Jedino mrežno odredište je Satellite na vašoj vlastitoj LAN-i. Dijagnostika padova (Firebase Crashlytics) je uključena prema zadanim postavkama i možete je isključiti u svakom trenutku iz Postavki.
+
+
+PREUZMITE SATELLITE
+
+Besplatni Satellite pomoćnik dostupan je za Windows, macOS i Linux na tinkernorth.com/satellite. Bluetooth-host režim radi bez Satellite-a, ali Wi-Fi put pruža najbolje iskustvo.
+
+
+ZA ENTUZIJASTE
+
+Izvorni kod, sigurnosna politika i dokumentacija žičanog formata javni su na GitHub-u na github.com/TinkerNorth/dish-android. Cijeli proizvod — telefonski klijent, Satellite server i platformske varijante — gradi se u otvorenom kodu.

--- a/play/metadata/android/bs/short_description.txt
+++ b/play/metadata/android/bs/short_description.txt
@@ -1,1 +1,1 @@
-Pretvorite telefon u bežični gamepad za PC — Wi-Fi ili Bluetooth.
+Bežični gamepad: vrhunski kvalitet iz bilo kojeg fizičkog kontrolera ili telefona

--- a/play/metadata/android/bs/short_description.txt
+++ b/play/metadata/android/bs/short_description.txt
@@ -1,0 +1,1 @@
+Pretvorite telefon u bežični gamepad za PC — Wi-Fi ili Bluetooth.

--- a/play/metadata/android/bs/title.txt
+++ b/play/metadata/android/bs/title.txt
@@ -1,0 +1,1 @@
+Dish: Bežični gamepad za PC

--- a/play/metadata/android/de-DE/changelogs/10000.txt
+++ b/play/metadata/android/de-DE/changelogs/10000.txt
@@ -1,0 +1,7 @@
+Erstveröffentlichung.
+
+• Mache dein Handy zum drahtlosen Gamepad für PC.
+• Zwei Modi: Wi-Fi mit Satellite, oder Bluetooth-Gamepad an jeden Host.
+• Verwende das Bildschirm-Pad oder schließe deinen eigenen Controller an / koppel ihn.
+• Motion (Gyroskop), Touchpad und In-Game-Rumble auf dem Wi-Fi-Pfad.
+• Open Source unter LGPL-3.0.

--- a/play/metadata/android/de-DE/full_description.txt
+++ b/play/metadata/android/de-DE/full_description.txt
@@ -1,0 +1,37 @@
+Dish verwandelt dein Android-Handy in ein drahtloses Gamepad für deinen PC. Egal ob du eine Wi-Fi-Verbindung mit niedriger Latenz, Motion-Aim und Touchpad möchtest oder die Einfachheit eines normalen Bluetooth-Controllers — Dish hat dich abgedeckt. Keine Pro-Spiel-Konfiguration, keine monatlichen Gebühren, keine Werbung.
+
+
+ZWEI VERBINDUNGSWEGE
+
+• Wi-Fi (mit Satellite, kostenlos): der schnellste Weg. Niedrigste Eingabelatenz, Motion (Gyroskop) als Zielassistenz und ein klickbares Touchpad für Menüs und Maussteuerung.
+
+• Bluetooth: Koppel dein Handy mit PC, Konsole oder Set-Top-Box als normales Bluetooth-Gamepad. Keine PC-Software nötig — funktioniert mit allem, das einen Bluetooth-Controller akzeptiert.
+
+
+DEINEN EIGENEN CONTROLLER VERWENDEN
+
+Stecke ein USB-Gamepad in den USB-C-Anschluss deines Handys für null zusätzliche Latenz, oder koppel einen Bluetooth-Controller (Xbox, DualSense, 8BitDo und mehr) direkt mit dem Handy. Dish leitet jeden Druck, jede Achse und jeden Trigger an deinen PC weiter.
+
+
+FÜRS GAMING ENTWORFEN
+
+• Native Eingabe-Pipeline (C++/JNI), damit deine Eingaben nicht hinter UI-Arbeit warten müssen
+• ChaCha20-Poly1305-verschlüsselter Wi-Fi-Stream über UDP — schnell und authentifiziert
+• Mehrere Satelliten gleichzeitig: koppel mehrere PCs und route zwischen ihnen pro Slot
+• Motion und Touchpad werden Spielen als Standard-PlayStation-Pad präsentiert
+• In-Game-Rumble vom Host bringt dein Handy zum Vibrieren
+
+
+PRIVATSPHÄRE, DIE DU PRÜFEN KANNST
+
+Dish ist Open Source unter der LGPL-3.0-Lizenz. Keine Werbung. Keine Analyse. Wir senden keine Daten an TinkerNorth-Server — weil wir keine haben. Das einzige Netzwerkziel ist der Satellite in deinem eigenen LAN. Crash-Diagnose (Firebase Crashlytics) ist standardmäßig aktiviert und kann jederzeit in den Einstellungen abgeschaltet werden.
+
+
+SATELLITE HOLEN
+
+Der kostenlose Satellite-Helfer ist für Windows, macOS und Linux unter tinkernorth.com/satellite verfügbar. Der Bluetooth-Host-Modus funktioniert ohne Satellite, aber das beste Erlebnis bietet der Wi-Fi-Pfad.
+
+
+FÜR BASTLER
+
+Quellcode, Sicherheitsrichtlinie und Wire-Format-Dokumentation sind öffentlich auf GitHub unter github.com/TinkerNorth/dish-android. Das gesamte Produkt — Handy-Client, Satellite-Server und Plattformvarianten — wird offen entwickelt.

--- a/play/metadata/android/de-DE/full_description.txt
+++ b/play/metadata/android/de-DE/full_description.txt
@@ -1,37 +1,32 @@
-Dish verwandelt dein Android-Handy in ein drahtloses Gamepad für deinen PC. Egal ob du eine Wi-Fi-Verbindung mit niedriger Latenz, Motion-Aim und Touchpad möchtest oder die Einfachheit eines normalen Bluetooth-Controllers — Dish hat dich abgedeckt. Keine Pro-Spiel-Konfiguration, keine monatlichen Gebühren, keine Werbung.
+Dish verwandelt jeden Controller oder jedes Android-Handy in ein drahtloses Gamepad mit niedriger Latenz. Egal ob du eine Wi-Fi-Verbindung mit niedriger Latenz, Motion-Aim und Touchpad möchtest oder die Einfachheit eines normalen Bluetooth-Controllers, Dish hat dich abgedeckt. Keine Pro-Spiel-Konfiguration, keine monatlichen Gebühren, keine Werbung.
 
 
 ZWEI VERBINDUNGSWEGE
 
 • Wi-Fi (mit Satellite, kostenlos): der schnellste Weg. Niedrigste Eingabelatenz, Motion (Gyroskop) als Zielassistenz und ein klickbares Touchpad für Menüs und Maussteuerung.
 
-• Bluetooth: Koppel dein Handy mit PC, Konsole oder Set-Top-Box als normales Bluetooth-Gamepad. Keine PC-Software nötig — funktioniert mit allem, das einen Bluetooth-Controller akzeptiert.
+• Bluetooth: Koppel dein Handy mit PC, Konsole oder Set-Top-Box als normales Bluetooth-Gamepad. Funktioniert mit allem, das einen Bluetooth-Controller akzeptiert.
 
 
 DEINEN EIGENEN CONTROLLER VERWENDEN
 
-Stecke ein USB-Gamepad in den USB-C-Anschluss deines Handys für null zusätzliche Latenz, oder koppel einen Bluetooth-Controller (Xbox, DualSense, 8BitDo und mehr) direkt mit dem Handy. Dish leitet jeden Druck, jede Achse und jeden Trigger an deinen PC weiter.
+Stecke ein USB-Gamepad in den USB-Anschluss deines Handys für null zusätzliche Latenz, oder koppel einen Bluetooth-Controller (Xbox, DualSense, 8BitDo und mehr) direkt mit dem Handy. Dish leitet jeden Druck, jede Achse und jeden Trigger an deinen Host weiter.
 
 
 FÜRS GAMING ENTWORFEN
 
-• Native Eingabe-Pipeline (C++/JNI), damit deine Eingaben nicht hinter UI-Arbeit warten müssen
-• ChaCha20-Poly1305-verschlüsselter Wi-Fi-Stream über UDP — schnell und authentifiziert
+• Optimierter Hot-Path für niedrigste Latenz
+• Verschlüsselter Wi-Fi-Stream
 • Mehrere Satelliten gleichzeitig: koppel mehrere PCs und route zwischen ihnen pro Slot
 • Motion und Touchpad werden Spielen als Standard-PlayStation-Pad präsentiert
 • In-Game-Rumble vom Host bringt dein Handy zum Vibrieren
 
 
-PRIVATSPHÄRE, DIE DU PRÜFEN KANNST
-
-Dish ist Open Source unter der LGPL-3.0-Lizenz. Keine Werbung. Keine Analyse. Wir senden keine Daten an TinkerNorth-Server — weil wir keine haben. Das einzige Netzwerkziel ist der Satellite in deinem eigenen LAN. Crash-Diagnose (Firebase Crashlytics) ist standardmäßig aktiviert und kann jederzeit in den Einstellungen abgeschaltet werden.
-
-
 SATELLITE HOLEN
 
-Der kostenlose Satellite-Helfer ist für Windows, macOS und Linux unter tinkernorth.com/satellite verfügbar. Der Bluetooth-Host-Modus funktioniert ohne Satellite, aber das beste Erlebnis bietet der Wi-Fi-Pfad.
+Der kostenlose Satellite-Helfer ist für Windows, macOS und Linux unter https://dish.tinkernorth.com/downloads/satellite verfügbar. Der Bluetooth-Host-Modus funktioniert ohne Satellite, aber der Wi-Fi-Pfad bietet das beste Erlebnis.
 
 
 FÜR BASTLER
 
-Quellcode, Sicherheitsrichtlinie und Wire-Format-Dokumentation sind öffentlich auf GitHub unter github.com/TinkerNorth/dish-android. Das gesamte Produkt — Handy-Client, Satellite-Server und Plattformvarianten — wird offen entwickelt.
+Quellcode, Sicherheitsrichtlinie und Wire-Format-Dokumentation sind öffentlich auf GitHub unter github.com/TinkerNorth/dish-android. Handy-Client, Satellite-Server und Plattformvarianten.

--- a/play/metadata/android/de-DE/short_description.txt
+++ b/play/metadata/android/de-DE/short_description.txt
@@ -1,0 +1,1 @@
+Verwandle dein Handy in ein drahtloses PC-Gamepad — Wi-Fi oder Bluetooth.

--- a/play/metadata/android/de-DE/short_description.txt
+++ b/play/metadata/android/de-DE/short_description.txt
@@ -1,1 +1,1 @@
-Verwandle dein Handy in ein drahtloses PC-Gamepad — Wi-Fi oder Bluetooth.
+Drahtloses Gamepad: Flaggschiff-Qualität aus jedem Controller oder Handy

--- a/play/metadata/android/de-DE/title.txt
+++ b/play/metadata/android/de-DE/title.txt
@@ -1,0 +1,1 @@
+Dish: Drahtloses PC-Gamepad

--- a/play/metadata/android/en-US/changelogs/10000.txt
+++ b/play/metadata/android/en-US/changelogs/10000.txt
@@ -1,0 +1,7 @@
+Initial release.
+
+• Turn your phone into a wireless gamepad for PC.
+• Two modes: Wi-Fi with Satellite, or Bluetooth gamepad to any host.
+• Use the on-screen pad, or plug in / pair your own controller.
+• Motion (gyro), touchpad, and in-game rumble on the Wi-Fi path.
+• Open source under LGPL-3.0.

--- a/play/metadata/android/en-US/full_description.txt
+++ b/play/metadata/android/en-US/full_description.txt
@@ -1,0 +1,37 @@
+Dish turns your Android phone into a wireless gamepad for your PC. Whether you want a low-latency Wi-Fi link with motion-aim and a touchpad, or the simplicity of pairing as a regular Bluetooth controller, Dish has you covered — no per-game configuration, no monthly fees, no ads.
+
+
+TWO WAYS TO CONNECT
+
+• Wi-Fi (with Satellite, free): the fastest path. Lowest input latency, motion (gyro) aim assist, and a clickable touchpad for menus and mouse control.
+
+• Bluetooth: pair your phone to a PC, console, or set-top box as a regular Bluetooth gamepad. No PC software required — works with anything that accepts a Bluetooth controller.
+
+
+USE YOUR OWN CONTROLLER
+
+Plug a USB gamepad into your phone's USB-C port for zero added latency, or pair a Bluetooth controller (Xbox, DualSense, 8BitDo, and more) directly to your phone. Dish forwards every press, axis, and trigger to your PC.
+
+
+DESIGNED FOR GAMING
+
+• Native input pipeline (C++/JNI), so your inputs aren't queued behind UI work
+• ChaCha20-Poly1305 encrypted Wi-Fi stream over UDP — fast and authenticated
+• Multiple satellites side-by-side: pair more than one PC and route between them per slot
+• Motion and touchpad presented to games as a standard PlayStation-style pad
+• In-game rumble from the host vibrates your phone
+
+
+PRIVACY YOU CAN AUDIT
+
+Dish is open source under the LGPL-3.0 license. No ads. No analytics. We don't ship any data to TinkerNorth servers — because we don't have any. The only network destination is the Satellite on your own LAN. Crash diagnostics (Firebase Crashlytics) are on by default and can be switched off any time in Settings.
+
+
+GET SATELLITE
+
+The free Satellite helper is available for Windows, macOS, and Linux at tinkernorth.com/satellite. Bluetooth-host mode works without Satellite, but the Wi-Fi path is the best experience.
+
+
+FOR TINKERERS
+
+Source code, security policy, and wire-format docs are public on GitHub at github.com/TinkerNorth/dish-android. The whole product — phone client, Satellite server, and platform variants — is built in the open.

--- a/play/metadata/android/en-US/full_description.txt
+++ b/play/metadata/android/en-US/full_description.txt
@@ -1,37 +1,27 @@
-Dish turns your Android phone into a wireless gamepad for your PC. Whether you want a low-latency Wi-Fi link with motion-aim and a touchpad, or the simplicity of pairing as a regular Bluetooth controller, Dish has you covered — no per-game configuration, no monthly fees, no ads.
-
+Dish turns any controller or Android phone into a low latency wireless gamepad. Whether you want a low-latency Wi-Fi link with motion-aim and a touchpad, or the simplicity of pairing as a regular Bluetooth controller, Dish has you covered. No per-game configuration, no monthly fees, no ads.
 
 TWO WAYS TO CONNECT
 
 • Wi-Fi (with Satellite, free): the fastest path. Lowest input latency, motion (gyro) aim assist, and a clickable touchpad for menus and mouse control.
 
-• Bluetooth: pair your phone to a PC, console, or set-top box as a regular Bluetooth gamepad. No PC software required — works with anything that accepts a Bluetooth controller.
-
+• Bluetooth: pair your phone to a PC, console, or set-top box as a regular Bluetooth gamepad. Works with anything that accepts a Bluetooth controller.
 
 USE YOUR OWN CONTROLLER
 
-Plug a USB gamepad into your phone's USB-C port for zero added latency, or pair a Bluetooth controller (Xbox, DualSense, 8BitDo, and more) directly to your phone. Dish forwards every press, axis, and trigger to your PC.
-
+Plug a USB gamepad into your phone's USB port for zero added latency, or pair a Bluetooth controller (Xbox, DualSense, 8BitDo, and more) directly to your phone. Dish forwards every press, axis, and trigger to your host.
 
 DESIGNED FOR GAMING
 
-• Native input pipeline (C++/JNI), so your inputs aren't queued behind UI work
-• ChaCha20-Poly1305 encrypted Wi-Fi stream over UDP — fast and authenticated
+• Optimized hot path for lowest latency
+• Encrypted Wi-Fi stream
 • Multiple satellites side-by-side: pair more than one PC and route between them per slot
 • Motion and touchpad presented to games as a standard PlayStation-style pad
 • In-game rumble from the host vibrates your phone
 
-
-PRIVACY YOU CAN AUDIT
-
-Dish is open source under the LGPL-3.0 license. No ads. No analytics. We don't ship any data to TinkerNorth servers — because we don't have any. The only network destination is the Satellite on your own LAN. Crash diagnostics (Firebase Crashlytics) are on by default and can be switched off any time in Settings.
-
-
 GET SATELLITE
 
-The free Satellite helper is available for Windows, macOS, and Linux at tinkernorth.com/satellite. Bluetooth-host mode works without Satellite, but the Wi-Fi path is the best experience.
-
+The free Satellite helper is available for Windows, macOS, and Linux at https://dish.tinkernorth.com/downloads/satellite. Bluetooth-host mode works without Satellite, but the Wi-Fi path is the best experience.
 
 FOR TINKERERS
 
-Source code, security policy, and wire-format docs are public on GitHub at github.com/TinkerNorth/dish-android. The whole product — phone client, Satellite server, and platform variants — is built in the open.
+Source code, security policy, and wire-format docs are public on GitHub at github.com/TinkerNorth/dish-android. Phone client, Satellite server, and platform variants.

--- a/play/metadata/android/en-US/short_description.txt
+++ b/play/metadata/android/en-US/short_description.txt
@@ -1,0 +1,1 @@
+Wireless gamepad for your PC — Wi-Fi or Bluetooth, with motion and touchpad.

--- a/play/metadata/android/en-US/short_description.txt
+++ b/play/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Wireless gamepad for your PC — Wi-Fi or Bluetooth, with motion and touchpad.
+Wireless gamepad: Get flagship quality out of any physical controller or phone

--- a/play/metadata/android/en-US/title.txt
+++ b/play/metadata/android/en-US/title.txt
@@ -1,0 +1,1 @@
+Dish: Wireless PC Gamepad

--- a/play/metadata/android/es-ES/changelogs/10000.txt
+++ b/play/metadata/android/es-ES/changelogs/10000.txt
@@ -1,0 +1,7 @@
+Versión inicial.
+
+• Convierte tu teléfono en un gamepad inalámbrico para PC.
+• Dos modos: Wi-Fi con Satellite, o gamepad Bluetooth para cualquier host.
+• Usa el pad en pantalla, o conecta / empareja tu propio mando.
+• Motion (giroscopio), touchpad y rumble en juego en la vía Wi-Fi.
+• Código abierto bajo LGPL-3.0.

--- a/play/metadata/android/es-ES/full_description.txt
+++ b/play/metadata/android/es-ES/full_description.txt
@@ -1,37 +1,32 @@
-Dish convierte tu teléfono Android en un gamepad inalámbrico para tu PC. Ya quieras una conexión Wi-Fi de baja latencia con motion-aim y touchpad, o la simplicidad de emparejar como un mando Bluetooth normal — Dish te cubre. Sin configuración por juego, sin suscripciones mensuales, sin anuncios.
+Dish convierte cualquier mando o teléfono Android en un gamepad inalámbrico de baja latencia. Ya quieras una conexión Wi-Fi de baja latencia con motion-aim y touchpad, o la simplicidad de emparejar como un mando Bluetooth normal, Dish te cubre. Sin configuración por juego, sin suscripciones mensuales, sin anuncios.
 
 
 DOS FORMAS DE CONECTAR
 
 • Wi-Fi (con Satellite, gratis): el camino más rápido. Latencia de entrada más baja, motion (giroscopio) como asistencia de puntería y un touchpad clicable para menús y control del ratón.
 
-• Bluetooth: empareja tu teléfono con un PC, consola o set-top box como un gamepad Bluetooth normal. No requiere software de PC — funciona con cualquier cosa que acepte un mando Bluetooth.
+• Bluetooth: empareja tu teléfono con un PC, consola o set-top box como un gamepad Bluetooth normal. Funciona con cualquier cosa que acepte un mando Bluetooth.
 
 
 USA TU PROPIO MANDO
 
-Conecta un gamepad USB en el puerto USB-C de tu teléfono para cero latencia añadida, o empareja un mando Bluetooth (Xbox, DualSense, 8BitDo y más) directamente con tu teléfono. Dish reenvía cada pulsación, eje y gatillo a tu PC.
+Conecta un gamepad USB en el puerto USB de tu teléfono para cero latencia añadida, o empareja un mando Bluetooth (Xbox, DualSense, 8BitDo y más) directamente con tu teléfono. Dish reenvía cada pulsación, eje y gatillo a tu host.
 
 
 DISEÑADO PARA JUGAR
 
-• Pipeline de entrada nativo (C++/JNI), para que tus entradas no queden detrás del trabajo de UI
-• Stream Wi-Fi cifrado con ChaCha20-Poly1305 sobre UDP — rápido y autenticado
+• Ruta optimizada para latencia mínima
+• Stream Wi-Fi cifrado
 • Múltiples satélites a la vez: empareja más de un PC y enruta entre ellos por slot
 • Motion y touchpad presentados a los juegos como un pad estándar estilo PlayStation
 • Rumble en juego desde el host hace vibrar tu teléfono
 
 
-PRIVACIDAD QUE PUEDES AUDITAR
-
-Dish es open source bajo la licencia LGPL-3.0. Sin anuncios. Sin análisis. No enviamos datos a servidores de TinkerNorth — porque no tenemos ninguno. El único destino de red es el Satellite en tu propia LAN. El diagnóstico de fallos (Firebase Crashlytics) está activado por defecto y puedes desactivarlo en cualquier momento desde Ajustes.
-
-
 OBTÉN SATELLITE
 
-El ayudante gratuito Satellite está disponible para Windows, macOS y Linux en tinkernorth.com/satellite. El modo Bluetooth-host funciona sin Satellite, pero la mejor experiencia es por la vía Wi-Fi.
+El ayudante gratuito Satellite está disponible para Windows, macOS y Linux en https://dish.tinkernorth.com/downloads/satellite. El modo Bluetooth-host funciona sin Satellite, pero la mejor experiencia es por la vía Wi-Fi.
 
 
 PARA EXPERIMENTADORES
 
-El código fuente, política de seguridad y documentación del formato de cable son públicos en GitHub en github.com/TinkerNorth/dish-android. Todo el producto — cliente de teléfono, servidor Satellite y variantes de plataforma — se construye en código abierto.
+El código fuente, política de seguridad y documentación del formato de cable son públicos en GitHub en github.com/TinkerNorth/dish-android. Cliente de teléfono, servidor Satellite y variantes de plataforma.

--- a/play/metadata/android/es-ES/full_description.txt
+++ b/play/metadata/android/es-ES/full_description.txt
@@ -1,0 +1,37 @@
+Dish convierte tu teléfono Android en un gamepad inalámbrico para tu PC. Ya quieras una conexión Wi-Fi de baja latencia con motion-aim y touchpad, o la simplicidad de emparejar como un mando Bluetooth normal — Dish te cubre. Sin configuración por juego, sin suscripciones mensuales, sin anuncios.
+
+
+DOS FORMAS DE CONECTAR
+
+• Wi-Fi (con Satellite, gratis): el camino más rápido. Latencia de entrada más baja, motion (giroscopio) como asistencia de puntería y un touchpad clicable para menús y control del ratón.
+
+• Bluetooth: empareja tu teléfono con un PC, consola o set-top box como un gamepad Bluetooth normal. No requiere software de PC — funciona con cualquier cosa que acepte un mando Bluetooth.
+
+
+USA TU PROPIO MANDO
+
+Conecta un gamepad USB en el puerto USB-C de tu teléfono para cero latencia añadida, o empareja un mando Bluetooth (Xbox, DualSense, 8BitDo y más) directamente con tu teléfono. Dish reenvía cada pulsación, eje y gatillo a tu PC.
+
+
+DISEÑADO PARA JUGAR
+
+• Pipeline de entrada nativo (C++/JNI), para que tus entradas no queden detrás del trabajo de UI
+• Stream Wi-Fi cifrado con ChaCha20-Poly1305 sobre UDP — rápido y autenticado
+• Múltiples satélites a la vez: empareja más de un PC y enruta entre ellos por slot
+• Motion y touchpad presentados a los juegos como un pad estándar estilo PlayStation
+• Rumble en juego desde el host hace vibrar tu teléfono
+
+
+PRIVACIDAD QUE PUEDES AUDITAR
+
+Dish es open source bajo la licencia LGPL-3.0. Sin anuncios. Sin análisis. No enviamos datos a servidores de TinkerNorth — porque no tenemos ninguno. El único destino de red es el Satellite en tu propia LAN. El diagnóstico de fallos (Firebase Crashlytics) está activado por defecto y puedes desactivarlo en cualquier momento desde Ajustes.
+
+
+OBTÉN SATELLITE
+
+El ayudante gratuito Satellite está disponible para Windows, macOS y Linux en tinkernorth.com/satellite. El modo Bluetooth-host funciona sin Satellite, pero la mejor experiencia es por la vía Wi-Fi.
+
+
+PARA EXPERIMENTADORES
+
+El código fuente, política de seguridad y documentación del formato de cable son públicos en GitHub en github.com/TinkerNorth/dish-android. Todo el producto — cliente de teléfono, servidor Satellite y variantes de plataforma — se construye en código abierto.

--- a/play/metadata/android/es-ES/short_description.txt
+++ b/play/metadata/android/es-ES/short_description.txt
@@ -1,0 +1,1 @@
+Convierte tu teléfono en un gamepad inalámbrico para PC — Wi-Fi o Bluetooth.

--- a/play/metadata/android/es-ES/short_description.txt
+++ b/play/metadata/android/es-ES/short_description.txt
@@ -1,1 +1,1 @@
-Convierte tu teléfono en un gamepad inalámbrico para PC — Wi-Fi o Bluetooth.
+Gamepad inalámbrico: calidad de gama alta con cualquier mando o teléfono

--- a/play/metadata/android/es-ES/title.txt
+++ b/play/metadata/android/es-ES/title.txt
@@ -1,0 +1,1 @@
+Dish: Gamepad inalámbrico PC

--- a/play/metadata/android/fr-FR/changelogs/10000.txt
+++ b/play/metadata/android/fr-FR/changelogs/10000.txt
@@ -1,0 +1,7 @@
+Version initiale.
+
+• Transformez votre téléphone en manette sans fil pour PC.
+• Deux modes : Wi-Fi avec Satellite, ou manette Bluetooth pour n'importe quel hôte.
+• Utilisez la manette à l'écran, ou branchez / appairez votre propre manette.
+• Mouvement (gyroscope), pavé tactile et vibration en jeu sur le chemin Wi-Fi.
+• Open source sous LGPL-3.0.

--- a/play/metadata/android/fr-FR/full_description.txt
+++ b/play/metadata/android/fr-FR/full_description.txt
@@ -1,37 +1,32 @@
-Dish transforme votre téléphone Android en manette sans fil pour votre PC. Que vous souhaitiez une connexion Wi-Fi à faible latence avec motion-aim et pavé tactile, ou la simplicité d'un appairage en manette Bluetooth classique — Dish vous couvre. Pas de configuration par jeu, pas d'abonnement mensuel, pas de publicité.
+Dish transforme n'importe quelle manette ou téléphone Android en manette sans fil à faible latence. Que vous souhaitiez une connexion Wi-Fi à faible latence avec motion-aim et pavé tactile, ou la simplicité d'un appairage en manette Bluetooth classique, Dish vous couvre. Pas de configuration par jeu, pas d'abonnement mensuel, pas de publicité.
 
 
 DEUX MOYENS DE CONNEXION
 
 • Wi-Fi (avec Satellite, gratuit) : le chemin le plus rapide. Latence d'entrée la plus basse, mouvement (gyroscope) comme assistance à la visée et un pavé tactile cliquable pour les menus et le contrôle de la souris.
 
-• Bluetooth : appairez votre téléphone avec un PC, une console ou un boîtier TV comme manette Bluetooth classique. Aucun logiciel PC requis — fonctionne avec tout ce qui accepte une manette Bluetooth.
+• Bluetooth : appairez votre téléphone avec un PC, une console ou un boîtier TV comme manette Bluetooth classique. Fonctionne avec tout ce qui accepte une manette Bluetooth.
 
 
 UTILISEZ VOTRE PROPRE MANETTE
 
-Branchez une manette USB sur le port USB-C de votre téléphone pour zéro latence ajoutée, ou appairez une manette Bluetooth (Xbox, DualSense, 8BitDo et plus) directement à votre téléphone. Dish transmet chaque appui, axe et gâchette à votre PC.
+Branchez une manette USB sur le port USB de votre téléphone pour zéro latence ajoutée, ou appairez une manette Bluetooth (Xbox, DualSense, 8BitDo et plus) directement à votre téléphone. Dish transmet chaque appui, axe et gâchette à votre hôte.
 
 
 CONÇU POUR LE JEU
 
-• Pipeline d'entrée natif (C++/JNI), pour que vos entrées n'attendent pas derrière le travail d'UI
-• Flux Wi-Fi chiffré ChaCha20-Poly1305 sur UDP — rapide et authentifié
+• Chemin rapide optimisé pour une latence minimale
+• Flux Wi-Fi chiffré
 • Plusieurs satellites côte à côte : appairez plus d'un PC et routez entre eux par slot
 • Mouvement et pavé tactile présentés aux jeux comme un pad standard de style PlayStation
 • Vibration en jeu depuis l'hôte fait vibrer votre téléphone
 
 
-UNE CONFIDENTIALITÉ QUE VOUS POUVEZ AUDITER
-
-Dish est open source sous licence LGPL-3.0. Pas de publicité. Pas d'analyse. Nous n'envoyons aucune donnée à des serveurs TinkerNorth — parce que nous n'en avons pas. La seule destination réseau est le Satellite sur votre propre LAN. Le diagnostic des plantages (Firebase Crashlytics) est activé par défaut et peut être désactivé à tout moment dans les Paramètres.
-
-
 OBTENIR SATELLITE
 
-L'assistant gratuit Satellite est disponible pour Windows, macOS et Linux sur tinkernorth.com/satellite. Le mode Bluetooth-hôte fonctionne sans Satellite, mais la meilleure expérience passe par le chemin Wi-Fi.
+L'assistant gratuit Satellite est disponible pour Windows, macOS et Linux sur https://dish.tinkernorth.com/downloads/satellite. Le mode Bluetooth-hôte fonctionne sans Satellite, mais le chemin Wi-Fi offre la meilleure expérience.
 
 
 POUR LES BIDOUILLEURS
 
-Le code source, la politique de sécurité et la documentation du format filaire sont publics sur GitHub à github.com/TinkerNorth/dish-android. Tout le produit — client téléphone, serveur Satellite et variantes de plateforme — est construit en open source.
+Le code source, la politique de sécurité et la documentation du format filaire sont publics sur GitHub à github.com/TinkerNorth/dish-android. Client téléphone, serveur Satellite et variantes de plateforme.

--- a/play/metadata/android/fr-FR/full_description.txt
+++ b/play/metadata/android/fr-FR/full_description.txt
@@ -1,0 +1,37 @@
+Dish transforme votre téléphone Android en manette sans fil pour votre PC. Que vous souhaitiez une connexion Wi-Fi à faible latence avec motion-aim et pavé tactile, ou la simplicité d'un appairage en manette Bluetooth classique — Dish vous couvre. Pas de configuration par jeu, pas d'abonnement mensuel, pas de publicité.
+
+
+DEUX MOYENS DE CONNEXION
+
+• Wi-Fi (avec Satellite, gratuit) : le chemin le plus rapide. Latence d'entrée la plus basse, mouvement (gyroscope) comme assistance à la visée et un pavé tactile cliquable pour les menus et le contrôle de la souris.
+
+• Bluetooth : appairez votre téléphone avec un PC, une console ou un boîtier TV comme manette Bluetooth classique. Aucun logiciel PC requis — fonctionne avec tout ce qui accepte une manette Bluetooth.
+
+
+UTILISEZ VOTRE PROPRE MANETTE
+
+Branchez une manette USB sur le port USB-C de votre téléphone pour zéro latence ajoutée, ou appairez une manette Bluetooth (Xbox, DualSense, 8BitDo et plus) directement à votre téléphone. Dish transmet chaque appui, axe et gâchette à votre PC.
+
+
+CONÇU POUR LE JEU
+
+• Pipeline d'entrée natif (C++/JNI), pour que vos entrées n'attendent pas derrière le travail d'UI
+• Flux Wi-Fi chiffré ChaCha20-Poly1305 sur UDP — rapide et authentifié
+• Plusieurs satellites côte à côte : appairez plus d'un PC et routez entre eux par slot
+• Mouvement et pavé tactile présentés aux jeux comme un pad standard de style PlayStation
+• Vibration en jeu depuis l'hôte fait vibrer votre téléphone
+
+
+UNE CONFIDENTIALITÉ QUE VOUS POUVEZ AUDITER
+
+Dish est open source sous licence LGPL-3.0. Pas de publicité. Pas d'analyse. Nous n'envoyons aucune donnée à des serveurs TinkerNorth — parce que nous n'en avons pas. La seule destination réseau est le Satellite sur votre propre LAN. Le diagnostic des plantages (Firebase Crashlytics) est activé par défaut et peut être désactivé à tout moment dans les Paramètres.
+
+
+OBTENIR SATELLITE
+
+L'assistant gratuit Satellite est disponible pour Windows, macOS et Linux sur tinkernorth.com/satellite. Le mode Bluetooth-hôte fonctionne sans Satellite, mais la meilleure expérience passe par le chemin Wi-Fi.
+
+
+POUR LES BIDOUILLEURS
+
+Le code source, la politique de sécurité et la documentation du format filaire sont publics sur GitHub à github.com/TinkerNorth/dish-android. Tout le produit — client téléphone, serveur Satellite et variantes de plateforme — est construit en open source.

--- a/play/metadata/android/fr-FR/short_description.txt
+++ b/play/metadata/android/fr-FR/short_description.txt
@@ -1,1 +1,1 @@
-Transformez votre téléphone en manette sans fil pour PC — Wi-Fi ou Bluetooth.
+Manette sans fil : qualité premium avec n'importe quelle manette ou téléphone

--- a/play/metadata/android/fr-FR/short_description.txt
+++ b/play/metadata/android/fr-FR/short_description.txt
@@ -1,0 +1,1 @@
+Transformez votre téléphone en manette sans fil pour PC — Wi-Fi ou Bluetooth.

--- a/play/metadata/android/fr-FR/title.txt
+++ b/play/metadata/android/fr-FR/title.txt
@@ -1,0 +1,1 @@
+Dish : Manette PC sans fil

--- a/play/metadata/android/pt-BR/changelogs/10000.txt
+++ b/play/metadata/android/pt-BR/changelogs/10000.txt
@@ -1,0 +1,7 @@
+Versão inicial.
+
+• Transforme seu celular em um gamepad sem fio para PC.
+• Dois modos: Wi-Fi com Satellite, ou gamepad Bluetooth para qualquer host.
+• Use o pad na tela, ou conecte / pareie seu próprio controle.
+• Motion (giroscópio), touchpad e rumble no jogo no caminho Wi-Fi.
+• Código aberto sob LGPL-3.0.

--- a/play/metadata/android/pt-BR/full_description.txt
+++ b/play/metadata/android/pt-BR/full_description.txt
@@ -1,0 +1,37 @@
+O Dish transforma seu celular Android em um gamepad sem fio para seu PC. Seja para uma conexão Wi-Fi de baixa latência com motion-aim e touchpad, ou a simplicidade de parear como um controle Bluetooth comum — o Dish tem você coberto. Sem configuração por jogo, sem assinaturas mensais, sem anúncios.
+
+
+DUAS MANEIRAS DE CONECTAR
+
+• Wi-Fi (com Satellite, gratuito): o caminho mais rápido. Menor latência de entrada, motion (giroscópio) como assistência de mira e um touchpad clicável para menus e controle do mouse.
+
+• Bluetooth: pareie seu celular com um PC, console ou set-top box como um gamepad Bluetooth comum. Sem software de PC necessário — funciona com qualquer coisa que aceite um controle Bluetooth.
+
+
+USE SEU PRÓPRIO CONTROLE
+
+Conecte um gamepad USB na porta USB-C do seu celular para zero latência adicionada, ou pareie um controle Bluetooth (Xbox, DualSense, 8BitDo e mais) diretamente com seu celular. O Dish encaminha cada pressionamento, eixo e gatilho para seu PC.
+
+
+PROJETADO PARA JOGAR
+
+• Pipeline de entrada nativo (C++/JNI), para que suas entradas não fiquem esperando atrás do trabalho de UI
+• Stream Wi-Fi criptografado com ChaCha20-Poly1305 sobre UDP — rápido e autenticado
+• Múltiplos satélites lado a lado: pareie mais de um PC e direcione entre eles por slot
+• Motion e touchpad apresentados aos jogos como um pad padrão estilo PlayStation
+• Rumble no jogo do host faz seu celular vibrar
+
+
+PRIVACIDADE QUE VOCÊ PODE AUDITAR
+
+O Dish é código aberto sob a licença LGPL-3.0. Sem anúncios. Sem análise. Não enviamos dados para servidores da TinkerNorth — porque não temos nenhum. O único destino de rede é o Satellite na sua própria LAN. O diagnóstico de falhas (Firebase Crashlytics) está ligado por padrão e você pode desligá-lo a qualquer momento em Configurações.
+
+
+OBTENHA O SATELLITE
+
+O auxiliar gratuito Satellite está disponível para Windows, macOS e Linux em tinkernorth.com/satellite. O modo Bluetooth-host funciona sem o Satellite, mas a melhor experiência é pelo caminho Wi-Fi.
+
+
+PARA QUEM GOSTA DE EXPLORAR
+
+O código fonte, política de segurança e documentação do formato de fio são públicos no GitHub em github.com/TinkerNorth/dish-android. Todo o produto — cliente para celular, servidor Satellite e variantes de plataforma — é construído em código aberto.

--- a/play/metadata/android/pt-BR/full_description.txt
+++ b/play/metadata/android/pt-BR/full_description.txt
@@ -1,37 +1,32 @@
-O Dish transforma seu celular Android em um gamepad sem fio para seu PC. Seja para uma conexão Wi-Fi de baixa latência com motion-aim e touchpad, ou a simplicidade de parear como um controle Bluetooth comum — o Dish tem você coberto. Sem configuração por jogo, sem assinaturas mensais, sem anúncios.
+O Dish transforma qualquer controle ou celular Android em um gamepad sem fio de baixa latência. Seja para uma conexão Wi-Fi de baixa latência com motion-aim e touchpad, ou a simplicidade de parear como um controle Bluetooth comum, o Dish tem você coberto. Sem configuração por jogo, sem assinaturas mensais, sem anúncios.
 
 
 DUAS MANEIRAS DE CONECTAR
 
 • Wi-Fi (com Satellite, gratuito): o caminho mais rápido. Menor latência de entrada, motion (giroscópio) como assistência de mira e um touchpad clicável para menus e controle do mouse.
 
-• Bluetooth: pareie seu celular com um PC, console ou set-top box como um gamepad Bluetooth comum. Sem software de PC necessário — funciona com qualquer coisa que aceite um controle Bluetooth.
+• Bluetooth: pareie seu celular com um PC, console ou set-top box como um gamepad Bluetooth comum. Funciona com qualquer coisa que aceite um controle Bluetooth.
 
 
 USE SEU PRÓPRIO CONTROLE
 
-Conecte um gamepad USB na porta USB-C do seu celular para zero latência adicionada, ou pareie um controle Bluetooth (Xbox, DualSense, 8BitDo e mais) diretamente com seu celular. O Dish encaminha cada pressionamento, eixo e gatilho para seu PC.
+Conecte um gamepad USB na porta USB do seu celular para zero latência adicionada, ou pareie um controle Bluetooth (Xbox, DualSense, 8BitDo e mais) diretamente com seu celular. O Dish encaminha cada pressionamento, eixo e gatilho para seu host.
 
 
 PROJETADO PARA JOGAR
 
-• Pipeline de entrada nativo (C++/JNI), para que suas entradas não fiquem esperando atrás do trabalho de UI
-• Stream Wi-Fi criptografado com ChaCha20-Poly1305 sobre UDP — rápido e autenticado
+• Caminho otimizado para latência mínima
+• Stream Wi-Fi criptografado
 • Múltiplos satélites lado a lado: pareie mais de um PC e direcione entre eles por slot
 • Motion e touchpad apresentados aos jogos como um pad padrão estilo PlayStation
 • Rumble no jogo do host faz seu celular vibrar
 
 
-PRIVACIDADE QUE VOCÊ PODE AUDITAR
-
-O Dish é código aberto sob a licença LGPL-3.0. Sem anúncios. Sem análise. Não enviamos dados para servidores da TinkerNorth — porque não temos nenhum. O único destino de rede é o Satellite na sua própria LAN. O diagnóstico de falhas (Firebase Crashlytics) está ligado por padrão e você pode desligá-lo a qualquer momento em Configurações.
-
-
 OBTENHA O SATELLITE
 
-O auxiliar gratuito Satellite está disponível para Windows, macOS e Linux em tinkernorth.com/satellite. O modo Bluetooth-host funciona sem o Satellite, mas a melhor experiência é pelo caminho Wi-Fi.
+O auxiliar gratuito Satellite está disponível para Windows, macOS e Linux em https://dish.tinkernorth.com/downloads/satellite. O modo Bluetooth-host funciona sem o Satellite, mas o caminho Wi-Fi oferece a melhor experiência.
 
 
 PARA QUEM GOSTA DE EXPLORAR
 
-O código fonte, política de segurança e documentação do formato de fio são públicos no GitHub em github.com/TinkerNorth/dish-android. Todo o produto — cliente para celular, servidor Satellite e variantes de plataforma — é construído em código aberto.
+O código fonte, política de segurança e documentação do formato de fio são públicos no GitHub em github.com/TinkerNorth/dish-android. Cliente para celular, servidor Satellite e variantes de plataforma.

--- a/play/metadata/android/pt-BR/short_description.txt
+++ b/play/metadata/android/pt-BR/short_description.txt
@@ -1,1 +1,1 @@
-Transforme seu celular em um gamepad sem fio para PC — Wi-Fi ou Bluetooth.
+Gamepad sem fio: qualidade de ponta com qualquer controle físico ou celular

--- a/play/metadata/android/pt-BR/short_description.txt
+++ b/play/metadata/android/pt-BR/short_description.txt
@@ -1,0 +1,1 @@
+Transforme seu celular em um gamepad sem fio para PC — Wi-Fi ou Bluetooth.

--- a/play/metadata/android/pt-BR/title.txt
+++ b/play/metadata/android/pt-BR/title.txt
@@ -1,0 +1,1 @@
+Dish: Gamepad sem fio para PC

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,3 +24,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "Dish"
 include(":app")
+include(":baselineprofile")


### PR DESCRIPTION
## Summary

Three independent v1.0 launch-readiness changes audited as part of the Editor's Choice push:

- **Baseline Profile** — new `:baselineprofile` Gradle Managed Device test module, wired into `release.yml` to bake an AOT compilation hint into the AAB at release time. Targets a Pixel 6 API 34 emulator on the runner.
- **Form-factor surfacing** — three `<uses-feature ... required="false">` entries (`touchscreen`, `faketouch`, `gamepad`) so Play surfaces the app on ChromeOS, tablets, and foldables. Without these, Play filters the app out of those categories regardless of `sw600dp` layouts. Leanback/TV intentionally omitted.
- **A11y label** — `picker_motion_toggle.xml` reuses the already-localized motion-toggle label as its `contentDescription`.

Pre-existing accessibility audit was confirmed: the codebase has 31 a11y attributes (10 `contentDescription` + 21 `importantForAccessibility="no"`); the picker switch was the only missing case across all 26 layouts.

## Notes for reviewers

- `androidx.baselineprofile` is on `1.5.0-alpha06` because the stable `1.4.1` does not support AGP 9 (errors with `Module ':app' is not a supported android module`). Bump to a stable `1.5.x` once one is published.
- `org.jetbrains.kotlin.android` is intentionally NOT declared anywhere — AGP 9 auto-applies Kotlin and the explicit plugin alias is rejected.
- `gradle/verification-metadata.xml` is gitignored, so CI builds without dependency verification. Locally-generated metadata will need a regen against the new deps before any local builds with verification enabled.
- `licenses.json` regenerated for `profileinstaller 1.4.0 → 1.4.1`.

## Test plan

- [x] `./gradlew ktlintCheck detekt lint testDebugUnitTest assembleDebug :baselineprofile:assembleNonMinifiedRelease` — passes locally on Windows / JDK 21 (Android Studio JBR)
- [ ] CI `Android CI` workflow runs on PR
- [ ] CI `Release` workflow (manual `workflow_dispatch` with a `v*` tag) generates a baseline profile and bakes it into the AAB
- [ ] Manual TalkBack pass over the settings → motion-toggle picker
- [ ] Play Console internal test on a ChromeOS device / Pixel Fold to confirm device surfacing