### PR TITLE
fix(ui): let standard activities recreate on rotation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -86,7 +86,7 @@
             android:exported="false"
             android:resizeableActivity="true"
             android:theme="@style/Theme.Dish"
-            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden"
+            android:configChanges="keyboardHidden"
             android:parentActivityName=".ui.main.MainActivity"
             tools:targetApi="p" />
 
@@ -95,7 +95,7 @@
             android:exported="false"
             android:resizeableActivity="true"
             android:theme="@style/Theme.Dish"
-            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden"
+            android:configChanges="keyboardHidden"
             android:parentActivityName=".ui.main.MainActivity"
             tools:targetApi="p" />
 
@@ -104,7 +104,7 @@
             android:exported="false"
             android:resizeableActivity="true"
             android:theme="@style/Theme.Dish"
-            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden"
+            android:configChanges="keyboardHidden"
             android:parentActivityName=".ui.settings.SettingsActivity"
             tools:targetApi="p" />
 
@@ -113,7 +113,7 @@
             android:exported="false"
             android:resizeableActivity="true"
             android:theme="@style/Theme.Dish"
-            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden"
+            android:configChanges="keyboardHidden"
             tools:targetApi="p" />
 
         <activity
@@ -121,7 +121,7 @@
             android:exported="false"
             android:resizeableActivity="true"
             android:theme="@style/Theme.Dish"
-            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden"
+            android:configChanges="keyboardHidden"
             android:parentActivityName=".ui.main.MainActivity"
             tools:targetApi="p" />
 
@@ -130,7 +130,7 @@
             android:exported="false"
             android:resizeableActivity="true"
             android:theme="@style/Theme.Dish"
-            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden"
+            android:configChanges="keyboardHidden"
             android:parentActivityName=".ui.settings.SettingsActivity"
             tools:targetApi="p" />
 


### PR DESCRIPTION
## Summary

- Drops `orientation|screenSize|smallestScreenSize|screenLayout` from `android:configChanges` on the six non-overlay, non-game activities so Android destroys and recreates them on rotation. The same layout XML is now re-inflated against the new aspect ratio instead of being held in place from the originating orientation, which is the most likely root cause of the "weird layouts after rotation" report.
- `keyboardHidden` is retained on each updated activity (benign; covers hardware-keyboard hide/show).
- Three activities are intentionally untouched (see below).

## Activities updated (configChanges now `keyboardHidden` only)

- `ConnectionsActivity`
- `SettingsActivity`
- `LicensesActivity`
- `WelcomeActivity` (already saves step index via `onSaveInstanceState`)
- `SetupWizardActivity` (already saves step / selections via `onSaveInstanceState`)
- `HelpActivity`

## Activities NOT changed, and why

| Activity | Reason |
|---|---|
| `MainActivity` | Extends `com.google.androidgamesdk.GameActivity`, a `NativeActivity`-derived class with its own native surface lifecycle and `android.app.lib_name` (`satellite`) attach. Standard NativeActivity convention is to consume `orientation\|screenSize` to avoid a native surface re-attach on each rotation. The dashboard layout (`CoordinatorLayout` > vertical `LinearLayout` > `RecyclerView` with `weight=1`) already adapts to landscape without recreation, so the risk/reward favours leaving this one alone. |
| `GamepadOverlayActivity` | Pinned to `android:screenOrientation="landscape"`. The only rotation event is a reverse-landscape flip mid-input. Recreating would tear down the 250 Hz resend loop, the `motionSource` IMU listener, and the satellite send pipeline in flight. The `BaseInputOverlayActivity` `WindowInsets` listener already re-fires on rotation for edge padding, so visible layout already adapts. |
| `TouchpadOverlayActivity` | Same reasoning as `GamepadOverlayActivity`: landscape-locked, recreating mid-stream would interrupt the bound satellite session. |
| `NativeUnavailableActivity` | Declares no `configChanges` to begin with. Already uses the standard destroy/recreate lifecycle on rotation. |

## Test plan

- [ ] Rotate `ConnectionsActivity` portrait <-> landscape. Confirm rows lay out cleanly in both, satellite + Bluetooth list scrolls, empty-state text wraps correctly, banners (BT off / no network) render edge-to-edge.
- [ ] Rotate `SettingsActivity` portrait <-> landscape. Confirm theme chip group, crash-reporting switch, license link, and version footer reflow cleanly.
- [ ] Rotate `LicensesActivity`. RecyclerView should re-measure and license rows should stay legible.
- [ ] Rotate `WelcomeActivity` while on a non-zero page. Step indicator dots should re-build for the new orientation and the saved-instance-state-restored page index should match.
- [ ] Rotate `SetupWizardActivity` mid-flow (e.g., on step 2 with a selection made). Selection strokes, primary-action enablement, and step copy should survive recreation via `onSaveInstanceState`.
- [ ] Rotate `HelpActivity` with an FAQ expanded. Note: expanded state is not currently persisted, so the FAQ will collapse after rotation. Confirm this is the expected/acceptable behaviour before merge, or follow up by persisting expanded row IDs in `onSaveInstanceState`.
- [ ] Smoke `MainActivity`, `GamepadOverlayActivity`, `TouchpadOverlayActivity` to confirm no regression (these were not touched).

## Follow-ups out of scope

- If `MainActivity` is reported as one of the "weird layout" cases, consider adding `-land` layout variants or moving to ConstraintLayout-driven aspect-aware constraints, rather than removing its `configChanges`.
- `HelpActivity` expanded-FAQ state persistence (above).