### PR TITLE
USB Direct mode: native controller hot path, per-device rumble, connections UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -226,9 +226,8 @@ tasks.named("check") {
     dependsOn("nativeTest")
 }
 
-// 512m default OOMs SatelliteConnectionTest reflection cache; matches daemon heap.
 tasks.withType<Test>().configureEach {
-    maxHeapSize = "2g"
+    maxHeapSize = "512m"
 }
 
 val licensesOutputFile =

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
     <uses-feature android:name="android.hardware.faketouch" android:required="false" />
     <uses-feature android:name="android.hardware.gamepad" android:required="false" />
+    <uses-feature android:name="android.hardware.usb.host" android:required="false" />
 
     <!-- network_security_config denies cleartext as a belt-and-braces signal for Play's pre-launch checks. -->
     <application

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -58,7 +58,11 @@ target_compile_definitions(sodium_static PRIVATE
 target_compile_options(sodium_static PRIVATE -O2 -fvisibility=hidden -Wno-unused-function -Wno-unused-variable)
 
 # ── Main satellite library ──────────────────────────────────────────────────
-add_library(satellite SHARED satellite_jni.cpp gamepad_input.cpp)
+add_library(satellite SHARED
+    satellite_jni.cpp
+    gamepad_input.cpp
+    usb_host.cpp
+    usb_parsers.cpp)
 
 target_compile_options(satellite PRIVATE -O2 -Wall -Wextra -Wpedantic)
 target_link_options(satellite PRIVATE "-Wl,-z,max-page-size=16384")

--- a/app/src/main/cpp/dispatch.h
+++ b/app/src/main/cpp/dispatch.h
@@ -8,26 +8,14 @@
 
 namespace dispatch {
 
-// Default-constructs the device entry now, so the first hot-path applyUsbReport call doesn't
-// trigger an unordered_map node allocation under the devices mutex. Called from attach.
 void prewarmDevice(int32_t deviceId);
 
-// Copies the input/axis fields from `nu` into the device's tracked state under the existing
-// devices mutex, then runs the standard publishIfChanged path so a USB-host fast-lane report
-// flows out through the same encrypted-UDP send queue as a framework-routed event.
 void applyUsbReport(int32_t deviceId, const gamepad::DeviceState& nu);
 
-// Resets the device's tracked state to neutral and runs publishIfChanged so an unplug or
-// fast-lane teardown clears any held buttons on the satellite side.
 void resetAndPublish(int32_t deviceId);
 
-// Drops the device entry entirely. Use on USB detach so a future re-plug starts clean.
 void forgetDevice(int32_t deviceId);
 
-// Routes a decoded IMU sample (wire units) to the device's bound satellite session as MSG_MOTION.
-// No-ops if the device isn't bound to a satellite. The server only consumes it when the slot's
-// advertised caps include motion (i.e. the user's motion toggle is on), so this stays gated by the
-// existing caps/sink mechanism.
 void applyUsbMotion(int32_t deviceId, int16_t gyroX, int16_t gyroY, int16_t gyroZ, int16_t accelX,
                     int16_t accelY, int16_t accelZ, uint32_t timestampDeltaUs);
 

--- a/app/src/main/cpp/dispatch.h
+++ b/app/src/main/cpp/dispatch.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <stdint.h>
+
+#include "gamepad_input.h"
+
+namespace dispatch {
+
+// Default-constructs the device entry now, so the first hot-path applyUsbReport call doesn't
+// trigger an unordered_map node allocation under the devices mutex. Called from attach.
+void prewarmDevice(int32_t deviceId);
+
+// Copies the input/axis fields from `nu` into the device's tracked state under the existing
+// devices mutex, then runs the standard publishIfChanged path so a USB-host fast-lane report
+// flows out through the same encrypted-UDP send queue as a framework-routed event.
+void applyUsbReport(int32_t deviceId, const gamepad::DeviceState& nu);
+
+// Resets the device's tracked state to neutral and runs publishIfChanged so an unplug or
+// fast-lane teardown clears any held buttons on the satellite side.
+void resetAndPublish(int32_t deviceId);
+
+// Drops the device entry entirely. Use on USB detach so a future re-plug starts clean.
+void forgetDevice(int32_t deviceId);
+
+// Routes a decoded IMU sample (wire units) to the device's bound satellite session as MSG_MOTION.
+// No-ops if the device isn't bound to a satellite. The server only consumes it when the slot's
+// advertised caps include motion (i.e. the user's motion toggle is on), so this stays gated by the
+// existing caps/sink mechanism.
+void applyUsbMotion(int32_t deviceId, int16_t gyroX, int16_t gyroY, int16_t gyroZ, int16_t accelX,
+                    int16_t accelY, int16_t accelZ, uint32_t timestampDeltaUs);
+
+} // namespace dispatch

--- a/app/src/main/cpp/gamepad_input.h
+++ b/app/src/main/cpp/gamepad_input.h
@@ -72,8 +72,6 @@ struct DeviceState {
 
     float flatX = 0.f, flatY = 0.f, flatZ = 0.f, flatRZ = 0.f;
 
-    // Motion in wire units, filled by parsers that decode an on-controller IMU. Not part of
-    // consumePublishIfChanged (gamepad data); the USB poll loop ships these separately as MSG_MOTION.
     bool motionValid = false;
     int16_t gyroX = 0, gyroY = 0, gyroZ = 0;
     int16_t accelX = 0, accelY = 0, accelZ = 0;

--- a/app/src/main/cpp/gamepad_input.h
+++ b/app/src/main/cpp/gamepad_input.h
@@ -16,6 +16,7 @@ constexpr uint16_t XUSB_THUMB_L = 0x0040;
 constexpr uint16_t XUSB_THUMB_R = 0x0080;
 constexpr uint16_t XUSB_LB = 0x0100;
 constexpr uint16_t XUSB_RB = 0x0200;
+constexpr uint16_t XUSB_GUIDE = 0x0400;
 constexpr uint16_t XUSB_A = 0x1000;
 constexpr uint16_t XUSB_B = 0x2000;
 constexpr uint16_t XUSB_X = 0x4000;

--- a/app/src/main/cpp/gamepad_input.h
+++ b/app/src/main/cpp/gamepad_input.h
@@ -71,6 +71,12 @@ struct DeviceState {
     int16_t lastSLX = 0, lastSLY = 0, lastSRX = 0, lastSRY = 0;
 
     float flatX = 0.f, flatY = 0.f, flatZ = 0.f, flatRZ = 0.f;
+
+    // Motion in wire units, filled by parsers that decode an on-controller IMU. Not part of
+    // consumePublishIfChanged (gamepad data); the USB poll loop ships these separately as MSG_MOTION.
+    bool motionValid = false;
+    int16_t gyroX = 0, gyroY = 0, gyroZ = 0;
+    int16_t accelX = 0, accelY = 0, accelZ = 0;
 };
 
 int16_t scaleAxis(float v, float max);

--- a/app/src/main/cpp/satellite_jni.cpp
+++ b/app/src/main/cpp/satellite_jni.cpp
@@ -29,7 +29,10 @@
 #include <vector>
 #include <sodium.h>
 
+#include "dispatch.h"
 #include "gamepad_input.h"
+#include "usb_host.h"
+#include "usb_parsers.h"
 #include "wire_encoders.h"
 
 #define TAG "SatelliteJNI"
@@ -228,6 +231,56 @@ static void publishIfChanged(int32_t deviceId, DeviceState& s) {
         });
     }
 }
+
+namespace dispatch {
+
+void prewarmDevice(int32_t deviceId) {
+    std::lock_guard<std::mutex> lock(g_devicesMtx);
+    g_devices[deviceId];
+}
+
+void applyUsbReport(int32_t deviceId, const gamepad::DeviceState& nu) {
+    std::lock_guard<std::mutex> lock(g_devicesMtx);
+    auto& s = g_devices[deviceId];
+    s.wButtons = nu.wButtons;
+    s.bLT = nu.bLT;
+    s.bRT = nu.bRT;
+    s.sLX = nu.sLX;
+    s.sLY = nu.sLY;
+    s.sRX = nu.sRX;
+    s.sRY = nu.sRY;
+    publishIfChanged(deviceId, s);
+}
+
+void resetAndPublish(int32_t deviceId) {
+    std::lock_guard<std::mutex> lock(g_devicesMtx);
+    auto it = g_devices.find(deviceId);
+    if (it == g_devices.end()) return;
+    gamepad::resetState(it->second);
+    publishIfChanged(deviceId, it->second);
+}
+
+void forgetDevice(int32_t deviceId) {
+    std::lock_guard<std::mutex> lock(g_devicesMtx);
+    g_devices.erase(deviceId);
+}
+
+void applyUsbMotion(int32_t deviceId, int16_t gyroX, int16_t gyroY, int16_t gyroZ, int16_t accelX,
+                    int16_t accelY, int16_t accelZ, uint32_t timestampDeltaUs) {
+    std::lock_guard<std::mutex> lock(g_slotsMtx);
+    auto it = g_slots.find(deviceId);
+    if (it == g_slots.end()) return;
+    const SlotBinding& binding = it->second;
+    if (binding.kind != SLOT_SATELLITE) return;
+    auto session = getSession(binding.sessionHandle);
+    if (!session) return;
+    uint8_t payload[17];
+    dish_wire::encodeMotionPayload(payload, (uint8_t)(binding.controllerIndex & 0xFF), gyroX, gyroY,
+                                   gyroZ, accelX, accelY, accelZ, timestampDeltaUs);
+    sendEncrypted(session.get(), MSG_MOTION, payload, sizeof(payload));
+}
+
+} // namespace dispatch
 
 // Returning true consumes the event so it can't trigger incidental View focus navigation.
 static bool gamepadKeyFilter(const GameActivityKeyEvent* ev) {
@@ -910,6 +963,69 @@ Java_com_tinkernorth_dish_hotpath_input_RumbleBridge_nativeInstall(JNIEnv* env, 
             env->ExceptionClear();
         }
     }
+}
+
+// USB host fast-lane exports. The Kotlin side has already claimed the interface and given us a
+// usbdevfs fd from UsbDeviceConnection.getFileDescriptor(). From here the controller runs
+// entirely in C: URB submit/reap on a dedicated thread, decode, publishIfChanged into the
+// existing encrypted-UDP send path. No per-event JNI.
+//
+// Returns the synthetic deviceId (negative int) on success, or 0 on failure. Caller passes -1
+// as interfaceNumber to skip CLAIMINTERFACE if Kotlin already holds the interface lock.
+JNIEXPORT jint JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_attachUsbDevice(
+    JNIEnv*, jobject, jint fd, jint vid, jint pid, jint interfaceNumber, jint epIn,
+    jint epInMaxPacket, jint epOut) {
+    int dupFd = dup(fd);
+    if (dupFd < 0) {
+        LOGE("attachUsbDevice: dup(%d) failed: %s", fd, strerror(errno));
+        return 0;
+    }
+    usbhost::AttachResult r = usbhost::attachDevice(dupFd, (uint16_t)(vid & 0xFFFF),
+                                                    (uint16_t)(pid & 0xFFFF), interfaceNumber,
+                                                    (uint8_t)(epIn & 0xFF),
+                                                    (uint16_t)(epInMaxPacket & 0xFFFF),
+                                                    (uint8_t)(epOut & 0xFF));
+    return r.ok ? (jint)r.syntheticDeviceId : 0;
+}
+
+JNIEXPORT void JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_detachUsbDevice(
+    JNIEnv*, jobject, jint syntheticDeviceId) {
+    usbhost::detachDevice((int32_t)syntheticDeviceId);
+}
+
+// Cold-path lookup of a known controller model name by VID/PID — lets Kotlin show the friendly
+// product label ("Sony DualSense", "Xbox Series X|S Controller") even before the user grants USB
+// permission. Returns the empty string if the VID/PID isn't in our table; Kotlin falls back to
+// whatever the framework reports (UsbDevice.productName / InputDevice.name).
+JNIEXPORT jstring JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_lookupKnownModelName(
+    JNIEnv* env, jobject, jint vid, jint pid) {
+    const usbparsers::KnownDevice* k =
+        usbparsers::lookupKnown((uint16_t)(vid & 0xFFFF), (uint16_t)(pid & 0xFFFF));
+    return env->NewStringUTF(k ? k->name : "");
+}
+
+JNIEXPORT jboolean JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_isKnownFastLaneModel(
+    JNIEnv*, jobject, jint vid, jint pid) {
+    const usbparsers::KnownDevice* k =
+        usbparsers::lookupKnown((uint16_t)(vid & 0xFFFF), (uint16_t)(pid & 0xFFFF));
+    if (!k) return JNI_FALSE;
+    return k->parser != usbparsers::Parser::NONE ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_modelHasImu(
+    JNIEnv*, jobject, jint vid, jint pid) {
+    const usbparsers::KnownDevice* k =
+        usbparsers::lookupKnown((uint16_t)(vid & 0xFFFF), (uint16_t)(pid & 0xFFFF));
+    if (!k) return JNI_FALSE;
+    return usbparsers::parserHasImu(k->parser) ? JNI_TRUE : JNI_FALSE;
+}
+
+// Monotonic URB completion counter for the device. Kotlin samples this on a fixed interval and
+// derives an instantaneous Hz from the delta. The atomic read is wait-free; no JNI work on the
+// hot path itself.
+JNIEXPORT jlong JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_getDeviceUrbCount(
+    JNIEnv*, jobject, jint deviceId) {
+    return (jlong)usbhost::getUrbCount((int32_t)deviceId);
 }
 }
 

--- a/app/src/main/cpp/satellite_jni.cpp
+++ b/app/src/main/cpp/satellite_jni.cpp
@@ -884,6 +884,11 @@ Java_com_tinkernorth_dish_core_jni_SatelliteNative_clearAllPhysicalSlots(JNIEnv*
     g_slots.clear();
 }
 
+JNIEXPORT void JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_forgetPhysicalDevice(
+    JNIEnv*, jobject, jint deviceId) {
+    dispatch::forgetDevice((int32_t)deviceId);
+}
+
 JNIEXPORT void JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_setDeviceDeadzones(
     JNIEnv*, jobject, jint deviceId, jfloat flatX, jfloat flatY, jfloat flatZ, jfloat flatRZ) {
     std::lock_guard<std::mutex> lock(g_devicesMtx);
@@ -986,17 +991,21 @@ JNIEXPORT jint JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_attach
         LOGE("attachUsbDevice: dup(%d) failed: %s", fd, strerror(errno));
         return 0;
     }
-    usbhost::AttachResult r = usbhost::attachDevice(dupFd, (uint16_t)(vid & 0xFFFF),
-                                                    (uint16_t)(pid & 0xFFFF), interfaceNumber,
-                                                    (uint8_t)(epIn & 0xFF),
-                                                    (uint16_t)(epInMaxPacket & 0xFFFF),
-                                                    (uint8_t)(epOut & 0xFF));
+    usbhost::AttachResult r = usbhost::attachDevice(
+        dupFd, (uint16_t)(vid & 0xFFFF), (uint16_t)(pid & 0xFFFF), interfaceNumber,
+        (uint8_t)(epIn & 0xFF), (uint16_t)(epInMaxPacket & 0xFFFF), (uint8_t)(epOut & 0xFF));
     return r.ok ? (jint)r.syntheticDeviceId : 0;
 }
 
 JNIEXPORT void JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_detachUsbDevice(
     JNIEnv*, jobject, jint syntheticDeviceId) {
     usbhost::detachDevice((int32_t)syntheticDeviceId);
+}
+
+JNIEXPORT void JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_sendUsbRumble(
+    JNIEnv*, jobject, jint syntheticDeviceId, jint strong, jint weak) {
+    usbhost::sendRumble((int32_t)syntheticDeviceId, (uint16_t)(strong & 0xFFFF),
+                        (uint16_t)(weak & 0xFFFF));
 }
 
 JNIEXPORT jstring JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_lookupKnownModelName(

--- a/app/src/main/cpp/satellite_jni.cpp
+++ b/app/src/main/cpp/satellite_jni.cpp
@@ -232,6 +232,17 @@ static void publishIfChanged(int32_t deviceId, DeviceState& s) {
     }
 }
 
+// USB-direct reports skip gamepad::applyAxes, so the per-device flat (deadzone) is never applied; a
+// resting stick would otherwise stream jitter and drift. Radial hard cutoff, ~8% of int16 range.
+static constexpr int32_t kUsbStickDeadzone = 2600;
+static inline void applyUsbStickDeadzone(int16_t& x, int16_t& y) {
+    const int64_t mag2 = static_cast<int64_t>(x) * x + static_cast<int64_t>(y) * y;
+    if (mag2 < static_cast<int64_t>(kUsbStickDeadzone) * kUsbStickDeadzone) {
+        x = 0;
+        y = 0;
+    }
+}
+
 namespace dispatch {
 
 void prewarmDevice(int32_t deviceId) {
@@ -249,6 +260,8 @@ void applyUsbReport(int32_t deviceId, const gamepad::DeviceState& nu) {
     s.sLY = nu.sLY;
     s.sRX = nu.sRX;
     s.sRY = nu.sRY;
+    applyUsbStickDeadzone(s.sLX, s.sLY);
+    applyUsbStickDeadzone(s.sRX, s.sRY);
     publishIfChanged(deviceId, s);
 }
 
@@ -965,13 +978,6 @@ Java_com_tinkernorth_dish_hotpath_input_RumbleBridge_nativeInstall(JNIEnv* env, 
     }
 }
 
-// USB host fast-lane exports. The Kotlin side has already claimed the interface and given us a
-// usbdevfs fd from UsbDeviceConnection.getFileDescriptor(). From here the controller runs
-// entirely in C: URB submit/reap on a dedicated thread, decode, publishIfChanged into the
-// existing encrypted-UDP send path. No per-event JNI.
-//
-// Returns the synthetic deviceId (negative int) on success, or 0 on failure. Caller passes -1
-// as interfaceNumber to skip CLAIMINTERFACE if Kotlin already holds the interface lock.
 JNIEXPORT jint JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_attachUsbDevice(
     JNIEnv*, jobject, jint fd, jint vid, jint pid, jint interfaceNumber, jint epIn,
     jint epInMaxPacket, jint epOut) {
@@ -993,10 +999,6 @@ JNIEXPORT void JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_detach
     usbhost::detachDevice((int32_t)syntheticDeviceId);
 }
 
-// Cold-path lookup of a known controller model name by VID/PID — lets Kotlin show the friendly
-// product label ("Sony DualSense", "Xbox Series X|S Controller") even before the user grants USB
-// permission. Returns the empty string if the VID/PID isn't in our table; Kotlin falls back to
-// whatever the framework reports (UsbDevice.productName / InputDevice.name).
 JNIEXPORT jstring JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_lookupKnownModelName(
     JNIEnv* env, jobject, jint vid, jint pid) {
     const usbparsers::KnownDevice* k =
@@ -1020,9 +1022,6 @@ JNIEXPORT jboolean JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_mo
     return usbparsers::parserHasImu(k->parser) ? JNI_TRUE : JNI_FALSE;
 }
 
-// Monotonic URB completion counter for the device. Kotlin samples this on a fixed interval and
-// derives an instantaneous Hz from the delta. The atomic read is wait-free; no JNI work on the
-// hot path itself.
 JNIEXPORT jlong JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_getDeviceUrbCount(
     JNIEnv*, jobject, jint deviceId) {
     return (jlong)usbhost::getUrbCount((int32_t)deviceId);

--- a/app/src/main/cpp/usb_host.cpp
+++ b/app/src/main/cpp/usb_host.cpp
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "usb_host.h"
+
+#include <android/log.h>
+#include <linux/usbdevice_fs.h>
+#include <poll.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <time.h>
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "dispatch.h"
+#include "gamepad_input.h"
+#include "usb_parsers.h"
+
+#define TAG "SatelliteUsbHost"
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, TAG, __VA_ARGS__)
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, TAG, __VA_ARGS__)
+
+namespace usbhost {
+
+namespace {
+
+struct DeviceCtx {
+    int32_t syntheticDeviceId = 0;
+    int fd = -1;
+    uint16_t vid = 0;
+    uint16_t pid = 0;
+    uint8_t epIn = 0;
+    uint16_t epInMaxPacket = 64;
+    uint8_t epOut = 0;
+    int interfaceNumber = 0;
+    usbparsers::Parser parser = usbparsers::Parser::NONE;
+    std::string modelName;
+    std::string parserName;
+    usbparsers::StickAutoRange stickRange;
+
+    // Monotonic-clock timestamp (ns) of the last MSG_MOTION shipped for this device, used for the
+    // inter-sample delta and rate limiting. 0 until the first motion sample.
+    int64_t lastMotionNs = 0;
+
+    // Successful URB completions since attach. Read by Kotlin's PollRateSampler at a fixed
+    // interval to derive the measured Hz; the delta-over-time approach gives a true sampled
+    // rate that includes whatever stalls or coalescing the kernel and the device introduce.
+    std::atomic<uint64_t> urbCount{0};
+
+    std::atomic<bool> stop{false};
+    std::thread poller;
+};
+
+std::mutex g_mtx;
+std::unordered_map<int32_t, std::shared_ptr<DeviceCtx>> g_devices;
+std::atomic<int32_t> g_nextSyntheticId{-1000};
+
+int32_t allocSyntheticId() {
+    return g_nextSyntheticId.fetch_sub(1, std::memory_order_relaxed);
+}
+
+// Number of URBs kept in flight per device. Two is enough to eliminate the gap between
+// REAP and the next SUBMIT for any HID gamepad we target (highest declared bInterval is 1 ms);
+// a third URB never gets filled in steady state because by the time it's queued the kernel has
+// already redelivered the one we just resubmitted.
+static constexpr int kInFlightUrbs = 2;
+
+// Minimum spacing between MSG_MOTION sends per device (~125 Hz). Caps the motion stream so a
+// high-rate IMU (DS4/DualSense report far above the Switch's rate) can't flood the UDP queue;
+// the input reports themselves are never throttled.
+static constexpr int64_t kMotionMinIntervalNs = 8000000;
+
+// usbdevfs_urb carries a trailing flexible array (iso_frame_desc[]), so it cannot be embedded as
+// a value inside another struct. We hold a separate heap-allocated urb per slot via unique_ptr;
+// HID interrupt URBs never populate iso_frame_desc, so the default-constructed zero-sized tail
+// is what the kernel expects.
+struct UrbSlot {
+    std::unique_ptr<usbdevfs_urb> urb;
+    std::vector<uint8_t> buf;
+    bool pending = false;
+};
+
+void pollLoop(std::shared_ptr<DeviceCtx> ctx) {
+    std::unique_ptr<UrbSlot> slotStorage[kInFlightUrbs];
+    UrbSlot* slots[kInFlightUrbs];
+    for (int i = 0; i < kInFlightUrbs; i++) {
+        slotStorage[i] = std::make_unique<UrbSlot>();
+        slotStorage[i]->urb = std::make_unique<usbdevfs_urb>();
+        slotStorage[i]->buf.resize(ctx->epInMaxPacket);
+        slots[i] = slotStorage[i].get();
+    }
+
+    auto submitSlot = [&](UrbSlot& s) -> bool {
+        memset(s.urb.get(), 0, sizeof(*s.urb));
+        s.urb->type = USBDEVFS_URB_TYPE_INTERRUPT;
+        s.urb->endpoint = ctx->epIn;
+        s.urb->buffer = s.buf.data();
+        s.urb->buffer_length = (int)s.buf.size();
+        if (ioctl(ctx->fd, USBDEVFS_SUBMITURB, s.urb.get()) < 0) {
+            LOGE("dev=%d SUBMITURB(ep=0x%02X) failed: %s", ctx->syntheticDeviceId, ctx->epIn,
+                 strerror(errno));
+            return false;
+        }
+        s.pending = true;
+        return true;
+    };
+
+    int initial = 0;
+    for (int i = 0; i < kInFlightUrbs; i++) {
+        if (!submitSlot(*slots[i])) break;
+        initial++;
+    }
+    if (initial == 0) {
+        LOGE("dev=%d initial submit failed, exiting poll loop", ctx->syntheticDeviceId);
+        return;
+    }
+
+    gamepad::DeviceState scratch{};
+    bool running = true;
+
+    while (running && !ctx->stop.load(std::memory_order_relaxed)) {
+        struct pollfd pfd = {};
+        pfd.fd = ctx->fd;
+        pfd.events = POLLOUT;
+        // The 100 ms timeout bounds stop-flag latency. URBs wake poll the instant the kernel
+        // marks the device fd writable, so this timeout never gates per-event latency.
+        int pr = poll(&pfd, 1, 100);
+        if (ctx->stop.load(std::memory_order_relaxed)) break;
+        if (pr < 0) {
+            if (errno == EINTR) continue;
+            LOGE("dev=%d poll failed: %s", ctx->syntheticDeviceId, strerror(errno));
+            break;
+        }
+        if (pr == 0) continue;
+
+        // Drain every completed URB before going back to poll. The kernel may have completed
+        // multiple in the time we were asleep; reaping all of them in one wake keeps the
+        // pipeline saturated and avoids extra poll syscalls per report.
+        while (running) {
+            usbdevfs_urb* reaped = nullptr;
+            int r = ioctl(ctx->fd, USBDEVFS_REAPURBNDELAY, &reaped);
+            if (r < 0) {
+                if (errno == EAGAIN) break;
+                LOGE("dev=%d REAPURB failed: %s", ctx->syntheticDeviceId, strerror(errno));
+                running = false;
+                break;
+            }
+            if (reaped == nullptr) break;
+
+            UrbSlot* completed = nullptr;
+            for (int i = 0; i < kInFlightUrbs; i++) {
+                if (slots[i]->urb.get() == reaped) {
+                    completed = slots[i];
+                    break;
+                }
+            }
+            if (completed == nullptr) continue;
+            completed->pending = false;
+
+            if (reaped->status == -ENODEV) {
+                LOGI("dev=%d disappeared (ENODEV), exiting poll loop", ctx->syntheticDeviceId);
+                running = false;
+                break;
+            }
+
+            if (reaped->status == 0 && reaped->actual_length > 0) {
+                ctx->urbCount.fetch_add(1, std::memory_order_relaxed);
+                memset(&scratch, 0, sizeof(scratch));
+                if (usbparsers::decodeReport(ctx->parser, completed->buf.data(),
+                                             (size_t)reaped->actual_length, scratch,
+                                             &ctx->stickRange)) {
+                    dispatch::applyUsbReport(ctx->syntheticDeviceId, scratch);
+
+                    if (scratch.motionValid) {
+                        struct timespec ts;
+                        clock_gettime(CLOCK_MONOTONIC, &ts);
+                        int64_t nowNs = (int64_t)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+                        if (ctx->lastMotionNs == 0 ||
+                            nowNs - ctx->lastMotionNs >= kMotionMinIntervalNs) {
+                            uint32_t deltaUs =
+                                ctx->lastMotionNs == 0
+                                    ? 0
+                                    : (uint32_t)((nowNs - ctx->lastMotionNs) / 1000);
+                            ctx->lastMotionNs = nowNs;
+                            dispatch::applyUsbMotion(ctx->syntheticDeviceId, scratch.gyroX,
+                                                     scratch.gyroY, scratch.gyroZ, scratch.accelX,
+                                                     scratch.accelY, scratch.accelZ, deltaUs);
+                        }
+                    }
+                }
+            }
+
+            if (!submitSlot(*completed)) {
+                running = false;
+                break;
+            }
+        }
+    }
+
+    int pendingCount = 0;
+    for (int i = 0; i < kInFlightUrbs; i++) {
+        if (slots[i]->pending) {
+            ioctl(ctx->fd, USBDEVFS_DISCARDURB, slots[i]->urb.get());
+            pendingCount++;
+        }
+    }
+    while (pendingCount > 0) {
+        usbdevfs_urb* dummy = nullptr;
+        if (ioctl(ctx->fd, USBDEVFS_REAPURB, &dummy) < 0) break;
+        pendingCount--;
+    }
+    LOGI("dev=%d poll loop exited", ctx->syntheticDeviceId);
+}
+
+void shutdownLocked(const std::shared_ptr<DeviceCtx>& ctx) {
+    ctx->stop.store(true, std::memory_order_relaxed);
+    if (ctx->poller.joinable()) {
+        // Joining outside the map lock would race with attach; the poll thread only ever
+        // ever touches ctx + dispatch, never g_mtx, so holding it here is safe.
+        ctx->poller.join();
+    }
+    if (ctx->interfaceNumber >= 0) {
+        unsigned int iface = (unsigned int)ctx->interfaceNumber;
+        ioctl(ctx->fd, USBDEVFS_RELEASEINTERFACE, &iface);
+    }
+    if (ctx->fd >= 0) {
+        ::close(ctx->fd);
+    }
+}
+
+constexpr int kProbeMaxReads = 16;
+constexpr unsigned kProbeReadTimeoutMs = 80;
+constexpr int kProbeMaxTimeouts = 4;
+
+// Returns true if the device emits a report our parser recognises within a short window.
+// attachDevice uses this to avoid stealing a controller from the framework path when we can't
+// actually decode it: on failure the interface is released so the controller stays on Android's
+// standard input instead of being claimed into a dead Direct-mode card. Uses synchronous bulk
+// reads (usbfs routes these to interrupt endpoints, like the init writes) to avoid managing async
+// URB lifetimes here.
+bool probeDecodable(int fd, uint8_t epIn, uint16_t epInMaxPacket, usbparsers::Parser parser) {
+    std::vector<uint8_t> buf(epInMaxPacket == 0 ? 64 : epInMaxPacket);
+    gamepad::DeviceState scratch{};
+    usbparsers::StickAutoRange probeSticks;
+    int consecutiveTimeouts = 0;
+    for (int i = 0; i < kProbeMaxReads; i++) {
+        struct usbdevfs_bulktransfer xfer = {};
+        xfer.ep = epIn;
+        xfer.len = (unsigned int)buf.size();
+        xfer.timeout = kProbeReadTimeoutMs;
+        xfer.data = buf.data();
+        int n = ioctl(fd, USBDEVFS_BULK, &xfer);
+        if (n <= 0) {
+            if (++consecutiveTimeouts >= kProbeMaxTimeouts) break;
+            continue;
+        }
+        consecutiveTimeouts = 0;
+        memset(&scratch, 0, sizeof(scratch));
+        if (usbparsers::decodeReport(parser, buf.data(), (size_t)n, scratch, &probeSticks)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+AttachResult attachDevice(int fd, uint16_t vid, uint16_t pid, int interfaceNumber, uint8_t epIn,
+                          uint16_t epInMaxPacket, uint8_t epOut) {
+    AttachResult out;
+
+    const usbparsers::KnownDevice* known = usbparsers::lookupKnown(vid, pid);
+    std::string modelName;
+    usbparsers::Parser parser = usbparsers::Parser::NONE;
+    usbparsers::InitKind init = usbparsers::InitKind::NONE;
+    if (known) {
+        modelName = known->name;
+        parser = known->parser;
+        init = known->init;
+    } else {
+        modelName = "USB controller";
+        parser = usbparsers::Parser::GENERIC_HID_GAMEPAD;
+    }
+
+    // We expect Kotlin to have already called UsbDeviceConnection.claimInterface(force=true);
+    // CLAIMINTERFACE here is idempotent (returns EBUSY if already held by our process, which is
+    // fine). Without claiming, USBDEVFS_SUBMITURB fails with EBUSY because the kernel HID driver
+    // holds the interface.
+    if (interfaceNumber >= 0) {
+        unsigned int iface = (unsigned int)interfaceNumber;
+        if (ioctl(fd, USBDEVFS_CLAIMINTERFACE, &iface) < 0 && errno != EBUSY) {
+            LOGE("CLAIMINTERFACE %d failed: %s", interfaceNumber, strerror(errno));
+            ::close(fd);
+            return out;
+        }
+    }
+
+    if (!usbparsers::runInit(fd, epOut, parser, init)) {
+        LOGI("attach %04X:%04X (%s): init failed, falling back to routed", vid, pid,
+             modelName.c_str());
+        if (interfaceNumber >= 0) {
+            unsigned int iface = (unsigned int)interfaceNumber;
+            ioctl(fd, USBDEVFS_RELEASEINTERFACE, &iface);
+        }
+        ::close(fd);
+        return out;
+    }
+
+    if (!probeDecodable(fd, epIn, epInMaxPacket, parser)) {
+        LOGI("attach %04X:%04X (%s): no parseable reports, releasing to framework", vid, pid,
+             modelName.c_str());
+        if (interfaceNumber >= 0) {
+            unsigned int iface = (unsigned int)interfaceNumber;
+            ioctl(fd, USBDEVFS_RELEASEINTERFACE, &iface);
+        }
+        ::close(fd);
+        return out;
+    }
+
+    auto ctx = std::make_shared<DeviceCtx>();
+    ctx->syntheticDeviceId = allocSyntheticId();
+    ctx->fd = fd;
+    ctx->vid = vid;
+    ctx->pid = pid;
+    ctx->epIn = epIn;
+    ctx->epInMaxPacket = epInMaxPacket == 0 ? 64 : epInMaxPacket;
+    ctx->epOut = epOut;
+    ctx->interfaceNumber = interfaceNumber;
+    ctx->parser = parser;
+    ctx->modelName = modelName;
+    ctx->parserName = usbparsers::parserName(parser);
+
+    {
+        std::lock_guard<std::mutex> lock(g_mtx);
+        g_devices[ctx->syntheticDeviceId] = ctx;
+    }
+
+    dispatch::prewarmDevice(ctx->syntheticDeviceId);
+
+    ctx->poller = std::thread(pollLoop, ctx);
+
+    LOGI("attach ok: %04X:%04X (%s) dev=%d parser=%s ep=0x%02X max=%u", vid, pid,
+         modelName.c_str(), ctx->syntheticDeviceId, ctx->parserName.c_str(), ctx->epIn,
+         (unsigned)ctx->epInMaxPacket);
+
+    out.syntheticDeviceId = ctx->syntheticDeviceId;
+    out.ok = true;
+    return out;
+}
+
+void detachDevice(int32_t syntheticDeviceId) {
+    std::shared_ptr<DeviceCtx> ctx;
+    {
+        std::lock_guard<std::mutex> lock(g_mtx);
+        auto it = g_devices.find(syntheticDeviceId);
+        if (it == g_devices.end()) return;
+        ctx = it->second;
+        g_devices.erase(it);
+    }
+    if (!ctx) return;
+    shutdownLocked(ctx);
+    dispatch::resetAndPublish(syntheticDeviceId);
+    dispatch::forgetDevice(syntheticDeviceId);
+    LOGI("detach dev=%d (%s) done", syntheticDeviceId, ctx->modelName.c_str());
+}
+
+uint64_t getUrbCount(int32_t deviceId) {
+    std::lock_guard<std::mutex> lock(g_mtx);
+    auto it = g_devices.find(deviceId);
+    if (it == g_devices.end()) return 0;
+    return it->second->urbCount.load(std::memory_order_relaxed);
+}
+
+} // namespace usbhost

--- a/app/src/main/cpp/usb_host.cpp
+++ b/app/src/main/cpp/usb_host.cpp
@@ -41,11 +41,16 @@ struct DeviceCtx {
     usbparsers::Parser parser = usbparsers::Parser::NONE;
     std::string modelName;
     std::string parserName;
-    usbparsers::StickAutoRange stickRange;
+    usbparsers::ParserState stickRange;
 
     int64_t lastMotionNs = 0;
 
     std::atomic<uint64_t> urbCount{0};
+
+    // Guards rumble writes to epOut against the detach that closes fd; outSeq is the output report
+    // counter for protocols that carry one (Xbox One serial, Switch Pro packet number).
+    std::mutex outMtx;
+    uint8_t outSeq = 0;
 
     std::atomic<bool> stop{false};
     std::thread poller;
@@ -55,9 +60,7 @@ std::mutex g_mtx;
 std::unordered_map<int32_t, std::shared_ptr<DeviceCtx>> g_devices;
 std::atomic<int32_t> g_nextSyntheticId{-1000};
 
-int32_t allocSyntheticId() {
-    return g_nextSyntheticId.fetch_sub(1, std::memory_order_relaxed);
-}
+int32_t allocSyntheticId() { return g_nextSyntheticId.fetch_sub(1, std::memory_order_relaxed); }
 
 // Number of URBs kept in flight per device. Two is enough to eliminate the gap between
 // REAP and the next SUBMIT for any HID gamepad we target (highest declared bInterval is 1 ms);
@@ -172,10 +175,9 @@ void pollLoop(std::shared_ptr<DeviceCtx> ctx) {
                         int64_t nowNs = (int64_t)ts.tv_sec * 1000000000LL + ts.tv_nsec;
                         if (ctx->lastMotionNs == 0 ||
                             nowNs - ctx->lastMotionNs >= kMotionMinIntervalNs) {
-                            uint32_t deltaUs =
-                                ctx->lastMotionNs == 0
-                                    ? 0
-                                    : (uint32_t)((nowNs - ctx->lastMotionNs) / 1000);
+                            uint32_t deltaUs = ctx->lastMotionNs == 0
+                                                   ? 0
+                                                   : (uint32_t)((nowNs - ctx->lastMotionNs) / 1000);
                             ctx->lastMotionNs = nowNs;
                             dispatch::applyUsbMotion(ctx->syntheticDeviceId, scratch.gyroX,
                                                      scratch.gyroY, scratch.gyroZ, scratch.accelX,
@@ -211,15 +213,18 @@ void shutdownLocked(const std::shared_ptr<DeviceCtx>& ctx) {
     ctx->stop.store(true, std::memory_order_relaxed);
     if (ctx->poller.joinable()) {
         // Joining outside the map lock would race with attach; the poll thread only ever
-        // ever touches ctx + dispatch, never g_mtx, so holding it here is safe.
+        // touches ctx + dispatch, never g_mtx, so holding it here is safe.
         ctx->poller.join();
     }
+    // outMtx so an in-flight sendRumble finishes before the fd it is writing to is closed.
+    std::lock_guard<std::mutex> lock(ctx->outMtx);
     if (ctx->interfaceNumber >= 0) {
         unsigned int iface = (unsigned int)ctx->interfaceNumber;
         ioctl(ctx->fd, USBDEVFS_RELEASEINTERFACE, &iface);
     }
     if (ctx->fd >= 0) {
         ::close(ctx->fd);
+        ctx->fd = -1;
     }
 }
 
@@ -230,7 +235,7 @@ constexpr int kProbeMaxTimeouts = 4;
 bool probeDecodable(int fd, uint8_t epIn, uint16_t epInMaxPacket, usbparsers::Parser parser) {
     std::vector<uint8_t> buf(epInMaxPacket == 0 ? 64 : epInMaxPacket);
     gamepad::DeviceState scratch{};
-    usbparsers::StickAutoRange probeSticks;
+    usbparsers::ParserState probeSticks;
     int consecutiveTimeouts = 0;
     for (int i = 0; i < kProbeMaxReads; i++) {
         struct usbdevfs_bulktransfer xfer = {};
@@ -328,9 +333,8 @@ AttachResult attachDevice(int fd, uint16_t vid, uint16_t pid, int interfaceNumbe
 
     ctx->poller = std::thread(pollLoop, ctx);
 
-    LOGI("attach ok: %04X:%04X (%s) dev=%d parser=%s ep=0x%02X max=%u", vid, pid,
-         modelName.c_str(), ctx->syntheticDeviceId, ctx->parserName.c_str(), ctx->epIn,
-         (unsigned)ctx->epInMaxPacket);
+    LOGI("attach ok: %04X:%04X (%s) dev=%d parser=%s ep=0x%02X max=%u", vid, pid, modelName.c_str(),
+         ctx->syntheticDeviceId, ctx->parserName.c_str(), ctx->epIn, (unsigned)ctx->epInMaxPacket);
 
     out.syntheticDeviceId = ctx->syntheticDeviceId;
     out.ok = true;
@@ -358,6 +362,21 @@ uint64_t getUrbCount(int32_t deviceId) {
     auto it = g_devices.find(deviceId);
     if (it == g_devices.end()) return 0;
     return it->second->urbCount.load(std::memory_order_relaxed);
+}
+
+void sendRumble(int32_t syntheticDeviceId, uint16_t strong, uint16_t weak) {
+    std::shared_ptr<DeviceCtx> ctx;
+    {
+        std::lock_guard<std::mutex> lock(g_mtx);
+        auto it = g_devices.find(syntheticDeviceId);
+        if (it == g_devices.end()) return;
+        ctx = it->second;
+    }
+    if (!ctx) return;
+    std::lock_guard<std::mutex> lock(ctx->outMtx);
+    if (ctx->fd < 0) return;
+    uint8_t seq = ctx->outSeq++;
+    usbparsers::runRumble(ctx->fd, ctx->epOut, ctx->parser, strong, weak, seq);
 }
 
 } // namespace usbhost

--- a/app/src/main/cpp/usb_host.cpp
+++ b/app/src/main/cpp/usb_host.cpp
@@ -43,13 +43,8 @@ struct DeviceCtx {
     std::string parserName;
     usbparsers::StickAutoRange stickRange;
 
-    // Monotonic-clock timestamp (ns) of the last MSG_MOTION shipped for this device, used for the
-    // inter-sample delta and rate limiting. 0 until the first motion sample.
     int64_t lastMotionNs = 0;
 
-    // Successful URB completions since attach. Read by Kotlin's PollRateSampler at a fixed
-    // interval to derive the measured Hz; the delta-over-time approach gives a true sampled
-    // rate that includes whatever stalls or coalescing the kernel and the device introduce.
     std::atomic<uint64_t> urbCount{0};
 
     std::atomic<bool> stop{false};
@@ -127,8 +122,6 @@ void pollLoop(std::shared_ptr<DeviceCtx> ctx) {
         struct pollfd pfd = {};
         pfd.fd = ctx->fd;
         pfd.events = POLLOUT;
-        // The 100 ms timeout bounds stop-flag latency. URBs wake poll the instant the kernel
-        // marks the device fd writable, so this timeout never gates per-event latency.
         int pr = poll(&pfd, 1, 100);
         if (ctx->stop.load(std::memory_order_relaxed)) break;
         if (pr < 0) {
@@ -138,9 +131,6 @@ void pollLoop(std::shared_ptr<DeviceCtx> ctx) {
         }
         if (pr == 0) continue;
 
-        // Drain every completed URB before going back to poll. The kernel may have completed
-        // multiple in the time we were asleep; reaping all of them in one wake keeps the
-        // pipeline saturated and avoids extra poll syscalls per report.
         while (running) {
             usbdevfs_urb* reaped = nullptr;
             int r = ioctl(ctx->fd, USBDEVFS_REAPURBNDELAY, &reaped);
@@ -237,12 +227,6 @@ constexpr int kProbeMaxReads = 16;
 constexpr unsigned kProbeReadTimeoutMs = 80;
 constexpr int kProbeMaxTimeouts = 4;
 
-// Returns true if the device emits a report our parser recognises within a short window.
-// attachDevice uses this to avoid stealing a controller from the framework path when we can't
-// actually decode it: on failure the interface is released so the controller stays on Android's
-// standard input instead of being claimed into a dead Direct-mode card. Uses synchronous bulk
-// reads (usbfs routes these to interrupt endpoints, like the init writes) to avoid managing async
-// URB lifetimes here.
 bool probeDecodable(int fd, uint8_t epIn, uint16_t epInMaxPacket, usbparsers::Parser parser) {
     std::vector<uint8_t> buf(epInMaxPacket == 0 ? 64 : epInMaxPacket);
     gamepad::DeviceState scratch{};

--- a/app/src/main/cpp/usb_host.h
+++ b/app/src/main/cpp/usb_host.h
@@ -19,4 +19,6 @@ void detachDevice(int32_t syntheticDeviceId);
 
 uint64_t getUrbCount(int32_t deviceId);
 
+void sendRumble(int32_t syntheticDeviceId, uint16_t strong, uint16_t weak);
+
 } // namespace usbhost

--- a/app/src/main/cpp/usb_host.h
+++ b/app/src/main/cpp/usb_host.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <stdint.h>
+#include <string>
+
+namespace usbhost {
+
+struct AttachResult {
+    int32_t syntheticDeviceId = 0;
+    bool ok = false;
+};
+
+AttachResult attachDevice(int fd, uint16_t vid, uint16_t pid, int interfaceNumber,
+                          uint8_t endpointIn, uint16_t endpointInMaxPacket, uint8_t endpointOut);
+
+void detachDevice(int32_t syntheticDeviceId);
+
+uint64_t getUrbCount(int32_t deviceId);
+
+} // namespace usbhost

--- a/app/src/main/cpp/usb_parsers.cpp
+++ b/app/src/main/cpp/usb_parsers.cpp
@@ -32,30 +32,13 @@ using gamepad::XUSB_THUMB_R;
 using gamepad::XUSB_X;
 using gamepad::XUSB_Y;
 
-// VID/PID table. Order is informational; lookupKnown does a linear scan since the table is small
-// and only consulted on plug-in (cold path).
-//
-// Categories:
-//   XINPUT_360       Microsoft Xbox 360 wire protocol. Most "PC gamepads" emulate this when set
-//                    to XInput mode (Logitech F310/F710/F510, 8BitDo, PowerA, Hori, Mad Catz,
-//                    PDP, Razer, Afterglow, Thrustmaster, etc.).
-//   XBOX_ONE_GIP     Microsoft GIP protocol used by Xbox One / Series / Elite / Adaptive
-//                    controllers when wired.
-//   DUALSHOCK4       Sony PS4 controllers (CUH-ZCT1/2, Nacon, Razer, Hori PS4 sticks).
-//   DUALSENSE        Sony PS5 controllers.
-//   SWITCH_PRO_USB   Nintendo Switch Pro Controller. Sends the USB handshake + set-report-mode
-//                    sequence on attach, then decodes the 0x30 standard full report.
-//   STADIA           Google Stadia controller (HID gamepad with extras).
-//   GENERIC_HID_GAMEPAD  Best-effort fallback for unrecognised HID gamepads.
 static const KnownDevice kKnown[] = {
-    // ── Microsoft Xbox 360 ────────────────────────────────────────────────
     {0x045E, 0x028E, "Xbox 360 Controller", Parser::XINPUT_360, InitKind::NONE},
     {0x045E, 0x028F, "Xbox 360 Wireless Receiver (wired)", Parser::XINPUT_360, InitKind::NONE},
     {0x045E, 0x02A1, "Xbox 360 Wireless Controller (PC)", Parser::XINPUT_360, InitKind::NONE},
     {0x045E, 0x0291, "Xbox 360 Wireless Receiver (rev 1)", Parser::XINPUT_360, InitKind::NONE},
     {0x045E, 0x0719, "Xbox 360 Wireless Receiver (rev 2)", Parser::XINPUT_360, InitKind::NONE},
 
-    // ── Microsoft Xbox One / Series / Elite (GIP) ────────────────────────
     {0x045E, 0x02D1, "Xbox One Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
     {0x045E, 0x02DD, "Xbox One Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
     {0x045E, 0x02E3, "Xbox One Elite Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
@@ -68,7 +51,6 @@ static const KnownDevice kKnown[] = {
     {0x045E, 0x0B13, "Xbox Series X|S Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
     {0x045E, 0x0B22, "Xbox Adaptive Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
 
-    // ── Logitech F-Series (XInput mode) ──────────────────────────────────
     {0x046D, 0xC218, "Logitech F310 (XInput)", Parser::XINPUT_360, InitKind::NONE},
     {0x046D, 0xC219, "Logitech F710 (XInput)", Parser::XINPUT_360, InitKind::NONE},
     {0x046D, 0xC21D, "Logitech F310 (XInput)", Parser::XINPUT_360, InitKind::NONE},
@@ -76,7 +58,6 @@ static const KnownDevice kKnown[] = {
     {0x046D, 0xC21F, "Logitech F710 (XInput)", Parser::XINPUT_360, InitKind::NONE},
     {0x046D, 0xCAA3, "Logitech G29 Driving Force (XInput)", Parser::XINPUT_360, InitKind::NONE},
 
-    // ── 8BitDo (XInput mode) ─────────────────────────────────────────────
     {0x2DC8, 0x9000, "8BitDo Pro 2", Parser::XINPUT_360, InitKind::NONE},
     {0x2DC8, 0x9001, "8BitDo SN30 Pro", Parser::XINPUT_360, InitKind::NONE},
     {0x2DC8, 0x9003, "8BitDo SN30 Pro+", Parser::XINPUT_360, InitKind::NONE},
@@ -84,7 +65,6 @@ static const KnownDevice kKnown[] = {
     {0x2DC8, 0x6101, "8BitDo Ultimate (XInput)", Parser::XINPUT_360, InitKind::NONE},
     {0x2DC8, 0x6001, "8BitDo M30", Parser::XINPUT_360, InitKind::NONE},
 
-    // ── PowerA / PDP / Hori / Mad Catz (Xbox 360 protocol) ───────────────
     {0x0738, 0x4716, "Mad Catz Xbox 360 Controller", Parser::XINPUT_360, InitKind::NONE},
     {0x0738, 0x4726, "Mad Catz Xbox 360 Controller", Parser::XINPUT_360, InitKind::NONE},
     {0x0738, 0x4728, "Mad Catz Street Fighter IV FightPad", Parser::XINPUT_360, InitKind::NONE},
@@ -120,7 +100,6 @@ static const KnownDevice kKnown[] = {
     {0x24C6, 0x551A, "PowerA FUSION Pro Controller", Parser::XINPUT_360, InitKind::NONE},
     {0x24C6, 0x561A, "PowerA FUSION Controller", Parser::XINPUT_360, InitKind::NONE},
 
-    // ── PowerA / Hori / PDP Xbox One ────────────────────────────────────
     {0x0E6F, 0x0139, "Afterglow Prismatic Wired Xbox One", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
     {0x0E6F, 0x013B, "PDP Xbox One Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
     {0x0E6F, 0x0146, "Rock Candy Xbox One", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
@@ -140,7 +119,6 @@ static const KnownDevice kKnown[] = {
     {0x24C6, 0x791A, "PowerA Fusion FightPad", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
     {0x1532, 0x0A03, "Razer Wildcat", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
 
-    // ── Sony DualShock 4 / PS4 family ───────────────────────────────────
     {0x054C, 0x05C4, "Sony DualShock 4 (CUH-ZCT1)", Parser::DUALSHOCK4, InitKind::NONE},
     {0x054C, 0x09CC, "Sony DualShock 4 v2 (CUH-ZCT2)", Parser::DUALSHOCK4, InitKind::NONE},
     {0x054C, 0x0BA0, "Sony DualShock 4 USB Wireless Adapter", Parser::DUALSHOCK4, InitKind::NONE},
@@ -158,16 +136,13 @@ static const KnownDevice kKnown[] = {
     {0x1532, 0x1200, "Razer Raiju Ultimate", Parser::DUALSHOCK4, InitKind::NONE},
     {0x7545, 0x0104, "Armor3 Armor Titan", Parser::DUALSHOCK4, InitKind::NONE},
 
-    // ── Sony DualSense / PS5 family ─────────────────────────────────────
     {0x054C, 0x0CE6, "Sony DualSense", Parser::DUALSENSE, InitKind::NONE},
     {0x054C, 0x0DF2, "Sony DualSense Edge", Parser::DUALSENSE, InitKind::NONE},
 
-    // ── Nintendo Switch Pro ─────────────────────────────────────────────
     {0x057E, 0x2009, "Nintendo Switch Pro Controller", Parser::SWITCH_PRO_USB, InitKind::SWITCH_PRO_HANDSHAKE},
     {0x057E, 0x200E, "Nintendo Joy-Con Charging Grip", Parser::SWITCH_PRO_USB, InitKind::SWITCH_PRO_HANDSHAKE},
     {0x057E, 0x2017, "Nintendo SNES Online Controller", Parser::SWITCH_PRO_USB, InitKind::SWITCH_PRO_HANDSHAKE},
 
-    // ── Google Stadia ───────────────────────────────────────────────────
     {0x18D1, 0x9400, "Google Stadia Controller", Parser::STADIA, InitKind::NONE},
 };
 
@@ -201,13 +176,11 @@ const char* parserName(Parser p) {
 }
 
 bool parserHasImu(Parser p) {
-    // Extend as IMU parsing lands for each family (DualShock 4, DualSense next).
     return p == Parser::SWITCH_PRO_USB;
 }
 
 namespace {
 
-// Bulk-write helper used for init handshakes. Returns true if all bytes were accepted.
 bool bulkWrite(int fd, uint8_t epOut, const uint8_t* data, size_t len, unsigned timeoutMs) {
     if (epOut == 0) return false;
     struct usbdevfs_bulktransfer xfer = {};
@@ -236,17 +209,25 @@ int16_t scaleU8Centered(uint8_t v, bool invert) {
 // asymmetric: scaling both sides by one shared reach leaves the smaller side short of the rail.
 // Each side stretches its own learned reach to the full extent, so every direction can hit the
 // edge. Center stays at the nominal 2048.
+// Inner deadzone in the raw 12-bit domain. The Switch Pro's stick center wanders per unit (a resting
+// stick can sit a few hundred counts off 2048) and we read no factory calibration, so without this
+// the auto-range amplifies that offset into large resting drift. Counts within the deadzone read as
+// center; the throw beyond it is auto-ranged to full scale.
+static constexpr int32_t kSwitchStickRawDeadzone = 320;
+
 int16_t scaleSwitchStickAuto(uint16_t raw12, AxisAutoRange& axis) {
     int32_t centered = (int32_t)raw12 - 2048;
+    int32_t mag = centered >= 0 ? centered : -centered;
+    if (mag <= kSwitchStickRawDeadzone) return 0;
+    int32_t adj = mag - kSwitchStickRawDeadzone;
     if (centered >= 0) {
-        if (centered > axis.posReach) axis.posReach = centered;
-        int32_t scaled = (centered * 32767) / axis.posReach;
+        if (adj > axis.posReach) axis.posReach = adj;
+        int32_t scaled = (adj * 32767) / axis.posReach;
         if (scaled > 32767) scaled = 32767;
         return (int16_t)scaled;
     }
-    int32_t mag = -centered;
-    if (mag > axis.negReach) axis.negReach = mag;
-    int32_t scaled = (mag * 32768) / axis.negReach;
+    if (adj > axis.negReach) axis.negReach = adj;
+    int32_t scaled = (adj * 32768) / axis.negReach;
     if (scaled > 32768) scaled = 32768;
     return (int16_t)(-scaled);
 }

--- a/app/src/main/cpp/usb_parsers.cpp
+++ b/app/src/main/cpp/usb_parsers.cpp
@@ -1,0 +1,634 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "usb_parsers.h"
+
+#include <android/log.h>
+#include <linux/usbdevice_fs.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <algorithm>
+
+#define TAG "SatelliteUsbParse"
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, TAG, __VA_ARGS__)
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, TAG, __VA_ARGS__)
+
+namespace usbparsers {
+
+using gamepad::DeviceState;
+using gamepad::XUSB_A;
+using gamepad::XUSB_B;
+using gamepad::XUSB_BACK;
+using gamepad::XUSB_DPAD_DOWN;
+using gamepad::XUSB_DPAD_LEFT;
+using gamepad::XUSB_DPAD_RIGHT;
+using gamepad::XUSB_DPAD_UP;
+using gamepad::XUSB_LB;
+using gamepad::XUSB_RB;
+using gamepad::XUSB_START;
+using gamepad::XUSB_THUMB_L;
+using gamepad::XUSB_THUMB_R;
+using gamepad::XUSB_X;
+using gamepad::XUSB_Y;
+
+// VID/PID table. Order is informational; lookupKnown does a linear scan since the table is small
+// and only consulted on plug-in (cold path).
+//
+// Categories:
+//   XINPUT_360       Microsoft Xbox 360 wire protocol. Most "PC gamepads" emulate this when set
+//                    to XInput mode (Logitech F310/F710/F510, 8BitDo, PowerA, Hori, Mad Catz,
+//                    PDP, Razer, Afterglow, Thrustmaster, etc.).
+//   XBOX_ONE_GIP     Microsoft GIP protocol used by Xbox One / Series / Elite / Adaptive
+//                    controllers when wired.
+//   DUALSHOCK4       Sony PS4 controllers (CUH-ZCT1/2, Nacon, Razer, Hori PS4 sticks).
+//   DUALSENSE        Sony PS5 controllers.
+//   SWITCH_PRO_USB   Nintendo Switch Pro Controller. Sends the USB handshake + set-report-mode
+//                    sequence on attach, then decodes the 0x30 standard full report.
+//   STADIA           Google Stadia controller (HID gamepad with extras).
+//   GENERIC_HID_GAMEPAD  Best-effort fallback for unrecognised HID gamepads.
+static const KnownDevice kKnown[] = {
+    // ── Microsoft Xbox 360 ────────────────────────────────────────────────
+    {0x045E, 0x028E, "Xbox 360 Controller", Parser::XINPUT_360, InitKind::NONE},
+    {0x045E, 0x028F, "Xbox 360 Wireless Receiver (wired)", Parser::XINPUT_360, InitKind::NONE},
+    {0x045E, 0x02A1, "Xbox 360 Wireless Controller (PC)", Parser::XINPUT_360, InitKind::NONE},
+    {0x045E, 0x0291, "Xbox 360 Wireless Receiver (rev 1)", Parser::XINPUT_360, InitKind::NONE},
+    {0x045E, 0x0719, "Xbox 360 Wireless Receiver (rev 2)", Parser::XINPUT_360, InitKind::NONE},
+
+    // ── Microsoft Xbox One / Series / Elite (GIP) ────────────────────────
+    {0x045E, 0x02D1, "Xbox One Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x045E, 0x02DD, "Xbox One Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x045E, 0x02E3, "Xbox One Elite Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x045E, 0x02EA, "Xbox One S Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x045E, 0x02FD, "Xbox One S Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x045E, 0x0B00, "Xbox Elite Series 2 Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x045E, 0x0B05, "Xbox Elite Series 2 Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x045E, 0x0B0A, "Xbox Adaptive Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x045E, 0x0B12, "Xbox Series X|S Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x045E, 0x0B13, "Xbox Series X|S Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x045E, 0x0B22, "Xbox Adaptive Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+
+    // ── Logitech F-Series (XInput mode) ──────────────────────────────────
+    {0x046D, 0xC218, "Logitech F310 (XInput)", Parser::XINPUT_360, InitKind::NONE},
+    {0x046D, 0xC219, "Logitech F710 (XInput)", Parser::XINPUT_360, InitKind::NONE},
+    {0x046D, 0xC21D, "Logitech F310 (XInput)", Parser::XINPUT_360, InitKind::NONE},
+    {0x046D, 0xC21E, "Logitech F510 (XInput)", Parser::XINPUT_360, InitKind::NONE},
+    {0x046D, 0xC21F, "Logitech F710 (XInput)", Parser::XINPUT_360, InitKind::NONE},
+    {0x046D, 0xCAA3, "Logitech G29 Driving Force (XInput)", Parser::XINPUT_360, InitKind::NONE},
+
+    // ── 8BitDo (XInput mode) ─────────────────────────────────────────────
+    {0x2DC8, 0x9000, "8BitDo Pro 2", Parser::XINPUT_360, InitKind::NONE},
+    {0x2DC8, 0x9001, "8BitDo SN30 Pro", Parser::XINPUT_360, InitKind::NONE},
+    {0x2DC8, 0x9003, "8BitDo SN30 Pro+", Parser::XINPUT_360, InitKind::NONE},
+    {0x2DC8, 0x310A, "8BitDo Pro 2 (XInput)", Parser::XINPUT_360, InitKind::NONE},
+    {0x2DC8, 0x6101, "8BitDo Ultimate (XInput)", Parser::XINPUT_360, InitKind::NONE},
+    {0x2DC8, 0x6001, "8BitDo M30", Parser::XINPUT_360, InitKind::NONE},
+
+    // ── PowerA / PDP / Hori / Mad Catz (Xbox 360 protocol) ───────────────
+    {0x0738, 0x4716, "Mad Catz Xbox 360 Controller", Parser::XINPUT_360, InitKind::NONE},
+    {0x0738, 0x4726, "Mad Catz Xbox 360 Controller", Parser::XINPUT_360, InitKind::NONE},
+    {0x0738, 0x4728, "Mad Catz Street Fighter IV FightPad", Parser::XINPUT_360, InitKind::NONE},
+    {0x0738, 0x4736, "Mad Catz MicroCon Gamepad", Parser::XINPUT_360, InitKind::NONE},
+    {0x0738, 0x4738, "Mad Catz Wired Xbox 360 Controller (SFIV)", Parser::XINPUT_360, InitKind::NONE},
+    {0x0738, 0x4740, "Mad Catz Beat Pad", Parser::XINPUT_360, InitKind::NONE},
+    {0x0738, 0xCB02, "Saitek Cyborg Rumble Pad PC/Xbox 360", Parser::XINPUT_360, InitKind::NONE},
+    {0x0E6F, 0x0105, "HSM3 Xbox360 dancepad", Parser::XINPUT_360, InitKind::NONE},
+    {0x0E6F, 0x0113, "Afterglow AX.1 Gamepad for Xbox 360", Parser::XINPUT_360, InitKind::NONE},
+    {0x0E6F, 0x011F, "Rock Candy Wired Controller for Xbox 360", Parser::XINPUT_360, InitKind::NONE},
+    {0x0E6F, 0x0301, "Logic3 Controller", Parser::XINPUT_360, InitKind::NONE},
+    {0x0E6F, 0x0401, "Logic3 Controller", Parser::XINPUT_360, InitKind::NONE},
+    {0x0E6F, 0x0413, "Afterglow AX.1 Gen 2 for Xbox 360", Parser::XINPUT_360, InitKind::NONE},
+    {0x0E6F, 0x0501, "PDP Xbox 360 Controller", Parser::XINPUT_360, InitKind::NONE},
+    {0x0F0D, 0x000A, "Hori Co. DOA4 FightStick", Parser::XINPUT_360, InitKind::NONE},
+    {0x0F0D, 0x000D, "Hori Fighting Stick EX2", Parser::XINPUT_360, InitKind::NONE},
+    {0x0F0D, 0x0016, "Hori Real Arcade Pro.EX", Parser::XINPUT_360, InitKind::NONE},
+    {0x0F0D, 0x001B, "Hori Real Arcade Pro VX", Parser::XINPUT_360, InitKind::NONE},
+    {0x1038, 0x1430, "SteelSeries Stratus Duo", Parser::XINPUT_360, InitKind::NONE},
+    {0x1038, 0x1431, "SteelSeries Stratus Duo", Parser::XINPUT_360, InitKind::NONE},
+    {0x12AB, 0x0004, "PowerA Pro Ex", Parser::XINPUT_360, InitKind::NONE},
+    {0x12AB, 0x0301, "PDP AFTERGLOW AX.1", Parser::XINPUT_360, InitKind::NONE},
+    {0x1532, 0x0037, "Razer Sabertooth", Parser::XINPUT_360, InitKind::NONE},
+    {0x1532, 0x0A00, "Razer Atrox Arcade Stick", Parser::XINPUT_360, InitKind::NONE},
+    {0x24C6, 0x5000, "Razer Atrox Arcade Stick", Parser::XINPUT_360, InitKind::NONE},
+    {0x24C6, 0x5300, "PowerA MINI PROEX", Parser::XINPUT_360, InitKind::NONE},
+    {0x24C6, 0x5303, "Xbox Airflo Wired Controller", Parser::XINPUT_360, InitKind::NONE},
+    {0x24C6, 0x5500, "Hori XBOX 360 EX 2 with Turbo", Parser::XINPUT_360, InitKind::NONE},
+    {0x24C6, 0x5501, "Hori Real Arcade Pro VX-SA", Parser::XINPUT_360, InitKind::NONE},
+    {0x24C6, 0x5506, "Hori SOULCALIBUR V Stick", Parser::XINPUT_360, InitKind::NONE},
+    {0x24C6, 0x550D, "Hori GEM Xbox controller", Parser::XINPUT_360, InitKind::NONE},
+    {0x24C6, 0x550E, "Hori Real Arcade Pro V Kai 360", Parser::XINPUT_360, InitKind::NONE},
+    {0x24C6, 0x551A, "PowerA FUSION Pro Controller", Parser::XINPUT_360, InitKind::NONE},
+    {0x24C6, 0x561A, "PowerA FUSION Controller", Parser::XINPUT_360, InitKind::NONE},
+
+    // ── PowerA / Hori / PDP Xbox One ────────────────────────────────────
+    {0x0E6F, 0x0139, "Afterglow Prismatic Wired Xbox One", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x0E6F, 0x013B, "PDP Xbox One Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x0E6F, 0x0146, "Rock Candy Xbox One", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x0E6F, 0x0161, "PDP Xbox One Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x0E6F, 0x0162, "PDP Xbox One Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x0E6F, 0x0163, "PDP Xbox One Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x0E6F, 0x0164, "PDP Battlefield One", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x0E6F, 0x0165, "PDP Titanfall 2", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x0F0D, 0x0063, "Hori Real Arcade Pro Hayabusa (Xbox One)", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x0F0D, 0x0067, "Hori HORIPAD ONE", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x0F0D, 0x0078, "Hori Real Arcade Pro V Kai (Xbox One)", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x24C6, 0x541A, "PowerA Xbox One Mini Wired", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x24C6, 0x542A, "Xbox 360 Pro EX Controller (XOne)", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x24C6, 0x543A, "PowerA Xbox One Wired", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x24C6, 0x551A, "PowerA FUSION Pro Wired Xbox One", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x24C6, 0x561A, "PowerA FUSION Wired Xbox One", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x24C6, 0x791A, "PowerA Fusion FightPad", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x1532, 0x0A03, "Razer Wildcat", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+
+    // ── Sony DualShock 4 / PS4 family ───────────────────────────────────
+    {0x054C, 0x05C4, "Sony DualShock 4 (CUH-ZCT1)", Parser::DUALSHOCK4, InitKind::NONE},
+    {0x054C, 0x09CC, "Sony DualShock 4 v2 (CUH-ZCT2)", Parser::DUALSHOCK4, InitKind::NONE},
+    {0x054C, 0x0BA0, "Sony DualShock 4 USB Wireless Adapter", Parser::DUALSHOCK4, InitKind::NONE},
+    {0x0F0D, 0x005C, "Hori Real Arcade Pro 4", Parser::DUALSHOCK4, InitKind::NONE},
+    {0x0F0D, 0x005E, "Hori Fighting Commander PS4", Parser::DUALSHOCK4, InitKind::NONE},
+    {0x0F0D, 0x008C, "Hori Real Arcade Pro 4 V", Parser::DUALSHOCK4, InitKind::NONE},
+    {0x0F0D, 0x00EE, "Hori Wired Mini PS4 Controller", Parser::DUALSHOCK4, InitKind::NONE},
+    {0x146B, 0x0D01, "Nacon Revolution Pro Controller", Parser::DUALSHOCK4, InitKind::NONE},
+    {0x146B, 0x0D02, "Nacon Revolution Pro Controller v2", Parser::DUALSHOCK4, InitKind::NONE},
+    {0x146B, 0x0D08, "Nacon Daija Arcade Stick", Parser::DUALSHOCK4, InitKind::NONE},
+    {0x146B, 0x0D10, "Nacon Revolution Infinite", Parser::DUALSHOCK4, InitKind::NONE},
+    {0x1532, 0x0401, "Razer Panthera Arcade Stick", Parser::DUALSHOCK4, InitKind::NONE},
+    {0x1532, 0x1000, "Razer Raiju", Parser::DUALSHOCK4, InitKind::NONE},
+    {0x1532, 0x1100, "Razer Raiju Tournament", Parser::DUALSHOCK4, InitKind::NONE},
+    {0x1532, 0x1200, "Razer Raiju Ultimate", Parser::DUALSHOCK4, InitKind::NONE},
+    {0x7545, 0x0104, "Armor3 Armor Titan", Parser::DUALSHOCK4, InitKind::NONE},
+
+    // ── Sony DualSense / PS5 family ─────────────────────────────────────
+    {0x054C, 0x0CE6, "Sony DualSense", Parser::DUALSENSE, InitKind::NONE},
+    {0x054C, 0x0DF2, "Sony DualSense Edge", Parser::DUALSENSE, InitKind::NONE},
+
+    // ── Nintendo Switch Pro ─────────────────────────────────────────────
+    {0x057E, 0x2009, "Nintendo Switch Pro Controller", Parser::SWITCH_PRO_USB, InitKind::SWITCH_PRO_HANDSHAKE},
+    {0x057E, 0x200E, "Nintendo Joy-Con Charging Grip", Parser::SWITCH_PRO_USB, InitKind::SWITCH_PRO_HANDSHAKE},
+    {0x057E, 0x2017, "Nintendo SNES Online Controller", Parser::SWITCH_PRO_USB, InitKind::SWITCH_PRO_HANDSHAKE},
+
+    // ── Google Stadia ───────────────────────────────────────────────────
+    {0x18D1, 0x9400, "Google Stadia Controller", Parser::STADIA, InitKind::NONE},
+};
+
+const KnownDevice* lookupKnown(uint16_t vid, uint16_t pid) {
+    for (const auto& d : kKnown) {
+        if (d.vid == vid && d.pid == pid) return &d;
+    }
+    return nullptr;
+}
+
+const char* parserName(Parser p) {
+    switch (p) {
+    case Parser::XINPUT_360:
+        return "Xbox 360 protocol";
+    case Parser::XBOX_ONE_GIP:
+        return "Xbox One protocol";
+    case Parser::DUALSHOCK4:
+        return "DualShock 4 protocol";
+    case Parser::DUALSENSE:
+        return "DualSense protocol";
+    case Parser::SWITCH_PRO_USB:
+        return "Switch Pro protocol";
+    case Parser::STADIA:
+        return "Stadia protocol";
+    case Parser::GENERIC_HID_GAMEPAD:
+        return "Generic HID gamepad";
+    case Parser::NONE:
+        return "Unknown";
+    }
+    return "Unknown";
+}
+
+bool parserHasImu(Parser p) {
+    // Extend as IMU parsing lands for each family (DualShock 4, DualSense next).
+    return p == Parser::SWITCH_PRO_USB;
+}
+
+namespace {
+
+// Bulk-write helper used for init handshakes. Returns true if all bytes were accepted.
+bool bulkWrite(int fd, uint8_t epOut, const uint8_t* data, size_t len, unsigned timeoutMs) {
+    if (epOut == 0) return false;
+    struct usbdevfs_bulktransfer xfer = {};
+    xfer.ep = epOut;
+    xfer.len = (unsigned int)len;
+    xfer.timeout = timeoutMs;
+    xfer.data = (void*)data;
+    int n = ioctl(fd, USBDEVFS_BULK, &xfer);
+    if (n < 0) {
+        LOGE("USBDEVFS_BULK out to 0x%02X failed: %s", epOut, strerror(errno));
+        return false;
+    }
+    return (size_t)n == len;
+}
+
+int16_t scaleU8Centered(uint8_t v, bool invert) {
+    int32_t s = invert ? (128 - (int32_t)v) : ((int32_t)v - 128);
+    int32_t scaled = s * 257;
+    if (scaled > 32767) scaled = 32767;
+    if (scaled < -32768) scaled = -32768;
+    return (int16_t)scaled;
+}
+
+// Maps a 12-bit Switch stick value (centered near 2048) to a full-range XUSB axis. The push and
+// pull sides of each axis are auto-ranged independently because a Pro Controller's throw is usually
+// asymmetric: scaling both sides by one shared reach leaves the smaller side short of the rail.
+// Each side stretches its own learned reach to the full extent, so every direction can hit the
+// edge. Center stays at the nominal 2048.
+int16_t scaleSwitchStickAuto(uint16_t raw12, AxisAutoRange& axis) {
+    int32_t centered = (int32_t)raw12 - 2048;
+    if (centered >= 0) {
+        if (centered > axis.posReach) axis.posReach = centered;
+        int32_t scaled = (centered * 32767) / axis.posReach;
+        if (scaled > 32767) scaled = 32767;
+        return (int16_t)scaled;
+    }
+    int32_t mag = -centered;
+    if (mag > axis.negReach) axis.negReach = mag;
+    int32_t scaled = (mag * 32768) / axis.negReach;
+    if (scaled > 32768) scaled = 32768;
+    return (int16_t)(-scaled);
+}
+
+int16_t rdLe16(const uint8_t* b, int off) {
+    return (int16_t)((uint16_t)b[off] | ((uint16_t)b[off + 1] << 8));
+}
+
+// Switch Pro IMU default scaling (no factory calibration yet). SDL uses gyro = raw / 14.2842 deg/s
+// and accel = raw / 4096 g; the wire format wants deg/s / 2000 * 32767 and g / 4 * 32767, so the
+// combined integer factors are 32767/28568 (gyro) and 32767/16384 (accel).
+int16_t switchGyroToWire(int16_t raw) {
+    int64_t wire = (int64_t)raw * 32767 / 28568;
+    if (wire > 32767) wire = 32767;
+    if (wire < -32768) wire = -32768;
+    return (int16_t)wire;
+}
+
+int16_t switchAccelToWire(int16_t raw) {
+    int64_t wire = (int64_t)raw * 32767 / 16384;
+    if (wire > 32767) wire = 32767;
+    if (wire < -32768) wire = -32768;
+    return (int16_t)wire;
+}
+
+uint16_t setDpadFromHat(uint16_t buttons, uint8_t hat) {
+    buttons = (uint16_t)(buttons & ~(XUSB_DPAD_UP | XUSB_DPAD_DOWN | XUSB_DPAD_LEFT | XUSB_DPAD_RIGHT));
+    switch (hat & 0x0F) {
+    case 0:
+        buttons |= XUSB_DPAD_UP;
+        break;
+    case 1:
+        buttons |= (uint16_t)(XUSB_DPAD_UP | XUSB_DPAD_RIGHT);
+        break;
+    case 2:
+        buttons |= XUSB_DPAD_RIGHT;
+        break;
+    case 3:
+        buttons |= (uint16_t)(XUSB_DPAD_DOWN | XUSB_DPAD_RIGHT);
+        break;
+    case 4:
+        buttons |= XUSB_DPAD_DOWN;
+        break;
+    case 5:
+        buttons |= (uint16_t)(XUSB_DPAD_DOWN | XUSB_DPAD_LEFT);
+        break;
+    case 6:
+        buttons |= XUSB_DPAD_LEFT;
+        break;
+    case 7:
+        buttons |= (uint16_t)(XUSB_DPAD_UP | XUSB_DPAD_LEFT);
+        break;
+    default:
+        break;
+    }
+    return buttons;
+}
+
+// Xbox 360 wired interrupt-IN report. Fixed 20 bytes; byte 0 is report type (0x00 for input),
+// byte 1 is the length. Stick axes are little-endian int16, triggers are 8-bit unsigned.
+bool decodeXInput360(const uint8_t* buf, size_t len, DeviceState& s) {
+    if (len < 14) return false;
+    if (buf[0] != 0x00) return false;
+
+    uint16_t b = 0;
+    if (buf[2] & 0x01) b |= XUSB_DPAD_UP;
+    if (buf[2] & 0x02) b |= XUSB_DPAD_DOWN;
+    if (buf[2] & 0x04) b |= XUSB_DPAD_LEFT;
+    if (buf[2] & 0x08) b |= XUSB_DPAD_RIGHT;
+    if (buf[2] & 0x10) b |= XUSB_START;
+    if (buf[2] & 0x20) b |= XUSB_BACK;
+    if (buf[2] & 0x40) b |= XUSB_THUMB_L;
+    if (buf[2] & 0x80) b |= XUSB_THUMB_R;
+    if (buf[3] & 0x01) b |= XUSB_LB;
+    if (buf[3] & 0x02) b |= XUSB_RB;
+    if (buf[3] & 0x10) b |= XUSB_A;
+    if (buf[3] & 0x20) b |= XUSB_B;
+    if (buf[3] & 0x40) b |= XUSB_X;
+    if (buf[3] & 0x80) b |= XUSB_Y;
+    s.wButtons = b;
+
+    s.bLT = buf[4];
+    s.bRT = buf[5];
+
+    s.sLX = (int16_t)((uint16_t)buf[6] | ((uint16_t)buf[7] << 8));
+    s.sLY = (int16_t)((uint16_t)buf[8] | ((uint16_t)buf[9] << 8));
+    s.sRX = (int16_t)((uint16_t)buf[10] | ((uint16_t)buf[11] << 8));
+    s.sRY = (int16_t)((uint16_t)buf[12] | ((uint16_t)buf[13] << 8));
+    return true;
+}
+
+// Xbox One GIP input report 0x20. Triggers are 10-bit little-endian (0..1023); scaled to XUSB's
+// 0..255 below. Sticks are little-endian int16, same convention as XInput.
+bool decodeXboxOneGip(const uint8_t* buf, size_t len, DeviceState& s) {
+    if (len < 18) return false;
+    if (buf[0] != 0x20) return false;
+
+    uint16_t b = 0;
+    if (buf[4] & 0x04) b |= XUSB_START;
+    if (buf[4] & 0x08) b |= XUSB_BACK;
+    if (buf[4] & 0x10) b |= XUSB_A;
+    if (buf[4] & 0x20) b |= XUSB_B;
+    if (buf[4] & 0x40) b |= XUSB_X;
+    if (buf[4] & 0x80) b |= XUSB_Y;
+    if (buf[5] & 0x01) b |= XUSB_DPAD_UP;
+    if (buf[5] & 0x02) b |= XUSB_DPAD_DOWN;
+    if (buf[5] & 0x04) b |= XUSB_DPAD_LEFT;
+    if (buf[5] & 0x08) b |= XUSB_DPAD_RIGHT;
+    if (buf[5] & 0x10) b |= XUSB_LB;
+    if (buf[5] & 0x20) b |= XUSB_RB;
+    if (buf[5] & 0x40) b |= XUSB_THUMB_L;
+    if (buf[5] & 0x80) b |= XUSB_THUMB_R;
+    s.wButtons = b;
+
+    uint16_t lt = (uint16_t)buf[6] | ((uint16_t)buf[7] << 8);
+    uint16_t rt = (uint16_t)buf[8] | ((uint16_t)buf[9] << 8);
+    if (lt > 1023) lt = 1023;
+    if (rt > 1023) rt = 1023;
+    s.bLT = (uint8_t)((lt * 255) / 1023);
+    s.bRT = (uint8_t)((rt * 255) / 1023);
+
+    s.sLX = (int16_t)((uint16_t)buf[10] | ((uint16_t)buf[11] << 8));
+    s.sLY = (int16_t)((uint16_t)buf[12] | ((uint16_t)buf[13] << 8));
+    s.sRX = (int16_t)((uint16_t)buf[14] | ((uint16_t)buf[15] << 8));
+    s.sRY = (int16_t)((uint16_t)buf[16] | ((uint16_t)buf[17] << 8));
+    return true;
+}
+
+// DualShock 4 USB report 0x01. Sticks are uint8 with 128 = center. Y axes are down-positive so
+// they're inverted to match XUSB's up-positive convention. Face buttons are remapped to the
+// XInput "muscle memory" positions: Cross is A, Circle is B, Square is X, Triangle is Y.
+bool decodeDualShock4(const uint8_t* buf, size_t len, DeviceState& s) {
+    if (len < 10) return false;
+    if (buf[0] != 0x01) return false;
+
+    s.sLX = scaleU8Centered(buf[1], false);
+    s.sLY = scaleU8Centered(buf[2], true);
+    s.sRX = scaleU8Centered(buf[3], false);
+    s.sRY = scaleU8Centered(buf[4], true);
+
+    uint16_t b = 0;
+    if (buf[5] & 0x10) b |= XUSB_X;      // Square
+    if (buf[5] & 0x20) b |= XUSB_A;      // Cross
+    if (buf[5] & 0x40) b |= XUSB_B;      // Circle
+    if (buf[5] & 0x80) b |= XUSB_Y;      // Triangle
+    if (buf[6] & 0x01) b |= XUSB_LB;     // L1
+    if (buf[6] & 0x02) b |= XUSB_RB;     // R1
+    if (buf[6] & 0x10) b |= XUSB_BACK;   // Share
+    if (buf[6] & 0x20) b |= XUSB_START;  // Options
+    if (buf[6] & 0x40) b |= XUSB_THUMB_L;
+    if (buf[6] & 0x80) b |= XUSB_THUMB_R;
+    b = setDpadFromHat(b, buf[5] & 0x0F);
+    s.wButtons = b;
+
+    s.bLT = buf[8];
+    s.bRT = buf[9];
+    return true;
+}
+
+// DualSense USB report 0x01. Same axis conventions as DS4 but the byte layout shifts: triggers
+// move to bytes 5/6 and the button bytes are at 8/9/10.
+bool decodeDualSense(const uint8_t* buf, size_t len, DeviceState& s) {
+    if (len < 11) return false;
+    if (buf[0] != 0x01) return false;
+
+    s.sLX = scaleU8Centered(buf[1], false);
+    s.sLY = scaleU8Centered(buf[2], true);
+    s.sRX = scaleU8Centered(buf[3], false);
+    s.sRY = scaleU8Centered(buf[4], true);
+
+    s.bLT = buf[5];
+    s.bRT = buf[6];
+
+    uint16_t b = 0;
+    if (buf[8] & 0x10) b |= XUSB_X;      // Square
+    if (buf[8] & 0x20) b |= XUSB_A;      // Cross
+    if (buf[8] & 0x40) b |= XUSB_B;      // Circle
+    if (buf[8] & 0x80) b |= XUSB_Y;      // Triangle
+    if (buf[9] & 0x01) b |= XUSB_LB;
+    if (buf[9] & 0x02) b |= XUSB_RB;
+    if (buf[9] & 0x10) b |= XUSB_BACK;   // Create
+    if (buf[9] & 0x20) b |= XUSB_START;  // Options
+    if (buf[9] & 0x40) b |= XUSB_THUMB_L;
+    if (buf[9] & 0x80) b |= XUSB_THUMB_R;
+    b = setDpadFromHat(b, buf[8] & 0x0F);
+    s.wButtons = b;
+    return true;
+}
+
+// Switch Pro standard full input report 0x30 over USB. Buttons are split across three bytes
+// (right/shared/left) and sticks are packed 12-bit values. The XUSB mapping matches by physical
+// position rather than label, the same convention used for DualShock 4: Switch A (right face) →
+// XUSB_B (right face), Switch B (bottom) → XUSB_A (bottom), Switch X (top) → XUSB_Y, Switch Y
+// (left) → XUSB_X. This is what PC games and ViGEm expect.
+bool decodeSwitchProUsb(const uint8_t* buf, size_t len, DeviceState& s, StickAutoRange& sticks) {
+    if (len < 12) return false;
+    if (buf[0] != 0x30) return false;
+
+    const uint8_t br = buf[3];
+    const uint8_t bs = buf[4];
+    const uint8_t bl = buf[5];
+
+    uint16_t b = 0;
+    if (br & 0x01) b |= XUSB_X;     // Y label (left position) → XUSB X
+    if (br & 0x02) b |= XUSB_Y;     // X label (top position) → XUSB Y
+    if (br & 0x04) b |= XUSB_A;     // B label (bottom position) → XUSB A
+    if (br & 0x08) b |= XUSB_B;     // A label (right position) → XUSB B
+    if (br & 0x40) b |= XUSB_RB;
+    if (bs & 0x01) b |= XUSB_BACK;  // Minus
+    if (bs & 0x02) b |= XUSB_START; // Plus
+    if (bs & 0x04) b |= XUSB_THUMB_R;
+    if (bs & 0x08) b |= XUSB_THUMB_L;
+    if (bl & 0x01) b |= XUSB_DPAD_DOWN;
+    if (bl & 0x02) b |= XUSB_DPAD_UP;
+    if (bl & 0x04) b |= XUSB_DPAD_RIGHT;
+    if (bl & 0x08) b |= XUSB_DPAD_LEFT;
+    if (bl & 0x40) b |= XUSB_LB;
+    s.wButtons = b;
+
+    // ZL/ZR are digital on the Pro, so triggers are either fully pressed or released.
+    s.bLT = (bl & 0x80) ? 255 : 0;
+    s.bRT = (br & 0x80) ? 255 : 0;
+
+    const uint16_t lx = (uint16_t)buf[6] | (((uint16_t)buf[7] & 0x0F) << 8);
+    const uint16_t ly = ((uint16_t)buf[7] >> 4) | ((uint16_t)buf[8] << 4);
+    const uint16_t rx = (uint16_t)buf[9] | (((uint16_t)buf[10] & 0x0F) << 8);
+    const uint16_t ry = ((uint16_t)buf[10] >> 4) | ((uint16_t)buf[11] << 4);
+
+    s.sLX = scaleSwitchStickAuto(lx, sticks.lx);
+    s.sLY = scaleSwitchStickAuto(ly, sticks.ly);
+    s.sRX = scaleSwitchStickAuto(rx, sticks.rx);
+    s.sRY = scaleSwitchStickAuto(ry, sticks.ry);
+
+    // IMU: three 12-byte frames start at byte 13 (accel int16 LE at +0/+2/+4, gyro at +6/+8/+10).
+    // Use the first frame. Straight axis mapping; signs may need an on-device flip to match the
+    // wire convention.
+    if (len >= 25) {
+        s.accelX = switchAccelToWire(rdLe16(buf, 13));
+        s.accelY = switchAccelToWire(rdLe16(buf, 15));
+        s.accelZ = switchAccelToWire(rdLe16(buf, 17));
+        s.gyroX = switchGyroToWire(rdLe16(buf, 19));
+        s.gyroY = switchGyroToWire(rdLe16(buf, 21));
+        s.gyroZ = switchGyroToWire(rdLe16(buf, 23));
+        s.motionValid = true;
+    }
+    return true;
+}
+
+// Stadia controller HID report 0x03 (basic gamepad layout).
+bool decodeStadia(const uint8_t* buf, size_t len, DeviceState& s) {
+    if (len < 11) return false;
+    if (buf[0] != 0x03) return false;
+    s.sLX = scaleU8Centered(buf[1], false);
+    s.sLY = scaleU8Centered(buf[2], true);
+    s.sRX = scaleU8Centered(buf[3], false);
+    s.sRY = scaleU8Centered(buf[4], true);
+    s.bLT = buf[5];
+    s.bRT = buf[6];
+    uint16_t b = 0;
+    if (buf[8] & 0x40) b |= XUSB_A;
+    if (buf[8] & 0x20) b |= XUSB_B;
+    if (buf[8] & 0x10) b |= XUSB_X;
+    if (buf[8] & 0x08) b |= XUSB_Y;
+    if (buf[8] & 0x04) b |= XUSB_LB;
+    if (buf[8] & 0x02) b |= XUSB_RB;
+    if (buf[9] & 0x80) b |= XUSB_START;
+    if (buf[9] & 0x40) b |= XUSB_BACK;
+    if (buf[9] & 0x20) b |= XUSB_THUMB_L;
+    if (buf[9] & 0x10) b |= XUSB_THUMB_R;
+    b = setDpadFromHat(b, buf[7] & 0x0F);
+    s.wButtons = b;
+    return true;
+}
+
+} // namespace
+
+bool decodeReport(Parser p, const uint8_t* buf, size_t len, DeviceState& s, StickAutoRange* sticks) {
+    switch (p) {
+    case Parser::XINPUT_360:
+        return decodeXInput360(buf, len, s);
+    case Parser::XBOX_ONE_GIP:
+        return decodeXboxOneGip(buf, len, s);
+    case Parser::DUALSHOCK4:
+        return decodeDualShock4(buf, len, s);
+    case Parser::DUALSENSE:
+        return decodeDualSense(buf, len, s);
+    case Parser::SWITCH_PRO_USB:
+        return sticks != nullptr && decodeSwitchProUsb(buf, len, s, *sticks);
+    case Parser::STADIA:
+        return decodeStadia(buf, len, s);
+    case Parser::GENERIC_HID_GAMEPAD:
+        return decodeGenericHidGamepad(buf, len, s);
+    case Parser::NONE:
+        return false;
+    }
+    return false;
+}
+
+bool decodeGenericHidGamepad(const uint8_t* buf, size_t len, DeviceState& s) {
+    // Conservative shape check: most generic HID gamepads produce reports >= 7 bytes (4 axes,
+    // hat+buttons low/high). Anything shorter probably isn't gamepad-shaped; bail rather than
+    // publish noise.
+    if (len < 7) return false;
+    s.sLX = scaleU8Centered(buf[0], false);
+    s.sLY = scaleU8Centered(buf[1], true);
+    s.sRX = scaleU8Centered(buf[2], false);
+    s.sRY = scaleU8Centered(buf[3], true);
+    uint16_t b = 0;
+    uint8_t hat = buf[4] & 0x0F;
+    b = setDpadFromHat(b, hat);
+    uint8_t btnLo = buf[4];
+    uint8_t btnHi = len > 5 ? buf[5] : 0;
+    if (btnLo & 0x10) b |= XUSB_A;
+    if (btnLo & 0x20) b |= XUSB_B;
+    if (btnLo & 0x40) b |= XUSB_X;
+    if (btnLo & 0x80) b |= XUSB_Y;
+    if (btnHi & 0x01) b |= XUSB_LB;
+    if (btnHi & 0x02) b |= XUSB_RB;
+    if (btnHi & 0x04) b |= XUSB_BACK;
+    if (btnHi & 0x08) b |= XUSB_START;
+    if (btnHi & 0x10) b |= XUSB_THUMB_L;
+    if (btnHi & 0x20) b |= XUSB_THUMB_R;
+    s.wButtons = b;
+    s.bLT = (btnHi & 0x40) ? 255 : 0;
+    s.bRT = (btnHi & 0x80) ? 255 : 0;
+    return true;
+}
+
+bool runInit(int fd, uint8_t epOut, Parser p, InitKind init) {
+    switch (init) {
+    case InitKind::NONE:
+        return true;
+    case InitKind::XBOX_ONE_POWERON: {
+        // GIP "power on" sequence: tells the controller to start sending input reports. Without
+        // this, modern Xbox One/Series pads stay silent on the IN endpoint.
+        static const uint8_t kPowerOn[] = {0x05, 0x20, 0x00, 0x01, 0x00};
+        bool ok = bulkWrite(fd, epOut, kPowerOn, sizeof(kPowerOn), 200);
+        if (!ok) LOGE("Xbox One power-on write failed");
+        return ok;
+    }
+    case InitKind::SWITCH_PRO_HANDSHAKE: {
+        (void)p;
+        if (epOut == 0) {
+            LOGE("Switch Pro: no OUT endpoint, cannot init");
+            return false;
+        }
+        // Status request. The Pro responds with controller info on its IN endpoint; we don't
+        // need to read the reply, only send the request so the device transitions out of any
+        // residual state the kernel driver left it in when we stole the interface.
+        static const uint8_t kStatus[] = {0x80, 0x02};
+        if (!bulkWrite(fd, epOut, kStatus, sizeof(kStatus), 100)) {
+            LOGE("Switch Pro: status request failed");
+            return false;
+        }
+        usleep(40000);
+
+        // Disable USB timeout. Without this the controller sleeps after a few seconds of idle
+        // and stops emitting input reports.
+        static const uint8_t kDisableTimeout[] = {0x80, 0x04};
+        if (!bulkWrite(fd, epOut, kDisableTimeout, sizeof(kDisableTimeout), 100)) {
+            LOGI("Switch Pro: disable-timeout write failed (non-fatal)");
+        }
+        usleep(40000);
+
+        // Set input report mode 0x30 (standard full report: buttons + sticks + IMU). The format
+        // is one rumble + subcommand HID output report: report id 0x01, packet counter, 8-byte
+        // neutral rumble pattern, subcommand id 0x03, argument 0x30.
+        uint8_t setReportMode[] = {
+            0x01,
+            0x00,
+            0x00, 0x01, 0x40, 0x40, 0x00, 0x01, 0x40, 0x40,
+            0x03, 0x30,
+        };
+        if (!bulkWrite(fd, epOut, setReportMode, sizeof(setReportMode), 200)) {
+            LOGE("Switch Pro: set-report-mode write failed");
+            return false;
+        }
+        LOGI("Switch Pro USB init sequence sent");
+        return true;
+    }
+    }
+    return false;
+}
+
+} // namespace usbparsers

--- a/app/src/main/cpp/usb_parsers.cpp
+++ b/app/src/main/cpp/usb_parsers.cpp
@@ -2,17 +2,22 @@
 
 #include "usb_parsers.h"
 
+#include <string.h>
+#include <algorithm>
+
+// The decoders and report builders here are pure and host-tested (usb_parsers_test.cpp). Only the
+// USB transfer helpers need the kernel ioctls, so they are fenced to the Android build.
+#ifdef __ANDROID__
 #include <android/log.h>
 #include <linux/usbdevice_fs.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
 #include <errno.h>
-#include <string.h>
-#include <algorithm>
 
 #define TAG "SatelliteUsbParse"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, TAG, __VA_ARGS__)
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, TAG, __VA_ARGS__)
+#endif
 
 namespace usbparsers {
 
@@ -24,6 +29,7 @@ using gamepad::XUSB_DPAD_DOWN;
 using gamepad::XUSB_DPAD_LEFT;
 using gamepad::XUSB_DPAD_RIGHT;
 using gamepad::XUSB_DPAD_UP;
+using gamepad::XUSB_GUIDE;
 using gamepad::XUSB_LB;
 using gamepad::XUSB_RB;
 using gamepad::XUSB_START;
@@ -44,11 +50,15 @@ static const KnownDevice kKnown[] = {
     {0x045E, 0x02E3, "Xbox One Elite Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
     {0x045E, 0x02EA, "Xbox One S Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
     {0x045E, 0x02FD, "Xbox One S Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
-    {0x045E, 0x0B00, "Xbox Elite Series 2 Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
-    {0x045E, 0x0B05, "Xbox Elite Series 2 Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x045E, 0x0B00, "Xbox Elite Series 2 Controller", Parser::XBOX_ONE_GIP,
+     InitKind::XBOX_ONE_POWERON},
+    {0x045E, 0x0B05, "Xbox Elite Series 2 Controller", Parser::XBOX_ONE_GIP,
+     InitKind::XBOX_ONE_POWERON},
     {0x045E, 0x0B0A, "Xbox Adaptive Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
-    {0x045E, 0x0B12, "Xbox Series X|S Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
-    {0x045E, 0x0B13, "Xbox Series X|S Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x045E, 0x0B12, "Xbox Series X|S Controller", Parser::XBOX_ONE_GIP,
+     InitKind::XBOX_ONE_POWERON},
+    {0x045E, 0x0B13, "Xbox Series X|S Controller", Parser::XBOX_ONE_GIP,
+     InitKind::XBOX_ONE_POWERON},
     {0x045E, 0x0B22, "Xbox Adaptive Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
 
     {0x046D, 0xC218, "Logitech F310 (XInput)", Parser::XINPUT_360, InitKind::NONE},
@@ -69,12 +79,14 @@ static const KnownDevice kKnown[] = {
     {0x0738, 0x4726, "Mad Catz Xbox 360 Controller", Parser::XINPUT_360, InitKind::NONE},
     {0x0738, 0x4728, "Mad Catz Street Fighter IV FightPad", Parser::XINPUT_360, InitKind::NONE},
     {0x0738, 0x4736, "Mad Catz MicroCon Gamepad", Parser::XINPUT_360, InitKind::NONE},
-    {0x0738, 0x4738, "Mad Catz Wired Xbox 360 Controller (SFIV)", Parser::XINPUT_360, InitKind::NONE},
+    {0x0738, 0x4738, "Mad Catz Wired Xbox 360 Controller (SFIV)", Parser::XINPUT_360,
+     InitKind::NONE},
     {0x0738, 0x4740, "Mad Catz Beat Pad", Parser::XINPUT_360, InitKind::NONE},
     {0x0738, 0xCB02, "Saitek Cyborg Rumble Pad PC/Xbox 360", Parser::XINPUT_360, InitKind::NONE},
     {0x0E6F, 0x0105, "HSM3 Xbox360 dancepad", Parser::XINPUT_360, InitKind::NONE},
     {0x0E6F, 0x0113, "Afterglow AX.1 Gamepad for Xbox 360", Parser::XINPUT_360, InitKind::NONE},
-    {0x0E6F, 0x011F, "Rock Candy Wired Controller for Xbox 360", Parser::XINPUT_360, InitKind::NONE},
+    {0x0E6F, 0x011F, "Rock Candy Wired Controller for Xbox 360", Parser::XINPUT_360,
+     InitKind::NONE},
     {0x0E6F, 0x0301, "Logic3 Controller", Parser::XINPUT_360, InitKind::NONE},
     {0x0E6F, 0x0401, "Logic3 Controller", Parser::XINPUT_360, InitKind::NONE},
     {0x0E6F, 0x0413, "Afterglow AX.1 Gen 2 for Xbox 360", Parser::XINPUT_360, InitKind::NONE},
@@ -100,7 +112,8 @@ static const KnownDevice kKnown[] = {
     {0x24C6, 0x551A, "PowerA FUSION Pro Controller", Parser::XINPUT_360, InitKind::NONE},
     {0x24C6, 0x561A, "PowerA FUSION Controller", Parser::XINPUT_360, InitKind::NONE},
 
-    {0x0E6F, 0x0139, "Afterglow Prismatic Wired Xbox One", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x0E6F, 0x0139, "Afterglow Prismatic Wired Xbox One", Parser::XBOX_ONE_GIP,
+     InitKind::XBOX_ONE_POWERON},
     {0x0E6F, 0x013B, "PDP Xbox One Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
     {0x0E6F, 0x0146, "Rock Candy Xbox One", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
     {0x0E6F, 0x0161, "PDP Xbox One Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
@@ -108,14 +121,20 @@ static const KnownDevice kKnown[] = {
     {0x0E6F, 0x0163, "PDP Xbox One Controller", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
     {0x0E6F, 0x0164, "PDP Battlefield One", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
     {0x0E6F, 0x0165, "PDP Titanfall 2", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
-    {0x0F0D, 0x0063, "Hori Real Arcade Pro Hayabusa (Xbox One)", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x0F0D, 0x0063, "Hori Real Arcade Pro Hayabusa (Xbox One)", Parser::XBOX_ONE_GIP,
+     InitKind::XBOX_ONE_POWERON},
     {0x0F0D, 0x0067, "Hori HORIPAD ONE", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
-    {0x0F0D, 0x0078, "Hori Real Arcade Pro V Kai (Xbox One)", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
-    {0x24C6, 0x541A, "PowerA Xbox One Mini Wired", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
-    {0x24C6, 0x542A, "Xbox 360 Pro EX Controller (XOne)", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x0F0D, 0x0078, "Hori Real Arcade Pro V Kai (Xbox One)", Parser::XBOX_ONE_GIP,
+     InitKind::XBOX_ONE_POWERON},
+    {0x24C6, 0x541A, "PowerA Xbox One Mini Wired", Parser::XBOX_ONE_GIP,
+     InitKind::XBOX_ONE_POWERON},
+    {0x24C6, 0x542A, "Xbox 360 Pro EX Controller (XOne)", Parser::XBOX_ONE_GIP,
+     InitKind::XBOX_ONE_POWERON},
     {0x24C6, 0x543A, "PowerA Xbox One Wired", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
-    {0x24C6, 0x551A, "PowerA FUSION Pro Wired Xbox One", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
-    {0x24C6, 0x561A, "PowerA FUSION Wired Xbox One", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
+    {0x24C6, 0x551A, "PowerA FUSION Pro Wired Xbox One", Parser::XBOX_ONE_GIP,
+     InitKind::XBOX_ONE_POWERON},
+    {0x24C6, 0x561A, "PowerA FUSION Wired Xbox One", Parser::XBOX_ONE_GIP,
+     InitKind::XBOX_ONE_POWERON},
     {0x24C6, 0x791A, "PowerA Fusion FightPad", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
     {0x1532, 0x0A03, "Razer Wildcat", Parser::XBOX_ONE_GIP, InitKind::XBOX_ONE_POWERON},
 
@@ -139,9 +158,12 @@ static const KnownDevice kKnown[] = {
     {0x054C, 0x0CE6, "Sony DualSense", Parser::DUALSENSE, InitKind::NONE},
     {0x054C, 0x0DF2, "Sony DualSense Edge", Parser::DUALSENSE, InitKind::NONE},
 
-    {0x057E, 0x2009, "Nintendo Switch Pro Controller", Parser::SWITCH_PRO_USB, InitKind::SWITCH_PRO_HANDSHAKE},
-    {0x057E, 0x200E, "Nintendo Joy-Con Charging Grip", Parser::SWITCH_PRO_USB, InitKind::SWITCH_PRO_HANDSHAKE},
-    {0x057E, 0x2017, "Nintendo SNES Online Controller", Parser::SWITCH_PRO_USB, InitKind::SWITCH_PRO_HANDSHAKE},
+    {0x057E, 0x2009, "Nintendo Switch Pro Controller", Parser::SWITCH_PRO_USB,
+     InitKind::SWITCH_PRO_HANDSHAKE},
+    {0x057E, 0x200E, "Nintendo Joy-Con Charging Grip", Parser::SWITCH_PRO_USB,
+     InitKind::SWITCH_PRO_HANDSHAKE},
+    {0x057E, 0x2017, "Nintendo SNES Online Controller", Parser::SWITCH_PRO_USB,
+     InitKind::SWITCH_PRO_HANDSHAKE},
 
     {0x18D1, 0x9400, "Google Stadia Controller", Parser::STADIA, InitKind::NONE},
 };
@@ -175,12 +197,11 @@ const char* parserName(Parser p) {
     return "Unknown";
 }
 
-bool parserHasImu(Parser p) {
-    return p == Parser::SWITCH_PRO_USB;
-}
+bool parserHasImu(Parser p) { return p == Parser::SWITCH_PRO_USB; }
 
 namespace {
 
+#ifdef __ANDROID__
 bool bulkWrite(int fd, uint8_t epOut, const uint8_t* data, size_t len, unsigned timeoutMs) {
     if (epOut == 0) return false;
     struct usbdevfs_bulktransfer xfer = {};
@@ -195,6 +216,7 @@ bool bulkWrite(int fd, uint8_t epOut, const uint8_t* data, size_t len, unsigned 
     }
     return (size_t)n == len;
 }
+#endif
 
 int16_t scaleU8Centered(uint8_t v, bool invert) {
     int32_t s = invert ? (128 - (int32_t)v) : ((int32_t)v - 128);
@@ -209,10 +231,10 @@ int16_t scaleU8Centered(uint8_t v, bool invert) {
 // asymmetric: scaling both sides by one shared reach leaves the smaller side short of the rail.
 // Each side stretches its own learned reach to the full extent, so every direction can hit the
 // edge. Center stays at the nominal 2048.
-// Inner deadzone in the raw 12-bit domain. The Switch Pro's stick center wanders per unit (a resting
-// stick can sit a few hundred counts off 2048) and we read no factory calibration, so without this
-// the auto-range amplifies that offset into large resting drift. Counts within the deadzone read as
-// center; the throw beyond it is auto-ranged to full scale.
+// Inner deadzone in the raw 12-bit domain. The Switch Pro's stick center wanders per unit (a
+// resting stick can sit a few hundred counts off 2048) and we read no factory calibration, so
+// without this the auto-range amplifies that offset into large resting drift. Counts within the
+// deadzone read as center; the throw beyond it is auto-ranged to full scale.
 static constexpr int32_t kSwitchStickRawDeadzone = 320;
 
 int16_t scaleSwitchStickAuto(uint16_t raw12, AxisAutoRange& axis) {
@@ -254,7 +276,8 @@ int16_t switchAccelToWire(int16_t raw) {
 }
 
 uint16_t setDpadFromHat(uint16_t buttons, uint8_t hat) {
-    buttons = (uint16_t)(buttons & ~(XUSB_DPAD_UP | XUSB_DPAD_DOWN | XUSB_DPAD_LEFT | XUSB_DPAD_RIGHT));
+    buttons =
+        (uint16_t)(buttons & ~(XUSB_DPAD_UP | XUSB_DPAD_DOWN | XUSB_DPAD_LEFT | XUSB_DPAD_RIGHT));
     switch (hat & 0x0F) {
     case 0:
         buttons |= XUSB_DPAD_UP;
@@ -320,8 +343,20 @@ bool decodeXInput360(const uint8_t* buf, size_t len, DeviceState& s) {
 }
 
 // Xbox One GIP input report 0x20. Triggers are 10-bit little-endian (0..1023); scaled to XUSB's
-// 0..255 below. Sticks are little-endian int16, same convention as XInput.
-bool decodeXboxOneGip(const uint8_t* buf, size_t len, DeviceState& s) {
+// 0..255 below. Sticks are little-endian int16, same convention as XInput. The Guide button arrives
+// in a separate virtual-key report (0x07, state in byte 4); it is sticky and merged into the main
+// report via ParserState so a guide press survives the interleaved 0x20 frames.
+bool decodeXboxOneGip(const uint8_t* buf, size_t len, DeviceState& s, ParserState& st) {
+    if (len >= 5 && buf[0] == 0x07) {
+        st.xboxGuideHeld = (buf[4] & 0x03) != 0;
+        s = st.xboxLastMain;
+        if (st.xboxGuideHeld) {
+            s.wButtons |= XUSB_GUIDE;
+        } else {
+            s.wButtons = (uint16_t)(s.wButtons & ~XUSB_GUIDE);
+        }
+        return true;
+    }
     if (len < 18) return false;
     if (buf[0] != 0x20) return false;
 
@@ -353,6 +388,9 @@ bool decodeXboxOneGip(const uint8_t* buf, size_t len, DeviceState& s) {
     s.sLY = (int16_t)((uint16_t)buf[12] | ((uint16_t)buf[13] << 8));
     s.sRX = (int16_t)((uint16_t)buf[14] | ((uint16_t)buf[15] << 8));
     s.sRY = (int16_t)((uint16_t)buf[16] | ((uint16_t)buf[17] << 8));
+
+    st.xboxLastMain = s;
+    if (st.xboxGuideHeld) s.wButtons |= XUSB_GUIDE;
     return true;
 }
 
@@ -369,14 +407,14 @@ bool decodeDualShock4(const uint8_t* buf, size_t len, DeviceState& s) {
     s.sRY = scaleU8Centered(buf[4], true);
 
     uint16_t b = 0;
-    if (buf[5] & 0x10) b |= XUSB_X;      // Square
-    if (buf[5] & 0x20) b |= XUSB_A;      // Cross
-    if (buf[5] & 0x40) b |= XUSB_B;      // Circle
-    if (buf[5] & 0x80) b |= XUSB_Y;      // Triangle
-    if (buf[6] & 0x01) b |= XUSB_LB;     // L1
-    if (buf[6] & 0x02) b |= XUSB_RB;     // R1
-    if (buf[6] & 0x10) b |= XUSB_BACK;   // Share
-    if (buf[6] & 0x20) b |= XUSB_START;  // Options
+    if (buf[5] & 0x10) b |= XUSB_X;
+    if (buf[5] & 0x20) b |= XUSB_A;
+    if (buf[5] & 0x40) b |= XUSB_B;
+    if (buf[5] & 0x80) b |= XUSB_Y;
+    if (buf[6] & 0x01) b |= XUSB_LB;
+    if (buf[6] & 0x02) b |= XUSB_RB;
+    if (buf[6] & 0x10) b |= XUSB_BACK;
+    if (buf[6] & 0x20) b |= XUSB_START;
     if (buf[6] & 0x40) b |= XUSB_THUMB_L;
     if (buf[6] & 0x80) b |= XUSB_THUMB_R;
     b = setDpadFromHat(b, buf[5] & 0x0F);
@@ -402,14 +440,14 @@ bool decodeDualSense(const uint8_t* buf, size_t len, DeviceState& s) {
     s.bRT = buf[6];
 
     uint16_t b = 0;
-    if (buf[8] & 0x10) b |= XUSB_X;      // Square
-    if (buf[8] & 0x20) b |= XUSB_A;      // Cross
-    if (buf[8] & 0x40) b |= XUSB_B;      // Circle
-    if (buf[8] & 0x80) b |= XUSB_Y;      // Triangle
+    if (buf[8] & 0x10) b |= XUSB_X;
+    if (buf[8] & 0x20) b |= XUSB_A;
+    if (buf[8] & 0x40) b |= XUSB_B;
+    if (buf[8] & 0x80) b |= XUSB_Y;
     if (buf[9] & 0x01) b |= XUSB_LB;
     if (buf[9] & 0x02) b |= XUSB_RB;
-    if (buf[9] & 0x10) b |= XUSB_BACK;   // Create
-    if (buf[9] & 0x20) b |= XUSB_START;  // Options
+    if (buf[9] & 0x10) b |= XUSB_BACK;
+    if (buf[9] & 0x20) b |= XUSB_START;
     if (buf[9] & 0x40) b |= XUSB_THUMB_L;
     if (buf[9] & 0x80) b |= XUSB_THUMB_R;
     b = setDpadFromHat(b, buf[8] & 0x0F);
@@ -422,7 +460,7 @@ bool decodeDualSense(const uint8_t* buf, size_t len, DeviceState& s) {
 // position rather than label, the same convention used for DualShock 4: Switch A (right face) →
 // XUSB_B (right face), Switch B (bottom) → XUSB_A (bottom), Switch X (top) → XUSB_Y, Switch Y
 // (left) → XUSB_X. This is what PC games and ViGEm expect.
-bool decodeSwitchProUsb(const uint8_t* buf, size_t len, DeviceState& s, StickAutoRange& sticks) {
+bool decodeSwitchProUsb(const uint8_t* buf, size_t len, DeviceState& s, ParserState& sticks) {
     if (len < 12) return false;
     if (buf[0] != 0x30) return false;
 
@@ -431,13 +469,13 @@ bool decodeSwitchProUsb(const uint8_t* buf, size_t len, DeviceState& s, StickAut
     const uint8_t bl = buf[5];
 
     uint16_t b = 0;
-    if (br & 0x01) b |= XUSB_X;     // Y label (left position) → XUSB X
-    if (br & 0x02) b |= XUSB_Y;     // X label (top position) → XUSB Y
-    if (br & 0x04) b |= XUSB_A;     // B label (bottom position) → XUSB A
-    if (br & 0x08) b |= XUSB_B;     // A label (right position) → XUSB B
+    if (br & 0x01) b |= XUSB_X;
+    if (br & 0x02) b |= XUSB_Y;
+    if (br & 0x04) b |= XUSB_A;
+    if (br & 0x08) b |= XUSB_B;
     if (br & 0x40) b |= XUSB_RB;
-    if (bs & 0x01) b |= XUSB_BACK;  // Minus
-    if (bs & 0x02) b |= XUSB_START; // Plus
+    if (bs & 0x01) b |= XUSB_BACK;
+    if (bs & 0x02) b |= XUSB_START;
     if (bs & 0x04) b |= XUSB_THUMB_R;
     if (bs & 0x08) b |= XUSB_THUMB_L;
     if (bl & 0x01) b |= XUSB_DPAD_DOWN;
@@ -476,7 +514,6 @@ bool decodeSwitchProUsb(const uint8_t* buf, size_t len, DeviceState& s, StickAut
     return true;
 }
 
-// Stadia controller HID report 0x03 (basic gamepad layout).
 bool decodeStadia(const uint8_t* buf, size_t len, DeviceState& s) {
     if (len < 11) return false;
     if (buf[0] != 0x03) return false;
@@ -502,14 +539,43 @@ bool decodeStadia(const uint8_t* buf, size_t len, DeviceState& s) {
     return true;
 }
 
+// Switch Pro HD-rumble amplitude codes from the Linux hid-nintendo table; frequency held at the
+// neutral default so a coarse strong/weak motor still encodes a faithful buzz. See docs/rumble.md.
+struct SwitchAmpCode {
+    uint8_t high;
+    uint16_t low;
+    uint16_t amp;
+};
+
+const SwitchAmpCode kSwitchAmpCodes[] = {
+    {0x00, 0x0040, 0},   {0x02, 0x8040, 10},  {0x08, 0x0042, 17},  {0x10, 0x0044, 33},
+    {0x40, 0x0050, 230}, {0x70, 0x005c, 387}, {0xa0, 0x0068, 650}, {0xc8, 0x0072, 1003},
+};
+
+void switchEncodeMotor(uint8_t* out, uint16_t magnitude) {
+    uint32_t amp = (uint32_t)magnitude * 1003u / 65535u;
+    const SwitchAmpCode* code = &kSwitchAmpCodes[0];
+    for (const auto& e : kSwitchAmpCodes) {
+        if (e.amp <= amp) {
+            code = &e;
+        } else {
+            break;
+        }
+    }
+    out[0] = 0x00;
+    out[1] = (uint8_t)(0x01 + code->high);
+    out[2] = (uint8_t)(0x40 + ((code->low >> 8) & 0xFF));
+    out[3] = (uint8_t)(code->low & 0xFF);
+}
+
 } // namespace
 
-bool decodeReport(Parser p, const uint8_t* buf, size_t len, DeviceState& s, StickAutoRange* sticks) {
+bool decodeReport(Parser p, const uint8_t* buf, size_t len, DeviceState& s, ParserState* sticks) {
     switch (p) {
     case Parser::XINPUT_360:
         return decodeXInput360(buf, len, s);
     case Parser::XBOX_ONE_GIP:
-        return decodeXboxOneGip(buf, len, s);
+        return sticks != nullptr && decodeXboxOneGip(buf, len, s, *sticks);
     case Parser::DUALSHOCK4:
         return decodeDualShock4(buf, len, s);
     case Parser::DUALSENSE:
@@ -556,6 +622,72 @@ bool decodeGenericHidGamepad(const uint8_t* buf, size_t len, DeviceState& s) {
     return true;
 }
 
+// Per-device rumble output reports. Motor convention: strong = large/low-frequency (left), weak =
+// small/high-frequency (right), both wire-scale 0..65535. Report layouts and sources (Linux xpad,
+// hid-playstation, hid-nintendo) are documented in docs/rumble.md.
+size_t buildRumbleReport(Parser p, uint16_t strong, uint16_t weak, uint8_t seq, uint8_t* out,
+                         size_t outCap) {
+    switch (p) {
+    case Parser::XINPUT_360:
+        if (outCap < 8) return 0;
+        out[0] = 0x00;
+        out[1] = 0x08;
+        out[2] = 0x00;
+        out[3] = (uint8_t)(strong >> 8);
+        out[4] = (uint8_t)(weak >> 8);
+        out[5] = 0x00;
+        out[6] = 0x00;
+        out[7] = 0x00;
+        return 8;
+    case Parser::XBOX_ONE_GIP:
+        if (outCap < 13) return 0;
+        out[0] = 0x09;
+        out[1] = 0x00;
+        out[2] = seq;
+        out[3] = 0x09;
+        out[4] = 0x00;
+        out[5] = 0x0F;
+        out[6] = 0x00;
+        out[7] = 0x00;
+        out[8] = (uint8_t)(strong / 512);
+        out[9] = (uint8_t)(weak / 512);
+        out[10] = 0xFF;
+        out[11] = 0x00;
+        out[12] = 0xFF;
+        return 13;
+    case Parser::DUALSHOCK4:
+        if (outCap < 32) return 0;
+        memset(out, 0, 32);
+        out[0] = 0x05;
+        out[1] = 0x01;
+        out[4] = (uint8_t)(weak >> 8);
+        out[5] = (uint8_t)(strong >> 8);
+        return 32;
+    case Parser::DUALSENSE:
+        if (outCap < 63) return 0;
+        memset(out, 0, 63);
+        out[0] = 0x02;
+        out[1] = 0x01;
+        out[3] = (uint8_t)(weak >> 8);
+        out[4] = (uint8_t)(strong >> 8);
+        return 63;
+    case Parser::SWITCH_PRO_USB:
+        if (outCap < 10) return 0;
+        memset(out, 0, 10);
+        out[0] = 0x10;
+        out[1] = (uint8_t)(seq & 0x0F);
+        switchEncodeMotor(&out[2], strong);
+        switchEncodeMotor(&out[6], weak);
+        return 10;
+    case Parser::STADIA:
+    case Parser::GENERIC_HID_GAMEPAD:
+    case Parser::NONE:
+        return 0;
+    }
+    return 0;
+}
+
+#ifdef __ANDROID__
 bool runInit(int fd, uint8_t epOut, Parser p, InitKind init) {
     switch (init) {
     case InitKind::NONE:
@@ -596,14 +728,21 @@ bool runInit(int fd, uint8_t epOut, Parser p, InitKind init) {
         // is one rumble + subcommand HID output report: report id 0x01, packet counter, 8-byte
         // neutral rumble pattern, subcommand id 0x03, argument 0x30.
         uint8_t setReportMode[] = {
-            0x01,
-            0x00,
-            0x00, 0x01, 0x40, 0x40, 0x00, 0x01, 0x40, 0x40,
-            0x03, 0x30,
+            0x01, 0x00, 0x00, 0x01, 0x40, 0x40, 0x00, 0x01, 0x40, 0x40, 0x03, 0x30,
         };
         if (!bulkWrite(fd, epOut, setReportMode, sizeof(setReportMode), 200)) {
             LOGE("Switch Pro: set-report-mode write failed");
             return false;
+        }
+        usleep(40000);
+
+        // Enable vibration (subcommand 0x48, arg 0x01) so later rumble-only (0x10) reports take
+        // effect.
+        uint8_t enableVibration[] = {
+            0x01, 0x01, 0x00, 0x01, 0x40, 0x40, 0x00, 0x01, 0x40, 0x40, 0x48, 0x01,
+        };
+        if (!bulkWrite(fd, epOut, enableVibration, sizeof(enableVibration), 200)) {
+            LOGI("Switch Pro: enable-vibration write failed (non-fatal)");
         }
         LOGI("Switch Pro USB init sequence sent");
         return true;
@@ -611,5 +750,14 @@ bool runInit(int fd, uint8_t epOut, Parser p, InitKind init) {
     }
     return false;
 }
+
+bool runRumble(int fd, uint8_t epOut, Parser p, uint16_t strong, uint16_t weak, uint8_t seq) {
+    if (epOut == 0) return false;
+    uint8_t buf[64];
+    size_t n = buildRumbleReport(p, strong, weak, seq, buf, sizeof(buf));
+    if (n == 0) return false;
+    return bulkWrite(fd, epOut, buf, n, 100);
+}
+#endif
 
 } // namespace usbparsers

--- a/app/src/main/cpp/usb_parsers.h
+++ b/app/src/main/cpp/usb_parsers.h
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <stdint.h>
+#include <string>
+
+#include "gamepad_input.h"
+
+namespace usbparsers {
+
+enum class Parser : uint8_t {
+    NONE = 0,
+    XINPUT_360 = 1,
+    XBOX_ONE_GIP = 2,
+    DUALSHOCK4 = 3,
+    DUALSENSE = 4,
+    SWITCH_PRO_USB = 5,
+    STADIA = 6,
+    GENERIC_HID_GAMEPAD = 7,
+};
+
+enum class InitKind : uint8_t {
+    NONE = 0,
+    XBOX_ONE_POWERON = 1,
+    SWITCH_PRO_HANDSHAKE = 2,
+};
+
+struct KnownDevice {
+    uint16_t vid;
+    uint16_t pid;
+    const char* name;
+    Parser parser;
+    InitKind init;
+};
+
+// Per-device, expand-only auto-range for sticks that report raw ADC values. We don't read the
+// controller's factory calibration from SPI flash, and the usable deflection varies per unit and
+// per direction, so each axis tracks the largest deflection seen on each side of center
+// independently and stretches each side to full scale. A full sweep into every corner teaches it
+// the true range; the seed sits below any healthy stick's throw so each direction can still reach
+// the rail before it is fully learned.
+struct AxisAutoRange {
+    int32_t posReach = 1000;
+    int32_t negReach = 1000;
+};
+
+struct StickAutoRange {
+    AxisAutoRange lx;
+    AxisAutoRange ly;
+    AxisAutoRange rx;
+    AxisAutoRange ry;
+};
+
+const KnownDevice* lookupKnown(uint16_t vid, uint16_t pid);
+
+const char* parserName(Parser p);
+
+// True if this parser decodes an on-controller IMU into DeviceState's motion fields. Lets Kotlin
+// mark the synthetic device hasGyro so the motion toggle becomes available in Direct mode.
+bool parserHasImu(Parser p);
+
+bool runInit(int fd, uint8_t epOut, Parser p, InitKind init);
+
+// Returns true if the report was consumed and state was updated. `sticks` carries the per-device
+// auto-range state for parsers that need it (Switch Pro); pass the device's persistent instance.
+bool decodeReport(Parser p, const uint8_t* buf, size_t len, gamepad::DeviceState& s,
+                  StickAutoRange* sticks);
+
+// Best-effort fallback for devices we don't have a per-model parser for. Tries the simple HID
+// gamepad layout (4 sticks as 1-byte axes, two trigger bytes, button bitmask). Returns false if
+// the report doesn't look gamepad-shaped, so the caller can fall back to ROUTED instead of
+// publishing garbage.
+bool decodeGenericHidGamepad(const uint8_t* buf, size_t len, gamepad::DeviceState& s);
+
+} // namespace usbparsers

--- a/app/src/main/cpp/usb_parsers.h
+++ b/app/src/main/cpp/usb_parsers.h
@@ -56,21 +56,13 @@ const KnownDevice* lookupKnown(uint16_t vid, uint16_t pid);
 
 const char* parserName(Parser p);
 
-// True if this parser decodes an on-controller IMU into DeviceState's motion fields. Lets Kotlin
-// mark the synthetic device hasGyro so the motion toggle becomes available in Direct mode.
 bool parserHasImu(Parser p);
 
 bool runInit(int fd, uint8_t epOut, Parser p, InitKind init);
 
-// Returns true if the report was consumed and state was updated. `sticks` carries the per-device
-// auto-range state for parsers that need it (Switch Pro); pass the device's persistent instance.
 bool decodeReport(Parser p, const uint8_t* buf, size_t len, gamepad::DeviceState& s,
                   StickAutoRange* sticks);
 
-// Best-effort fallback for devices we don't have a per-model parser for. Tries the simple HID
-// gamepad layout (4 sticks as 1-byte axes, two trigger bytes, button bitmask). Returns false if
-// the report doesn't look gamepad-shaped, so the caller can fall back to ROUTED instead of
-// publishing garbage.
 bool decodeGenericHidGamepad(const uint8_t* buf, size_t len, gamepad::DeviceState& s);
 
 } // namespace usbparsers

--- a/app/src/main/cpp/usb_parsers.h
+++ b/app/src/main/cpp/usb_parsers.h
@@ -45,11 +45,14 @@ struct AxisAutoRange {
     int32_t negReach = 1000;
 };
 
-struct StickAutoRange {
+struct ParserState {
     AxisAutoRange lx;
     AxisAutoRange ly;
     AxisAutoRange rx;
     AxisAutoRange ry;
+    // Xbox One guide button (GIP report 0x07) is sticky state merged into the main 0x20 reports.
+    bool xboxGuideHeld = false;
+    gamepad::DeviceState xboxLastMain;
 };
 
 const KnownDevice* lookupKnown(uint16_t vid, uint16_t pid);
@@ -60,8 +63,15 @@ bool parserHasImu(Parser p);
 
 bool runInit(int fd, uint8_t epOut, Parser p, InitKind init);
 
+bool runRumble(int fd, uint8_t epOut, Parser p, uint16_t strong, uint16_t weak, uint8_t seq);
+
+// Pure: writes the device's rumble report into out, returns its length (0 if unsupported or out is
+// too small). Host-tested in usb_parsers_test.cpp; runRumble is the Android write wrapper.
+size_t buildRumbleReport(Parser p, uint16_t strong, uint16_t weak, uint8_t seq, uint8_t* out,
+                         size_t outCap);
+
 bool decodeReport(Parser p, const uint8_t* buf, size_t len, gamepad::DeviceState& s,
-                  StickAutoRange* sticks);
+                  ParserState* sticks);
 
 bool decodeGenericHidGamepad(const uint8_t* buf, size_t len, gamepad::DeviceState& s);
 

--- a/app/src/main/java/com/tinkernorth/dish/DishApplication.kt
+++ b/app/src/main/java/com/tinkernorth/dish/DishApplication.kt
@@ -13,6 +13,7 @@ import com.tinkernorth.dish.hotpath.input.BluetoothGamepadBridge
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.hotpath.input.PhysicalSlotBindingObserver
 import com.tinkernorth.dish.hotpath.input.RumbleBridge
+import com.tinkernorth.dish.hotpath.input.RumbleRouter
 import com.tinkernorth.dish.source.bluetooth.BluetoothGamepadRegistry
 import com.tinkernorth.dish.source.sensor.PhysicalBatterySource
 import com.tinkernorth.dish.source.sensor.PhysicalMotionSource
@@ -64,6 +65,8 @@ class DishApplication : Application() {
     @Inject lateinit var usbGamepadManager: UsbGamepadManager
 
     @Inject lateinit var pollRateSampler: PollRateSampler
+
+    @Inject lateinit var rumbleRouter: RumbleRouter
 
     // Exposed so StreamingService (framework-owned lifecycle) can reuse the Hilt singleton scope.
     @Inject lateinit var processScope: CoroutineScope
@@ -131,7 +134,7 @@ class DishApplication : Application() {
         lifecycle.addObserver(bluetoothPermissionStateObserver)
         lifecycle.addObserver(networkStateObserver)
         lifecycle.addObserver(streamingServiceController)
-        RumbleBridge.install(this)
+        RumbleBridge.install(rumbleRouter)
     }
 
     companion object {

--- a/app/src/main/java/com/tinkernorth/dish/DishApplication.kt
+++ b/app/src/main/java/com/tinkernorth/dish/DishApplication.kt
@@ -118,12 +118,7 @@ class DishApplication : Application() {
         lifecycle.addObserver(connectionForegroundObserver)
         // Process-scoped so bindings survive the MainActivity → GamepadOverlayActivity handoff.
         physicalGamepadRegistry.install()
-        // Also process-scoped: USB host claims survive activity recreation, and the broadcast
-        // receiver listening for plug/unplug needs to be alive even while the app is backgrounded
-        // so we can detach cleanly when the user unplugs without opening the app first.
         usbGamepadManager.install()
-        // Process-scope sampler so the dashboard's Hz badge keeps updating across activity
-        // recreations; sample cost is one atomic read per direct-mode device every 500 ms.
         pollRateSampler.install()
         lifecycle.addObserver(physicalSlotBindingObserver)
         lifecycle.addObserver(physicalBatterySource)

--- a/app/src/main/java/com/tinkernorth/dish/DishApplication.kt
+++ b/app/src/main/java/com/tinkernorth/dish/DishApplication.kt
@@ -23,6 +23,8 @@ import com.tinkernorth.dish.source.system.BluetoothBondMonitor
 import com.tinkernorth.dish.source.system.BluetoothPermissionStateObserver
 import com.tinkernorth.dish.source.system.ConnectionForegroundObserver
 import com.tinkernorth.dish.source.system.NetworkStateObserver
+import com.tinkernorth.dish.source.usb.PollRateSampler
+import com.tinkernorth.dish.source.usb.UsbGamepadManager
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import javax.inject.Inject
@@ -58,6 +60,10 @@ class DishApplication : Application() {
     @Inject lateinit var crashReportingController: CrashReportingController
 
     @Inject lateinit var themePreferenceStore: ThemePreferenceStore
+
+    @Inject lateinit var usbGamepadManager: UsbGamepadManager
+
+    @Inject lateinit var pollRateSampler: PollRateSampler
 
     // Exposed so StreamingService (framework-owned lifecycle) can reuse the Hilt singleton scope.
     @Inject lateinit var processScope: CoroutineScope
@@ -112,6 +118,13 @@ class DishApplication : Application() {
         lifecycle.addObserver(connectionForegroundObserver)
         // Process-scoped so bindings survive the MainActivity → GamepadOverlayActivity handoff.
         physicalGamepadRegistry.install()
+        // Also process-scoped: USB host claims survive activity recreation, and the broadcast
+        // receiver listening for plug/unplug needs to be alive even while the app is backgrounded
+        // so we can detach cleanly when the user unplugs without opening the app first.
+        usbGamepadManager.install()
+        // Process-scope sampler so the dashboard's Hz badge keeps updating across activity
+        // recreations; sample cost is one atomic read per direct-mode device every 500 ms.
+        pollRateSampler.install()
         lifecycle.addObserver(physicalSlotBindingObserver)
         lifecycle.addObserver(physicalBatterySource)
         lifecycle.addObserver(virtualBatterySource)

--- a/app/src/main/java/com/tinkernorth/dish/composer/ConnectionHub.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/ConnectionHub.kt
@@ -92,6 +92,22 @@ class ConnectionHub
             typeStore.clear(connId, slotId)
         }
 
+        fun migrateSlotBinding(
+            fromSlotId: String,
+            toSlotId: String,
+        ) {
+            if (fromSlotId == toSlotId) return
+            val connId = bindingStore.connectionFor(fromSlotId) ?: return
+            val type = typeStore.typeFor(connId, fromSlotId)
+            bindingStore.unbind(fromSlotId)
+            bindingStore.bind(toSlotId, connId)
+            if (type != null) {
+                typeStore.clear(connId, fromSlotId)
+                typeStore.setType(connId, toSlotId, type)
+            }
+            satellite.get(connId)?.renameSlot(fromSlotId, toSlotId)
+        }
+
         fun setSatelliteControllerType(
             connectionId: String,
             slotId: String,

--- a/app/src/main/java/com/tinkernorth/dish/composer/ConnectionHub.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/ConnectionHub.kt
@@ -105,7 +105,25 @@ class ConnectionHub
                 typeStore.clear(connId, fromSlotId)
                 typeStore.setType(connId, toSlotId, type)
             }
-            satellite.get(connId)?.renameSlot(fromSlotId, toSlotId)
+            val conn = satellite.get(connId) ?: return
+            if (!conn.renameSlot(fromSlotId, toSlotId)) {
+                scope.launch { conn.attachSlot(toSlotId, controllerType = type ?: CONTROLLER_TYPE_XBOX) }
+            }
+        }
+
+        fun bindClaimedSynthetic(
+            twinSlotId: String?,
+            syntheticSlotId: String,
+        ) {
+            if (twinSlotId != null && bindingStore.connectionFor(twinSlotId) != null) {
+                migrateSlotBinding(twinSlotId, syntheticSlotId)
+                return
+            }
+            val target =
+                connections.value.singleOrNull {
+                    it.kind == ConnectionKind.SATELLITE && it.live == LinkState.Connected
+                }
+            if (target != null) bind(syntheticSlotId, target.id)
         }
 
         fun setSatelliteControllerType(

--- a/app/src/main/java/com/tinkernorth/dish/core/jni/PhysicalInputNative.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/jni/PhysicalInputNative.kt
@@ -58,5 +58,13 @@ class PhysicalInputNative
             SatelliteNative.detachUsbDevice(syntheticDeviceId)
         }
 
+        fun sendUsbRumble(
+            syntheticDeviceId: Int,
+            strong: Int,
+            weak: Int,
+        ) {
+            SatelliteNative.sendUsbRumble(syntheticDeviceId, strong, weak)
+        }
+
         fun getDeviceUrbCount(deviceId: Int): Long = SatelliteNative.getDeviceUrbCount(deviceId)
     }

--- a/app/src/main/java/com/tinkernorth/dish/core/jni/PhysicalInputNative.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/jni/PhysicalInputNative.kt
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.core.jni
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PhysicalInputNative
+    @Inject
+    constructor() {
+        fun isKnownFastLaneModel(
+            vendorId: Int,
+            productId: Int,
+        ): Boolean = SatelliteNative.isKnownFastLaneModel(vendorId, productId)
+
+        fun modelHasImu(
+            vendorId: Int,
+            productId: Int,
+        ): Boolean = SatelliteNative.modelHasImu(vendorId, productId)
+
+        fun lookupKnownModelName(
+            vendorId: Int,
+            productId: Int,
+        ): String = SatelliteNative.lookupKnownModelName(vendorId, productId)
+
+        fun setDeviceDeadzones(
+            deviceId: Int,
+            flatX: Float,
+            flatY: Float,
+            flatZ: Float,
+            flatRZ: Float,
+        ) {
+            SatelliteNative.setDeviceDeadzones(deviceId, flatX, flatY, flatZ, flatRZ)
+        }
+
+        @Suppress("LongParameterList")
+        fun attachUsbDevice(
+            fd: Int,
+            vendorId: Int,
+            productId: Int,
+            interfaceNumber: Int,
+            endpointIn: Int,
+            endpointInMaxPacket: Int,
+            endpointOut: Int,
+        ): Int =
+            SatelliteNative.attachUsbDevice(
+                fd = fd,
+                vendorId = vendorId,
+                productId = productId,
+                interfaceNumber = interfaceNumber,
+                endpointIn = endpointIn,
+                endpointInMaxPacket = endpointInMaxPacket,
+                endpointOut = endpointOut,
+            )
+
+        fun detachUsbDevice(syntheticDeviceId: Int) {
+            SatelliteNative.detachUsbDevice(syntheticDeviceId)
+        }
+
+        fun getDeviceUrbCount(deviceId: Int): Long = SatelliteNative.getDeviceUrbCount(deviceId)
+    }

--- a/app/src/main/java/com/tinkernorth/dish/core/jni/SatelliteNative.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/jni/SatelliteNative.kt
@@ -138,6 +138,8 @@ object SatelliteNative {
 
     external fun clearAllPhysicalSlots()
 
+    external fun forgetPhysicalDevice(deviceId: Int)
+
     // Without this, axes near rest stream tiny non-zero values upstream.
     external fun setDeviceDeadzones(
         deviceId: Int,
@@ -167,6 +169,13 @@ object SatelliteNative {
     ): Int
 
     external fun detachUsbDevice(syntheticDeviceId: Int)
+
+    // strong/weak are wire-scale 0..65535; native maps to each device's rumble output report.
+    external fun sendUsbRumble(
+        syntheticDeviceId: Int,
+        strong: Int,
+        weak: Int,
+    )
 
     external fun isKnownFastLaneModel(
         vendorId: Int,

--- a/app/src/main/java/com/tinkernorth/dish/core/jni/SatelliteNative.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/jni/SatelliteNative.kt
@@ -156,6 +156,44 @@ object SatelliteNative {
         keyCode: Int,
     ): Boolean
 
+    // USB host fast-lane attach. Kotlin claims the interface via UsbDeviceConnection and hands
+    // the file descriptor down. Native dups the fd, owns a poll thread for the device, decodes
+    // HID reports straight to the encrypted-UDP send path. Returns the synthetic deviceId
+    // (negative int) on success, or 0 on failure.
+    external fun attachUsbDevice(
+        fd: Int,
+        vendorId: Int,
+        productId: Int,
+        interfaceNumber: Int,
+        endpointIn: Int,
+        endpointInMaxPacket: Int,
+        endpointOut: Int,
+    ): Int
+
+    external fun detachUsbDevice(syntheticDeviceId: Int)
+
+    // Cold-path: does our parser table know this VID/PID? Lets Kotlin decide whether to even
+    // request USB permission for an unknown device.
+    external fun isKnownFastLaneModel(
+        vendorId: Int,
+        productId: Int,
+    ): Boolean
+
+    external fun modelHasImu(
+        vendorId: Int,
+        productId: Int,
+    ): Boolean
+
+    external fun lookupKnownModelName(
+        vendorId: Int,
+        productId: Int,
+    ): String
+
+    // Returns the cumulative count of successfully completed input URBs for the USB-host device.
+    // Kotlin's PollRateSampler reads this on a fixed cadence and computes the measured Hz from
+    // the delta over time. Returns 0 for unknown deviceIds.
+    external fun getDeviceUrbCount(deviceId: Int): Long
+
     // Flat parameter list (not packed) so each axis stays primitive Float — no per-event allocation.
     @Suppress("LongParameterList")
     external fun processGamepadMotionEvent(

--- a/app/src/main/java/com/tinkernorth/dish/core/jni/SatelliteNative.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/jni/SatelliteNative.kt
@@ -156,10 +156,6 @@ object SatelliteNative {
         keyCode: Int,
     ): Boolean
 
-    // USB host fast-lane attach. Kotlin claims the interface via UsbDeviceConnection and hands
-    // the file descriptor down. Native dups the fd, owns a poll thread for the device, decodes
-    // HID reports straight to the encrypted-UDP send path. Returns the synthetic deviceId
-    // (negative int) on success, or 0 on failure.
     external fun attachUsbDevice(
         fd: Int,
         vendorId: Int,
@@ -172,8 +168,6 @@ object SatelliteNative {
 
     external fun detachUsbDevice(syntheticDeviceId: Int)
 
-    // Cold-path: does our parser table know this VID/PID? Lets Kotlin decide whether to even
-    // request USB permission for an unknown device.
     external fun isKnownFastLaneModel(
         vendorId: Int,
         productId: Int,
@@ -189,9 +183,6 @@ object SatelliteNative {
         productId: Int,
     ): String
 
-    // Returns the cumulative count of successfully completed input URBs for the USB-host device.
-    // Kotlin's PollRateSampler reads this on a fixed cadence and computes the measured Hz from
-    // the delta over time. Returns 0 for unknown deviceIds.
     external fun getDeviceUrbCount(deviceId: Int): Long
 
     // Flat parameter list (not packed) so each axis stays primitive Float — no per-event allocation.

--- a/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistry.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistry.kt
@@ -8,10 +8,11 @@ import android.hardware.usb.UsbManager
 import android.util.Log
 import android.view.InputDevice
 import android.view.MotionEvent
-import com.tinkernorth.dish.core.jni.SatelliteNative
+import com.tinkernorth.dish.core.jni.PhysicalInputNative
 import com.tinkernorth.dish.source.sensor.PhysicalMotionProbe
 import com.tinkernorth.dish.source.usb.PathMode
 import com.tinkernorth.dish.source.usb.PathReason
+import com.tinkernorth.dish.source.usb.classifyDirectPathReason
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -19,8 +20,11 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -30,6 +34,7 @@ class PhysicalGamepadRegistry
     constructor(
         @ApplicationContext context: Context,
         private val scope: CoroutineScope,
+        private val native: PhysicalInputNative,
     ) : InputManager.InputDeviceListener {
         data class Device(
             val id: Int,
@@ -57,7 +62,7 @@ class PhysicalGamepadRegistry
 
         @Volatile private var installed = false
 
-        private val disconnectJobs = HashMap<Int, Job>()
+        private val disconnectJobs = ConcurrentHashMap<Int, Job>()
 
         fun install() {
             if (installed) return
@@ -82,13 +87,9 @@ class PhysicalGamepadRegistry
             if (!isGamepad(dev)) return
             pushDeadzones(dev)
             cancelDisconnect(deviceId)
-            _devices.value = _devices.value + (deviceId to makeRoutedDevice(deviceId, dev))
+            _devices.update { it + (deviceId to makeRoutedDevice(deviceId, dev)) }
         }
 
-        // Classifies a framework-routed controller. A known fast-lane model on the USB bus is an
-        // Eligible Direct-mode candidate (the card offers a "Try Direct mode" action) unless a prior
-        // attempt failed, in which case it shows that locked reason. Off the USB bus (Bluetooth)
-        // Direct mode can't apply; unknown models stay UnknownModel.
         private fun makeRoutedDevice(
             deviceId: Int,
             dev: InputDevice,
@@ -96,12 +97,13 @@ class PhysicalGamepadRegistry
             val vid = runCatching { dev.vendorId }.getOrDefault(0)
             val pid = runCatching { dev.productId }.getOrDefault(0)
             val reason =
-                when {
-                    vid == 0 || pid == 0 -> PathReason.UnknownModel
-                    !SatelliteNative.isKnownFastLaneModel(vid, pid) -> PathReason.UnknownModel
-                    !isUsbDevicePresent(vid, pid) -> PathReason.Bluetooth
-                    else -> directFailed[vpKey(vid, pid)] ?: PathReason.Eligible
-                }
+                classifyDirectPathReason(
+                    vendorId = vid,
+                    productId = pid,
+                    isKnownFastLaneModel = native.isKnownFastLaneModel(vid, pid),
+                    isUsbPresent = isUsbDevicePresent(vid, pid),
+                    priorFailure = directFailed[vpKey(vid, pid)],
+                )
             return Device(
                 id = deviceId,
                 name = dev.name,
@@ -121,29 +123,28 @@ class PhysicalGamepadRegistry
                 it.vendorId == vendorId && it.productId == productId
             }
 
-        private val directFailed = HashMap<Int, PathReason>()
+        private val directFailed = ConcurrentHashMap<Int, PathReason>()
 
         private fun vpKey(
             vendorId: Int,
             productId: Int,
         ): Int = (vendorId shl 16) or (productId and 0xFFFF)
 
-        // Called by UsbGamepadManager when a Direct-mode claim fails. Locks the matching framework
-        // card to the failure reason (no retry affordance) until the controller is re-plugged.
         fun markDirectFailed(
             vendorId: Int,
             productId: Int,
             reason: PathReason,
         ) {
             directFailed[vpKey(vendorId, productId)] = reason
-            _devices.value =
-                _devices.value.mapValues { (_, d) ->
+            _devices.update { map ->
+                map.mapValues { (_, d) ->
                     if (!d.isUsbSynthetic && d.vendorId == vendorId && d.productId == productId) {
                         d.copy(pathReason = reason)
                     } else {
                         d
                     }
                 }
+            }
         }
 
         fun clearDirectFailed(
@@ -181,8 +182,7 @@ class PhysicalGamepadRegistry
                             "${current?.hasGyro} -> $nextHasGyro",
                     )
                 }
-                _devices.value =
-                    _devices.value + (deviceId to makeRoutedDevice(deviceId, dev))
+                _devices.update { it + (deviceId to makeRoutedDevice(deviceId, dev)) }
             }
         }
 
@@ -192,28 +192,28 @@ class PhysicalGamepadRegistry
                 scope.launch {
                     var remaining = DISCONNECT_GRACE_SEC
                     while (isActive && remaining > 0) {
-                        val current = _devices.value[device.id] ?: return@launch
-                        _devices.value =
-                            _devices.value + (device.id to current.copy(disconnectingTimeLeftSec = remaining))
+                        val snapshot =
+                            _devices.updateAndGet { map ->
+                                val cur = map[device.id] ?: return@updateAndGet map
+                                map + (device.id to cur.copy(disconnectingTimeLeftSec = remaining))
+                            }
+                        if (device.id !in snapshot) return@launch
                         delay(1000L)
                         remaining -= 1
                     }
-                    _devices.value = _devices.value - device.id
+                    _devices.update { it - device.id }
                     disconnectJobs.remove(device.id)
                 }
         }
 
         private fun cancelDisconnect(deviceId: Int) {
             disconnectJobs.remove(deviceId)?.cancel()
-            val cur = _devices.value[deviceId] ?: return
-            if (cur.isDisconnecting) {
-                _devices.value = _devices.value + (deviceId to cur.copy(disconnectingTimeLeftSec = null))
+            _devices.update { map ->
+                val cur = map[deviceId] ?: return@update map
+                if (cur.isDisconnecting) map + (deviceId to cur.copy(disconnectingTimeLeftSec = null)) else map
             }
         }
 
-        // Called by UsbGamepadManager after a successful claim. The synthetic deviceId is the
-        // negative integer returned by SatelliteNative.attachUsbDevice; the slot binding observer
-        // treats it like any other physical device.
         fun addUsbSynthetic(
             deviceId: Int,
             name: String,
@@ -222,44 +222,43 @@ class PhysicalGamepadRegistry
             vendorId: Int,
             productId: Int,
         ) {
-            _devices.value =
-                _devices.value +
-                (
-                    deviceId to
-                        Device(
-                            id = deviceId,
-                            name = name,
-                            hasGyro = hasGyro,
-                            pathMode = PathMode.Direct,
-                            pathReason = PathReason.None,
-                            isUsbSynthetic = true,
-                            pollRateHz = pollRateHz,
-                            vendorId = vendorId,
-                            productId = productId,
-                        )
-                )
+            _devices.update { map ->
+                map +
+                    (
+                        deviceId to
+                            Device(
+                                id = deviceId,
+                                name = name,
+                                hasGyro = hasGyro,
+                                pathMode = PathMode.Direct,
+                                pathReason = PathReason.None,
+                                isUsbSynthetic = true,
+                                pollRateHz = pollRateHz,
+                                vendorId = vendorId,
+                                productId = productId,
+                            )
+                    )
+            }
         }
 
         fun removeUsbSynthetic(deviceId: Int) {
-            _devices.value = _devices.value - deviceId
+            _devices.update { it - deviceId }
         }
 
-        // Called by PollRateSampler with the measured Hz computed from native URB-count deltas.
-        // Replaces the advertised rate set at attach with the actual live rate so the UI shows
-        // what the controller is doing right now rather than what its descriptor claims.
         fun updateMeasuredPollRate(
             deviceId: Int,
             rateHz: Int,
         ) {
-            val cur = _devices.value[deviceId] ?: return
-            if (cur.pollRateHz == rateHz) return
-            _devices.value = _devices.value + (deviceId to cur.copy(pollRateHz = rateHz))
+            _devices.update { map ->
+                val cur = map[deviceId] ?: return@update map
+                if (cur.pollRateHz == rateHz) map else map + (deviceId to cur.copy(pollRateHz = rateHz))
+            }
         }
 
         // Pushed at device-add time so the native input thread never crosses back into Java per event.
         private fun pushDeadzones(dev: InputDevice) {
             val src = InputDevice.SOURCE_JOYSTICK
-            SatelliteNative.setDeviceDeadzones(
+            native.setDeviceDeadzones(
                 dev.id,
                 dev.getMotionRange(MotionEvent.AXIS_X, src)?.flat ?: 0f,
                 dev.getMotionRange(MotionEvent.AXIS_Y, src)?.flat ?: 0f,
@@ -319,11 +318,13 @@ class PhysicalGamepadRegistry
         // Generic HID joysticks expose buttons as KEYCODE_BUTTON_1..16; gating on hasKeys would hide them.
         private fun isGamepad(d: InputDevice): Boolean = isGamepadDeviceFromCapabilities(d.sources, d.keyboardType)
 
-        private companion object {
-            const val TAG = "PhysicalGamepadRegistry"
+        companion object {
+            private const val TAG = "PhysicalGamepadRegistry"
 
             // Covers a USB cable jiggle / re-enumeration without holding state long enough that a real removal feels stuck.
-            const val DISCONNECT_GRACE_SEC = 5
+            private const val DISCONNECT_GRACE_SEC = 5
+
+            fun isSyntheticId(deviceId: Int): Boolean = deviceId < 0
         }
     }
 

--- a/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistry.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistry.kt
@@ -4,11 +4,14 @@ package com.tinkernorth.dish.hotpath.input
 
 import android.content.Context
 import android.hardware.input.InputManager
+import android.hardware.usb.UsbManager
 import android.util.Log
 import android.view.InputDevice
 import android.view.MotionEvent
 import com.tinkernorth.dish.core.jni.SatelliteNative
 import com.tinkernorth.dish.source.sensor.PhysicalMotionProbe
+import com.tinkernorth.dish.source.usb.PathMode
+import com.tinkernorth.dish.source.usb.PathReason
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -33,12 +36,21 @@ class PhysicalGamepadRegistry
             val name: String,
             val disconnectingTimeLeftSec: Int? = null,
             val hasGyro: Boolean = false,
+            val pathMode: PathMode = PathMode.Routed,
+            val pathReason: PathReason = PathReason.None,
+            val isUsbSynthetic: Boolean = false,
+            val pollRateHz: Int = 0,
+            val vendorId: Int = 0,
+            val productId: Int = 0,
         ) {
             val isDisconnecting: Boolean get() = disconnectingTimeLeftSec != null
         }
 
         private val inputManager =
             context.getSystemService(Context.INPUT_SERVICE) as InputManager
+
+        private val usbManager =
+            context.getSystemService(Context.USB_SERVICE) as UsbManager
 
         private val _devices = MutableStateFlow<Map<Int, Device>>(emptyMap())
         val devices: StateFlow<Map<Int, Device>> = _devices.asStateFlow()
@@ -60,7 +72,7 @@ class PhysicalGamepadRegistry
                 val dev = InputDevice.getDevice(id) ?: continue
                 if (!isGamepad(dev)) continue
                 pushDeadzones(dev)
-                next[id] = Device(id, dev.name, hasGyro = PhysicalMotionProbe.hasGyro(id))
+                next[id] = makeRoutedDevice(id, dev)
             }
             _devices.value = next
         }
@@ -70,9 +82,75 @@ class PhysicalGamepadRegistry
             if (!isGamepad(dev)) return
             pushDeadzones(dev)
             cancelDisconnect(deviceId)
+            _devices.value = _devices.value + (deviceId to makeRoutedDevice(deviceId, dev))
+        }
+
+        // Classifies a framework-routed controller. A known fast-lane model on the USB bus is an
+        // Eligible Direct-mode candidate (the card offers a "Try Direct mode" action) unless a prior
+        // attempt failed, in which case it shows that locked reason. Off the USB bus (Bluetooth)
+        // Direct mode can't apply; unknown models stay UnknownModel.
+        private fun makeRoutedDevice(
+            deviceId: Int,
+            dev: InputDevice,
+        ): Device {
+            val vid = runCatching { dev.vendorId }.getOrDefault(0)
+            val pid = runCatching { dev.productId }.getOrDefault(0)
+            val reason =
+                when {
+                    vid == 0 || pid == 0 -> PathReason.UnknownModel
+                    !SatelliteNative.isKnownFastLaneModel(vid, pid) -> PathReason.UnknownModel
+                    !isUsbDevicePresent(vid, pid) -> PathReason.Bluetooth
+                    else -> directFailed[vpKey(vid, pid)] ?: PathReason.Eligible
+                }
+            return Device(
+                id = deviceId,
+                name = dev.name,
+                hasGyro = PhysicalMotionProbe.hasGyro(deviceId),
+                pathMode = PathMode.Routed,
+                pathReason = reason,
+                vendorId = vid,
+                productId = pid,
+            )
+        }
+
+        private fun isUsbDevicePresent(
+            vendorId: Int,
+            productId: Int,
+        ): Boolean =
+            usbManager.deviceList.values.any {
+                it.vendorId == vendorId && it.productId == productId
+            }
+
+        private val directFailed = HashMap<Int, PathReason>()
+
+        private fun vpKey(
+            vendorId: Int,
+            productId: Int,
+        ): Int = (vendorId shl 16) or (productId and 0xFFFF)
+
+        // Called by UsbGamepadManager when a Direct-mode claim fails. Locks the matching framework
+        // card to the failure reason (no retry affordance) until the controller is re-plugged.
+        fun markDirectFailed(
+            vendorId: Int,
+            productId: Int,
+            reason: PathReason,
+        ) {
+            directFailed[vpKey(vendorId, productId)] = reason
             _devices.value =
-                _devices.value +
-                (deviceId to Device(deviceId, dev.name, hasGyro = PhysicalMotionProbe.hasGyro(deviceId)))
+                _devices.value.mapValues { (_, d) ->
+                    if (!d.isUsbSynthetic && d.vendorId == vendorId && d.productId == productId) {
+                        d.copy(pathReason = reason)
+                    } else {
+                        d
+                    }
+                }
+        }
+
+        fun clearDirectFailed(
+            vendorId: Int,
+            productId: Int,
+        ) {
+            directFailed.remove(vpKey(vendorId, productId))
         }
 
         override fun onInputDeviceRemoved(deviceId: Int) {
@@ -104,8 +182,7 @@ class PhysicalGamepadRegistry
                     )
                 }
                 _devices.value =
-                    _devices.value +
-                    (deviceId to Device(deviceId, dev.name, hasGyro = nextHasGyro))
+                    _devices.value + (deviceId to makeRoutedDevice(deviceId, dev))
             }
         }
 
@@ -132,6 +209,51 @@ class PhysicalGamepadRegistry
             if (cur.isDisconnecting) {
                 _devices.value = _devices.value + (deviceId to cur.copy(disconnectingTimeLeftSec = null))
             }
+        }
+
+        // Called by UsbGamepadManager after a successful claim. The synthetic deviceId is the
+        // negative integer returned by SatelliteNative.attachUsbDevice; the slot binding observer
+        // treats it like any other physical device.
+        fun addUsbSynthetic(
+            deviceId: Int,
+            name: String,
+            hasGyro: Boolean,
+            pollRateHz: Int,
+            vendorId: Int,
+            productId: Int,
+        ) {
+            _devices.value =
+                _devices.value +
+                (
+                    deviceId to
+                        Device(
+                            id = deviceId,
+                            name = name,
+                            hasGyro = hasGyro,
+                            pathMode = PathMode.Direct,
+                            pathReason = PathReason.None,
+                            isUsbSynthetic = true,
+                            pollRateHz = pollRateHz,
+                            vendorId = vendorId,
+                            productId = productId,
+                        )
+                )
+        }
+
+        fun removeUsbSynthetic(deviceId: Int) {
+            _devices.value = _devices.value - deviceId
+        }
+
+        // Called by PollRateSampler with the measured Hz computed from native URB-count deltas.
+        // Replaces the advertised rate set at attach with the actual live rate so the UI shows
+        // what the controller is doing right now rather than what its descriptor claims.
+        fun updateMeasuredPollRate(
+            deviceId: Int,
+            rateHz: Int,
+        ) {
+            val cur = _devices.value[deviceId] ?: return
+            if (cur.pollRateHz == rateHz) return
+            _devices.value = _devices.value + (deviceId to cur.copy(pollRateHz = rateHz))
         }
 
         // Pushed at device-add time so the native input thread never crosses back into Java per event.

--- a/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalSlotBindingObserver.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalSlotBindingObserver.kt
@@ -74,6 +74,9 @@ class PhysicalSlotBindingObserver
             val disappeared = lastBoundDeviceIds - present
             for (id in disappeared) {
                 SatelliteNative.unbindPhysicalSlot(id)
+                // Reclaim the native input-state entry for a departed framework device; a claimed
+                // USB synthetic (negative id) is freed by detachUsbDevice instead.
+                if (id >= 0) SatelliteNative.forgetPhysicalDevice(id)
                 hub.unbind(id.toString())
             }
             for (id in present) {

--- a/app/src/main/java/com/tinkernorth/dish/hotpath/input/RumbleBridge.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/input/RumbleBridge.kt
@@ -2,33 +2,16 @@
 
 package com.tinkernorth.dish.hotpath.input
 
-import android.content.Context
-import android.os.Build
-import android.os.CombinedVibration
-import android.os.VibrationEffect
-import android.os.Vibrator
-import android.os.VibratorManager
-import androidx.annotation.RequiresApi
-
-// All rumble routed to phone vibrator by design; no fallback to physical pad actuators.
 object RumbleBridge {
     init {
         System.loadLibrary("satellite")
     }
 
-    @Volatile private var vibratorManager: VibratorManager? = null
-
-    @Volatile private var vibrator: Vibrator? = null
+    @Volatile private var router: RumbleRouter? = null
 
     // Must run from a JVM call so the app classloader is on the stack (FindClass in JNI_OnLoad would fail).
-    fun install(context: Context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            vibratorManager =
-                context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager?
-        } else {
-            @Suppress("DEPRECATION")
-            vibrator = context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator?
-        }
+    fun install(router: RumbleRouter) {
+        this.router = router
         nativeInstall()
     }
 
@@ -37,93 +20,12 @@ object RumbleBridge {
 
     @JvmStatic
     fun dispatchRumble(
-        @Suppress("UNUSED_PARAMETER") sessionHandle: Int,
-        @Suppress("UNUSED_PARAMETER") controllerIndex: Int,
+        sessionHandle: Int,
+        controllerIndex: Int,
         strongMagnitude: Int,
         weakMagnitude: Int,
         durationMs: Int,
     ) {
-        if (durationMs == 0 || (strongMagnitude == 0 && weakMagnitude == 0)) {
-            cancelAll()
-            return
-        }
-        // Bound worst case at "the user's wrist survives one bad packet" from a buggy/malicious satellite.
-        val safeDuration = durationMs.coerceIn(1, 1500).toLong()
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            dispatchApi31(strongMagnitude, weakMagnitude, safeDuration)
-        } else {
-            dispatchLegacy(strongMagnitude, weakMagnitude, safeDuration)
-        }
+        router?.dispatch(sessionHandle, controllerIndex, strongMagnitude, weakMagnitude, durationMs)
     }
-
-    @RequiresApi(Build.VERSION_CODES.S)
-    private fun dispatchApi31(
-        strongMagnitude: Int,
-        weakMagnitude: Int,
-        durationMs: Long,
-    ) {
-        val mgr = vibratorManager ?: return
-        val ids = mgr.vibratorIds
-        if (ids.isEmpty()) {
-            return
-        }
-        val combinedBuilder = CombinedVibration.startParallel()
-        val strongAmp = magnitudeTo255(strongMagnitude)
-        val weakAmp = magnitudeTo255(weakMagnitude)
-        if (strongAmp > 0) {
-            combinedBuilder.addVibrator(ids[0], VibrationEffect.createOneShot(durationMs, strongAmp))
-        }
-        if (ids.size >= 2 && weakAmp > 0) {
-            combinedBuilder.addVibrator(ids[1], VibrationEffect.createOneShot(durationMs, weakAmp))
-        } else if (ids.size < 2 && weakAmp > 0 && strongAmp == 0) {
-            // Single actuator + weak-only: still drive ids[0], else mgr.vibrate on an empty combination is a silent no-op.
-            combinedBuilder.addVibrator(ids[0], VibrationEffect.createOneShot(durationMs, weakAmp))
-        }
-        try {
-            mgr.vibrate(combinedBuilder.combine())
-        } catch (_: IllegalStateException) {
-        }
-    }
-
-    private fun dispatchLegacy(
-        strongMagnitude: Int,
-        weakMagnitude: Int,
-        durationMs: Long,
-    ) {
-        val v = vibrator ?: return
-        val peak = maxOf(strongMagnitude, weakMagnitude)
-        val amp = magnitudeTo255(peak)
-        if (amp == 0) return
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            v.vibrate(VibrationEffect.createOneShot(durationMs, amp))
-        } else {
-            @Suppress("DEPRECATION")
-            v.vibrate(durationMs)
-        }
-    }
-
-    private fun cancelAll() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            vibratorManager?.cancel()
-        } else {
-            vibrator?.cancel()
-        }
-    }
-
-    private fun magnitudeTo255(magnitude: Int): Int = rumbleMagnitudeTo255(magnitude)
-}
-
-// Returns 0 only for exact zero; tiny magnitudes clamp to 1 so on/off response matches a physical pad.
-internal fun rumbleMagnitudeTo255(magnitude: Int): Int {
-    val clamped = magnitude.coerceIn(0, 65535)
-    if (clamped == 0) return 0
-    val scaled = (clamped * 255 + 32767) / 65535
-    return scaled.coerceIn(1, 255)
-}
-
-// Cap at 1500ms so a buggy/malicious satellite can't strand a multi-second buzz on the device.
-internal fun rumbleSafeDurationMs(durationMs: Int): Int {
-    if (durationMs == 0) return 0
-    return durationMs.coerceIn(1, 1500)
 }

--- a/app/src/main/java/com/tinkernorth/dish/hotpath/input/RumbleRouter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/input/RumbleRouter.kt
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.hotpath.input
+
+import android.content.Context
+import android.os.Build
+import android.os.CombinedVibration
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import android.view.InputDevice
+import androidx.annotation.RequiresApi
+import com.tinkernorth.dish.core.jni.PhysicalInputNative
+import com.tinkernorth.dish.source.connection.SatelliteConnection
+import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
+import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+sealed interface RumbleTarget {
+    object Phone : RumbleTarget
+
+    data class Framework(
+        val deviceId: Int,
+    ) : RumbleTarget
+
+    data class DirectUsb(
+        val deviceId: Int,
+    ) : RumbleTarget
+
+    object None : RumbleTarget
+}
+
+@Singleton
+class RumbleRouter
+    @Inject
+    constructor(
+        @ApplicationContext context: Context,
+        private val satellite: SatelliteConnectionManager,
+        private val native: PhysicalInputNative,
+        private val scope: CoroutineScope,
+    ) {
+        // A claimed USB pad has no oneshot duration, so a dropped session could leave it buzzing;
+        // each rumble schedules a stop at the clamped duration, cancelled by the next rumble.
+        private val usbStopJobs = ConcurrentHashMap<Int, Job>()
+
+        private val phoneVibratorManager: VibratorManager? =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager?
+            } else {
+                null
+            }
+
+        @Suppress("DEPRECATION")
+        private val phoneVibrator: Vibrator? =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                null
+            } else {
+                context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator?
+            }
+
+        fun dispatch(
+            sessionHandle: Int,
+            controllerIndex: Int,
+            strongMagnitude: Int,
+            weakMagnitude: Int,
+            durationMs: Int,
+        ) {
+            val target = resolveTarget(sessionHandle, controllerIndex)
+            if (target is RumbleTarget.None) return
+            if (durationMs == 0 || (strongMagnitude == 0 && weakMagnitude == 0)) {
+                cancel(target)
+                return
+            }
+            val safeDuration = rumbleSafeDurationMs(durationMs).toLong()
+            actuate(target, strongMagnitude, weakMagnitude, safeDuration)
+        }
+
+        private fun resolveTarget(
+            sessionHandle: Int,
+            controllerIndex: Int,
+        ): RumbleTarget {
+            if (sessionHandle < 0) return RumbleTarget.None
+            val conn =
+                satellite.connections.value.values
+                    .firstOrNull { it.handle == sessionHandle }
+                    ?: return RumbleTarget.None
+            val slotId = resolveSlotId(conn.slots.value, controllerIndex) ?: return RumbleTarget.None
+            return classifyTarget(slotId)
+        }
+
+        private fun actuate(
+            target: RumbleTarget,
+            strongMagnitude: Int,
+            weakMagnitude: Int,
+            durationMs: Long,
+        ) {
+            when (target) {
+                RumbleTarget.Phone ->
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        phoneVibratorManager?.let { vibrateManager(it, strongMagnitude, weakMagnitude, durationMs) }
+                    } else {
+                        phoneVibrator?.let { vibrateSingle(it, strongMagnitude, weakMagnitude, durationMs) }
+                    }
+                is RumbleTarget.Framework -> {
+                    val dev = InputDevice.getDevice(target.deviceId) ?: return
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        vibrateManager(dev.vibratorManager, strongMagnitude, weakMagnitude, durationMs)
+                    } else {
+                        @Suppress("DEPRECATION")
+                        vibrateSingle(dev.vibrator, strongMagnitude, weakMagnitude, durationMs)
+                    }
+                }
+                is RumbleTarget.DirectUsb -> {
+                    usbStopJobs.remove(target.deviceId)?.cancel()
+                    native.sendUsbRumble(target.deviceId, strongMagnitude, weakMagnitude)
+                    val job =
+                        scope.launch {
+                            delay(durationMs)
+                            native.sendUsbRumble(target.deviceId, 0, 0)
+                        }
+                    usbStopJobs[target.deviceId] = job
+                    job.invokeOnCompletion { usbStopJobs.remove(target.deviceId, job) }
+                }
+                RumbleTarget.None -> Unit
+            }
+        }
+
+        private fun cancel(target: RumbleTarget) {
+            when (target) {
+                RumbleTarget.Phone ->
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        phoneVibratorManager?.cancel()
+                    } else {
+                        phoneVibrator?.cancel()
+                    }
+                is RumbleTarget.Framework -> {
+                    val dev = InputDevice.getDevice(target.deviceId) ?: return
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        dev.vibratorManager.cancel()
+                    } else {
+                        @Suppress("DEPRECATION")
+                        dev.vibrator.cancel()
+                    }
+                }
+                is RumbleTarget.DirectUsb -> {
+                    usbStopJobs.remove(target.deviceId)?.cancel()
+                    native.sendUsbRumble(target.deviceId, 0, 0)
+                }
+                RumbleTarget.None -> Unit
+            }
+        }
+
+        @RequiresApi(Build.VERSION_CODES.S)
+        private fun vibrateManager(
+            mgr: VibratorManager,
+            strongMagnitude: Int,
+            weakMagnitude: Int,
+            durationMs: Long,
+        ) {
+            val ids = mgr.vibratorIds
+            if (ids.isEmpty()) return
+            val combinedBuilder = CombinedVibration.startParallel()
+            val strongAmp = rumbleMagnitudeTo255(strongMagnitude)
+            val weakAmp = rumbleMagnitudeTo255(weakMagnitude)
+            if (strongAmp > 0) {
+                combinedBuilder.addVibrator(ids[0], VibrationEffect.createOneShot(durationMs, strongAmp))
+            }
+            if (ids.size >= 2 && weakAmp > 0) {
+                combinedBuilder.addVibrator(ids[1], VibrationEffect.createOneShot(durationMs, weakAmp))
+            } else if (ids.size < 2 && weakAmp > 0 && strongAmp == 0) {
+                // Single actuator + weak-only: still drive ids[0], else vibrate on an empty combination is a no-op.
+                combinedBuilder.addVibrator(ids[0], VibrationEffect.createOneShot(durationMs, weakAmp))
+            }
+            try {
+                mgr.vibrate(combinedBuilder.combine())
+            } catch (_: IllegalStateException) {
+            }
+        }
+
+        private fun vibrateSingle(
+            vibrator: Vibrator,
+            strongMagnitude: Int,
+            weakMagnitude: Int,
+            durationMs: Long,
+        ) {
+            if (!vibrator.hasVibrator()) return
+            val amp = rumbleMagnitudeTo255(maxOf(strongMagnitude, weakMagnitude))
+            if (amp == 0) return
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                vibrator.vibrate(VibrationEffect.createOneShot(durationMs, amp))
+            } else {
+                @Suppress("DEPRECATION")
+                vibrator.vibrate(durationMs)
+            }
+        }
+    }
+
+internal fun resolveSlotId(
+    slots: Map<String, SatelliteConnection.SlotBinding>,
+    controllerIndex: Int,
+): String? = slots.entries.firstOrNull { it.value.controllerIndex == controllerIndex }?.key
+
+internal fun classifyTarget(slotId: String): RumbleTarget {
+    if (slotId == VIRTUAL_SLOT_ID) return RumbleTarget.Phone
+    val id = slotId.toIntOrNull() ?: return RumbleTarget.None
+    return if (id < 0) RumbleTarget.DirectUsb(id) else RumbleTarget.Framework(id)
+}
+
+// Returns 0 only for exact zero; tiny magnitudes clamp to 1 so on/off response matches a physical pad.
+internal fun rumbleMagnitudeTo255(magnitude: Int): Int {
+    val clamped = magnitude.coerceIn(0, 65535)
+    if (clamped == 0) return 0
+    val scaled = (clamped * 255 + 32767) / 65535
+    return scaled.coerceIn(1, 255)
+}
+
+// Cap at 1500ms so a buggy/malicious satellite can't strand a multi-second buzz on the device.
+internal fun rumbleSafeDurationMs(durationMs: Int): Int {
+    if (durationMs == 0) return 0
+    return durationMs.coerceIn(1, 1500)
+}

--- a/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
@@ -315,6 +315,24 @@ class SatelliteConnection(
         }
     }
 
+    fun renameSlot(
+        fromSlotId: String,
+        toSlotId: String,
+    ) {
+        if (fromSlotId == toSlotId) return
+        _slots.update { map ->
+            val cur = map[fromSlotId] ?: return@update map
+            if (map.containsKey(toSlotId)) return@update map
+            (map - fromSlotId) + (toSlotId to cur)
+        }
+        motionBackendStatusStore?.let { store ->
+            store.statusFor(id, fromSlotId)?.let { status ->
+                store.setStatus(id, toSlotId, status)
+                store.clear(id, fromSlotId)
+            }
+        }
+    }
+
     fun sendReport(
         slotId: String,
         buttons: Int,

--- a/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
@@ -196,16 +196,32 @@ class SatelliteConnection(
                 val info = _slots.value[slotId] ?: return@withContext
                 if (info.registered) return@withContext
                 if (handle < 0) return@withContext
-                controllerRepo.resetControllerAck(handle)
                 val caps = BASE_CAPABILITIES or motionCapsBitsFor(slotId)
-                controllerRepo.addController(handle, info.controllerIndex, caps)
-                var ack = -1
-                repeat(ACK_WAIT_ATTEMPTS) {
-                    ack = controllerRepo.getLastControllerAck(handle)
-                    if (ack != -1) return@repeat
-                    delay(ACK_WAIT_INTERVAL_MS)
+                // Retry the ADD a few times: a dropped UDP packet on the first attempt would
+                // otherwise leave the slot stuck unregistered until the user manually rebinds.
+                //
+                // ALREADY_EXISTS is treated as success either way. The two cases we see it in
+                // are (a) our own ADD's ACK was dropped on a previous attempt in this loop and
+                // we're hearing about the still-live controller, or (b) a previous session's
+                // REMOVE was dropped and the server is still holding a controller at our index.
+                // Both cases mean the slot is live server-side and the send path will work.
+                var result: Int? = null
+                for (attempt in 1..ADD_MAX_ATTEMPTS) {
+                    if (handle < 0) return@withContext
+                    controllerRepo.resetControllerAck(handle)
+                    controllerRepo.addController(handle, info.controllerIndex, caps)
+                    var ack = -1
+                    repeat(ACK_WAIT_ATTEMPTS) {
+                        ack = controllerRepo.getLastControllerAck(handle)
+                        if (ack != -1) return@repeat
+                        delay(ACK_WAIT_INTERVAL_MS)
+                    }
+                    if (ack != -1) {
+                        val raw = ack and ACK_RESULT_MASK
+                        result = if (raw == ACK_ERR_ALREADY_EXISTS) ACK_OK else raw
+                        break
+                    }
                 }
-                val result = if (ack == -1) null else ack and ACK_RESULT_MASK
                 if (result == ACK_OK) {
                     // Pre-extension satellite returns -1 — leave store absent so composer uses its heuristic.
                     val motionFlags = controllerRepo.getLastControllerMotionFlags(handle)
@@ -283,7 +299,19 @@ class SatelliteConnection(
         val info = removed ?: return
         motionBackendStatusStore?.clear(id, slotId)
         if (handle >= 0 && info.registered) {
-            controllerRepo.removeController(handle, info.controllerIndex)
+            val originalHandle = handle
+            // The remove path has no ack/retry-from-server. A single UDP drop here would leave a
+            // ghost controller on the satellite indefinitely. Fire the remove a few times spaced
+            // apart so at least one almost certainly survives even on a lossy link; the server
+            // treats "remove a controller that doesn't exist" as a no-op.
+            scope.launch(ioDispatcher) {
+                repeat(REMOVE_RETRIES) { attempt ->
+                    val snap = live ?: return@launch
+                    if (snap.handle != originalHandle) return@launch
+                    controllerRepo.removeController(snap.handle, info.controllerIndex)
+                    if (attempt < REMOVE_RETRIES - 1) delay(REMOVE_RETRY_INTERVAL_MS)
+                }
+            }
         }
     }
 
@@ -379,6 +407,9 @@ class SatelliteConnection(
         private const val ALIVE_POLL_MS = 1000L
         private const val ACK_WAIT_ATTEMPTS = 20
         private const val ACK_WAIT_INTERVAL_MS = 100L
+        private const val ADD_MAX_ATTEMPTS = 3
+        private const val REMOVE_RETRIES = 3
+        private const val REMOVE_RETRY_INTERVAL_MS = 200L
 
         private const val FALTER_THRESHOLD = 2
         private const val FALTER_TO_DEAD = 5

--- a/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
@@ -197,14 +197,6 @@ class SatelliteConnection(
                 if (info.registered) return@withContext
                 if (handle < 0) return@withContext
                 val caps = BASE_CAPABILITIES or motionCapsBitsFor(slotId)
-                // Retry the ADD a few times: a dropped UDP packet on the first attempt would
-                // otherwise leave the slot stuck unregistered until the user manually rebinds.
-                //
-                // ALREADY_EXISTS is treated as success either way. The two cases we see it in
-                // are (a) our own ADD's ACK was dropped on a previous attempt in this loop and
-                // we're hearing about the still-live controller, or (b) a previous session's
-                // REMOVE was dropped and the server is still holding a controller at our index.
-                // Both cases mean the slot is live server-side and the send path will work.
                 var result: Int? = null
                 for (attempt in 1..ADD_MAX_ATTEMPTS) {
                     if (handle < 0) return@withContext
@@ -300,10 +292,6 @@ class SatelliteConnection(
         motionBackendStatusStore?.clear(id, slotId)
         if (handle >= 0 && info.registered) {
             val originalHandle = handle
-            // The remove path has no ack/retry-from-server. A single UDP drop here would leave a
-            // ghost controller on the satellite indefinitely. Fire the remove a few times spaced
-            // apart so at least one almost certainly survives even on a lossy link; the server
-            // treats "remove a controller that doesn't exist" as a no-op.
             scope.launch(ioDispatcher) {
                 repeat(REMOVE_RETRIES) { attempt ->
                     val snap = live ?: return@launch
@@ -318,19 +306,24 @@ class SatelliteConnection(
     fun renameSlot(
         fromSlotId: String,
         toSlotId: String,
-    ) {
-        if (fromSlotId == toSlotId) return
+    ): Boolean {
+        if (fromSlotId == toSlotId) return _slots.value.containsKey(toSlotId)
+        var renamed = false
         _slots.update { map ->
             val cur = map[fromSlotId] ?: return@update map
             if (map.containsKey(toSlotId)) return@update map
+            renamed = true
             (map - fromSlotId) + (toSlotId to cur)
         }
-        motionBackendStatusStore?.let { store ->
-            store.statusFor(id, fromSlotId)?.let { status ->
-                store.setStatus(id, toSlotId, status)
-                store.clear(id, fromSlotId)
+        if (renamed) {
+            motionBackendStatusStore?.let { store ->
+                store.statusFor(id, fromSlotId)?.let { status ->
+                    store.setStatus(id, toSlotId, status)
+                    store.clear(id, fromSlotId)
+                }
             }
         }
+        return _slots.value.containsKey(toSlotId)
     }
 
     fun sendReport(

--- a/app/src/main/java/com/tinkernorth/dish/source/usb/PathMode.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/usb/PathMode.kt
@@ -2,15 +2,11 @@
 
 package com.tinkernorth.dish.source.usb
 
-// How a controller's input reaches the host. Direct = the native USB fast lane; Routed = Android's
-// standard input layer.
 enum class PathMode {
     Routed,
     Direct,
 }
 
-// Why a routed controller isn't on the direct fast lane, used to pick the explanation shown under
-// the Standard-mode badge. None means no explanation is needed.
 enum class PathReason {
     None,
     Bluetooth,
@@ -21,8 +17,5 @@ enum class PathReason {
     InitFailed,
     Detached,
     SupportedNoFastPathYet,
-
-    // Recognised USB controller that could move to Direct mode but hasn't been claimed yet. The
-    // dashboard offers a "Try Direct mode" action for this state.
     Eligible,
 }

--- a/app/src/main/java/com/tinkernorth/dish/source/usb/PathMode.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/usb/PathMode.kt
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.usb
+
+// How a controller's input reaches the host. Direct = the native USB fast lane; Routed = Android's
+// standard input layer.
+enum class PathMode {
+    Routed,
+    Direct,
+}
+
+// Why a routed controller isn't on the direct fast lane, used to pick the explanation shown under
+// the Standard-mode badge. None means no explanation is needed.
+enum class PathReason {
+    None,
+    Bluetooth,
+    OnScreen,
+    PermissionDenied,
+    UnknownModel,
+    Busy,
+    InitFailed,
+    Detached,
+    SupportedNoFastPathYet,
+
+    // Recognised USB controller that could move to Direct mode but hasn't been claimed yet. The
+    // dashboard offers a "Try Direct mode" action for this state.
+    Eligible,
+}

--- a/app/src/main/java/com/tinkernorth/dish/source/usb/PathReasonClassifier.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/usb/PathReasonClassifier.kt
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.usb
+
+internal fun classifyDirectPathReason(
+    vendorId: Int,
+    productId: Int,
+    isKnownFastLaneModel: Boolean,
+    isUsbPresent: Boolean,
+    priorFailure: PathReason?,
+): PathReason =
+    when {
+        vendorId == 0 || productId == 0 -> PathReason.UnknownModel
+        !isKnownFastLaneModel -> PathReason.UnknownModel
+        !isUsbPresent -> PathReason.Bluetooth
+        else -> priorFailure ?: PathReason.Eligible
+    }

--- a/app/src/main/java/com/tinkernorth/dish/source/usb/PollRateSampler.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/usb/PollRateSampler.kt
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.usb
+
+import android.os.SystemClock
+import com.tinkernorth.dish.core.jni.SatelliteNative
+import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+// Periodically reads the native URB-completion counter for each direct-mode controller, derives
+// an instantaneous Hz from the delta over the sampling window, and pushes the result into the
+// PhysicalGamepadRegistry. The UI then updates through the existing reactive flow.
+//
+// The sampler holds one snapshot per known device. Devices that disappear between samples are
+// pruned. A device whose count hasn't moved (no input, no kernel completions) reports 0 Hz
+// rather than freezing at the previous reading, which matches the user's intuition: "if I'm not
+// holding it and nothing's polling, the rate is zero."
+@Singleton
+class PollRateSampler
+    @Inject
+    constructor(
+        private val registry: PhysicalGamepadRegistry,
+        private val scope: CoroutineScope,
+    ) {
+        private data class Snapshot(
+            val count: Long,
+            val elapsedMs: Long,
+        )
+
+        private val snapshots = HashMap<Int, Snapshot>()
+        private var job: Job? = null
+
+        fun install() {
+            if (job != null) return
+            job =
+                scope.launch {
+                    while (true) {
+                        delay(SAMPLE_INTERVAL_MS)
+                        sampleAll()
+                    }
+                }
+        }
+
+        private fun sampleAll() {
+            val nowMs = SystemClock.elapsedRealtime()
+            val present = registry.devices.value
+            for ((id, device) in present) {
+                if (!device.isUsbSynthetic) continue
+                val count = SatelliteNative.getDeviceUrbCount(id)
+                val prev = snapshots[id]
+                snapshots[id] = Snapshot(count, nowMs)
+                if (prev == null) continue
+                val deltaCount = count - prev.count
+                val deltaMs = nowMs - prev.elapsedMs
+                if (deltaMs <= 0) continue
+                val rate = ((deltaCount * MILLIS_PER_SEC) / deltaMs).toInt()
+                registry.updateMeasuredPollRate(id, rate)
+            }
+            snapshots.keys.retainAll(present.keys)
+        }
+
+        private companion object {
+            // 500 ms gives a responsive but stable reading: long enough that a 1 ms-poll-rate pad
+            // accumulates ~500 samples (smoothing transients), short enough that a controller
+            // plug-in shows a live rate within a second.
+            const val SAMPLE_INTERVAL_MS = 500L
+            const val MILLIS_PER_SEC = 1000L
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/source/usb/PollRateSampler.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/usb/PollRateSampler.kt
@@ -3,7 +3,7 @@
 package com.tinkernorth.dish.source.usb
 
 import android.os.SystemClock
-import com.tinkernorth.dish.core.jni.SatelliteNative
+import com.tinkernorth.dish.core.jni.PhysicalInputNative
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -12,20 +12,13 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
-// Periodically reads the native URB-completion counter for each direct-mode controller, derives
-// an instantaneous Hz from the delta over the sampling window, and pushes the result into the
-// PhysicalGamepadRegistry. The UI then updates through the existing reactive flow.
-//
-// The sampler holds one snapshot per known device. Devices that disappear between samples are
-// pruned. A device whose count hasn't moved (no input, no kernel completions) reports 0 Hz
-// rather than freezing at the previous reading, which matches the user's intuition: "if I'm not
-// holding it and nothing's polling, the rate is zero."
 @Singleton
 class PollRateSampler
     @Inject
     constructor(
         private val registry: PhysicalGamepadRegistry,
         private val scope: CoroutineScope,
+        private val native: PhysicalInputNative,
     ) {
         private data class Snapshot(
             val count: Long,
@@ -41,34 +34,28 @@ class PollRateSampler
                 scope.launch {
                     while (true) {
                         delay(SAMPLE_INTERVAL_MS)
-                        sampleAll()
+                        sampleAll(SystemClock.elapsedRealtime())
                     }
                 }
         }
 
-        private fun sampleAll() {
-            val nowMs = SystemClock.elapsedRealtime()
+        internal fun sampleAll(nowMs: Long) {
             val present = registry.devices.value
             for ((id, device) in present) {
                 if (!device.isUsbSynthetic) continue
-                val count = SatelliteNative.getDeviceUrbCount(id)
+                val count = native.getDeviceUrbCount(id)
                 val prev = snapshots[id]
                 snapshots[id] = Snapshot(count, nowMs)
                 if (prev == null) continue
-                val deltaCount = count - prev.count
-                val deltaMs = nowMs - prev.elapsedMs
-                if (deltaMs <= 0) continue
-                val rate = ((deltaCount * MILLIS_PER_SEC) / deltaMs).toInt()
-                registry.updateMeasuredPollRate(id, rate)
+                registry.updateMeasuredPollRate(
+                    id,
+                    measuredPollRateHz(count - prev.count, nowMs - prev.elapsedMs),
+                )
             }
             snapshots.keys.retainAll(present.keys)
         }
 
         private companion object {
-            // 500 ms gives a responsive but stable reading: long enough that a 1 ms-poll-rate pad
-            // accumulates ~500 samples (smoothing transients), short enough that a controller
-            // plug-in shows a live rate within a second.
             const val SAMPLE_INTERVAL_MS = 500L
-            const val MILLIS_PER_SEC = 1000L
         }
     }

--- a/app/src/main/java/com/tinkernorth/dish/source/usb/UsbGamepadManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/usb/UsbGamepadManager.kt
@@ -17,6 +17,7 @@ import android.os.Build
 import android.util.Log
 import androidx.core.content.ContextCompat
 import com.tinkernorth.dish.R
+import com.tinkernorth.dish.composer.ConnectionHub
 import com.tinkernorth.dish.core.jni.SatelliteNative
 import com.tinkernorth.dish.core.model.DishNotification
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
@@ -26,6 +27,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 
 // Hilt singleton that manages the USB-host fast lane. Direct mode is opt-in per connection: when a
@@ -40,6 +42,7 @@ class UsbGamepadManager
     constructor(
         @ApplicationContext private val context: Context,
         private val registry: PhysicalGamepadRegistry,
+        private val connectionHubProvider: Provider<ConnectionHub>,
         private val notifications: DishNotifications,
         private val scope: CoroutineScope,
     ) {
@@ -191,6 +194,14 @@ class UsbGamepadManager
             if (claimedDevices.containsKey(key)) return null
             val (intf, epIn, epOut) =
                 findInterruptInPair(device) ?: return PathReason.SupportedNoFastPathYet
+            val routedSlotId =
+                registry.devices.value.values
+                    .firstOrNull {
+                        !it.isUsbSynthetic &&
+                            it.vendorId == device.vendorId &&
+                            it.productId == device.productId
+                    }?.id
+                    ?.toString()
             val conn = usbManager.openDevice(device) ?: return PathReason.Busy
             if (!conn.claimInterface(intf, true)) {
                 conn.close()
@@ -224,6 +235,9 @@ class UsbGamepadManager
                 vendorId = device.vendorId,
                 productId = device.productId,
             )
+            if (routedSlotId != null) {
+                connectionHubProvider.get().migrateSlotBinding(routedSlotId, synthetic.toString())
+            }
             Log.i(TAG, "claimed ${device.vendorId.toHex4()}:${device.productId.toHex4()} ($displayName) → dev=$synthetic")
             return null
         }

--- a/app/src/main/java/com/tinkernorth/dish/source/usb/UsbGamepadManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/usb/UsbGamepadManager.kt
@@ -18,7 +18,7 @@ import android.util.Log
 import androidx.core.content.ContextCompat
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.composer.ConnectionHub
-import com.tinkernorth.dish.core.jni.SatelliteNative
+import com.tinkernorth.dish.core.jni.PhysicalInputNative
 import com.tinkernorth.dish.core.model.DishNotification
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.source.notification.DishNotifications
@@ -26,16 +26,11 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
 
-// Hilt singleton that manages the USB-host fast lane. Direct mode is opt-in per connection: when a
-// recognised controller is attached we post a themed prompt asking whether to move it to the
-// C-level fast lane. Accepting (prompt action or the per-card button) requests USB permission,
-// claims the interface, and hands the fd to SatelliteNative.attachUsbDevice; the per-device hot
-// path then runs entirely in C. This class is only touched on plug-in, prompt/button action,
-// permission-grant, and unplug.
 @Singleton
 class UsbGamepadManager
     @Inject
@@ -45,11 +40,12 @@ class UsbGamepadManager
         private val connectionHubProvider: Provider<ConnectionHub>,
         private val notifications: DishNotifications,
         private val scope: CoroutineScope,
+        private val native: PhysicalInputNative,
     ) {
         private val usbManager = context.getSystemService(Context.USB_SERVICE) as UsbManager
 
-        private val claimedDevices = HashMap<String, ClaimedDevice>()
-        private val promptedDevices = HashSet<String>()
+        private val claimedDevices = ConcurrentHashMap<String, ClaimedDevice>()
+        private val promptedDevices = ConcurrentHashMap.newKeySet<String>()
 
         @Volatile private var installed = false
 
@@ -79,9 +75,6 @@ class UsbGamepadManager
         }
 
         private fun scanExistingDevices() {
-            // App start: the dashboard isn't up yet, so a prompt would be dropped. Silently restore
-            // devices we already hold permission for; reconcileForeground() prompts the rest once
-            // the UI is showing.
             for (device in usbManager.deviceList.values) {
                 claimIfPermitted(device)
             }
@@ -93,18 +86,12 @@ class UsbGamepadManager
             if (usbManager.hasPermission(device)) claimAndReport(device, notify = false)
         }
 
-        // Called when the dashboard comes to the foreground: silently restores already-permitted
-        // candidates and prompts the rest (once per connection), covering controllers plugged in
-        // while the app was closed.
         fun reconcileForeground() {
             for (device in usbManager.deviceList.values) {
                 handleAttached(device)
             }
         }
 
-        // Entry point for the prompt's "Try" action and the per-card "Try Direct mode" button.
-        // Claims the device (permission already held) or pops the system permission dialog; the
-        // outcome surfaces as a themed toast.
         fun tryDirectMode(
             vendorId: Int,
             productId: Int,
@@ -140,8 +127,6 @@ class UsbGamepadManager
                             val device = deviceFromIntent(intent) ?: return
                             val granted =
                                 intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)
-                            // Denial leaves the controller eligible (the card keeps its "Try Direct
-                            // mode" button); only a real claim failure locks it.
                             if (granted) claimAndReport(device, notify = true)
                         }
                     }
@@ -163,7 +148,7 @@ class UsbGamepadManager
             promptedDevices.remove(key)
             registry.clearDirectFailed(device.vendorId, device.productId)
             val claimed = claimedDevices.remove(key) ?: return
-            SatelliteNative.detachUsbDevice(claimed.syntheticDeviceId)
+            native.detachUsbDevice(claimed.syntheticDeviceId)
             runCatching {
                 claimed.connection.releaseInterface(claimed.intf)
                 claimed.connection.close()
@@ -186,9 +171,6 @@ class UsbGamepadManager
             }
         }
 
-        // Returns null on success (the device is now on the fast lane), or the PathReason explaining
-        // why it couldn't be claimed. Surfaces nothing to the user; the caller decides whether to
-        // toast (user-initiated) or stay silent (background restore).
         private fun attemptClaim(device: UsbDevice): PathReason? {
             val key = keyFor(device)
             if (claimedDevices.containsKey(key)) return null
@@ -202,13 +184,9 @@ class UsbGamepadManager
                             it.productId == device.productId
                     }?.id
                     ?.toString()
-            val conn = usbManager.openDevice(device) ?: return PathReason.Busy
-            if (!conn.claimInterface(intf, true)) {
-                conn.close()
-                return PathReason.Busy
-            }
+            val conn = openAndClaim(device, intf) ?: return PathReason.Busy
             val synthetic =
-                SatelliteNative.attachUsbDevice(
+                native.attachUsbDevice(
                     fd = conn.fileDescriptor,
                     vendorId = device.vendorId,
                     productId = device.productId,
@@ -226,19 +204,27 @@ class UsbGamepadManager
             }
             claimedDevices[key] = ClaimedDevice(device, conn, intf, synthetic)
             val displayName = friendlyName(device)
-            val pollRateHz = computePollRateHz(epIn.interval, epIn.maxPacketSize)
+            val pollRateHz = computeUsbPollRateHz(epIn.interval, epIn.maxPacketSize)
             registry.addUsbSynthetic(
                 deviceId = synthetic,
                 name = displayName,
-                hasGyro = SatelliteNative.modelHasImu(device.vendorId, device.productId),
+                hasGyro = native.modelHasImu(device.vendorId, device.productId),
                 pollRateHz = pollRateHz,
                 vendorId = device.vendorId,
                 productId = device.productId,
             )
-            if (routedSlotId != null) {
-                connectionHubProvider.get().migrateSlotBinding(routedSlotId, synthetic.toString())
-            }
+            connectionHubProvider.get().bindClaimedSynthetic(routedSlotId, synthetic.toString())
             Log.i(TAG, "claimed ${device.vendorId.toHex4()}:${device.productId.toHex4()} ($displayName) → dev=$synthetic")
+            return null
+        }
+
+        private fun openAndClaim(
+            device: UsbDevice,
+            intf: UsbInterface,
+        ): UsbDeviceConnection? {
+            val conn = usbManager.openDevice(device) ?: return null
+            if (conn.claimInterface(intf, true)) return conn
+            conn.close()
             return null
         }
 
@@ -273,10 +259,6 @@ class UsbGamepadManager
             }
         }
 
-        // The PendingIntent must be MUTABLE on API 31+: UsbManager fills EXTRA_DEVICE and
-        // EXTRA_PERMISSION_GRANTED into the result when it fires, which it can't do on an immutable
-        // one (the grant then never reaches our receiver). Safe here: the intent is package-scoped
-        // and the receiver is not exported.
         private fun requestPermission(device: UsbDevice) {
             val intent = Intent(ACTION_USB_PERMISSION).setPackage(context.packageName)
             val flags =
@@ -291,18 +273,14 @@ class UsbGamepadManager
             }
         }
 
-        // A controller is a Direct-mode candidate if it's gamepad-shaped and its VID/PID is in our
-        // parser table. Both are readable without USB permission, so we decide before prompting.
         private fun isCandidate(device: UsbDevice): Boolean =
             isGamepadShaped(device) &&
-                SatelliteNative.isKnownFastLaneModel(device.vendorId, device.productId)
+                native.isKnownFastLaneModel(device.vendorId, device.productId)
 
-        // Stable per-connection key: deviceName is the USB bus path, identical at attach and detach,
-        // unique per attached device, and readable without USB permission.
         private fun keyFor(device: UsbDevice): String = device.deviceName
 
         private fun friendlyName(device: UsbDevice): String {
-            val known = SatelliteNative.lookupKnownModelName(device.vendorId, device.productId)
+            val known = native.lookupKnownModelName(device.vendorId, device.productId)
             if (known.isNotEmpty()) return known
             val product = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) device.productName else null
             return product?.takeIf { it.isNotBlank() } ?: device.deviceName
@@ -345,31 +323,6 @@ class UsbGamepadManager
             return null
         }
 
-        // Derives the controller's advertised poll rate from the endpoint descriptor. USB-HID
-        // interrupt endpoints encode this differently per device speed: low/full-speed devices
-        // report bInterval in 1ms frames (rate = 1000 / bInterval), high-speed devices encode it
-        // as a power-of-2 microframe exponent (rate = 8000 / 2^(bInterval-1)).
-        //
-        // Android's UsbEndpoint.getInterval returns the raw bInterval byte and does not expose
-        // the negotiated USB speed. We infer high-speed from the IN endpoint's max packet size:
-        // anything over 64 bytes can only come from a high-speed (or faster) endpoint.
-        private fun computePollRateHz(
-            epInterval: Int,
-            epMaxPacketSize: Int,
-        ): Int {
-            if (epInterval <= 0) return 0
-            val isHighSpeed = epMaxPacketSize > MAX_FS_INTERRUPT_PACKET
-            val periodMicros =
-                if (isHighSpeed) {
-                    val exp = (epInterval - 1).coerceIn(0, 15)
-                    (1L shl exp) * 125L
-                } else {
-                    epInterval.toLong() * 1000L
-                }
-            if (periodMicros <= 0L) return 0
-            return (1_000_000L / periodMicros).toInt()
-        }
-
         private fun deviceFromIntent(intent: Intent): UsbDevice? =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 intent.getParcelableExtra(UsbManager.EXTRA_DEVICE, UsbDevice::class.java)
@@ -383,6 +336,5 @@ class UsbGamepadManager
         private companion object {
             const val TAG = "UsbGamepadManager"
             const val ACTION_USB_PERMISSION = "com.tinkernorth.dish.USB_PERMISSION"
-            const val MAX_FS_INTERRUPT_PACKET = 64
         }
     }

--- a/app/src/main/java/com/tinkernorth/dish/source/usb/UsbGamepadManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/usb/UsbGamepadManager.kt
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.usb
+
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.hardware.usb.UsbConstants
+import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbDeviceConnection
+import android.hardware.usb.UsbEndpoint
+import android.hardware.usb.UsbInterface
+import android.hardware.usb.UsbManager
+import android.os.Build
+import android.util.Log
+import androidx.core.content.ContextCompat
+import com.tinkernorth.dish.R
+import com.tinkernorth.dish.core.jni.SatelliteNative
+import com.tinkernorth.dish.core.model.DishNotification
+import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
+import com.tinkernorth.dish.source.notification.DishNotifications
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+// Hilt singleton that manages the USB-host fast lane. Direct mode is opt-in per connection: when a
+// recognised controller is attached we post a themed prompt asking whether to move it to the
+// C-level fast lane. Accepting (prompt action or the per-card button) requests USB permission,
+// claims the interface, and hands the fd to SatelliteNative.attachUsbDevice; the per-device hot
+// path then runs entirely in C. This class is only touched on plug-in, prompt/button action,
+// permission-grant, and unplug.
+@Singleton
+class UsbGamepadManager
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+        private val registry: PhysicalGamepadRegistry,
+        private val notifications: DishNotifications,
+        private val scope: CoroutineScope,
+    ) {
+        private val usbManager = context.getSystemService(Context.USB_SERVICE) as UsbManager
+
+        private val claimedDevices = HashMap<String, ClaimedDevice>()
+        private val promptedDevices = HashSet<String>()
+
+        @Volatile private var installed = false
+
+        private data class ClaimedDevice(
+            val device: UsbDevice,
+            val connection: UsbDeviceConnection,
+            val intf: UsbInterface,
+            val syntheticDeviceId: Int,
+        )
+
+        fun install() {
+            if (installed) return
+            installed = true
+            val filter =
+                IntentFilter().apply {
+                    addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED)
+                    addAction(UsbManager.ACTION_USB_DEVICE_DETACHED)
+                    addAction(ACTION_USB_PERMISSION)
+                }
+            ContextCompat.registerReceiver(
+                context,
+                receiver,
+                filter,
+                ContextCompat.RECEIVER_NOT_EXPORTED,
+            )
+            scanExistingDevices()
+        }
+
+        private fun scanExistingDevices() {
+            // App start: the dashboard isn't up yet, so a prompt would be dropped. Silently restore
+            // devices we already hold permission for; reconcileForeground() prompts the rest once
+            // the UI is showing.
+            for (device in usbManager.deviceList.values) {
+                claimIfPermitted(device)
+            }
+        }
+
+        private fun claimIfPermitted(device: UsbDevice) {
+            if (!isCandidate(device)) return
+            if (claimedDevices.containsKey(keyFor(device))) return
+            if (usbManager.hasPermission(device)) claimAndReport(device, notify = false)
+        }
+
+        // Called when the dashboard comes to the foreground: silently restores already-permitted
+        // candidates and prompts the rest (once per connection), covering controllers plugged in
+        // while the app was closed.
+        fun reconcileForeground() {
+            for (device in usbManager.deviceList.values) {
+                handleAttached(device)
+            }
+        }
+
+        // Entry point for the prompt's "Try" action and the per-card "Try Direct mode" button.
+        // Claims the device (permission already held) or pops the system permission dialog; the
+        // outcome surfaces as a themed toast.
+        fun tryDirectMode(
+            vendorId: Int,
+            productId: Int,
+        ) {
+            val device =
+                usbManager.deviceList.values.firstOrNull {
+                    it.vendorId == vendorId && it.productId == productId
+                } ?: return
+            if (claimedDevices.containsKey(keyFor(device))) return
+            if (usbManager.hasPermission(device)) {
+                claimAndReport(device, notify = true)
+            } else {
+                requestPermission(device)
+            }
+        }
+
+        private val receiver =
+            object : BroadcastReceiver() {
+                override fun onReceive(
+                    ctx: Context,
+                    intent: Intent,
+                ) {
+                    when (intent.action) {
+                        UsbManager.ACTION_USB_DEVICE_ATTACHED -> {
+                            val device = deviceFromIntent(intent) ?: return
+                            handleAttached(device)
+                        }
+                        UsbManager.ACTION_USB_DEVICE_DETACHED -> {
+                            val device = deviceFromIntent(intent) ?: return
+                            handleDetached(device)
+                        }
+                        ACTION_USB_PERMISSION -> {
+                            val device = deviceFromIntent(intent) ?: return
+                            val granted =
+                                intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)
+                            // Denial leaves the controller eligible (the card keeps its "Try Direct
+                            // mode" button); only a real claim failure locks it.
+                            if (granted) claimAndReport(device, notify = true)
+                        }
+                    }
+                }
+            }
+
+        private fun handleAttached(device: UsbDevice) {
+            if (!isCandidate(device)) return
+            if (claimedDevices.containsKey(keyFor(device))) return
+            if (usbManager.hasPermission(device)) {
+                claimAndReport(device, notify = false)
+            } else {
+                promptTryDirect(device)
+            }
+        }
+
+        private fun handleDetached(device: UsbDevice) {
+            val key = keyFor(device)
+            promptedDevices.remove(key)
+            registry.clearDirectFailed(device.vendorId, device.productId)
+            val claimed = claimedDevices.remove(key) ?: return
+            SatelliteNative.detachUsbDevice(claimed.syntheticDeviceId)
+            runCatching {
+                claimed.connection.releaseInterface(claimed.intf)
+                claimed.connection.close()
+            }
+            registry.removeUsbSynthetic(claimed.syntheticDeviceId)
+        }
+
+        private fun claimAndReport(
+            device: UsbDevice,
+            notify: Boolean,
+        ) {
+            val failure = attemptClaim(device)
+            if (failure == null) {
+                registry.clearDirectFailed(device.vendorId, device.productId)
+                if (notify) notifyDirect(device, R.string.direct_enabled, success = true)
+            } else {
+                registry.markDirectFailed(device.vendorId, device.productId, failure)
+                Log.i(TAG, "direct failed ${device.vendorId.toHex4()}:${device.productId.toHex4()} reason=$failure")
+                if (notify) notifyDirect(device, R.string.direct_failed, success = false)
+            }
+        }
+
+        // Returns null on success (the device is now on the fast lane), or the PathReason explaining
+        // why it couldn't be claimed. Surfaces nothing to the user; the caller decides whether to
+        // toast (user-initiated) or stay silent (background restore).
+        private fun attemptClaim(device: UsbDevice): PathReason? {
+            val key = keyFor(device)
+            if (claimedDevices.containsKey(key)) return null
+            val (intf, epIn, epOut) =
+                findInterruptInPair(device) ?: return PathReason.SupportedNoFastPathYet
+            val conn = usbManager.openDevice(device) ?: return PathReason.Busy
+            if (!conn.claimInterface(intf, true)) {
+                conn.close()
+                return PathReason.Busy
+            }
+            val synthetic =
+                SatelliteNative.attachUsbDevice(
+                    fd = conn.fileDescriptor,
+                    vendorId = device.vendorId,
+                    productId = device.productId,
+                    interfaceNumber = intf.id,
+                    endpointIn = epIn.address,
+                    endpointInMaxPacket = epIn.maxPacketSize,
+                    endpointOut = epOut?.address ?: 0,
+                )
+            if (synthetic == 0) {
+                runCatching {
+                    conn.releaseInterface(intf)
+                    conn.close()
+                }
+                return PathReason.InitFailed
+            }
+            claimedDevices[key] = ClaimedDevice(device, conn, intf, synthetic)
+            val displayName = friendlyName(device)
+            val pollRateHz = computePollRateHz(epIn.interval, epIn.maxPacketSize)
+            registry.addUsbSynthetic(
+                deviceId = synthetic,
+                name = displayName,
+                hasGyro = SatelliteNative.modelHasImu(device.vendorId, device.productId),
+                pollRateHz = pollRateHz,
+                vendorId = device.vendorId,
+                productId = device.productId,
+            )
+            Log.i(TAG, "claimed ${device.vendorId.toHex4()}:${device.productId.toHex4()} ($displayName) → dev=$synthetic")
+            return null
+        }
+
+        private fun promptTryDirect(device: UsbDevice) {
+            if (!promptedDevices.add(keyFor(device))) return
+            val name = friendlyName(device)
+            val vendorId = device.vendorId
+            val productId = device.productId
+            notifications.info(
+                glyph = R.drawable.ic_gamepad,
+                title = context.getString(R.string.direct_prompt_title, name),
+                action =
+                    DishNotification.Action(
+                        label = context.getString(R.string.direct_prompt_action),
+                    ) { tryDirectMode(vendorId, productId) },
+                key = "direct-prompt:${keyFor(device)}",
+                durationMs = DishNotification.DURATION_LONG,
+            )
+        }
+
+        private fun notifyDirect(
+            device: UsbDevice,
+            titleRes: Int,
+            success: Boolean,
+        ) {
+            val title = context.getString(titleRes, friendlyName(device))
+            val key = "direct-result:${keyFor(device)}"
+            if (success) {
+                notifications.success(glyph = R.drawable.ic_gamepad, title = title, key = key)
+            } else {
+                notifications.warn(glyph = R.drawable.ic_gamepad, title = title, key = key)
+            }
+        }
+
+        // The PendingIntent must be MUTABLE on API 31+: UsbManager fills EXTRA_DEVICE and
+        // EXTRA_PERMISSION_GRANTED into the result when it fires, which it can't do on an immutable
+        // one (the grant then never reaches our receiver). Safe here: the intent is package-scoped
+        // and the receiver is not exported.
+        private fun requestPermission(device: UsbDevice) {
+            val intent = Intent(ACTION_USB_PERMISSION).setPackage(context.packageName)
+            val flags =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+                } else {
+                    PendingIntent.FLAG_UPDATE_CURRENT
+                }
+            val pending = PendingIntent.getBroadcast(context, device.deviceId, intent, flags)
+            scope.launch(Dispatchers.Main) {
+                usbManager.requestPermission(device, pending)
+            }
+        }
+
+        // A controller is a Direct-mode candidate if it's gamepad-shaped and its VID/PID is in our
+        // parser table. Both are readable without USB permission, so we decide before prompting.
+        private fun isCandidate(device: UsbDevice): Boolean =
+            isGamepadShaped(device) &&
+                SatelliteNative.isKnownFastLaneModel(device.vendorId, device.productId)
+
+        // Stable per-connection key: deviceName is the USB bus path, identical at attach and detach,
+        // unique per attached device, and readable without USB permission.
+        private fun keyFor(device: UsbDevice): String = device.deviceName
+
+        private fun friendlyName(device: UsbDevice): String {
+            val known = SatelliteNative.lookupKnownModelName(device.vendorId, device.productId)
+            if (known.isNotEmpty()) return known
+            val product = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) device.productName else null
+            return product?.takeIf { it.isNotBlank() } ?: device.deviceName
+        }
+
+        private fun isGamepadShaped(device: UsbDevice): Boolean {
+            for (i in 0 until device.interfaceCount) {
+                val intf = device.getInterface(i)
+                val isHid = intf.interfaceClass == UsbConstants.USB_CLASS_HID
+                val isVendor = intf.interfaceClass == UsbConstants.USB_CLASS_VENDOR_SPEC
+                if (!isHid && !isVendor) continue
+                for (e in 0 until intf.endpointCount) {
+                    val ep = intf.getEndpoint(e)
+                    if (ep.type == UsbConstants.USB_ENDPOINT_XFER_INT &&
+                        ep.direction == UsbConstants.USB_DIR_IN
+                    ) {
+                        return true
+                    }
+                }
+            }
+            return false
+        }
+
+        private fun findInterruptInPair(device: UsbDevice): Triple<UsbInterface, UsbEndpoint, UsbEndpoint?>? {
+            for (i in 0 until device.interfaceCount) {
+                val intf = device.getInterface(i)
+                val isHid = intf.interfaceClass == UsbConstants.USB_CLASS_HID
+                val isVendor = intf.interfaceClass == UsbConstants.USB_CLASS_VENDOR_SPEC
+                if (!isHid && !isVendor) continue
+                var epIn: UsbEndpoint? = null
+                var epOut: UsbEndpoint? = null
+                for (e in 0 until intf.endpointCount) {
+                    val ep = intf.getEndpoint(e)
+                    if (ep.type != UsbConstants.USB_ENDPOINT_XFER_INT) continue
+                    if (ep.direction == UsbConstants.USB_DIR_IN && epIn == null) epIn = ep
+                    if (ep.direction == UsbConstants.USB_DIR_OUT && epOut == null) epOut = ep
+                }
+                if (epIn != null) return Triple(intf, epIn, epOut)
+            }
+            return null
+        }
+
+        // Derives the controller's advertised poll rate from the endpoint descriptor. USB-HID
+        // interrupt endpoints encode this differently per device speed: low/full-speed devices
+        // report bInterval in 1ms frames (rate = 1000 / bInterval), high-speed devices encode it
+        // as a power-of-2 microframe exponent (rate = 8000 / 2^(bInterval-1)).
+        //
+        // Android's UsbEndpoint.getInterval returns the raw bInterval byte and does not expose
+        // the negotiated USB speed. We infer high-speed from the IN endpoint's max packet size:
+        // anything over 64 bytes can only come from a high-speed (or faster) endpoint.
+        private fun computePollRateHz(
+            epInterval: Int,
+            epMaxPacketSize: Int,
+        ): Int {
+            if (epInterval <= 0) return 0
+            val isHighSpeed = epMaxPacketSize > MAX_FS_INTERRUPT_PACKET
+            val periodMicros =
+                if (isHighSpeed) {
+                    val exp = (epInterval - 1).coerceIn(0, 15)
+                    (1L shl exp) * 125L
+                } else {
+                    epInterval.toLong() * 1000L
+                }
+            if (periodMicros <= 0L) return 0
+            return (1_000_000L / periodMicros).toInt()
+        }
+
+        private fun deviceFromIntent(intent: Intent): UsbDevice? =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                intent.getParcelableExtra(UsbManager.EXTRA_DEVICE, UsbDevice::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                intent.getParcelableExtra(UsbManager.EXTRA_DEVICE)
+            }
+
+        private fun Int.toHex4(): String = "%04x".format(this and 0xFFFF)
+
+        private companion object {
+            const val TAG = "UsbGamepadManager"
+            const val ACTION_USB_PERMISSION = "com.tinkernorth.dish.USB_PERMISSION"
+            const val MAX_FS_INTERRUPT_PACKET = 64
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/source/usb/UsbPollRate.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/usb/UsbPollRate.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.usb
+
+internal const val MAX_FS_INTERRUPT_PACKET = 64
+
+internal fun computeUsbPollRateHz(
+    epInterval: Int,
+    epMaxPacketSize: Int,
+): Int {
+    if (epInterval <= 0) return 0
+    val isHighSpeed = epMaxPacketSize > MAX_FS_INTERRUPT_PACKET
+    val periodMicros =
+        if (isHighSpeed) {
+            val exp = (epInterval - 1).coerceIn(0, 15)
+            (1L shl exp) * 125L
+        } else {
+            epInterval.toLong() * 1000L
+        }
+    if (periodMicros <= 0L) return 0
+    return (1_000_000L / periodMicros).toInt()
+}
+
+internal fun measuredPollRateHz(
+    deltaCount: Long,
+    deltaMs: Long,
+): Int {
+    if (deltaMs <= 0L) return 0
+    if (deltaCount <= 0L) return 0
+    return ((deltaCount * MILLIS_PER_SEC) / deltaMs).toInt()
+}
+
+private const val MILLIS_PER_SEC = 1000L

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
@@ -67,11 +67,11 @@ interface SlotActionListener {
 
 internal fun LinkState.isAvailableForPicker(): Boolean =
     when (this) {
-        LinkState.Connected, LinkState.Unstable,
+        LinkState.Connected, LinkState.Unstable -> true
         LinkState.Connecting,
         LinkState.Ready, LinkState.Found,
-        -> true
-        LinkState.Saved, LinkState.Stale -> false
+        LinkState.Saved, LinkState.Stale,
+        -> false
     }
 
 internal fun connectionsVisibleInPicker(

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
@@ -42,6 +42,8 @@ interface SlotActionListener {
 
     fun onUnbind(slotId: String)
 
+    fun onTryDirectMode(slotId: String)
+
     fun onOpenGamepad()
 
     fun onChangeDeviceType(
@@ -86,6 +88,7 @@ class ControllerAdapter(
         val expanded: Boolean,
         val motionCap: MotionCapability = MotionCapability.Off,
         val touchpadModes: Map<String, String> = emptyMap(),
+        val pathBadge: PathBadge? = null,
     )
 
     private val expandedIds = mutableSetOf(VIRTUAL_SLOT_ID)
@@ -95,6 +98,7 @@ class ControllerAdapter(
         connections: List<ConnectionSummary>,
         motionCapabilities: Map<String, MotionCapability> = emptyMap(),
         touchpadModes: Map<String, String> = emptyMap(),
+        pathBadges: Map<String, PathBadge> = emptyMap(),
     ) {
         submitList(
             slots.map { slot ->
@@ -104,6 +108,7 @@ class ControllerAdapter(
                     expanded = expandedIds.contains(slot.id),
                     motionCap = motionCapabilities[slot.id] ?: MotionCapability.Off,
                     touchpadModes = touchpadModes,
+                    pathBadge = pathBadges[slot.id],
                 )
             },
         )
@@ -129,6 +134,7 @@ class ControllerAdapter(
             b.tvControllerName.text = slot.name
             b.tvSlotStatus.text = slotStatusText(slot)
             bindBattery(slot.battery)
+            bindPathBadge(row.pathBadge, slot.id)
 
             setDot(
                 b.dotStatus,
@@ -484,6 +490,46 @@ class ControllerAdapter(
                     else -> R.string.battery_state_discharging
                 }
             return ctx.getString(R.string.battery_desc, levelText, ctx.getString(stateRes))
+        }
+
+        private fun bindPathBadge(
+            badge: PathBadge?,
+            slotId: String,
+        ) {
+            if (badge == null) {
+                b.tvPathBadge.visibility = View.GONE
+                b.tvPathReason.visibility = View.GONE
+                b.tvPathReason.setOnClickListener(null)
+                return
+            }
+            val ctx = b.root.context
+            b.tvPathBadge.visibility = View.VISIBLE
+            b.tvPathBadge.text = badge.label
+            val colorRes = if (badge.isDirect) R.color.colorSuccess else R.color.colorMuted
+            b.tvPathBadge.setTextColor(ctx.getColor(colorRes))
+            val subtitle = badge.subtitle
+            if (subtitle.isNullOrBlank()) {
+                b.tvPathReason.visibility = View.GONE
+                b.tvPathReason.setOnClickListener(null)
+                return
+            }
+            b.tvPathReason.visibility = View.VISIBLE
+            b.tvPathReason.text = subtitle
+            if (badge.actionable) {
+                val attr = android.util.TypedValue()
+                ctx.theme.resolveAttribute(android.R.attr.selectableItemBackground, attr, true)
+                b.tvPathReason.setBackgroundResource(attr.resourceId)
+                b.tvPathReason.setTextColor(ctx.getColor(R.color.colorPrimary))
+                b.tvPathReason.isClickable = true
+                b.tvPathReason.isFocusable = true
+                b.tvPathReason.setOnClickListener { listener.onTryDirectMode(slotId) }
+            } else {
+                b.tvPathReason.setTextColor(ctx.getColor(R.color.colorMuted))
+                b.tvPathReason.setOnClickListener(null)
+                b.tvPathReason.isClickable = false
+                b.tvPathReason.isFocusable = false
+                b.tvPathReason.background = null
+            }
         }
 
         private fun slotStatusText(s: ControllerSlot): String {

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
@@ -27,6 +27,7 @@ import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
 import com.tinkernorth.dish.source.store.OnboardingState
 import com.tinkernorth.dish.source.usb.UsbGamepadManager
 import com.tinkernorth.dish.ui.common.DishNavigator
+import com.tinkernorth.dish.ui.common.DishSpinnerDrawable
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.attachGamepadHost
@@ -59,6 +60,10 @@ class MainActivity :
     private lateinit var gamepadHost: GamepadActivityHost
 
     private val nav by lazy { DishNavigator(this) }
+
+    private val connectionsSpinner by lazy {
+        DishSpinnerDrawable(this, resources.getDimensionPixelSize(R.dimen.icon_battery))
+    }
 
     // Held by installSplashScreen()'s keep-on-screen gate; cleared either by the first
     // MainUiState render or the SPLASH_HOLD_MAX_MS fallback so a stalled ViewModel can't pin
@@ -118,6 +123,7 @@ class MainActivity :
     private fun setupUI() {
         binding.sectionConnections.labelSection.setText(R.string.section_connections)
         binding.sectionControllers.labelSection.setText(R.string.section_controllers)
+        binding.ivConnectionsLoading.setImageDrawable(connectionsSpinner)
         binding.rvControllers.adapter = controllerAdapter
         (binding.rvControllers.itemAnimator as? androidx.recyclerview.widget.SimpleItemAnimator)
             ?.supportsChangeAnimations = false
@@ -166,6 +172,9 @@ class MainActivity :
         splashHoldUntilFirstRender = false
         val liveCount = s.connections.count { it.live == LinkState.Connected }
         val totalCount = s.connections.size
+        val checking = s.anyConnecting
+        binding.ivConnectionsLoading.isVisible = checking
+        if (checking) connectionsSpinner.start() else connectionsSpinner.stop()
         binding.tvConnectionsSummary.text =
             when {
                 liveCount == 0 && totalCount == 0 -> getString(R.string.status_tap_manage)

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
@@ -25,15 +25,12 @@ import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.notification.DishNotifications
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
 import com.tinkernorth.dish.source.store.OnboardingState
-import com.tinkernorth.dish.source.usb.PathMode
-import com.tinkernorth.dish.source.usb.PathReason
 import com.tinkernorth.dish.source.usb.UsbGamepadManager
 import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.attachGamepadHost
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -113,8 +110,6 @@ class MainActivity :
 
     override fun onResume() {
         super.onResume()
-        // Restore already-permitted controllers and prompt any recognised ones connected while the
-        // app was closed (the prompt needs the dashboard up to render).
         if (!com.tinkernorth.dish.DishApplication.nativeLoadFailed) {
             usbGamepadManager.reconcileForeground()
         }
@@ -139,10 +134,7 @@ class MainActivity :
     private fun observeViewModel() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                // Combine path info into the same render so a USB plug-in / permission grant
-                // updates the per-controller badge in lockstep with the slot list.
-                combine(viewModel.uiState, gamepadRegistry.devices) { ui, devs -> ui to devs }
-                    .collect { (ui, devs) -> updateUI(ui, devs) }
+                viewModel.uiState.collect { updateUI(it) }
             }
         }
         lifecycleScope.launch {
@@ -166,10 +158,7 @@ class MainActivity :
         binding.cardDashboardHintInclude.cardDashboardHint.isVisible = shouldShow
     }
 
-    private fun updateUI(
-        s: MainUiState,
-        devices: Map<Int, com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry.Device> = gamepadRegistry.devices.value,
-    ) {
+    private fun updateUI(s: MainUiState) {
         // First emission has been rendered: release the splash hold so the
         // system splash exits and MainActivity becomes interactive. Idempotent
         // (the postDelayed safety net may also flip this) so subsequent
@@ -189,23 +178,10 @@ class MainActivity :
             s.connections,
             s.motionCapabilities,
             s.touchpadModesBySatellite,
-            computePathBadges(s.slots, devices),
+            s.pathBadges,
         )
         refreshDashboardHint(onboarding.state.value, s)
     }
-
-    private fun computePathBadges(
-        slots: List<ControllerSlot>,
-        devices: Map<Int, com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry.Device>,
-    ): Map<String, PathBadge> =
-        slots.associate { slot ->
-            val isOnScreen = slot.inputType == SlotInputType.VIRTUAL
-            val device = devices[slot.physicalDeviceId]
-            val mode = device?.pathMode ?: PathMode.Routed
-            val reason = device?.pathReason ?: PathReason.None
-            val rate = device?.pollRateHz ?: 0
-            slot.id to PathBadgeMapper.map(this, mode, reason, isOnScreen, rate)
-        }
 
     private fun handleEvent(event: MainEvent) {
         when (event) {

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
@@ -25,11 +25,15 @@ import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.notification.DishNotifications
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
 import com.tinkernorth.dish.source.store.OnboardingState
+import com.tinkernorth.dish.source.usb.PathMode
+import com.tinkernorth.dish.source.usb.PathReason
+import com.tinkernorth.dish.source.usb.UsbGamepadManager
 import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.attachGamepadHost
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -48,6 +52,8 @@ class MainActivity :
     @Inject lateinit var wakeState: WakeStateController
 
     @Inject lateinit var gamepadRegistry: PhysicalGamepadRegistry
+
+    @Inject lateinit var usbGamepadManager: UsbGamepadManager
 
     @Inject lateinit var notifications: DishNotifications
 
@@ -105,10 +111,21 @@ class MainActivity :
         gamepadHost.cancelDimOnStop()
     }
 
+    override fun onResume() {
+        super.onResume()
+        // Restore already-permitted controllers and prompt any recognised ones connected while the
+        // app was closed (the prompt needs the dashboard up to render).
+        if (!com.tinkernorth.dish.DishApplication.nativeLoadFailed) {
+            usbGamepadManager.reconcileForeground()
+        }
+    }
+
     private fun setupUI() {
         binding.sectionConnections.labelSection.setText(R.string.section_connections)
         binding.sectionControllers.labelSection.setText(R.string.section_controllers)
         binding.rvControllers.adapter = controllerAdapter
+        (binding.rvControllers.itemAnimator as? androidx.recyclerview.widget.SimpleItemAnimator)
+            ?.supportsChangeAnimations = false
         binding.btnManageConnections.setOnClickListener { nav.toConnections() }
         binding.btnSettings.setOnClickListener { nav.toSettings() }
         binding.cardDashboardHintInclude.btnDashboardHintOpen.setOnClickListener {
@@ -121,7 +138,12 @@ class MainActivity :
 
     private fun observeViewModel() {
         lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) { viewModel.uiState.collect { updateUI(it) } }
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                // Combine path info into the same render so a USB plug-in / permission grant
+                // updates the per-controller badge in lockstep with the slot list.
+                combine(viewModel.uiState, gamepadRegistry.devices) { ui, devs -> ui to devs }
+                    .collect { (ui, devs) -> updateUI(ui, devs) }
+            }
         }
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) { viewModel.events.collect { handleEvent(it) } }
@@ -144,7 +166,10 @@ class MainActivity :
         binding.cardDashboardHintInclude.cardDashboardHint.isVisible = shouldShow
     }
 
-    private fun updateUI(s: MainUiState) {
+    private fun updateUI(
+        s: MainUiState,
+        devices: Map<Int, com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry.Device> = gamepadRegistry.devices.value,
+    ) {
         // First emission has been rendered: release the splash hold so the
         // system splash exits and MainActivity becomes interactive. Idempotent
         // (the postDelayed safety net may also flip this) so subsequent
@@ -164,9 +189,23 @@ class MainActivity :
             s.connections,
             s.motionCapabilities,
             s.touchpadModesBySatellite,
+            computePathBadges(s.slots, devices),
         )
         refreshDashboardHint(onboarding.state.value, s)
     }
+
+    private fun computePathBadges(
+        slots: List<ControllerSlot>,
+        devices: Map<Int, com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry.Device>,
+    ): Map<String, PathBadge> =
+        slots.associate { slot ->
+            val isOnScreen = slot.inputType == SlotInputType.VIRTUAL
+            val device = devices[slot.physicalDeviceId]
+            val mode = device?.pathMode ?: PathMode.Routed
+            val reason = device?.pathReason ?: PathReason.None
+            val rate = device?.pollRateHz ?: 0
+            slot.id to PathBadgeMapper.map(this, mode, reason, isOnScreen, rate)
+        }
 
     private fun handleEvent(event: MainEvent) {
         when (event) {
@@ -195,6 +234,14 @@ class MainActivity :
     }
 
     override fun onSlotTapped(slotId: String) = controllerAdapter.toggleExpanded(slotId)
+
+    override fun onTryDirectMode(slotId: String) {
+        val device =
+            viewModel.uiState.value.slots
+                .firstOrNull { it.id == slotId }
+                ?.let { gamepadRegistry.devices.value[it.physicalDeviceId] } ?: return
+        usbGamepadManager.tryDirectMode(device.vendorId, device.productId)
+    }
 
     override fun onBind(
         slotId: String,

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainUiState.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainUiState.kt
@@ -55,6 +55,7 @@ data class MainUiState(
     val connections: List<ConnectionSummary> = emptyList(),
     val motionCapabilities: Map<String, MotionCapability> = emptyMap(),
     val touchpadModesBySatellite: Map<String, String> = emptyMap(),
+    val pathBadges: Map<String, PathBadge> = emptyMap(),
 ) {
     val virtualSlot get() = slots.first { it.id == VIRTUAL_SLOT_ID }
     val physicalSlots get() = slots.filter { it.inputType == SlotInputType.PHYSICAL }

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainUiState.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainUiState.kt
@@ -60,6 +60,7 @@ data class MainUiState(
     val virtualSlot get() = slots.first { it.id == VIRTUAL_SLOT_ID }
     val physicalSlots get() = slots.filter { it.inputType == SlotInputType.PHYSICAL }
     val anyConnected get() = connections.any { it.live == com.tinkernorth.dish.composer.LinkState.Connected }
+    val anyConnecting get() = connections.any { it.live == com.tinkernorth.dish.composer.LinkState.Connecting }
 
     // Distinct from connections.count { CONNECTED }: excludes physical slots with no device attached.
     val streamingSlotCount: Int get() =

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
@@ -68,17 +68,23 @@ class MainViewModel
                         inputType = SlotInputType.VIRTUAL,
                         name = context.getString(R.string.default_virtual_controller_name),
                     )
+                val directVidPids =
+                    devices.values
+                        .filter { it.isUsbSynthetic && it.vendorId != 0 && it.productId != 0 }
+                        .mapTo(mutableSetOf()) { it.vendorId to it.productId }
                 val physical =
-                    devices.values.map { dev ->
-                        ControllerSlot(
-                            id = dev.id.toString(),
-                            inputType = SlotInputType.PHYSICAL,
-                            name = dev.name,
-                            physicalDeviceId = dev.id,
-                            isDisconnecting = dev.isDisconnecting,
-                            disconnectTimeLeft = dev.disconnectingTimeLeftSec ?: 0,
-                        )
-                    }
+                    devices.values
+                        .filter { dev -> dev.isUsbSynthetic || (dev.vendorId to dev.productId) !in directVidPids }
+                        .map { dev ->
+                            ControllerSlot(
+                                id = dev.id.toString(),
+                                inputType = SlotInputType.PHYSICAL,
+                                name = dev.name,
+                                physicalDeviceId = dev.id,
+                                isDisconnecting = dev.isDisconnecting,
+                                disconnectTimeLeft = dev.disconnectingTimeLeftSec ?: 0,
+                            )
+                        }
                 val slots =
                     (listOf(virtual) + physical).map { slot ->
                         val cid = bindings[slot.id]

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
@@ -8,6 +8,8 @@ import androidx.lifecycle.viewModelScope
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.composer.ConnectionHub
 import com.tinkernorth.dish.composer.ConnectionKind
+import com.tinkernorth.dish.composer.ConnectionSummary
+import com.tinkernorth.dish.composer.MotionCapability
 import com.tinkernorth.dish.composer.MotionCapabilityComposer
 import com.tinkernorth.dish.composer.TouchpadModeComposer
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
@@ -17,6 +19,8 @@ import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.store.BatteryStatusStore
 import com.tinkernorth.dish.source.store.MotionEnabledStore
 import com.tinkernorth.dish.source.store.TouchpadModeStore
+import com.tinkernorth.dish.source.usb.PathMode
+import com.tinkernorth.dish.source.usb.PathReason
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -68,13 +72,10 @@ class MainViewModel
                         inputType = SlotInputType.VIRTUAL,
                         name = context.getString(R.string.default_virtual_controller_name),
                     )
-                val directVidPids =
-                    devices.values
-                        .filter { it.isUsbSynthetic && it.vendorId != 0 && it.productId != 0 }
-                        .mapTo(mutableSetOf()) { it.vendorId to it.productId }
+                val hiddenRoutedIds = routedTwinIdsHiddenBySynthetics(devices.values)
                 val physical =
                     devices.values
-                        .filter { dev -> dev.isUsbSynthetic || (dev.vendorId to dev.productId) !in directVidPids }
+                        .filter { dev -> dev.isUsbSynthetic || dev.id !in hiddenRoutedIds }
                         .map { dev ->
                             ControllerSlot(
                                 id = dev.id.toString(),
@@ -97,14 +98,15 @@ class MainViewModel
                                 },
                         )
                     }
-                Triple(slots, conns, motionCaps)
-            }.onEach { (slots, conns, motionCaps) ->
-                // `.update` (not `.value =`) so the parallel touchpad-mode collector's field isn't wiped on re-fire.
+                val pathBadges = slots.associate { it.id to pathBadgeFor(it, devices) }
+                SlotsRender(slots, conns, motionCaps, pathBadges)
+            }.onEach { render ->
                 _uiState.update { prev ->
                     prev.copy(
-                        slots = slots,
-                        connections = conns,
-                        motionCapabilities = motionCaps,
+                        slots = render.slots,
+                        connections = render.connections,
+                        motionCapabilities = render.motionCapabilities,
+                        pathBadges = render.pathBadges,
                     )
                 }
             }.launchIn(viewModelScope)
@@ -214,6 +216,27 @@ class MainViewModel
             if (closeQuote < 0) return null
             return json.substring(openQuote + 1, closeQuote)
         }
+
+        private fun pathBadgeFor(
+            slot: ControllerSlot,
+            devices: Map<Int, PhysicalGamepadRegistry.Device>,
+        ): PathBadge {
+            val device = devices[slot.physicalDeviceId]
+            return PathBadgeMapper.map(
+                ctx = context,
+                mode = device?.pathMode ?: PathMode.Routed,
+                reason = device?.pathReason ?: PathReason.None,
+                isOnScreen = slot.inputType == SlotInputType.VIRTUAL,
+                pollRateHz = device?.pollRateHz ?: 0,
+            )
+        }
+
+        private data class SlotsRender(
+            val slots: List<ControllerSlot>,
+            val connections: List<ConnectionSummary>,
+            val motionCapabilities: Map<String, MotionCapability>,
+            val pathBadges: Map<String, PathBadge>,
+        )
 
         private companion object {
             val ASSUMED_SUPPORTED_TOUCHPAD_MODES: Set<String> = TouchpadModeValue.ALL.toSet()

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/PathBadgeMapper.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/PathBadgeMapper.kt
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.main
+
+import android.content.Context
+import androidx.annotation.StringRes
+import com.tinkernorth.dish.R
+import com.tinkernorth.dish.source.usb.PathMode
+import com.tinkernorth.dish.source.usb.PathReason
+
+// Translates a PathMode + PathReason into a user-facing label + optional "why?" subtitle. Names
+// are intentionally non-technical so the dashboard reads "Direct mode" rather than "USB host fast
+// lane via libusb evdev" or "JNI-routed framework input".
+data class PathBadge(
+    val label: String,
+    val subtitle: String?,
+    val isDirect: Boolean,
+    val actionable: Boolean = false,
+)
+
+object PathBadgeMapper {
+    fun map(
+        ctx: Context,
+        mode: PathMode,
+        reason: PathReason,
+        isOnScreen: Boolean,
+        pollRateHz: Int = 0,
+    ): PathBadge {
+        if (isOnScreen) {
+            return PathBadge(
+                label = ctx.getString(R.string.path_label_standard),
+                subtitle = ctx.getString(R.string.path_reason_onscreen),
+                isDirect = false,
+            )
+        }
+        return when (mode) {
+            PathMode.Direct -> {
+                val label =
+                    if (pollRateHz > 0) {
+                        ctx.getString(R.string.path_label_direct_with_rate, pollRateHz)
+                    } else {
+                        ctx.getString(R.string.path_label_direct)
+                    }
+                PathBadge(
+                    label = label,
+                    subtitle = ctx.getString(R.string.path_direct_explainer),
+                    isDirect = true,
+                )
+            }
+            PathMode.Routed ->
+                PathBadge(
+                    label = ctx.getString(R.string.path_label_standard),
+                    subtitle = reasonText(ctx, reason),
+                    isDirect = false,
+                    actionable = reason == PathReason.Eligible || reason == PathReason.PermissionDenied,
+                )
+        }
+    }
+
+    private fun reasonText(
+        ctx: Context,
+        reason: PathReason,
+    ): String? {
+        @StringRes val resId =
+            when (reason) {
+                PathReason.None -> R.string.path_reason_default
+                PathReason.Bluetooth -> R.string.path_reason_bluetooth
+                PathReason.OnScreen -> R.string.path_reason_onscreen
+                PathReason.Eligible -> R.string.path_action_try_direct
+                PathReason.PermissionDenied -> R.string.path_action_try_direct
+                PathReason.UnknownModel -> R.string.path_reason_unknown_model
+                PathReason.Busy -> R.string.path_reason_busy
+                PathReason.InitFailed -> R.string.path_reason_init_failed
+                PathReason.Detached -> R.string.path_reason_detached
+                PathReason.SupportedNoFastPathYet -> R.string.path_reason_not_yet
+            }
+        return ctx.getString(resId)
+    }
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/PathBadgeMapper.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/PathBadgeMapper.kt
@@ -8,9 +8,6 @@ import com.tinkernorth.dish.R
 import com.tinkernorth.dish.source.usb.PathMode
 import com.tinkernorth.dish.source.usb.PathReason
 
-// Translates a PathMode + PathReason into a user-facing label + optional "why?" subtitle. Names
-// are intentionally non-technical so the dashboard reads "Direct mode" rather than "USB host fast
-// lane via libusb evdev" or "JNI-routed framework input".
 data class PathBadge(
     val label: String,
     val subtitle: String?,

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/SyntheticTwinDedup.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/SyntheticTwinDedup.kt
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.main
+
+import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
+
+internal fun routedTwinIdsHiddenBySynthetics(devices: Collection<PhysicalGamepadRegistry.Device>): Set<Int> {
+    val syntheticModelCounts =
+        devices
+            .filter { it.isUsbSynthetic && it.vendorId != 0 && it.productId != 0 }
+            .groupingBy { it.vendorId to it.productId }
+            .eachCount()
+    if (syntheticModelCounts.isEmpty()) return emptySet()
+    return devices
+        .filter { !it.isUsbSynthetic && (it.vendorId to it.productId) in syntheticModelCounts }
+        .groupBy { it.vendorId to it.productId }
+        .flatMap { (model, routed) ->
+            routed
+                .sortedByDescending { it.isDisconnecting }
+                .take(syntheticModelCounts[model] ?: 0)
+                .map { it.id }
+        }.toSet()
+}

--- a/app/src/main/res/layout-sw600dp/activity_main.xml
+++ b/app/src/main/res/layout-sw600dp/activity_main.xml
@@ -113,6 +113,14 @@
                                 android:layout_weight="1"
                                 android:layout_marginStart="@dimen/spacing_2xl"
                                 android:text="@string/dashboard_connections_empty" />
+
+                            <ImageView
+                                android:id="@+id/ivConnectionsLoading"
+                                android:layout_width="@dimen/icon_battery"
+                                android:layout_height="@dimen/icon_battery"
+                                android:layout_marginStart="@dimen/spacing_md"
+                                android:importantForAccessibility="no"
+                                android:visibility="gone" />
                         </LinearLayout>
 
                         <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -93,6 +93,15 @@
                         android:layout_marginStart="@dimen/spacing_2xl"
                         android:text="@string/dashboard_connections_empty" />
 
+                    <ImageView
+                        android:id="@+id/ivConnectionsLoading"
+                        android:layout_width="@dimen/icon_battery"
+                        android:layout_height="@dimen/icon_battery"
+                        android:layout_marginStart="@dimen/spacing_md"
+                        android:layout_marginEnd="@dimen/spacing_md"
+                        android:importantForAccessibility="no"
+                        android:visibility="gone" />
+
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/btnManageConnections"
                         style="@style/Widget.Dish.Button.Outlined"

--- a/app/src/main/res/layout/item_controller.xml
+++ b/app/src/main/res/layout/item_controller.xml
@@ -46,6 +46,24 @@
                     style="@style/TextAppearance.Dish.BodySmall"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content" />
+
+                <TextView
+                    android:id="@+id/tvPathBadge"
+                    style="@style/TextAppearance.Dish.BodySmall"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_xs"
+                    android:textStyle="bold"
+                    android:visibility="gone" />
+
+                <TextView
+                    android:id="@+id/tvPathReason"
+                    style="@style/TextAppearance.Dish.BodySmall"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingVertical="@dimen/spacing_xs"
+                    android:textColor="@color/colorMuted"
+                    android:visibility="gone" />
             </LinearLayout>
 
             <ImageView

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -271,4 +271,21 @@
     <string name="settings_open_source_licenses_body">Napomene za biblioteke na kojima je Dish izgrađen.</string>
     <string name="licenses_open_external">Otvori licencu za %1$s</string>
     <string name="settings_version_label">VERZIJA</string>
+
+    <string name="path_label_direct">Brzi način</string>
+    <string name="path_label_direct_with_rate">Brzi način · %1$d Hz</string>
+    <string name="path_label_standard">Standardni način</string>
+    <string name="path_direct_explainer">Najmanje kašnjenje. Direktno do kontrolera.</string>
+    <string name="path_reason_default">Radi sa svakim kontrolerom koji Android prepoznaje.</string>
+    <string name="path_reason_bluetooth">Bluetooth kontroleri uvijek koriste Standardni način.</string>
+    <string name="path_reason_onscreen">Kontroleri na ekranu koriste Standardni način.</string>    <string name="path_reason_unknown_model">Ovaj kontroler još nije na brzoj listi.</string>
+    <string name="path_reason_busy">Druga aplikacija koristi ovaj kontroler.</string>
+    <string name="path_reason_init_failed">Nije moguće postaviti Brzi način. Koristi se Standardni način.</string>
+    <string name="path_reason_detached">Kontroler je isključen.</string>
+    <string name="path_reason_not_yet">Brzi način za ovaj kontroler dolazi uskoro.</string>
+    <string name="path_action_try_direct">Pokušaj Brzi način</string>
+    <string name="direct_prompt_title">Pokušati Brzi način za %1$s?</string>
+    <string name="direct_prompt_action">Pokušaj</string>
+    <string name="direct_enabled">%1$s sada koristi Brzi način.</string>
+    <string name="direct_failed">Nije moguće prebaciti %1$s na Brzi način.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -268,4 +268,21 @@
     <string name="settings_open_source_licenses_body">Hinweise zu den Bibliotheken, auf denen Dish aufbaut.</string>
     <string name="licenses_open_external">Lizenz für %1$s öffnen</string>
     <string name="settings_version_label">VERSION</string>
+
+    <string name="path_label_direct">Direktmodus</string>
+    <string name="path_label_direct_with_rate">Direktmodus · %1$d Hz</string>
+    <string name="path_label_standard">Standardmodus</string>
+    <string name="path_direct_explainer">Geringste Verzögerung. Direkter Zugriff auf den Controller.</string>
+    <string name="path_reason_default">Funktioniert mit jedem Controller, den Android erkennt.</string>
+    <string name="path_reason_bluetooth">Bluetooth-Controller verwenden immer den Standardmodus.</string>
+    <string name="path_reason_onscreen">Bildschirm-Controller verwenden den Standardmodus.</string>    <string name="path_reason_unknown_model">Dieser Controller ist noch nicht in der Schnellzugriffsliste.</string>
+    <string name="path_reason_busy">Eine andere App verwendet diesen Controller.</string>
+    <string name="path_reason_init_failed">Direktmodus konnte nicht eingerichtet werden. Standardmodus wird verwendet.</string>
+    <string name="path_reason_detached">Controller wurde getrennt.</string>
+    <string name="path_reason_not_yet">Direktmodus für diesen Controller kommt bald.</string>
+    <string name="path_action_try_direct">Direktmodus versuchen</string>
+    <string name="direct_prompt_title">Direktmodus für %1$s versuchen?</string>
+    <string name="direct_prompt_action">Versuchen</string>
+    <string name="direct_enabled">%1$s nutzt jetzt den Direktmodus.</string>
+    <string name="direct_failed">%1$s konnte nicht in den Direktmodus wechseln.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -272,4 +272,21 @@
     <string name="settings_open_source_licenses_body">Avisos de las bibliotecas sobre las que se construye Dish.</string>
     <string name="licenses_open_external">Abrir licencia de %1$s</string>
     <string name="settings_version_label">VERSIÓN</string>
+
+    <string name="path_label_direct">Modo directo</string>
+    <string name="path_label_direct_with_rate">Modo directo · %1$d Hz</string>
+    <string name="path_label_standard">Modo estándar</string>
+    <string name="path_direct_explainer">Menor retraso. Comunicación directa con el mando.</string>
+    <string name="path_reason_default">Funciona con cualquier mando que Android reconozca.</string>
+    <string name="path_reason_bluetooth">Los mandos Bluetooth siempre usan Modo estándar.</string>
+    <string name="path_reason_onscreen">Los mandos en pantalla usan Modo estándar.</string>    <string name="path_reason_unknown_model">Este mando aún no está en la lista rápida.</string>
+    <string name="path_reason_busy">Otra app está usando este mando.</string>
+    <string name="path_reason_init_failed">No se pudo activar el Modo directo. Se usa Modo estándar.</string>
+    <string name="path_reason_detached">El mando se desconectó.</string>
+    <string name="path_reason_not_yet">El Modo directo para este mando llegará pronto.</string>
+    <string name="path_action_try_direct">Probar Modo directo</string>
+    <string name="direct_prompt_title">¿Probar Modo directo para %1$s?</string>
+    <string name="direct_prompt_action">Probar</string>
+    <string name="direct_enabled">%1$s está en Modo directo.</string>
+    <string name="direct_failed">No se pudo cambiar %1$s a Modo directo.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -271,4 +271,21 @@
     <string name="settings_open_source_licenses_body">Mentions pour les bibliothèques sur lesquelles Dish s\'appuie.</string>
     <string name="licenses_open_external">Ouvrir la licence de %1$s</string>
     <string name="settings_version_label">VERSION</string>
+
+    <string name="path_label_direct">Mode direct</string>
+    <string name="path_label_direct_with_rate">Mode direct · %1$d Hz</string>
+    <string name="path_label_standard">Mode standard</string>
+    <string name="path_direct_explainer">Latence minimale. Communication directe avec la manette.</string>
+    <string name="path_reason_default">Compatible avec toute manette reconnue par Android.</string>
+    <string name="path_reason_bluetooth">Les manettes Bluetooth utilisent toujours le Mode standard.</string>
+    <string name="path_reason_onscreen">Les manettes à l\'écran utilisent le Mode standard.</string>    <string name="path_reason_unknown_model">Cette manette n\'est pas encore sur la liste rapide.</string>
+    <string name="path_reason_busy">Une autre app utilise cette manette.</string>
+    <string name="path_reason_init_failed">Impossible d\'activer le Mode direct. Mode standard utilisé.</string>
+    <string name="path_reason_detached">La manette a été déconnectée.</string>
+    <string name="path_reason_not_yet">Le Mode direct pour cette manette arrive bientôt.</string>
+    <string name="path_action_try_direct">Essayer le Mode direct</string>
+    <string name="direct_prompt_title">Essayer le Mode direct pour %1$s ?</string>
+    <string name="direct_prompt_action">Essayer</string>
+    <string name="direct_enabled">%1$s est en Mode direct.</string>
+    <string name="direct_failed">Impossible de passer %1$s en Mode direct.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -272,4 +272,21 @@
     <string name="settings_open_source_licenses_body">Créditos das bibliotecas em que o Dish é construído.</string>
     <string name="licenses_open_external">Abrir licença de %1$s</string>
     <string name="settings_version_label">VERSÃO</string>
+
+    <string name="path_label_direct">Modo direto</string>
+    <string name="path_label_direct_with_rate">Modo direto · %1$d Hz</string>
+    <string name="path_label_standard">Modo padrão</string>
+    <string name="path_direct_explainer">Menor atraso. Comunicação direta com o controle.</string>
+    <string name="path_reason_default">Funciona com qualquer controle reconhecido pelo Android.</string>
+    <string name="path_reason_bluetooth">Controles Bluetooth sempre usam o Modo padrão.</string>
+    <string name="path_reason_onscreen">Controles na tela usam o Modo padrão.</string>    <string name="path_reason_unknown_model">Este controle ainda não está na lista rápida.</string>
+    <string name="path_reason_busy">Outro app está usando este controle.</string>
+    <string name="path_reason_init_failed">Não foi possível ativar o Modo direto. Usando Modo padrão.</string>
+    <string name="path_reason_detached">O controle foi desconectado.</string>
+    <string name="path_reason_not_yet">O Modo direto para este controle chegará em breve.</string>
+    <string name="path_action_try_direct">Tentar Modo direto</string>
+    <string name="direct_prompt_title">Tentar Modo direto para %1$s?</string>
+    <string name="direct_prompt_action">Tentar</string>
+    <string name="direct_enabled">%1$s está no Modo direto.</string>
+    <string name="direct_failed">Não foi possível mudar %1$s para o Modo direto.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -354,7 +354,8 @@
     <string name="path_direct_explainer">Lowest delay. Talking straight to the controller.</string>
     <string name="path_reason_default">Works with every controller Android recognises.</string>
     <string name="path_reason_bluetooth">Bluetooth controllers always use Standard mode.</string>
-    <string name="path_reason_onscreen">On-screen controllers use Standard mode.</string>    <string name="path_reason_unknown_model">This controller isn\'t in the fast-path list yet.</string>
+    <string name="path_reason_onscreen">On-screen controllers use Standard mode.</string>
+    <string name="path_reason_unknown_model">This controller isn\'t in the fast-path list yet.</string>
     <string name="path_reason_busy">Another app is using this controller.</string>
     <string name="path_reason_init_failed">Couldn\'t set up Direct mode. Using Standard mode instead.</string>
     <string name="path_reason_detached">Controller was unplugged.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -340,4 +340,29 @@
          (GDPR, UK GDPR, CCPA/CPRA, LGPD) in sections inside the document. -->
     <string name="url_privacy_policy" translatable="false">https://dish.tinkernorth.com/privacy/dish-android/</string>
 
+    <!-- Input-path badges on the dashboard controller list. The "Direct mode" badge means the
+         controller is running through Dish\'s fast path: the app talks straight to the controller
+         over USB and forwards reports to the PC with the absolute minimum delay. "Standard mode"
+         means the controller goes through Android\'s built-in input layer, which works for every
+         controller but adds a small amount of delay. The reason strings explain why a particular
+         controller landed on Standard mode so the user can act on it (grant a permission, switch
+         to USB, etc.). All copy is intentionally non-technical: no mention of JNI, USB host,
+         interrupt endpoints, evdev, kernel, etc. -->
+    <string name="path_label_direct">Direct mode</string>
+    <string name="path_label_direct_with_rate">Direct mode · %1$d Hz</string>
+    <string name="path_label_standard">Standard mode</string>
+    <string name="path_direct_explainer">Lowest delay. Talking straight to the controller.</string>
+    <string name="path_reason_default">Works with every controller Android recognises.</string>
+    <string name="path_reason_bluetooth">Bluetooth controllers always use Standard mode.</string>
+    <string name="path_reason_onscreen">On-screen controllers use Standard mode.</string>    <string name="path_reason_unknown_model">This controller isn\'t in the fast-path list yet.</string>
+    <string name="path_reason_busy">Another app is using this controller.</string>
+    <string name="path_reason_init_failed">Couldn\'t set up Direct mode. Using Standard mode instead.</string>
+    <string name="path_reason_detached">Controller was unplugged.</string>
+    <string name="path_reason_not_yet">Direct mode for this controller is coming soon.</string>
+    <string name="path_action_try_direct">Try Direct mode</string>
+    <string name="direct_prompt_title">Try Direct mode for %1$s?</string>
+    <string name="direct_prompt_action">Try</string>
+    <string name="direct_enabled">%1$s is on Direct mode.</string>
+    <string name="direct_failed">Couldn\'t switch %1$s to Direct mode.</string>
+
 </resources>

--- a/app/src/test/cpp/CMakeLists.txt
+++ b/app/src/test/cpp/CMakeLists.txt
@@ -47,6 +47,17 @@ target_include_directories(wire_encoders_test PRIVATE "${SATELLITE_CPP}")
 target_compile_options(wire_encoders_test PRIVATE -Wall -Wextra -Wpedantic)
 target_link_libraries(wire_encoders_test PRIVATE GTest::gtest_main)
 
+# usb_parsers.cpp fences its USB I/O behind __ANDROID__, so the decoders and rumble
+# builders build and test host-side.
+add_executable(usb_parsers_test
+    usb_parsers_test.cpp
+    "${SATELLITE_CPP}/usb_parsers.cpp"
+)
+target_include_directories(usb_parsers_test PRIVATE "${SATELLITE_CPP}")
+target_compile_options(usb_parsers_test PRIVATE -Wall -Wextra -Wpedantic)
+target_link_libraries(usb_parsers_test PRIVATE GTest::gtest_main)
+
 include(GoogleTest)
 gtest_discover_tests(gamepad_input_test)
 gtest_discover_tests(wire_encoders_test)
+gtest_discover_tests(usb_parsers_test)

--- a/app/src/test/cpp/usb_parsers_test.cpp
+++ b/app/src/test/cpp/usb_parsers_test.cpp
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "usb_parsers.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+using gamepad::DeviceState;
+using gamepad::XUSB_A;
+using gamepad::XUSB_B;
+using gamepad::XUSB_GUIDE;
+using usbparsers::buildRumbleReport;
+using usbparsers::decodeReport;
+using usbparsers::Parser;
+using usbparsers::ParserState;
+
+namespace {
+
+std::vector<uint8_t> gipMain(uint8_t face = 0, int16_t lx = 0) {
+    std::vector<uint8_t> r(18, 0);
+    r[0] = 0x20;
+    r[4] = face;
+    r[10] = (uint8_t)(lx & 0xFF);
+    r[11] = (uint8_t)((lx >> 8) & 0xFF);
+    return r;
+}
+
+std::vector<uint8_t> gipGuide(bool pressed) {
+    std::vector<uint8_t> r(5, 0);
+    r[0] = 0x07;
+    r[4] = pressed ? 0x01 : 0x00;
+    return r;
+}
+
+bool decodeXbox(const std::vector<uint8_t>& buf, DeviceState& s, ParserState& st) {
+    return decodeReport(Parser::XBOX_ONE_GIP, buf.data(), buf.size(), s, &st);
+}
+
+} // namespace
+
+TEST(XboxGip, MainReportDecodesButtonsAndStick) {
+    ParserState st;
+    DeviceState s;
+    ASSERT_TRUE(decodeXbox(gipMain(/*A*/ 0x10, /*lx*/ 1000), s, st));
+    EXPECT_TRUE(s.wButtons & XUSB_A);
+    EXPECT_EQ(1000, s.sLX);
+    EXPECT_FALSE(s.wButtons & XUSB_GUIDE);
+}
+
+TEST(XboxGip, GuidePressSetsBitAndPreservesMainState) {
+    ParserState st;
+    DeviceState s;
+    ASSERT_TRUE(decodeXbox(gipMain(0x10, 1000), s, st));
+    // Guide arrives in its own report; the prior stick/button state must survive.
+    ASSERT_TRUE(decodeXbox(gipGuide(true), s, st));
+    EXPECT_TRUE(s.wButtons & XUSB_GUIDE);
+    EXPECT_TRUE(s.wButtons & XUSB_A);
+    EXPECT_EQ(1000, s.sLX);
+}
+
+TEST(XboxGip, GuideReleaseClearsBit) {
+    ParserState st;
+    DeviceState s;
+    ASSERT_TRUE(decodeXbox(gipMain(0x10, 1000), s, st));
+    ASSERT_TRUE(decodeXbox(gipGuide(true), s, st));
+    ASSERT_TRUE(decodeXbox(gipGuide(false), s, st));
+    EXPECT_FALSE(s.wButtons & XUSB_GUIDE);
+    EXPECT_TRUE(s.wButtons & XUSB_A);
+    EXPECT_EQ(1000, s.sLX);
+}
+
+TEST(XboxGip, HeldGuideSurvivesNextMainReport) {
+    ParserState st;
+    DeviceState s;
+    ASSERT_TRUE(decodeXbox(gipMain(0x10, 1000), s, st));
+    ASSERT_TRUE(decodeXbox(gipGuide(true), s, st));
+    // A fresh main report with a different button/stick must keep the still-held guide bit.
+    ASSERT_TRUE(decodeXbox(gipMain(/*B*/ 0x20, /*lx*/ 2000), s, st));
+    EXPECT_TRUE(s.wButtons & XUSB_GUIDE);
+    EXPECT_TRUE(s.wButtons & XUSB_B);
+    EXPECT_FALSE(s.wButtons & XUSB_A);
+    EXPECT_EQ(2000, s.sLX);
+}
+
+TEST(XboxGip, GuideBeforeAnyMainReportPublishesGuideOnRest) {
+    ParserState st;
+    DeviceState s;
+    ASSERT_TRUE(decodeXbox(gipGuide(true), s, st));
+    EXPECT_EQ(XUSB_GUIDE, s.wButtons);
+    EXPECT_EQ(0, s.sLX);
+}
+
+TEST(XboxGip, NullParserStateRejectsReport) {
+    DeviceState s;
+    auto buf = gipMain(0x10, 0);
+    EXPECT_FALSE(decodeReport(Parser::XBOX_ONE_GIP, buf.data(), buf.size(), s, nullptr));
+}
+
+TEST(XboxGip, ShortGuideReportIsRejected) {
+    ParserState st;
+    DeviceState s;
+    std::vector<uint8_t> tooShort = {0x07, 0x20, 0x00, 0x02};
+    EXPECT_FALSE(decodeXbox(tooShort, s, st));
+}
+
+TEST(Rumble, Xbox360Bytes) {
+    uint8_t out[64];
+    size_t n = buildRumbleReport(Parser::XINPUT_360, 0xFF00, 0x8000, 5, out, sizeof(out));
+    ASSERT_EQ(8u, n);
+    const uint8_t want[8] = {0x00, 0x08, 0x00, 0xFF, 0x80, 0x00, 0x00, 0x00};
+    for (size_t i = 0; i < n; i++) EXPECT_EQ(want[i], out[i]) << "byte " << i;
+}
+
+TEST(Rumble, XboxOneGipBytesAndSeq) {
+    uint8_t out[64];
+    size_t n = buildRumbleReport(Parser::XBOX_ONE_GIP, 0xFFFF, 0x0000, 0x2A, out, sizeof(out));
+    ASSERT_EQ(13u, n);
+    const uint8_t want[13] = {0x09, 0x00, 0x2A, 0x09, 0x00, 0x0F, 0x00,
+                              0x00, 0x7F, 0x00, 0xFF, 0x00, 0xFF};
+    for (size_t i = 0; i < n; i++) EXPECT_EQ(want[i], out[i]) << "byte " << i;
+}
+
+TEST(Rumble, DualShock4Bytes) {
+    uint8_t out[64];
+    size_t n = buildRumbleReport(Parser::DUALSHOCK4, 0xAA00, 0x5500, 0, out, sizeof(out));
+    ASSERT_EQ(32u, n);
+    EXPECT_EQ(0x05, out[0]);
+    EXPECT_EQ(0x01, out[1]);
+    EXPECT_EQ(0x55, out[4]);
+    EXPECT_EQ(0xAA, out[5]);
+    EXPECT_EQ(0x00, out[6]);
+}
+
+TEST(Rumble, DualSenseBytes) {
+    uint8_t out[64];
+    size_t n = buildRumbleReport(Parser::DUALSENSE, 0xAA00, 0x5500, 0, out, sizeof(out));
+    ASSERT_EQ(63u, n);
+    EXPECT_EQ(0x02, out[0]);
+    EXPECT_EQ(0x01, out[1]);
+    EXPECT_EQ(0x55, out[3]);
+    EXPECT_EQ(0xAA, out[4]);
+}
+
+TEST(Rumble, SwitchProNeutralWhenZero) {
+    uint8_t out[64];
+    size_t n = buildRumbleReport(Parser::SWITCH_PRO_USB, 0, 0, 3, out, sizeof(out));
+    ASSERT_EQ(10u, n);
+    EXPECT_EQ(0x10, out[0]);
+    EXPECT_EQ(0x03, out[1]);
+    const uint8_t neutral[4] = {0x00, 0x01, 0x40, 0x40};
+    for (int i = 0; i < 4; i++) {
+        EXPECT_EQ(neutral[i], out[2 + i]) << "left byte " << i;
+        EXPECT_EQ(neutral[i], out[6 + i]) << "right byte " << i;
+    }
+}
+
+TEST(Rumble, SwitchProMaxStrongEncodesTopAmplitude) {
+    uint8_t out[64];
+    size_t n = buildRumbleReport(Parser::SWITCH_PRO_USB, 0xFFFF, 0, 0, out, sizeof(out));
+    ASSERT_EQ(10u, n);
+    EXPECT_EQ(0x00, out[2]);
+    EXPECT_EQ(0xC9, out[3]);
+    EXPECT_EQ(0x40, out[4]);
+    EXPECT_EQ(0x72, out[5]);
+    const uint8_t neutral[4] = {0x00, 0x01, 0x40, 0x40};
+    for (int i = 0; i < 4; i++) EXPECT_EQ(neutral[i], out[6 + i]) << "right byte " << i;
+}
+
+TEST(Rumble, UnsupportedParsersReturnZero) {
+    uint8_t out[64];
+    EXPECT_EQ(0u, buildRumbleReport(Parser::STADIA, 0xFFFF, 0xFFFF, 0, out, sizeof(out)));
+    EXPECT_EQ(0u, buildRumbleReport(Parser::GENERIC_HID_GAMEPAD, 0xFFFF, 0xFFFF, 0, out, sizeof(out)));
+    EXPECT_EQ(0u, buildRumbleReport(Parser::NONE, 0xFFFF, 0xFFFF, 0, out, sizeof(out)));
+}
+
+TEST(Rumble, TooSmallBufferReturnsZero) {
+    uint8_t out[10];
+    EXPECT_EQ(0u, buildRumbleReport(Parser::DUALSENSE, 0xFFFF, 0xFFFF, 0, out, sizeof(out)));
+}
+
+// Guards the refactor that moved I/O out: a non-Xbox decoder still works through decodeReport.
+TEST(Decode, DualShock4StillDecodesAfterRefactor) {
+    std::vector<uint8_t> r(10, 0);
+    r[0] = 0x01;
+    r[1] = 128;
+    r[2] = 128;
+    r[3] = 128;
+    r[4] = 128;
+    r[5] = 0x20;
+    DeviceState s;
+    ParserState st;
+    ASSERT_TRUE(decodeReport(Parser::DUALSHOCK4, r.data(), r.size(), s, &st));
+    EXPECT_TRUE(s.wButtons & XUSB_A);
+    EXPECT_EQ(0, s.sLX);
+    EXPECT_EQ(0, s.sLY);
+}

--- a/app/src/test/java/com/tinkernorth/dish/composer/ConnectionHubTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/ConnectionHubTest.kt
@@ -643,6 +643,44 @@ class ConnectionHubTest {
     }
 
     @Test
+    fun `migrateSlotBinding carries binding and type to the new slot id and re-keys the satellite slot`() {
+        val satConn = mockk<SatelliteConnection>(relaxed = true)
+        every { satellite.get("s:1") } returns satConn
+        every { store.remembered() } returns
+            listOf(
+                RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
+            )
+        val hub = buildHub()
+
+        hub.bind("slot-fw", "s:1")
+        hub.setSatelliteControllerType("s:1", "slot-fw", CONTROLLER_TYPE_PLAYSTATION)
+        scope.testScheduler.runCurrent()
+
+        hub.migrateSlotBinding("slot-fw", "slot-usb")
+        scope.testScheduler.runCurrent()
+
+        assertEquals(mapOf("slot-usb" to "s:1"), hub.bindings.value)
+        val summary = hub.connections.value.first { it.id == "s:1" }
+        assertEquals(CONTROLLER_TYPE_PLAYSTATION, summary.satelliteControllerTypes["slot-usb"])
+        assertNull(summary.satelliteControllerTypes["slot-fw"])
+        verify { satConn.renameSlot("slot-fw", "slot-usb") }
+        verify(exactly = 0) { satConn.detachSlot(any()) }
+    }
+
+    @Test
+    fun `migrateSlotBinding does nothing when the source slot is unbound`() {
+        val satConn = mockk<SatelliteConnection>(relaxed = true)
+        every { satellite.get(any()) } returns satConn
+        val hub = buildHub()
+
+        hub.migrateSlotBinding("ghost", "slot-usb")
+        scope.testScheduler.runCurrent()
+
+        assertEquals(emptyMap<String, String>(), hub.bindings.value)
+        verify(exactly = 0) { satConn.renameSlot(any(), any()) }
+    }
+
+    @Test
     fun `stale bt marker does not override a connected bt host`() {
         every { store.rememberedBt() } returns
             listOf(RememberedBt(id = "bt:AA", name = "Xbox", mac = "AA", profileName = "Xbox"))

--- a/app/src/test/java/com/tinkernorth/dish/composer/ConnectionHubTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/ConnectionHubTest.kt
@@ -13,6 +13,7 @@ import com.tinkernorth.dish.source.connection.ConnectIntent
 import com.tinkernorth.dish.source.connection.SatelliteConnection
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.connection.SatelliteSessionState
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -646,6 +647,7 @@ class ConnectionHubTest {
     fun `migrateSlotBinding carries binding and type to the new slot id and re-keys the satellite slot`() {
         val satConn = mockk<SatelliteConnection>(relaxed = true)
         every { satellite.get("s:1") } returns satConn
+        every { satConn.renameSlot("slot-fw", "slot-usb") } returns true
         every { store.remembered() } returns
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
@@ -681,6 +683,27 @@ class ConnectionHubTest {
     }
 
     @Test
+    fun `migrateSlotBinding attaches the new slot when the source slot was never registered`() {
+        val satConn = mockk<SatelliteConnection>(relaxed = true)
+        every { satellite.get("s:1") } returns satConn
+        every { satConn.renameSlot("slot-fw", "slot-usb") } returns false
+        every { store.remembered() } returns
+            listOf(
+                RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
+            )
+        val hub = buildHub()
+
+        hub.bind("slot-fw", "s:1")
+        scope.testScheduler.runCurrent()
+
+        hub.migrateSlotBinding("slot-fw", "slot-usb")
+        scope.testScheduler.runCurrent()
+
+        assertEquals(mapOf("slot-usb" to "s:1"), hub.bindings.value)
+        coVerify { satConn.attachSlot("slot-usb", any()) }
+    }
+
+    @Test
     fun `stale bt marker does not override a connected bt host`() {
         every { store.rememberedBt() } returns
             listOf(RememberedBt(id = "bt:AA", name = "Xbox", mac = "AA", profileName = "Xbox"))
@@ -708,5 +731,93 @@ class ConnectionHubTest {
                 .first { it.id == "bt:AA" }
                 .live,
         )
+    }
+
+    private fun liveConn(
+        id: String,
+        ip: String,
+    ): SatelliteConnection =
+        mockk(relaxed = true) {
+            every { this@mockk.id } returns id
+            every { state } returns MutableStateFlow(SatelliteSessionState.Live)
+            every { server } returns
+                MutableStateFlow(DiscoveredServer(name = id, ip = ip, udpPort = 1, pairPort = 2, httpPort = 3))
+            every { slots } returns MutableStateFlow(emptyMap())
+        }
+
+    @Test
+    fun `bindClaimedSynthetic carries a bound twin's binding to the synthetic slot`() {
+        val satConn = mockk<SatelliteConnection>(relaxed = true)
+        every { satellite.get("s:1") } returns satConn
+        every { satConn.renameSlot("slot-fw", "-1000") } returns true
+        every { store.remembered() } returns
+            listOf(
+                RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
+            )
+        val hub = buildHub()
+
+        hub.bind("slot-fw", "s:1")
+        scope.testScheduler.runCurrent()
+
+        hub.bindClaimedSynthetic(twinSlotId = "slot-fw", syntheticSlotId = "-1000")
+        scope.testScheduler.runCurrent()
+
+        assertEquals(mapOf("-1000" to "s:1"), hub.bindings.value)
+        verify { satConn.renameSlot("slot-fw", "-1000") }
+    }
+
+    @Test
+    fun `bindClaimedSynthetic auto-binds to the sole live satellite when the twin was unbound`() {
+        val conn = liveConn("s:1", "1.1.1.1")
+        every { satellite.get("s:1") } returns conn
+        satConnsFlow.value = mapOf("s:1" to conn)
+        val hub = buildHub()
+
+        hub.bindClaimedSynthetic(twinSlotId = null, syntheticSlotId = "-1000")
+        scope.testScheduler.runCurrent()
+
+        assertEquals(mapOf("-1000" to "s:1"), hub.bindings.value)
+    }
+
+    @Test
+    fun `bindClaimedSynthetic with a never-bound twin still falls back to the sole live satellite`() {
+        val conn = liveConn("s:1", "1.1.1.1")
+        every { satellite.get("s:1") } returns conn
+        satConnsFlow.value = mapOf("s:1" to conn)
+        val hub = buildHub()
+
+        hub.bindClaimedSynthetic(twinSlotId = "ghost-twin", syntheticSlotId = "-1000")
+        scope.testScheduler.runCurrent()
+
+        assertEquals(mapOf("-1000" to "s:1"), hub.bindings.value)
+    }
+
+    @Test
+    fun `bindClaimedSynthetic leaves the device unbound when no satellite is live`() {
+        every { store.remembered() } returns
+            listOf(
+                RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
+            )
+        val hub = buildHub()
+
+        hub.bindClaimedSynthetic(twinSlotId = null, syntheticSlotId = "-1000")
+        scope.testScheduler.runCurrent()
+
+        assertEquals(emptyMap<String, String>(), hub.bindings.value)
+    }
+
+    @Test
+    fun `bindClaimedSynthetic leaves the device unbound when more than one satellite is live`() {
+        val a = liveConn("s:1", "1.1.1.1")
+        val b = liveConn("s:2", "2.2.2.2")
+        every { satellite.get("s:1") } returns a
+        every { satellite.get("s:2") } returns b
+        satConnsFlow.value = mapOf("s:1" to a, "s:2" to b)
+        val hub = buildHub()
+
+        hub.bindClaimedSynthetic(twinSlotId = null, syntheticSlotId = "-1000")
+        scope.testScheduler.runCurrent()
+
+        assertEquals(emptyMap<String, String>(), hub.bindings.value)
     }
 }

--- a/app/src/test/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistryTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistryTest.kt
@@ -2,8 +2,20 @@
 
 package com.tinkernorth.dish.hotpath.input
 
+import android.content.Context
+import android.hardware.input.InputManager
+import android.hardware.usb.UsbManager
 import android.view.InputDevice
+import com.tinkernorth.dish.source.usb.PathMode
+import com.tinkernorth.dish.source.usb.PathReason
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -127,5 +139,102 @@ class PhysicalGamepadRegistryTest {
                 keyboardType = InputDevice.KEYBOARD_TYPE_NON_ALPHABETIC,
             ),
         )
+    }
+
+    private fun buildRegistry(): PhysicalGamepadRegistry {
+        val ctx = mockk<Context>()
+        every { ctx.getSystemService(Context.INPUT_SERVICE) } returns mockk<InputManager>(relaxed = true)
+        every { ctx.getSystemService(Context.USB_SERVICE) } returns mockk<UsbManager>(relaxed = true)
+        return PhysicalGamepadRegistry(ctx, CoroutineScope(SupervisorJob()), mockk(relaxed = true))
+    }
+
+    @Test
+    fun `addUsbSynthetic publishes a Direct-mode device with the supplied fields`() {
+        val registry = buildRegistry()
+        registry.addUsbSynthetic(
+            deviceId = -1000,
+            name = "DualSense",
+            hasGyro = true,
+            pollRateHz = 250,
+            vendorId = 0x054C,
+            productId = 0x0CE6,
+        )
+        val d = registry.devices.value.getValue(-1000)
+        assertEquals("DualSense", d.name)
+        assertTrue(d.isUsbSynthetic)
+        assertEquals(PathMode.Direct, d.pathMode)
+        assertEquals(PathReason.None, d.pathReason)
+        assertTrue(d.hasGyro)
+        assertEquals(250, d.pollRateHz)
+        assertEquals(0x054C, d.vendorId)
+        assertEquals(0x0CE6, d.productId)
+    }
+
+    @Test
+    fun `removeUsbSynthetic drops the entry`() {
+        val registry = buildRegistry()
+        registry.addUsbSynthetic(-1000, "Pad", false, 0, 1, 2)
+        registry.removeUsbSynthetic(-1000)
+        assertNull(registry.devices.value[-1000])
+    }
+
+    @Test
+    fun `updateMeasuredPollRate sets the rate on a present device`() {
+        val registry = buildRegistry()
+        registry.addUsbSynthetic(-1000, "Pad", false, 0, 1, 2)
+        registry.updateMeasuredPollRate(-1000, 500)
+        assertEquals(500, registry.devices.value[-1000]?.pollRateHz)
+    }
+
+    @Test
+    fun `updateMeasuredPollRate never creates a device that is not present`() {
+        val registry = buildRegistry()
+        registry.updateMeasuredPollRate(-1000, 500)
+        assertNull(registry.devices.value[-1000])
+    }
+
+    @Test
+    fun `updateMeasuredPollRate after removal does not resurrect the device`() {
+        val registry = buildRegistry()
+        registry.addUsbSynthetic(-1000, "Pad", false, 0, 1, 2)
+        registry.removeUsbSynthetic(-1000)
+        registry.updateMeasuredPollRate(-1000, 500)
+        assertNull(registry.devices.value[-1000])
+    }
+
+    @Test
+    fun `updateMeasuredPollRate with the same rate is a no-op that does not re-emit`() {
+        val registry = buildRegistry()
+        registry.addUsbSynthetic(-1000, "Pad", false, 250, 1, 2)
+        val before = registry.devices.value
+        registry.updateMeasuredPollRate(-1000, 250)
+        assertSame(before, registry.devices.value)
+    }
+
+    @Test
+    fun `updating one synthetic preserves the others`() {
+        val registry = buildRegistry()
+        registry.addUsbSynthetic(-1000, "A", false, 0, 1, 2)
+        registry.addUsbSynthetic(-1001, "B", false, 0, 3, 4)
+        registry.updateMeasuredPollRate(-1000, 500)
+        assertEquals(2, registry.devices.value.size)
+        assertEquals(500, registry.devices.value[-1000]?.pollRateHz)
+        assertEquals(0, registry.devices.value[-1001]?.pollRateHz)
+    }
+
+    @Test
+    fun `markDirectFailed does not touch a synthetic device of the same model`() {
+        val registry = buildRegistry()
+        registry.addUsbSynthetic(-1000, "Pad", false, 0, vendorId = 1, productId = 2)
+        registry.markDirectFailed(1, 2, PathReason.Busy)
+        assertEquals(PathReason.None, registry.devices.value[-1000]?.pathReason)
+    }
+
+    @Test
+    fun `isSyntheticId treats negative ids as synthetic and non-negative as framework`() {
+        assertTrue(PhysicalGamepadRegistry.isSyntheticId(-1000))
+        assertTrue(PhysicalGamepadRegistry.isSyntheticId(-1))
+        assertFalse(PhysicalGamepadRegistry.isSyntheticId(0))
+        assertFalse(PhysicalGamepadRegistry.isSyntheticId(42))
     }
 }

--- a/app/src/test/java/com/tinkernorth/dish/hotpath/input/RumbleRouterTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/hotpath/input/RumbleRouterTest.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.hotpath.input
+
+import com.tinkernorth.dish.source.connection.SatelliteConnection
+import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class RumbleRouterTest {
+    private fun slot(index: Int) = SatelliteConnection.SlotBinding(controllerIndex = index, controllerType = 0, registered = true)
+
+    @Test
+    fun `resolveSlotId returns the slot whose controller index matches`() {
+        val slots = mapOf(VIRTUAL_SLOT_ID to slot(0), "1234" to slot(1), "-1000" to slot(2))
+        assertEquals(VIRTUAL_SLOT_ID, resolveSlotId(slots, 0))
+        assertEquals("1234", resolveSlotId(slots, 1))
+        assertEquals("-1000", resolveSlotId(slots, 2))
+    }
+
+    @Test
+    fun `resolveSlotId returns null when no slot matches or map is empty`() {
+        assertNull(resolveSlotId(mapOf(VIRTUAL_SLOT_ID to slot(0)), 3))
+        assertNull(resolveSlotId(emptyMap(), 0))
+    }
+
+    @Test
+    fun `classifyTarget routes the virtual slot to the phone`() {
+        assertEquals(RumbleTarget.Phone, classifyTarget(VIRTUAL_SLOT_ID))
+    }
+
+    @Test
+    fun `classifyTarget routes a framework device id to its own actuator`() {
+        assertEquals(RumbleTarget.Framework(1234), classifyTarget("1234"))
+        assertEquals(RumbleTarget.Framework(0), classifyTarget("0"))
+    }
+
+    @Test
+    fun `classifyTarget routes a negative synthetic id to the USB-direct path`() {
+        assertEquals(RumbleTarget.DirectUsb(-1000), classifyTarget("-1000"))
+        assertEquals(RumbleTarget.DirectUsb(-1), classifyTarget("-1"))
+    }
+
+    @Test
+    fun `classifyTarget yields None for an unparseable slot id`() {
+        assertEquals(RumbleTarget.None, classifyTarget("not-an-int"))
+        assertEquals(RumbleTarget.None, classifyTarget(""))
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionTest.kt
@@ -5,17 +5,20 @@ package com.tinkernorth.dish.source.connection
 import com.tinkernorth.dish.core.jni.ControllerRepository
 import com.tinkernorth.dish.core.model.DiscoveredServer
 import io.mockk.Runs
+import io.mockk.clearAllMocks
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -34,10 +37,12 @@ class SatelliteConnectionTest {
     private lateinit var repo: ControllerRepository
     private lateinit var scope: TestScope
     private lateinit var conn: SatelliteConnection
+    private val ackPollTimeoutMs = 500L
 
     @Before
     fun setUp() {
         repo = mockk(relaxed = true)
+        every { repo.receiveAck(any()) } answers { Thread.sleep(ackPollTimeoutMs) }
         scope = TestScope(StandardTestDispatcher())
         conn =
             SatelliteConnection(
@@ -51,6 +56,8 @@ class SatelliteConnectionTest {
     @After
     fun tearDown() {
         conn.markDisconnected()
+        scope.cancel()
+        clearAllMocks()
     }
 
     @Test
@@ -659,5 +666,46 @@ class SatelliteConnectionTest {
             }
 
             race.markDisconnected()
+        }
+
+    @Test
+    fun `renameSlot re-keys a present slot to a free id, preserves its binding, and returns true`() =
+        runTest {
+            conn.attachSlot(slotId = "a", controllerType = 1)
+            assertTrue(conn.renameSlot("a", "b"))
+            assertTrue(conn.slots.value.containsKey("b"))
+            assertFalse(conn.slots.value.containsKey("a"))
+            assertEquals(1, conn.slots.value["b"]?.controllerType)
+        }
+
+    @Test
+    fun `renameSlot onto itself returns whether that slot currently exists`() =
+        runTest {
+            conn.attachSlot(slotId = "a", controllerType = 0)
+            assertTrue(conn.renameSlot("a", "a"))
+            assertFalse(conn.renameSlot("x", "x"))
+        }
+
+    @Test
+    fun `renameSlot onto an already-present target does not merge and reports the target exists`() =
+        runTest {
+            conn.attachSlot(slotId = "a", controllerType = 0)
+            conn.attachSlot(slotId = "b", controllerType = 0)
+            assertTrue(conn.renameSlot("a", "b"))
+            assertTrue(conn.slots.value.containsKey("a"))
+            assertTrue(conn.slots.value.containsKey("b"))
+        }
+
+    @Test
+    fun `renameSlot of an absent source to an absent target returns false`() {
+        assertFalse(conn.renameSlot("ghost", "new"))
+        assertFalse(conn.slots.value.containsKey("new"))
+    }
+
+    @Test
+    fun `renameSlot of an absent source to a present target returns true`() =
+        runTest {
+            conn.attachSlot(slotId = "b", controllerType = 0)
+            assertTrue(conn.renameSlot("ghost", "b"))
         }
 }

--- a/app/src/test/java/com/tinkernorth/dish/source/usb/PathReasonClassifierTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/usb/PathReasonClassifierTest.kt
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.usb
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PathReasonClassifierTest {
+    @Test
+    fun `zero vendor id is UnknownModel even if everything else looks claimable`() {
+        assertEquals(
+            PathReason.UnknownModel,
+            classifyDirectPathReason(
+                vendorId = 0,
+                productId = 0x028E,
+                isKnownFastLaneModel = true,
+                isUsbPresent = true,
+                priorFailure = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `zero product id is UnknownModel`() {
+        assertEquals(
+            PathReason.UnknownModel,
+            classifyDirectPathReason(
+                vendorId = 0x045E,
+                productId = 0,
+                isKnownFastLaneModel = true,
+                isUsbPresent = true,
+                priorFailure = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `model not in the parser table is UnknownModel`() {
+        assertEquals(
+            PathReason.UnknownModel,
+            classifyDirectPathReason(
+                vendorId = 0x1234,
+                productId = 0x5678,
+                isKnownFastLaneModel = false,
+                isUsbPresent = true,
+                priorFailure = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `known model not present on the USB bus is Bluetooth`() {
+        assertEquals(
+            PathReason.Bluetooth,
+            classifyDirectPathReason(
+                vendorId = 0x057E,
+                productId = 0x2009,
+                isKnownFastLaneModel = true,
+                isUsbPresent = false,
+                priorFailure = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `known model on the USB bus with no prior failure is Eligible`() {
+        assertEquals(
+            PathReason.Eligible,
+            classifyDirectPathReason(
+                vendorId = 0x045E,
+                productId = 0x028E,
+                isKnownFastLaneModel = true,
+                isUsbPresent = true,
+                priorFailure = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `a prior failure on the USB bus locks the card to that reason`() {
+        assertEquals(
+            PathReason.Busy,
+            classifyDirectPathReason(
+                vendorId = 0x045E,
+                productId = 0x028E,
+                isKnownFastLaneModel = true,
+                isUsbPresent = true,
+                priorFailure = PathReason.Busy,
+            ),
+        )
+    }
+
+    @Test
+    fun `init-failed is carried through as the prior failure reason`() {
+        assertEquals(
+            PathReason.InitFailed,
+            classifyDirectPathReason(
+                vendorId = 0x045E,
+                productId = 0x028E,
+                isKnownFastLaneModel = true,
+                isUsbPresent = true,
+                priorFailure = PathReason.InitFailed,
+            ),
+        )
+    }
+
+    @Test
+    fun `missing vendor id takes precedence over a known model and a prior failure`() {
+        assertEquals(
+            PathReason.UnknownModel,
+            classifyDirectPathReason(
+                vendorId = 0,
+                productId = 0x028E,
+                isKnownFastLaneModel = true,
+                isUsbPresent = true,
+                priorFailure = PathReason.Busy,
+            ),
+        )
+    }
+
+    @Test
+    fun `not present takes precedence over a prior failure for a known model`() {
+        assertEquals(
+            PathReason.Bluetooth,
+            classifyDirectPathReason(
+                vendorId = 0x045E,
+                productId = 0x028E,
+                isKnownFastLaneModel = true,
+                isUsbPresent = false,
+                priorFailure = PathReason.Busy,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/source/usb/PollRateSamplerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/usb/PollRateSamplerTest.kt
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.usb
+
+import android.content.Context
+import android.hardware.input.InputManager
+import android.hardware.usb.UsbManager
+import com.tinkernorth.dish.core.jni.PhysicalInputNative
+import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class PollRateSamplerTest {
+    private lateinit var registry: PhysicalGamepadRegistry
+    private lateinit var native: PhysicalInputNative
+    private lateinit var sampler: PollRateSampler
+
+    private val deviceId = -1000
+
+    @Before
+    fun setUp() {
+        val ctx = mockk<Context>()
+        every { ctx.getSystemService(Context.INPUT_SERVICE) } returns mockk<InputManager>(relaxed = true)
+        every { ctx.getSystemService(Context.USB_SERVICE) } returns mockk<UsbManager>(relaxed = true)
+        native = mockk(relaxed = true)
+        registry = PhysicalGamepadRegistry(ctx, CoroutineScope(SupervisorJob()), native)
+        sampler = PollRateSampler(registry, CoroutineScope(SupervisorJob()), native)
+    }
+
+    private fun seedSynthetic() {
+        registry.addUsbSynthetic(
+            deviceId = deviceId,
+            name = "Pad",
+            hasGyro = false,
+            pollRateHz = 0,
+            vendorId = 1,
+            productId = 2,
+        )
+    }
+
+    private fun rateOf(): Int? = registry.devices.value[deviceId]?.pollRateHz
+
+    @Test
+    fun `derives Hz from the URB-count delta over the sampling window`() {
+        seedSynthetic()
+        every { native.getDeviceUrbCount(deviceId) } returns 0L
+        sampler.sampleAll(nowMs = 1000L)
+        every { native.getDeviceUrbCount(deviceId) } returns 500L
+        sampler.sampleAll(nowMs = 1500L)
+        assertEquals(1000, rateOf())
+    }
+
+    @Test
+    fun `first sample only snapshots and does not write a rate`() {
+        seedSynthetic()
+        every { native.getDeviceUrbCount(deviceId) } returns 500L
+        sampler.sampleAll(nowMs = 1000L)
+        assertEquals(0, rateOf())
+    }
+
+    @Test
+    fun `an idle controller whose count stops moving reports zero rather than freezing`() {
+        seedSynthetic()
+        every { native.getDeviceUrbCount(deviceId) } returns 0L
+        sampler.sampleAll(nowMs = 1000L)
+        every { native.getDeviceUrbCount(deviceId) } returns 500L
+        sampler.sampleAll(nowMs = 1500L)
+        assertEquals(1000, rateOf())
+        sampler.sampleAll(nowMs = 2000L)
+        assertEquals(0, rateOf())
+    }
+
+    @Test
+    fun `a counter reset cannot produce a negative rate`() {
+        seedSynthetic()
+        every { native.getDeviceUrbCount(deviceId) } returns 1000L
+        sampler.sampleAll(nowMs = 1000L)
+        every { native.getDeviceUrbCount(deviceId) } returns 5L
+        sampler.sampleAll(nowMs = 1500L)
+        assertEquals(0, rateOf())
+    }
+
+    @Test
+    fun `a detached device is not resurrected by a later sample`() {
+        seedSynthetic()
+        every { native.getDeviceUrbCount(deviceId) } returns 100L
+        sampler.sampleAll(nowMs = 1000L)
+        registry.removeUsbSynthetic(deviceId)
+        every { native.getDeviceUrbCount(deviceId) } returns 600L
+        sampler.sampleAll(nowMs = 1500L)
+        assertEquals(null, registry.devices.value[deviceId])
+    }
+
+    @Test
+    fun `re-attaching the same id after detach starts from a fresh snapshot`() {
+        seedSynthetic()
+        every { native.getDeviceUrbCount(deviceId) } returns 5000L
+        sampler.sampleAll(nowMs = 1000L)
+        registry.removeUsbSynthetic(deviceId)
+        sampler.sampleAll(nowMs = 1500L)
+
+        seedSynthetic()
+        every { native.getDeviceUrbCount(deviceId) } returns 10L
+        sampler.sampleAll(nowMs = 2000L)
+        assertEquals(0, rateOf())
+        every { native.getDeviceUrbCount(deviceId) } returns 510L
+        sampler.sampleAll(nowMs = 2500L)
+        assertEquals(1000, rateOf())
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/source/usb/UsbPollRateTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/usb/UsbPollRateTest.kt
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.usb
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UsbPollRateTest {
+    @Test
+    fun `full-speed 1ms interval is 1000 Hz`() {
+        assertEquals(1000, computeUsbPollRateHz(epInterval = 1, epMaxPacketSize = 64))
+    }
+
+    @Test
+    fun `full-speed 8ms interval is 125 Hz`() {
+        assertEquals(125, computeUsbPollRateHz(epInterval = 8, epMaxPacketSize = 64))
+    }
+
+    @Test
+    fun `full-speed 10ms interval is 100 Hz with a small packet`() {
+        assertEquals(100, computeUsbPollRateHz(epInterval = 10, epMaxPacketSize = 20))
+    }
+
+    @Test
+    fun `high-speed exponent 1 is 8000 Hz`() {
+        assertEquals(8000, computeUsbPollRateHz(epInterval = 1, epMaxPacketSize = 65))
+    }
+
+    @Test
+    fun `high-speed exponent 4 is 1000 Hz`() {
+        assertEquals(1000, computeUsbPollRateHz(epInterval = 4, epMaxPacketSize = 512))
+    }
+
+    @Test
+    fun `high-speed exponent 2 is 4000 Hz`() {
+        assertEquals(4000, computeUsbPollRateHz(epInterval = 2, epMaxPacketSize = 512))
+    }
+
+    @Test
+    fun `high-speed large max packet still decodes the exponent`() {
+        assertEquals(8000, computeUsbPollRateHz(epInterval = 1, epMaxPacketSize = 1024))
+    }
+
+    @Test
+    fun `packet size of exactly 64 is treated as full-speed`() {
+        assertEquals(1000, computeUsbPollRateHz(epInterval = 1, epMaxPacketSize = 64))
+    }
+
+    @Test
+    fun `packet size of 65 crosses into high-speed`() {
+        assertEquals(8000, computeUsbPollRateHz(epInterval = 1, epMaxPacketSize = 65))
+    }
+
+    @Test
+    fun `zero interval yields zero`() {
+        assertEquals(0, computeUsbPollRateHz(epInterval = 0, epMaxPacketSize = 64))
+    }
+
+    @Test
+    fun `negative interval yields zero`() {
+        assertEquals(0, computeUsbPollRateHz(epInterval = -5, epMaxPacketSize = 64))
+    }
+
+    @Test
+    fun `high-speed exponent is clamped so an absurd interval cannot overflow the shift`() {
+        assertEquals(0, computeUsbPollRateHz(epInterval = 16, epMaxPacketSize = 128))
+    }
+
+    @Test
+    fun `500 completions over 500 ms is 1000 Hz`() {
+        assertEquals(1000, measuredPollRateHz(deltaCount = 500, deltaMs = 500))
+    }
+
+    @Test
+    fun `125 completions over 1000 ms is 125 Hz`() {
+        assertEquals(125, measuredPollRateHz(deltaCount = 125, deltaMs = 1000))
+    }
+
+    @Test
+    fun `1000 completions over 500 ms is 2000 Hz`() {
+        assertEquals(2000, measuredPollRateHz(deltaCount = 1000, deltaMs = 500))
+    }
+
+    @Test
+    fun `no completions reports zero rather than the previous reading`() {
+        assertEquals(0, measuredPollRateHz(deltaCount = 0, deltaMs = 500))
+    }
+
+    @Test
+    fun `zero elapsed window yields zero`() {
+        assertEquals(0, measuredPollRateHz(deltaCount = 500, deltaMs = 0))
+    }
+
+    @Test
+    fun `negative elapsed window yields zero`() {
+        assertEquals(0, measuredPollRateHz(deltaCount = 500, deltaMs = -10))
+    }
+
+    @Test
+    fun `negative count delta from a counter reset yields zero not a negative rate`() {
+        assertEquals(0, measuredPollRateHz(deltaCount = -995, deltaMs = 500))
+    }
+
+    @Test
+    fun `rate is integer-floored`() {
+        assertEquals(1500, measuredPollRateHz(deltaCount = 3, deltaMs = 2))
+        assertEquals(333, measuredPollRateHz(deltaCount = 1, deltaMs = 3))
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/ConnectionsVisibleInPickerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/ConnectionsVisibleInPickerTest.kt
@@ -37,18 +37,18 @@ class ConnectionsVisibleInPickerTest {
     }
 
     @Test
-    fun `Connecting counts as available`() {
-        assertTrue(LinkState.Connecting.isAvailableForPicker())
+    fun `Connecting does not count as available — no live session yet`() {
+        assertFalse(LinkState.Connecting.isAvailableForPicker())
     }
 
     @Test
-    fun `Ready counts as available — paired and seen, just no session yet`() {
-        assertTrue(LinkState.Ready.isAvailableForPicker())
+    fun `Ready does not count as available — paired and seen, but not connected`() {
+        assertFalse(LinkState.Ready.isAvailableForPicker())
     }
 
     @Test
-    fun `Found counts as available — visible target, just unpaired`() {
-        assertTrue(LinkState.Found.isAvailableForPicker())
+    fun `Found does not count as available — visible target, but not connected`() {
+        assertFalse(LinkState.Found.isAvailableForPicker())
     }
 
     @Test
@@ -124,7 +124,7 @@ class ConnectionsVisibleInPickerTest {
     }
 
     @Test
-    fun `picker drops only the unreachable unbound entries`() {
+    fun `picker keeps only the live unbound entries`() {
         val online = summary("s:online", LinkState.Connected)
         val ready = summary("s:ready", LinkState.Ready)
         val offline = summary("s:offline", LinkState.Saved)
@@ -136,7 +136,7 @@ class ConnectionsVisibleInPickerTest {
                 boundConnectionId = null,
             )
 
-        assertEquals(listOf(online, ready), visible)
+        assertEquals(listOf(online), visible)
     }
 
     @Test
@@ -169,17 +169,17 @@ class ConnectionsVisibleInPickerTest {
     fun `picker preserves order even with mixed available and held-over rows`() {
         val a = summary("s:a", LinkState.Connected)
         val bSaved = summary("s:b", LinkState.Saved)
-        val c = summary("s:c", LinkState.Connecting)
+        val cConnecting = summary("s:c", LinkState.Connecting)
         val dSavedUnbound = summary("s:d", LinkState.Saved)
-        val e = summary("s:e", LinkState.Ready)
+        val e = summary("s:e", LinkState.Connected)
 
         val visible =
             connectionsVisibleInPicker(
-                listOf(a, bSaved, c, dSavedUnbound, e),
+                listOf(a, bSaved, cConnecting, dSavedUnbound, e),
                 boundConnectionId = "s:b",
             )
 
-        assertEquals(listOf(a, bSaved, c, e), visible)
+        assertEquals(listOf(a, bSaved, e), visible)
     }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/MainUiStateTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/MainUiStateTest.kt
@@ -264,4 +264,11 @@ class MainUiStateTest {
         assert(state.anyConnected)
         assertEquals(0, state.streamingSlotCount)
     }
+
+    @Test
+    fun `anyConnecting is true only while a connection is connecting`() {
+        assertTrue(MainUiState(connections = listOf(summary("s:1", LinkState.Connecting))).anyConnecting)
+        assertFalse(MainUiState(connections = listOf(summary("s:1", LinkState.Connected))).anyConnecting)
+        assertFalse(MainUiState().anyConnecting)
+    }
 }

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
@@ -16,6 +16,8 @@ import com.tinkernorth.dish.source.sensor.BatteryValidator.BatterySample
 import com.tinkernorth.dish.source.store.BatteryStatusStore
 import com.tinkernorth.dish.source.store.MotionEnabledStore
 import com.tinkernorth.dish.source.store.TouchpadModeStore
+import com.tinkernorth.dish.source.usb.PathMode
+import com.tinkernorth.dish.source.usb.PathReason
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -248,5 +250,146 @@ class MainViewModelTest {
                     .first { it.id == VIRTUAL_SLOT_ID }
             assertNull(virtual.boundConnectionId)
             assertNull(virtual.boundStatus)
+        }
+
+    private fun synthetic(
+        id: Int,
+        vid: Int,
+        pid: Int,
+        pollRateHz: Int = 0,
+    ) = PhysicalGamepadRegistry.Device(
+        id = id,
+        name = "Pad",
+        isUsbSynthetic = true,
+        pathMode = PathMode.Direct,
+        pollRateHz = pollRateHz,
+        vendorId = vid,
+        productId = pid,
+    )
+
+    private fun routed(
+        id: Int,
+        vid: Int,
+        pid: Int,
+        reason: PathReason = PathReason.None,
+        disconnecting: Boolean = false,
+    ) = PhysicalGamepadRegistry.Device(
+        id = id,
+        name = "Pad",
+        disconnectingTimeLeftSec = if (disconnecting) 3 else null,
+        isUsbSynthetic = false,
+        pathMode = PathMode.Routed,
+        pathReason = reason,
+        vendorId = vid,
+        productId = pid,
+    )
+
+    @Test
+    fun `synthetic device appears as a Direct-mode physical slot`() =
+        runTest(dispatcher) {
+            devicesFlow.value = mapOf(-1000 to synthetic(-1000, 1, 2, pollRateHz = 1000))
+            dispatcher.scheduler.runCurrent()
+
+            val slot =
+                vm.uiState.value.slots
+                    .first { it.inputType == SlotInputType.PHYSICAL }
+            assertEquals("-1000", slot.id)
+            assertEquals(
+                true,
+                vm.uiState.value.pathBadges["-1000"]
+                    ?.isDirect,
+            )
+        }
+
+    @Test
+    fun `a routed twin of a claimed synthetic is hidden from the slot list`() =
+        runTest(dispatcher) {
+            devicesFlow.value =
+                mapOf(
+                    -1000 to synthetic(-1000, 1, 2),
+                    50 to routed(50, 1, 2),
+                )
+            dispatcher.scheduler.runCurrent()
+
+            val physical =
+                vm.uiState.value.slots
+                    .filter { it.inputType == SlotInputType.PHYSICAL }
+            assertEquals(1, physical.size)
+            assertEquals("-1000", physical.first().id)
+        }
+
+    @Test
+    fun `a second identical routed controller stays visible alongside one synthetic`() =
+        runTest(dispatcher) {
+            devicesFlow.value =
+                mapOf(
+                    -1000 to synthetic(-1000, 1, 2),
+                    50 to routed(50, 1, 2),
+                    51 to routed(51, 1, 2),
+                )
+            dispatcher.scheduler.runCurrent()
+
+            val ids =
+                vm.uiState.value.slots
+                    .filter { it.inputType == SlotInputType.PHYSICAL }
+                    .map { it.id }
+            assertEquals(2, ids.size)
+            assertTrue(ids.contains("-1000"))
+        }
+
+    @Test
+    fun `the disconnecting twin is hidden first, keeping the live duplicate listed`() =
+        runTest(dispatcher) {
+            devicesFlow.value =
+                mapOf(
+                    -1000 to synthetic(-1000, 1, 2),
+                    50 to routed(50, 1, 2, disconnecting = false),
+                    51 to routed(51, 1, 2, disconnecting = true),
+                )
+            dispatcher.scheduler.runCurrent()
+
+            val ids =
+                vm.uiState.value.slots
+                    .filter { it.inputType == SlotInputType.PHYSICAL }
+                    .map { it.id }
+            assertTrue("live duplicate kept", ids.contains("50"))
+            assertTrue("disconnecting twin hidden", !ids.contains("51"))
+        }
+
+    @Test
+    fun `eligible routed controller produces an actionable standard badge`() =
+        runTest(dispatcher) {
+            devicesFlow.value = mapOf(60 to routed(60, 0x045E, 0x028E, reason = PathReason.Eligible))
+            dispatcher.scheduler.runCurrent()
+
+            val badge = vm.uiState.value.pathBadges["60"]
+            assertEquals(false, badge?.isDirect)
+            assertEquals(true, badge?.actionable)
+        }
+
+    @Test
+    fun `the virtual slot always carries a non-direct, non-actionable badge`() =
+        runTest(dispatcher) {
+            dispatcher.scheduler.runCurrent()
+            val badge = vm.uiState.value.pathBadges[VIRTUAL_SLOT_ID]
+            assertEquals(false, badge?.isDirect)
+            assertEquals(false, badge?.actionable)
+        }
+
+    @Test
+    fun `every rendered slot has a path badge`() =
+        runTest(dispatcher) {
+            devicesFlow.value =
+                mapOf(
+                    -1000 to synthetic(-1000, 1, 2),
+                    60 to routed(60, 0x045E, 0x028E, reason = PathReason.Eligible),
+                )
+            dispatcher.scheduler.runCurrent()
+
+            val slotIds =
+                vm.uiState.value.slots
+                    .map { it.id }
+                    .toSet()
+            assertEquals(slotIds, vm.uiState.value.pathBadges.keys)
         }
 }

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/PathBadgeMapperTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/PathBadgeMapperTest.kt
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.main
+
+import android.content.Context
+import com.tinkernorth.dish.R
+import com.tinkernorth.dish.source.usb.PathMode
+import com.tinkernorth.dish.source.usb.PathReason
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class PathBadgeMapperTest {
+    private lateinit var ctx: Context
+
+    @Before
+    fun setUp() {
+        ctx = mockk()
+        every { ctx.getString(any<Int>()) } answers { "res:${firstArg<Int>()}" }
+        every { ctx.getString(R.string.path_label_direct_with_rate, any<Any>()) } returns "RATE_LABEL"
+    }
+
+    private fun map(
+        mode: PathMode,
+        reason: PathReason,
+        isOnScreen: Boolean,
+        pollRateHz: Int = 0,
+    ) = PathBadgeMapper.map(ctx, mode, reason, isOnScreen, pollRateHz)
+
+    @Test
+    fun `on-screen controller always reads as Standard with the on-screen reason`() {
+        val badge = map(PathMode.Direct, PathReason.None, isOnScreen = true)
+        assertEquals("res:${R.string.path_label_standard}", badge.label)
+        assertEquals("res:${R.string.path_reason_onscreen}", badge.subtitle)
+        assertFalse(badge.isDirect)
+        assertFalse(badge.actionable)
+    }
+
+    @Test
+    fun `direct mode without a measured rate uses the plain direct label`() {
+        val badge = map(PathMode.Direct, PathReason.None, isOnScreen = false, pollRateHz = 0)
+        assertEquals("res:${R.string.path_label_direct}", badge.label)
+        assertEquals("res:${R.string.path_direct_explainer}", badge.subtitle)
+        assertTrue(badge.isDirect)
+        assertFalse(badge.actionable)
+    }
+
+    @Test
+    fun `direct mode with a measured rate uses the rate label`() {
+        val badge = map(PathMode.Direct, PathReason.None, isOnScreen = false, pollRateHz = 1000)
+        assertEquals("RATE_LABEL", badge.label)
+        assertTrue(badge.isDirect)
+    }
+
+    @Test
+    fun `eligible routed controller is actionable`() {
+        val badge = map(PathMode.Routed, PathReason.Eligible, isOnScreen = false)
+        assertEquals("res:${R.string.path_label_standard}", badge.label)
+        assertEquals("res:${R.string.path_action_try_direct}", badge.subtitle)
+        assertFalse(badge.isDirect)
+        assertTrue(badge.actionable)
+    }
+
+    @Test
+    fun `permission-denied routed controller is actionable and offers the try action`() {
+        val badge = map(PathMode.Routed, PathReason.PermissionDenied, isOnScreen = false)
+        assertEquals("res:${R.string.path_action_try_direct}", badge.subtitle)
+        assertTrue(badge.actionable)
+    }
+
+    @Test
+    fun `bluetooth reason is informational and not actionable`() {
+        val badge = map(PathMode.Routed, PathReason.Bluetooth, isOnScreen = false)
+        assertEquals("res:${R.string.path_reason_bluetooth}", badge.subtitle)
+        assertFalse(badge.actionable)
+    }
+
+    @Test
+    fun `routed with no reason falls back to the default explanation`() {
+        val badge = map(PathMode.Routed, PathReason.None, isOnScreen = false)
+        assertEquals("res:${R.string.path_reason_default}", badge.subtitle)
+        assertFalse(badge.actionable)
+    }
+
+    @Test
+    fun `each non-actionable routed reason maps to its own explanation string`() {
+        val expectations =
+            mapOf(
+                PathReason.UnknownModel to R.string.path_reason_unknown_model,
+                PathReason.Busy to R.string.path_reason_busy,
+                PathReason.InitFailed to R.string.path_reason_init_failed,
+                PathReason.Detached to R.string.path_reason_detached,
+                PathReason.SupportedNoFastPathYet to R.string.path_reason_not_yet,
+                PathReason.OnScreen to R.string.path_reason_onscreen,
+            )
+        for ((reason, resId) in expectations) {
+            val badge = map(PathMode.Routed, reason, isOnScreen = false)
+            assertEquals("reason $reason", "res:$resId", badge.subtitle)
+            assertFalse("reason $reason should not be actionable", badge.actionable)
+            assertFalse(badge.isDirect)
+        }
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/PickerFromMainUiStateTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/PickerFromMainUiStateTest.kt
@@ -55,17 +55,17 @@ class PickerFromMainUiStateTest {
     }
 
     @Test
-    fun `freshly discovered satellites populate the picker even unbound`() {
-        val a = summary("s:1", LinkState.Connected)
-        val b = summary("s:2", LinkState.Ready)
-        val c = summary("s:3", LinkState.Found)
+    fun `only live connections populate the picker — discovered-but-not-connected are hidden`() {
+        val live = summary("s:1", LinkState.Connected)
+        val ready = summary("s:2", LinkState.Ready)
+        val found = summary("s:3", LinkState.Found)
         val state =
             MainUiState(
                 slots = listOf(virtualSlot()),
-                connections = listOf(a, b, c),
+                connections = listOf(live, ready, found),
             )
 
-        assertEquals(listOf(a, b, c), pickerFor(state, state.virtualSlot))
+        assertEquals(listOf(live), pickerFor(state, state.virtualSlot))
     }
 
     @Test
@@ -249,6 +249,6 @@ class PickerFromMainUiStateTest {
             )
 
         val virtualPicker = pickerFor(state, state.virtualSlot)
-        assertEquals(listOf(online, connecting, staleHeld), virtualPicker)
+        assertEquals(listOf(online, staleHeld), virtualPicker)
     }
 }

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/SyntheticTwinDedupTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/SyntheticTwinDedupTest.kt
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.main
+
+import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry.Device
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SyntheticTwinDedupTest {
+    private fun routed(
+        id: Int,
+        vid: Int,
+        pid: Int,
+        disconnecting: Boolean = false,
+    ) = Device(
+        id = id,
+        name = "routed-$id",
+        disconnectingTimeLeftSec = if (disconnecting) 3 else null,
+        isUsbSynthetic = false,
+        vendorId = vid,
+        productId = pid,
+    )
+
+    private fun synthetic(
+        id: Int,
+        vid: Int,
+        pid: Int,
+    ) = Device(
+        id = id,
+        name = "synthetic-$id",
+        isUsbSynthetic = true,
+        vendorId = vid,
+        productId = pid,
+    )
+
+    @Test
+    fun `empty input hides nothing`() {
+        assertEquals(emptySet<Int>(), routedTwinIdsHiddenBySynthetics(emptyList()))
+    }
+
+    @Test
+    fun `with no synthetics nothing is hidden`() {
+        val devices = listOf(routed(1, 0x045E, 0x028E), routed(2, 0x054C, 0x05C4))
+        assertEquals(emptySet<Int>(), routedTwinIdsHiddenBySynthetics(devices))
+    }
+
+    @Test
+    fun `one synthetic hides its single same-model routed twin`() {
+        val devices =
+            listOf(
+                synthetic(-1000, 0x045E, 0x028E),
+                routed(7, 0x045E, 0x028E),
+            )
+        assertEquals(setOf(7), routedTwinIdsHiddenBySynthetics(devices))
+    }
+
+    @Test
+    fun `a routed controller of a different model is left visible`() {
+        val devices =
+            listOf(
+                synthetic(-1000, 0x045E, 0x028E),
+                routed(7, 0x054C, 0x05C4),
+            )
+        assertEquals(emptySet<Int>(), routedTwinIdsHiddenBySynthetics(devices))
+    }
+
+    @Test
+    fun `two synthetics of one model hide both same-model routed twins`() {
+        val devices =
+            listOf(
+                synthetic(-1000, 0x045E, 0x028E),
+                synthetic(-1001, 0x045E, 0x028E),
+                routed(7, 0x045E, 0x028E),
+                routed(8, 0x045E, 0x028E),
+            )
+        assertEquals(setOf(7, 8), routedTwinIdsHiddenBySynthetics(devices))
+    }
+
+    @Test
+    fun `one synthetic with two routed twins hides the disconnecting one first`() {
+        val devices =
+            listOf(
+                synthetic(-1000, 0x045E, 0x028E),
+                routed(7, 0x045E, 0x028E, disconnecting = false),
+                routed(8, 0x045E, 0x028E, disconnecting = true),
+            )
+        assertEquals(setOf(8), routedTwinIdsHiddenBySynthetics(devices))
+    }
+
+    @Test
+    fun `one synthetic with two live routed twins hides exactly one`() {
+        val devices =
+            listOf(
+                synthetic(-1000, 0x045E, 0x028E),
+                routed(7, 0x045E, 0x028E),
+                routed(8, 0x045E, 0x028E),
+            )
+        val hidden = routedTwinIdsHiddenBySynthetics(devices)
+        assertEquals(1, hidden.size)
+        assertTrue(hidden.single() in setOf(7, 8))
+    }
+
+    @Test
+    fun `more synthetics than routed twins hides every available twin without error`() {
+        val devices =
+            listOf(
+                synthetic(-1000, 0x045E, 0x028E),
+                synthetic(-1001, 0x045E, 0x028E),
+                routed(7, 0x045E, 0x028E),
+            )
+        assertEquals(setOf(7), routedTwinIdsHiddenBySynthetics(devices))
+    }
+
+    @Test
+    fun `synthetic with missing vendor and product id does not hide anything`() {
+        val devices =
+            listOf(
+                synthetic(-1000, 0, 0),
+                routed(7, 0, 0),
+            )
+        assertEquals(emptySet<Int>(), routedTwinIdsHiddenBySynthetics(devices))
+    }
+
+    @Test
+    fun `synthetics only hide twins of their own model`() {
+        val devices =
+            listOf(
+                synthetic(-1000, 0x045E, 0x028E),
+                routed(7, 0x045E, 0x028E),
+                routed(8, 0x054C, 0x05C4),
+            )
+        assertEquals(setOf(7), routedTwinIdsHiddenBySynthetics(devices))
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -234,7 +234,7 @@ satellite                                  dish-android
   ├─ MSG_RUMBLE (encrypted UDP) ────────────────►├─ receiveAck (Dispatchers.IO)
                                                  │   ├─ decrypt + parse
                                                  │   └─ JNI → RumbleBridge.dispatchRumble
-                                                 │         └─ VibratorManager / Vibrator
+                                                 │         └─ RumbleRouter → actuator
 ```
 
 `receiveAck` runs on `Dispatchers.IO`, which is JVM-attached, so the
@@ -242,15 +242,21 @@ JNI side calls into Java directly with no `AttachCurrentThread`
 ceremony and no dispatcher thread. The dispatch is synchronous on
 the JNI caller.
 
-All actuation is routed to the phone's vibrators — there is no
-fallback path that drives a connected physical pad's actuators.
-Letting the phone body handle every rumble keeps actuation
-single-rooted and avoids a "which device should buzz?" decision
-when a player is paired with a physical pad. This is intentional,
-not a missing case.
+`RumbleRouter` routes each `MSG_RUMBLE` to the device that owns the
+targeted slot (reverse-resolved from the session `handle` + `ctrlIdx`
+through `SatelliteConnection.slots`) instead of always buzzing the
+phone: the on-screen pad drives the phone vibrator, a framework gamepad
+drives its own `InputDevice` vibrator, and a claimed USB-direct pad
+gets a device-specific report written to its USB OUT endpoint
+(`SatelliteNative.sendUsbRumble` to `usbhost::sendRumble` to
+`usbparsers::runRumble`). Routing is strict: a pad with no usable
+actuator stays silent rather than buzzing the phone. Slot-kind routing,
+magnitude/duration mapping, the USB report layouts, and the satellite
+feature requests are in [`rumble.md`](rumble.md).
 
-Pure rumble helpers (`rumbleMagnitudeTo255`, `rumbleSafeDurationMs`)
-are covered by `RumbleBridgeHelpersTest.kt`.
+Pure rumble helpers (`rumbleMagnitudeTo255`, `rumbleSafeDurationMs`,
+`resolveSlotId`, `classifyTarget`) are covered by
+`RumbleBridgeHelpersTest.kt` and `RumbleRouterTest.kt`.
 
 ## Host-testable C++ split
 

--- a/docs/rumble.md
+++ b/docs/rumble.md
@@ -1,0 +1,147 @@
+# Rumble
+
+How rumble (force feedback) reaches the right device on dish-android,
+what the platform can and cannot drive, and the satellite-side feature
+requests needed to round out support. The wire layout is in
+[`wire-format.md`](wire-format.md) (`MSG_RUMBLE`, 0x0009); the runtime
+path is in [`architecture.md`](architecture.md) ("Rumble path").
+
+## Routing model
+
+The satellite sends `MSG_RUMBLE` with a `ctrlIdx`, a strong and a weak
+magnitude (u16 each, 0..65535), and a `durationMs` (u16). The client
+turns `(sessionHandle, ctrlIdx)` back into a bound slot and actuates
+the device that owns it:
+
+| Slot kind | Slot id | Actuator |
+|---|---|---|
+| On-screen virtual pad | `"virtual"` | phone vibrator (`VibratorManager` / `Vibrator`) |
+| Framework gamepad (Bluetooth, routed USB) | non-negative `deviceId` | that pad's `InputDevice.getVibratorManager()` / `getVibrator()` |
+| USB-direct (claimed) pad | negative synthetic id | device-specific report written to the pad's USB OUT endpoint |
+
+Resolution: find the `SatelliteConnection` whose `handle` matches, then
+the slot whose `controllerIndex` equals `ctrlIdx`
+(`RumbleRouter.resolveSlotId`), then classify by slot id
+(`RumbleRouter.classifyTarget`). Both are pure and unit-tested in
+`RumbleRouterTest.kt`.
+
+Routing is **strict**: only the targeted device buzzes. A physical pad
+that exposes no usable actuator (no `InputDevice` vibrator, no USB OUT
+endpoint, or a parser with no rumble builder) stays silent rather than
+buzzing the phone as a stand-in. This is the deliberate answer to "only
+the right device should rumble". If a phone-fallback is ever wanted for
+feedback parity, it would be a single branch in `RumbleRouter.actuate`,
+ideally behind a user setting.
+
+## What Android can drive
+
+Per target, the dimensions the platform actually exposes:
+
+| Dimension | Phone (`VibratorManager`) | Framework pad (`InputDevice`) | USB-direct (claimed) |
+|---|---|---|---|
+| Independent strong + weak | only if the body has two actuators (rare) | only if the pad exposes two vibrator ids (rare) | yes, in the device report |
+| Amplitude (magnitude) | yes, 1..255 (`hasAmplitudeControl`) | varies by pad (`hasAmplitudeControl`) | yes |
+| Duration / oneshot | yes | yes | yes |
+| Trigger (impulse) motors | not applicable | no public API | yes (Xbox One / Series GIP) |
+| Lightbar / LED | not applicable | no public API | yes (DualShock / DualSense) |
+
+Mapping rules the client applies:
+
+- **Magnitude:** wire 0..65535 maps to amplitude 1..255, rounding up so
+  any non-zero request is felt (`rumbleMagnitudeTo255`).
+- **Strong / weak:** sent to vibrator id 0 / id 1 when the target
+  exposes two actuators; single-actuator targets use one magnitude
+  (`max(strong, weak)` on the legacy path, strong-priority on the
+  combined path). Real dual-motor separation is only reachable on
+  USB-direct pads.
+- **Duration:** clamped to `[1, 1500]` ms (`rumbleSafeDurationMs`) to
+  bound a stranded buzz from a hung satellite.
+
+## Feature requests for the satellite / wire API
+
+These need a change on the satellite (and a mirror in `dish-linux`,
+`dish-mac`, `satellite`) before the client can do more.
+
+### FR-1: Define sustained-rumble semantics (highest value)
+
+XInput / ViGEm rumble has no duration: the game sets motor speeds and
+they run until changed. So `durationMs` is something the satellite
+synthesizes, and the contract is currently undocumented. If the
+satellite emits one packet per motor-state change with a short duration
+and does not re-send, any effect longer than that window stops early on
+the client, which clamps to a oneshot.
+
+Request: document the satellite behavior, and adopt the re-send model.
+While motors are non-zero, re-send `MSG_RUMBLE` on a fixed cadence
+(about every 1000 ms) carrying the current magnitudes, and send
+`strong = weak = 0` once on stop. The client already treats 0,0 as a
+stop and clamps duration to 1500 ms, so a ~1000 ms re-send under the
+1500 ms cap sustains cleanly with no wire change. If instead the
+satellite can know the true effect length, send that as `durationMs`.
+
+### FR-2: Trigger (impulse) rumble fields
+
+Xbox One / Series controllers have left and right trigger haptic
+motors. `MSG_RUMBLE` carries only strong + weak, so trigger haptics
+cannot be expressed. Request: either extend `MSG_RUMBLE` to 11 B with
+`leftTrigger u16 BE` and `rightTrigger u16 BE`, or add a new
+`MSG_RUMBLE_TRIGGERS` opcode, plus a `CAP_TRIGGER_RUMBLE` capability bit
+the client sets only for a bound device that can actuate triggers. This
+is only actuatable on USB-direct Xbox pads via GIP output reports, so it
+should land after the USB-direct rumble follow-up below.
+
+### FR-3: Per-slot rumble capability (nice to have)
+
+The client advertises `CAP_RUMBLE` for every slot. With routing, a slot
+backed by a motor-less pad cannot actuate. The client could revise
+`CAP_RUMBLE` per slot through `MSG_CONTROLLER_CAPS_UPDATE` so the host
+can skip rumble that would be dropped. Harmless if omitted (the host
+simply sends rumble that no-ops), so this is a refinement, not a
+blocker.
+
+### FR-4 (adjacent, not rumble): Lightbar over USB-direct
+
+`MSG_LIGHTBAR` (0x000D) already exists but Android drops it (no
+framework LED API). A claimed USB-direct DualShock / DualSense could
+drive its lightbar through the same OUT endpoint used for rumble. If
+wanted, the client would advertise `CAP_LIGHTBAR` only for those slots.
+Out of scope here; noted so the OUT-endpoint work is costed once.
+
+## USB-direct rumble output reports
+
+A claimed pad is driven by `usbparsers::runRumble`, which writes a
+device-specific report to the interrupt OUT endpoint. Magnitudes are
+the wire strong (large/low-frequency, left) and weak (small/high-
+frequency, right), 0..65535. Layouts follow the Linux kernel drivers:
+
+- **Xbox 360** (`XINPUT_360`, xpad): 8 bytes
+  `00 08 00 <strong>>8> <weak>>8> 00 00 00`.
+- **Xbox One / Series** (`XBOX_ONE_GIP`, xpad): 13 bytes
+  `09 00 <seq> 09 00 0F 00 00 <strong/512> <weak/512> FF 00 FF`, where
+  `seq` is a per-device output counter and `0F` is `GIP_MOTOR_ALL`.
+- **DualShock 4** (`DUALSHOCK4`, hid-playstation): 32-byte report `0x05`,
+  `valid_flag0 = 0x01`, `motor_right` at byte 4, `motor_left` at byte 5.
+  No CRC over USB.
+- **DualSense** (`DUALSENSE`, hid-playstation): 63-byte report `0x02`,
+  `valid_flag0 = 0x01` (compatible vibration), `motor_right` at byte 3,
+  `motor_left` at byte 4. No CRC over USB.
+- **Switch Pro** (`SWITCH_PRO_USB`, hid-nintendo): 10-byte rumble-only
+  report `0x10 <counter&0x0F> <left 4B> <right 4B>`. Each side is HD-
+  rumble encoded at the neutral frequency from a coarse amplitude table.
+  Vibration is enabled in `runInit` via subcommand `0x48`.
+
+Counters that the protocol carries (Xbox One serial, Switch Pro packet
+number) live in `DeviceCtx.outSeq`. The write is serialized against
+detach by `DeviceCtx.outMtx` so it never races the fd close.
+
+**Sources:** `drivers/input/joystick/xpad.c` (`xpad_play_effect`),
+`drivers/hid/hid-playstation.c`, `drivers/hid/hid-nintendo.c`
+(`joycon_encode_rumble`, `joycon_rumble_amplitudes`).
+
+**Not yet covered:** Stadia and the generic-HID parser have no rumble
+builder (Stadia rumble uses a SET_REPORT control transfer, not the
+interrupt OUT path, so it is left out rather than guessed). Xbox 360
+*wireless receivers* need a wrapped report and use the wired format for
+now. Trigger-motor haptics need FR-2. None of these report builders has
+been verified on hardware yet; see
+[`usb-direct-mode-followups.md`](usb-direct-mode-followups.md) item 7.

--- a/docs/usb-direct-mode-followups.md
+++ b/docs/usb-direct-mode-followups.md
@@ -1,0 +1,135 @@
+# USB Direct-mode follow-ups (low priority)
+
+Deferred items from the `explore/usb-direct-mode` review. The high and medium issues
+(resting-stick deadzone, off-main claim/detach, multi-identical-controller dedup, caps refresh
+after lane switch, migration attach fallback) are already fixed on the branch. Each item below is
+written so it can be picked up on its own. Verify file:line against current code first.
+
+---
+
+## 1. Xbox One (GIP) coverage is partial
+
+**Context:** `decodeXboxOneGip` only handles input report `0x20`. The Guide (Xbox) button arrives in
+a separate report and is never decoded, so it does nothing in Direct mode. The init is a single
+5-byte power-on (`runInit` / `InitKind::XBOX_ONE_POWERON`), which starts many controllers but not
+every Series/Elite model that expects the fuller GIP announce/identify handshake. `probeDecodable`
+gives up after ~320ms of no decodable report, so a slow-to-start GIP pad silently falls back to
+Routed.
+
+**Where:** `app/src/main/cpp/usb_parsers.cpp` (`decodeXboxOneGip`, `runInit`),
+`app/src/main/cpp/usb_host.cpp` (`probeDecodable` timeouts).
+
+**Task:** Decode the GIP guide-button report and map it (if a target XUSB bit is wanted). Consider a
+fuller GIP handshake for the models that stay silent. Re-evaluate the probe timeout/attempt counts so
+slow starters are not dropped.
+
+**Acceptance:** Guide button registers; a Series X|S and an Elite Series 2 both reach Direct mode
+reliably from cold plug-in.
+
+---
+
+## 2. Switch Pro IMU sign/orientation is unverified
+
+**Context:** The Switch Pro IMU scaling is correct (`32767/28568` gyro, `32767/16384` accel), but the
+per-axis signs and axis order were a straight map and were never checked on hardware (the code itself
+notes "signs may need an on-device flip").
+
+**Where:** `app/src/main/cpp/usb_parsers.cpp` (`decodeSwitchProUsb`, IMU block).
+
+**Task:** With a real Switch Pro in Direct mode, confirm gyro/accel axis directions against the
+satellite's motion expectation and flip signs / reorder axes as needed.
+
+**Acceptance:** Tilting/rotating the controller moves the in-game motion in the matching direction on
+all three axes.
+
+---
+
+## 3. Generic HID parser is unreachable
+
+**Context:** `decodeGenericHidGamepad` exists in C, but the Kotlin claim gate (`isCandidate` ->
+`isKnownFastLaneModel`) only allows devices whose VID/PID is in the parser table, and no table entry
+uses `GENERIC_HID_GAMEPAD`. So the generic path never runs through the normal flow.
+
+**Where:** `app/src/main/java/.../source/usb/UsbGamepadManager.kt` (`isCandidate`),
+`app/src/main/cpp/usb_parsers.cpp` (`decodeGenericHidGamepad`).
+
+**Task:** Decide the intent. Either (a) wire up an explicit, clearly-labelled "try an unknown
+gamepad-shaped HID device" opt-in that routes to the generic parser, or (b) remove the unreachable
+generic parser to cut dead code.
+
+**Acceptance:** Either an unknown gamepad can be attempted via a deliberate user action, or the dead
+path is gone. No silent generic claims.
+
+---
+
+## 4. Output mutex held across encrypt + sendto
+
+**Context:** `publishIfChanged` holds `g_slotsMtx` (and the caller `applyUsbReport` holds
+`g_devicesMtx`) across the ChaCha20-Poly1305 encrypt and the `sendto` syscall. Both mutexes are
+global and shared by the framework input path and every Direct-mode poll thread. Fine for one or two
+controllers; with four pads near 1kHz this serializes ~4k syscalls/sec through one lock. Pre-existing
+design, now exercised harder by the dedicated poll thread.
+
+**Where:** `app/src/main/cpp/satellite_jni.cpp` (`publishIfChanged`, `applyUsbReport`).
+
+**Task:** Measure under a 3 to 4 controller load. If the lock is a bottleneck, shrink the critical
+section (snapshot the report under the lock, encrypt+send outside it) without breaking the
+`devices < slots < sessions` lock order.
+
+**Acceptance:** No measurable added latency with four controllers streaming at their native rate.
+
+---
+
+## 5. Framework device state leaks on lane switch
+
+**Context:** When a controller is claimed into Direct mode, its old framework `g_devices[fwId]` entry
+is never erased (the binding observer only `unbindPhysicalSlot`s it). It is a small per-claim leak
+that lives until process death. This is the existing behaviour for framework devices generally, just
+more frequent now.
+
+**Where:** `app/src/main/cpp/satellite_jni.cpp` (`g_devices`),
+`app/src/main/java/.../hotpath/input/PhysicalSlotBindingObserver.kt` (disappeared handling).
+
+**Task:** When a framework device is removed (or superseded by a synthetic twin), call
+`dispatch::forgetDevice(fwId)` so the entry is reclaimed.
+
+**Acceptance:** `g_devices` size returns to baseline after a plug -> claim -> unplug cycle.
+
+---
+
+## 6. Move USB claim/detach off the main thread (safely)
+
+**Context:** The claim path (`attemptClaim`: USB init handshake + decode probe, up to ~400ms) and
+detach (`detachUsbDevice` joins the native poll thread) run synchronously on the broadcast/main
+thread, so a plug-in or unplug briefly hitches the UI. A first attempt to move them onto
+`Dispatchers.IO` REGRESSED streaming and was reverted: the claim path also mutates
+`PhysicalGamepadRegistry._devices` (via non-atomic `_devices.value = _devices.value + ...`) and the
+`directFailed` HashMap, both of which Android's `InputManager` callbacks write on the main thread.
+Off-main, `addUsbSynthetic` raced `onInputDeviceRemoved/Changed` for the just-stolen device, dropping
+the synthetic device so nothing registered on the host (symptoms: no virtual controller, multi-second
+"connecting", no timeout screen).
+
+**Prerequisite before retrying:** make `PhysicalGamepadRegistry` writes thread-safe first. Convert
+every `_devices.value = _devices.value <op>` to `_devices.update { <op> }`, and guard or replace the
+`directFailed` HashMap (ConcurrentHashMap, or confine to one dispatcher). `claimedDevices` /
+`promptedDevices` also need guarding plus an in-flight guard so a unplug-during-claim does not leave a
+stale entry. Only then move `attemptClaim` / `detachUsbDevice` to IO.
+
+**Where:** `UsbGamepadManager.kt` (`claimAndReport`, `attemptClaim`, `handleDetached`),
+`PhysicalGamepadRegistry.kt` (all `_devices` mutations + `directFailed`).
+
+**Acceptance:** Plug a recognised controller at app start with no UI hitch; repeated plug/unplug
+stress never drops the synthetic device or its host registration.
+
+---
+
+## 7. Cosmetic: two strings on one line
+
+**Context:** `path_reason_onscreen` and `path_reason_unknown_model` share a single physical line.
+Valid XML, just messy.
+
+**Where:** `app/src/main/res/values/strings.xml`.
+
+**Task:** Put each `<string>` on its own line.
+
+**Acceptance:** One string per line.

--- a/docs/usb-direct-mode-followups.md
+++ b/docs/usb-direct-mode-followups.md
@@ -23,6 +23,12 @@ Routed.
 fuller GIP handshake for the models that stay silent. Re-evaluate the probe timeout/attempt counts so
 slow starters are not dropped.
 
+**Status:** Guide-button decode is **done**. `decodeXboxOneGip` now handles the virtual-key report
+(0x07) and merges the sticky guide bit (`XUSB_GUIDE` = 0x0400) into the main 0x20 reports via
+`ParserState`; covered by `usb_parsers_test.cpp`. End-to-end depends on the satellite forwarding
+wButtons bit 0x0400 to ViGEm. Still open: the fuller GIP announce/identify handshake for silent
+Series/Elite models, and the probe timeout/attempt tuning (both need that hardware to verify).
+
 **Acceptance:** Guide button registers; a Series X|S and an Elite Series 2 both reach Direct mode
 reliably from cold plug-in.
 
@@ -93,6 +99,11 @@ more frequent now.
 **Task:** When a framework device is removed (or superseded by a synthetic twin), call
 `dispatch::forgetDevice(fwId)` so the entry is reclaimed.
 
+**Status:** **Done.** `SatelliteNative.forgetPhysicalDevice` exposes `dispatch::forgetDevice`, and
+`PhysicalSlotBindingObserver` calls it for every departed framework device id (non-negative; claimed
+synthetics are still freed by `detachUsbDevice`). The 5s registry disconnect-grace means the entry is
+reclaimed a few seconds after a claim/unplug rather than instantly.
+
 **Acceptance:** `g_devices` size returns to baseline after a plug -> claim -> unplug cycle.
 
 ---
@@ -123,13 +134,26 @@ stress never drops the synthetic device or its host registration.
 
 ---
 
-## 7. Cosmetic: two strings on one line
+## 7. USB-direct rumble output (implemented, needs hardware verification)
 
-**Context:** `path_reason_onscreen` and `path_reason_unknown_model` share a single physical line.
-Valid XML, just messy.
+**Status:** Implemented from the Linux kernel drivers, not yet verified on hardware. Builders exist
+for Xbox 360, Xbox One GIP, DualShock 4, DualSense, and Switch Pro. The write path, report layouts,
+counter handling, and sources are in `docs/rumble.md`.
 
-**Where:** `app/src/main/res/values/strings.xml`.
+**Remaining work:**
+- Verify each builder on real hardware (motor mapping, magnitude feel, and that no controller NAKs
+  the report). The Xbox One GIP `/512` divisor caps at half scale, matching xpad; revisit if weak.
+- Xbox 360 *wireless receivers* (PIDs 0x0291/0x0719/0x02A1) need the wrapped wireless rumble frame,
+  not the wired `00 08 00 ...` format currently sent.
+- Stadia uses a SET_REPORT control transfer (not interrupt OUT), so it has no builder yet; the
+  generic-HID parser has none either. Both stay silent rather than guess.
+- Trigger-motor haptics on GIP pads need the wire-format change in `docs/rumble.md` FR-2.
 
-**Task:** Put each `<string>` on its own line.
+**Where:** `app/src/main/cpp/usb_parsers.cpp` (`runRumble`, `switchEncodeMotor`, `runInit`),
+`app/src/main/cpp/usb_host.cpp` (`sendRumble`, `DeviceCtx`), `app/src/main/cpp/satellite_jni.cpp`
+(`sendUsbRumble` JNI), `SatelliteNative.kt` / `PhysicalInputNative.kt`,
+`app/src/main/java/.../hotpath/input/RumbleRouter.kt`.
 
-**Acceptance:** One string per line.
+**Acceptance:** A claimed USB-direct pad of each verified family rumbles on `MSG_RUMBLE` and stops on
+the 0,0 packet (or the safety auto-stop), with no effect on input latency. Unverified families either
+work or stay silent; none receives a malformed report.

--- a/docs/wire-format.md
+++ b/docs/wire-format.md
@@ -255,16 +255,17 @@ weak           u16 BE
 durationMs     u16 BE
 ```
 
-Magnitudes are wire-format 0..65535. On Android they map to
-`VibrationEffect` amplitude 1..255 with rounding-up: any non-zero
+Magnitudes are wire-format 0..65535. On the target actuator they map
+to `VibrationEffect` amplitude 1..255 with rounding-up: any non-zero
 request produces a perceptible buzz. `durationMs` is clamped to
 `[1, 1500]` to bound the worst-case stranded buzz from a hung
 satellite.
 
-Rumble drives the **phone's** vibrator (`VibratorManager` on API 31+,
-`Vibrator` on older). Strong → vibrator id 0, weak → vibrator id 1
-if the device exposes two. There is no fallback to a connected
-physical pad — the actuator stays single-rooted.
+`ctrlIdx` selects which controller buzzes; the client reverse-maps it
+(via the session handle and `SatelliteConnection.slots`) to the bound
+slot and actuates that device. Per-slot-kind routing (phone vibrator,
+framework `InputDevice` vibrator, or a USB-direct OUT-endpoint report)
+and the strong/weak mapping are in [`rumble.md`](rumble.md).
 
 ### `MSG_LIGHTBAR` (0x000D) — 4 B payload
 


### PR DESCRIPTION
## Description

Brings recognised USB controllers onto a direct, low-latency hot path and adds per-device rumble routing, with the supporting UI, docs, and tests.

**USB Direct mode (native hot path)**
- Claims a known USB gamepad and polls it on a dedicated native thread (URB ring on the interrupt-IN endpoint), decoding reports in C++ and publishing straight to the wire, bypassing the Android framework input path for lower latency.
- Per-device decoders: Xbox 360 (XInput), Xbox One / Series (GIP, including the Guide-button virtual-key report merged into the main report), DualShock 4, DualSense, Switch Pro (with IMU), Stadia, and a generic-HID fallback.
- Path classification surfaced as a Direct / Routed badge, with poll-rate sampling.
- Synthetic-device dedup so a claimed pad and its framework twin don't both appear.

**Rumble routing**
- `RumbleRouter` sends each `MSG_RUMBLE` to the device that owns the targeted slot: the phone vibrator for the on-screen pad, the gamepad's own `InputDevice` vibrator for a framework pad, or a device-specific USB OUT report for a claimed USB-direct pad (Xbox 360/One, DualShock 4, DualSense, Switch Pro). Routing is strict: a pad with no usable actuator stays silent instead of buzzing the phone.

**Connections UI**
- The controller picker lists a connection only when its link is live (Connected/Unstable), plus the slot's bound holdover, instead of flashing Connecting/Ready/Found entries while auto-reconnect settles. The Connections card shows an indeterminate spinner while any connection is still connecting.

**Fixes and housekeeping**
- Standard activities recreate cleanly on rotation.
- Comments trimmed to why-not-what (critical rationale stays in code, the rest in docs); JNI sources clang-formatted; new Kotlin is ktlint-clean.
- Docs: new `rumble.md`, updated `architecture.md` and `wire-format.md`, and a `usb-direct-mode-followups.md` backlog that tracks the remaining hardware verification.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update

## How Has This Been Tested?

- [x] Unit tests
- [ ] Instrumented tests
- [ ] Manual testing on device/emulator

JVM unit tests (`testDebugUnitTest`) and the host C++ gtest suites pass (`usb_parsers_test` 16/16, `gamepad_input_test` 55/55). ktlint, detekt, Android lint, clang-format, and `assembleDebug` all pass locally. The USB-direct rumble report builders and the Switch Pro IMU sign/orientation are implemented from the Linux kernel drivers but not yet verified on physical hardware; this is tracked in `docs/usb-direct-mode-followups.md`.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes