### PR TITLE
ci: bump actions/upload-artifact to v7.0.1 (Node 24)

### DIFF
--- a/.github/workflows/_security.yml
+++ b/.github/workflows/_security.yml
@@ -288,7 +288,7 @@ jobs:
 
       - name: Upload gitleaks SARIF
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gitleaks-report
           path: gitleaks-report.sarif

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -4,7 +4,7 @@ name: Android CI
 #   actions/checkout              @ v4.2.2 → 11bd71901bbe5b1630ceea73d27597364c9af683
 #   actions/setup-java            @ v5.2.0 → be666c2fcd27ec809703dec50e508c2fdc7f6654
 #   actions/setup-python          @ v5.3.0 → 0b93645e9fea7318ecaed2b359559ac225c90a2b
-#   actions/upload-artifact       @ v4.4.3 → b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+#   actions/upload-artifact       @ v7.0.1 → 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
 #   gradle/actions/setup-gradle   @ v4.1.0 → d156388eb19639ec20ade50009f3d199ce1e2808
 
 on:
@@ -70,7 +70,7 @@ jobs:
         run: ./gradlew assembleDebug
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: debug-apk
           path: app/build/outputs/apk/debug/*.apk
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload lint results
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: lint-results
           path: app/build/reports/lint-results-debug.html
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results
           path: app/build/reports/tests/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ on:
 # Pin map (verify with `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`):
 #   actions/checkout                @ v4.2.2  → 11bd71901bbe5b1630ceea73d27597364c9af683
 #   actions/setup-java              @ v5.2.0  → be666c2fcd27ec809703dec50e508c2fdc7f6654
-#   actions/upload-artifact         @ v4.4.3  → b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+#   actions/upload-artifact         @ v7.0.1  → 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
 #   actions/download-artifact       @ v4.1.8  → fa0a91b85d4f404e444e00e005971372dc801d16
 #   gradle/actions/setup-gradle     @ v4.1.0  → d156388eb19639ec20ade50009f3d199ce1e2808
 #   anchore/sbom-action             @ v0.17.4 → 8d0a6505bf28ced3e85154d13dc6af83299e13f1
@@ -221,7 +221,7 @@ jobs:
           fi
           ls -l dist/
 
-      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: android
           path: dist/
@@ -335,7 +335,7 @@ jobs:
           echo "hashes=${h}" >> "$GITHUB_OUTPUT"
 
       - name: Upload hardened bundle
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-bundle
           path: release/

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,7 +13,7 @@ name: Security
 #   actions/checkout              @ v4.2.2 → 11bd71901bbe5b1630ceea73d27597364c9af683
 #   actions/cache                 @ v5.0.5 → 27d5ce7f107fe9357f9df03efb73ab90386fccae
 #   actions/setup-java            @ v5.2.0 → be666c2fcd27ec809703dec50e508c2fdc7f6654
-#   actions/upload-artifact       @ v4.4.3 → b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+#   actions/upload-artifact       @ v7.0.1 → 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
 #   gradle/actions/setup-gradle   @ v4.1.0 → d156388eb19639ec20ade50009f3d199ce1e2808
 #   github/codeql-action/upload-sarif @ v4.35.2 → 95e58e9a2cdfd71adc6e0353d5c52f41a045d225
 
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload Dependency-Check report (always)
         if: ${{ always() }}
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dependency-check-report
           path: |


### PR DESCRIPTION
Bumps `actions/upload-artifact` from v4.4.3 to v7.0.1 (SHA-pinned) across all four workflows.

## Why
v4.4.3 runs on the deprecated Node 20 runtime. GitHub forces Node 24 by default on 2026-06-16, so the v4 pin has to move before then. v7.0.1 is the latest stable release and runs on Node 24.

## Changes
- `android-ci.yml`: build APK, lint, and test-result uploads
- `security.yml` + `_security.yml`: dependency-check report and gitleaks SARIF uploads
- `release.yml`: android dist and hardened-bundle uploads
- Pin-map header comments updated to match

Replaces the closed dependabot PR #64.
