### PR TITLE
feat: Bluetooth host pairing flow, single-call controller type, rumble fix

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,8 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
         android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
 
     <uses-feature android:name="android.hardware.bluetooth" android:required="false" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />

--- a/app/src/main/cpp/satellite_jni.cpp
+++ b/app/src/main/cpp/satellite_jni.cpp
@@ -570,15 +570,18 @@ JNIEXPORT void JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_sendRe
 }
 
 JNIEXPORT void JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_controllerAdd(
-    JNIEnv*, jobject, jint handle, jint controllerIndex, jint capabilities) {
+    JNIEnv*, jobject, jint handle, jint controllerIndex, jint capabilities, jint controllerType) {
     auto s = getSession(handle);
     if (!s) return;
-    uint8_t payload[3];
+    // 4-byte payload: idx(1) + caps(2 BE) + type(1). The trailing type byte lets
+    // the receiver plug the correct virtual device on the first add — no replug.
+    uint8_t payload[4];
     payload[0] = (uint8_t)(controllerIndex & 0xFF);
     putBE16(payload + 1, (uint16_t)(capabilities & 0xFFFF));
-    sendEncrypted(s.get(), MSG_CONTROLLER_ADD, payload, 3);
-    LOGI("Session %d: sent controller add idx=%d caps=0x%04X", handle, controllerIndex,
-         capabilities);
+    payload[3] = (uint8_t)(controllerType & 0xFF);
+    sendEncrypted(s.get(), MSG_CONTROLLER_ADD, payload, 4);
+    LOGI("Session %d: sent controller add idx=%d caps=0x%04X type=%d", handle, controllerIndex,
+         capabilities, controllerType);
 }
 
 JNIEXPORT void JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_controllerRemove(

--- a/app/src/main/java/com/tinkernorth/dish/core/jni/ControllerRepository.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/jni/ControllerRepository.kt
@@ -44,8 +44,9 @@ class ControllerRepository
             handle: Int,
             index: Int,
             capabilities: Int,
+            controllerType: Int,
         ) {
-            SatelliteNative.controllerAdd(handle, index, capabilities)
+            SatelliteNative.controllerAdd(handle, index, capabilities, controllerType)
         }
 
         fun removeController(

--- a/app/src/main/java/com/tinkernorth/dish/core/jni/SatelliteNative.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/jni/SatelliteNative.kt
@@ -37,6 +37,7 @@ object SatelliteNative {
         handle: Int,
         controllerIndex: Int,
         capabilities: Int,
+        controllerType: Int,
     )
 
     external fun controllerRemove(

--- a/app/src/main/java/com/tinkernorth/dish/core/model/Models.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/model/Models.kt
@@ -14,6 +14,7 @@ enum class DiscoverySource(
     BROADCAST(R.string.discovery_source_broadcast),
     MDNS(R.string.discovery_source_mdns),
     BOTH(R.string.discovery_source_both),
+    MANUAL(R.string.discovery_source_manual),
 }
 
 @Serializable

--- a/app/src/main/java/com/tinkernorth/dish/di/AppModule.kt
+++ b/app/src/main/java/com/tinkernorth/dish/di/AppModule.kt
@@ -2,10 +2,12 @@
 
 package com.tinkernorth.dish.di
 
+import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.os.Build
 import android.util.Log
 import com.tinkernorth.dish.source.bluetooth.AndroidHidProxyClient
+import com.tinkernorth.dish.source.bluetooth.BluetoothDeviceScanner
 import com.tinkernorth.dish.source.bluetooth.BluetoothHidSession
 import com.tinkernorth.dish.source.bluetooth.HidProxyClient
 import dagger.Module
@@ -77,6 +79,16 @@ object AppModule {
     @Provides
     @Singleton
     fun provideBluetoothHidSession(factory: @JvmSuppressWildcards () -> HidProxyClient): BluetoothHidSession = BluetoothHidSession(factory)
+
+    // Adapter resolved per call so a runtime BT toggle is reflected without re-injection.
+    @Provides
+    @Singleton
+    fun provideBluetoothDeviceScanner(
+        @ApplicationContext context: Context,
+    ): BluetoothDeviceScanner =
+        BluetoothDeviceScanner(context) {
+            (context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager)?.adapter
+        }
 }
 
 private object UnavailableHidProxyClient : HidProxyClient {

--- a/app/src/main/java/com/tinkernorth/dish/hotpath/input/RumbleRouter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/input/RumbleRouter.kt
@@ -166,17 +166,13 @@ class RumbleRouter
         ) {
             val ids = mgr.vibratorIds
             if (ids.isEmpty()) return
-            val combinedBuilder = CombinedVibration.startParallel()
             val strongAmp = rumbleMagnitudeTo255(strongMagnitude)
             val weakAmp = rumbleMagnitudeTo255(weakMagnitude)
-            if (strongAmp > 0) {
-                combinedBuilder.addVibrator(ids[0], VibrationEffect.createOneShot(durationMs, strongAmp))
-            }
-            if (ids.size >= 2 && weakAmp > 0) {
-                combinedBuilder.addVibrator(ids[1], VibrationEffect.createOneShot(durationMs, weakAmp))
-            } else if (ids.size < 2 && weakAmp > 0 && strongAmp == 0) {
-                // Single actuator + weak-only: still drive ids[0], else vibrate on an empty combination is a no-op.
-                combinedBuilder.addVibrator(ids[0], VibrationEffect.createOneShot(durationMs, weakAmp))
+            val plan = combinedRumblePlan(ids.size, strongAmp, weakAmp)
+            if (plan.isEmpty()) return
+            val combinedBuilder = CombinedVibration.startParallel()
+            for ((vibratorIndex, amplitude) in plan) {
+                combinedBuilder.addVibrator(ids[vibratorIndex], VibrationEffect.createOneShot(durationMs, amplitude))
             }
             try {
                 mgr.vibrate(combinedBuilder.combine())
@@ -211,6 +207,25 @@ internal fun classifyTarget(slotId: String): RumbleTarget {
     if (slotId == VIRTUAL_SLOT_ID) return RumbleTarget.Phone
     val id = slotId.toIntOrNull() ?: return RumbleTarget.None
     return if (id < 0) RumbleTarget.DirectUsb(id) else RumbleTarget.Framework(id)
+}
+
+// Two-actuator targets separate strong to index 0 / weak to index 1; a single actuator folds to
+// max(strong, weak) so a weak-only effect is still felt. Zero amplitudes are dropped so an empty
+// vibration combination is never submitted.
+internal fun combinedRumblePlan(
+    vibratorCount: Int,
+    strongAmp: Int,
+    weakAmp: Int,
+): List<Pair<Int, Int>> {
+    if (vibratorCount <= 0) return emptyList()
+    if (vibratorCount >= 2) {
+        return buildList {
+            if (strongAmp > 0) add(0 to strongAmp)
+            if (weakAmp > 0) add(1 to weakAmp)
+        }
+    }
+    val amp = maxOf(strongAmp, weakAmp)
+    return if (amp > 0) listOf(0 to amp) else emptyList()
 }
 
 // Returns 0 only for exact zero; tiny magnitudes clamp to 1 so on/off response matches a physical pad.

--- a/app/src/main/java/com/tinkernorth/dish/source/bluetooth/BluetoothDeviceScanner.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/bluetooth/BluetoothDeviceScanner.kt
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.bluetooth
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Build
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class BluetoothDeviceScanner(
+    private val context: Context,
+    private val adapterProvider: () -> BluetoothAdapter?,
+) {
+    data class Device(
+        val mac: String,
+        val name: String?,
+        val bonded: Boolean,
+    )
+
+    data class State(
+        val devices: List<Device> = emptyList(),
+        val scanning: Boolean = false,
+    )
+
+    private val lock = Any()
+    private val byMac = LinkedHashMap<String, Device>()
+    private var receiver: BroadcastReceiver? = null
+
+    private val _state = MutableStateFlow(State())
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    fun start(canScan: Boolean) {
+        synchronized(lock) {
+            teardownLocked()
+            byMac.clear()
+            seedBondedLocked()
+            if (!canScan) {
+                emitLocked(scanning = false)
+                return
+            }
+            receiver = registerReceiverLocked()
+            emitLocked(scanning = startDiscovery())
+        }
+    }
+
+    fun stop() {
+        synchronized(lock) {
+            teardownLocked()
+            byMac.clear()
+            emitLocked(scanning = false)
+        }
+    }
+
+    private fun teardownLocked() {
+        receiver?.let { rx -> runCatching { context.unregisterReceiver(rx) } }
+        receiver = null
+        cancelDiscovery()
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun seedBondedLocked() {
+        val bonded =
+            adapterProvider()?.let { adapter -> runCatching { adapter.bondedDevices }.getOrNull() } ?: return
+        for (device in bonded) {
+            val mac = device.address ?: continue
+            byMac[mac] = Device(mac, runCatching { device.name }.getOrNull(), bonded = true)
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun startDiscovery(): Boolean {
+        val adapter = adapterProvider() ?: return false
+        return runCatching { adapter.startDiscovery() }.getOrDefault(false)
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun cancelDiscovery() {
+        val adapter = adapterProvider() ?: return
+        runCatching { adapter.cancelDiscovery() }
+    }
+
+    private fun registerReceiverLocked(): BroadcastReceiver {
+        val filter =
+            IntentFilter().apply {
+                addAction(BluetoothDevice.ACTION_FOUND)
+                addAction(BluetoothAdapter.ACTION_DISCOVERY_FINISHED)
+            }
+        val rx =
+            object : BroadcastReceiver() {
+                override fun onReceive(
+                    ctx: Context,
+                    intent: Intent,
+                ) {
+                    when (intent.action) {
+                        BluetoothDevice.ACTION_FOUND -> onFound(intent)
+                        BluetoothAdapter.ACTION_DISCOVERY_FINISHED -> onDiscoveryFinished()
+                    }
+                }
+            }
+        ContextCompat.registerReceiver(context, rx, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
+        return rx
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun onFound(intent: Intent) {
+        val device = intentDevice(intent) ?: return
+        val mac = device.address ?: return
+        val name = runCatching { device.name }.getOrNull()
+        synchronized(lock) {
+            // Drop broadcasts delivered after stop(): a stale receiver must not resurrect state.
+            if (receiver == null) return
+            // Bonded entries already carry the richer paired label; don't downgrade them.
+            if (byMac[mac]?.bonded == true) return
+            byMac[mac] = Device(mac, name, bonded = false)
+            emitLocked(scanning = true)
+        }
+    }
+
+    private fun onDiscoveryFinished() {
+        synchronized(lock) {
+            if (receiver == null) return
+            emitLocked(scanning = false)
+        }
+    }
+
+    private fun emitLocked(scanning: Boolean) {
+        val ordered =
+            byMac.values.sortedWith(
+                compareByDescending<Device> { it.bonded }.thenBy { it.name ?: it.mac },
+            )
+        _state.value = State(ordered, scanning)
+    }
+
+    @Suppress("DEPRECATION")
+    private fun intentDevice(intent: Intent): BluetoothDevice? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice::class.java)
+        } else {
+            intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE)
+        }
+}

--- a/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
@@ -186,7 +186,26 @@ class SatelliteConnection(
         val snap = info ?: return
         if (snap.registered && handle >= 0) {
             withContext(ioDispatcher) {
+                controllerRepo.resetControllerAck(handle)
                 controllerRepo.sendControllerType(handle, snap.controllerIndex, controllerType)
+                var ack = -1
+                repeat(ACK_WAIT_ATTEMPTS) {
+                    ack = controllerRepo.getLastControllerAck(handle)
+                    if (ack != -1) return@repeat
+                    delay(ACK_WAIT_INTERVAL_MS)
+                }
+                if (ack != -1) {
+                    val motionFlags = controllerRepo.getLastControllerMotionFlags(handle)
+                    if (motionFlags >= 0) {
+                        motionBackendStatusStore?.setStatus(
+                            id,
+                            slotId,
+                            SatelliteMotionBackendStatus.fromFlags(motionFlags),
+                        )
+                    } else {
+                        motionBackendStatusStore?.clear(id, slotId)
+                    }
+                }
             }
         }
     }
@@ -202,7 +221,9 @@ class SatelliteConnection(
                 for (attempt in 1..ADD_MAX_ATTEMPTS) {
                     if (handle < 0) return@withContext
                     controllerRepo.resetControllerAck(handle)
-                    controllerRepo.addController(handle, info.controllerIndex, caps)
+                    // Single-call connect: the type travels in the add, so the receiver
+                    // plugs the correct virtual device on the first try (no replug).
+                    controllerRepo.addController(handle, info.controllerIndex, caps, info.controllerType)
                     var ack = -1
                     repeat(ACK_WAIT_ATTEMPTS) {
                         ack = controllerRepo.getLastControllerAck(handle)
@@ -227,6 +248,12 @@ class SatelliteConnection(
                     } else {
                         motionBackendStatusStore?.clear(id, slotId)
                     }
+                    // Backward-compat fallback: the type already travels in the add
+                    // (single-call connect), but a PRE-extension satellite ignores
+                    // that byte and plugs the default Xbox device. Re-send the type
+                    // so an old receiver still gets it. On a current receiver the
+                    // device is already the right type, so this is a no-op (same
+                    // type → no replug, no bounce).
                     controllerRepo.sendControllerType(handle, info.controllerIndex, info.controllerType)
                     // Close composer-emission-during-ACK race before flipping registered=true.
                     val currentCaps = BASE_CAPABILITIES or motionCapsBitsFor(slotId)

--- a/app/src/main/java/com/tinkernorth/dish/source/system/BluetoothPermissionStateObserver.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/system/BluetoothPermissionStateObserver.kt
@@ -13,10 +13,21 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
-enum class BluetoothPermissionState {
-    NOT_REQUIRED,
-    GRANTED,
-    DENIED,
+data class BluetoothPermissionState(
+    val required: Boolean,
+    val connectGranted: Boolean,
+    val scanGranted: Boolean,
+) {
+    val connectMissing: Boolean get() = required && !connectGranted
+
+    val scanMissing: Boolean get() = required && !scanGranted
+
+    val anyMissing: Boolean get() = connectMissing || scanMissing
+
+    companion object {
+        // Pre-S relies on the install-time BLUETOOTH/BLUETOOTH_ADMIN grants.
+        val SATISFIED = BluetoothPermissionState(required = false, connectGranted = true, scanGranted = true)
+    }
 }
 
 @Singleton
@@ -24,7 +35,7 @@ class BluetoothPermissionStateObserver
     @Inject
     constructor(
         @ApplicationContext private val context: Context,
-    ) : AbstractStateSource<BluetoothPermissionState>(BluetoothPermissionState.NOT_REQUIRED) {
+    ) : AbstractStateSource<BluetoothPermissionState>(BluetoothPermissionState.SATISFIED) {
         init {
             setState(currentState())
         }
@@ -39,10 +50,14 @@ class BluetoothPermissionStateObserver
         }
 
         private fun currentState(): BluetoothPermissionState {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return BluetoothPermissionState.NOT_REQUIRED
-            val granted =
-                ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_CONNECT) ==
-                    PackageManager.PERMISSION_GRANTED
-            return if (granted) BluetoothPermissionState.GRANTED else BluetoothPermissionState.DENIED
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return BluetoothPermissionState.SATISFIED
+            return BluetoothPermissionState(
+                required = true,
+                connectGranted = granted(Manifest.permission.BLUETOOTH_CONNECT),
+                scanGranted = granted(Manifest.permission.BLUETOOTH_SCAN),
+            )
         }
+
+        private fun granted(permission: String): Boolean =
+            ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
     }

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
@@ -12,10 +12,15 @@ import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.view.KeyEvent
+import android.view.Menu
+import android.view.MenuItem
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
@@ -24,6 +29,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.composer.ConnectionHub
 import com.tinkernorth.dish.composer.ConnectionKind
@@ -32,6 +39,7 @@ import com.tinkernorth.dish.composer.LinkState
 import com.tinkernorth.dish.composer.WakeStateController
 import com.tinkernorth.dish.core.input.BluetoothGamepad
 import com.tinkernorth.dish.core.model.DiscoveredServer
+import com.tinkernorth.dish.core.model.DiscoverySource
 import com.tinkernorth.dish.core.model.DishNotification
 import com.tinkernorth.dish.databinding.ActivityConnectionsBinding
 import com.tinkernorth.dish.databinding.RowConnectionBinding
@@ -39,6 +47,7 @@ import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.hotpath.overlay.GamepadActivityHost
 import com.tinkernorth.dish.repository.ConnectionStore
 import com.tinkernorth.dish.repository.RememberedBt
+import com.tinkernorth.dish.source.bluetooth.BluetoothDeviceScanner
 import com.tinkernorth.dish.source.bluetooth.BluetoothGamepadRegistry
 import com.tinkernorth.dish.source.bluetooth.BtStaleReason
 import com.tinkernorth.dish.source.connection.ConnectionEvent
@@ -62,6 +71,8 @@ import com.tinkernorth.dish.ui.common.setLoading
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import com.tinkernorth.dish.ui.common.statusChipText
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -70,6 +81,8 @@ class ConnectionsActivity : AppCompatActivity() {
     @Inject lateinit var satellite: SatelliteConnectionManager
 
     @Inject lateinit var btRegistry: BluetoothGamepadRegistry
+
+    @Inject lateinit var btScanner: BluetoothDeviceScanner
 
     @Inject lateinit var hub: ConnectionHub
 
@@ -102,6 +115,10 @@ class ConnectionsActivity : AppCompatActivity() {
 
     private var discoverabilityExpiryJob: kotlinx.coroutines.Job? = null
 
+    // Set before launching the discoverability prompt so the result routes back to the active
+    // caller (the new wait-for-host-first flow), bypassing the legacy pendingBtRegistration path.
+    private var onDiscoverableResult: ((granted: Boolean, durationSec: Int) -> Unit)? = null
+
     private var pinDialog: PairPinDialog? = null
 
     private var pairingServer: com.tinkernorth.dish.core.model.DiscoveredServer? = null
@@ -109,11 +126,11 @@ class ConnectionsActivity : AppCompatActivity() {
     private val btPermissionLauncher =
         registerForActivityResult(
             ActivityResultContracts.RequestMultiplePermissions(),
-        ) { results ->
+        ) { _ ->
             btPermissionState.refresh()
             val continueToAdd = addAfterPermission
             addAfterPermission = false
-            if (continueToAdd && results.values.all { it }) {
+            if (continueToAdd && !btPermissionState.state.value.connectMissing) {
                 showProfilePicker()
             }
         }
@@ -122,13 +139,22 @@ class ConnectionsActivity : AppCompatActivity() {
         registerForActivityResult(
             ActivityResultContracts.StartActivityForResult(),
         ) { result ->
+            val granted = result.resultCode != Activity.RESULT_CANCELED
+            // RESULT_OK for this intent carries the granted duration in seconds; fall back to our request.
+            val durationSec = if (result.resultCode > 0) result.resultCode else DISCOVERABLE_SECONDS
+            val callback = onDiscoverableResult
+            onDiscoverableResult = null
+            if (callback != null) {
+                callback(granted, durationSec)
+                return@registerForActivityResult
+            }
             val pending = pendingBtRegistration
             pendingBtRegistration = null
-            if (result.resultCode == Activity.RESULT_CANCELED || pending == null) {
+            if (!granted || pending == null) {
                 notifyDiscoverabilityDenied()
                 return@registerForActivityResult
             }
-            btRegistry.start(pending.tempId, pending.profile)
+            btRegistry.start(pending.tempId, pending.profile, pending.autoConnectMac)
             armDiscoverabilityExpiryTimer(pending.tempId)
         }
 
@@ -149,6 +175,20 @@ class ConnectionsActivity : AppCompatActivity() {
 
         handlePairPromptIntent(intent)
     }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.menu_connections, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean =
+        when (item.itemId) {
+            R.id.action_add_satellite -> {
+                showAddSatelliteDialog()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
 
     private fun observeSatelliteHub() {
         lifecycleScope.launch {
@@ -507,6 +547,7 @@ class ConnectionsActivity : AppCompatActivity() {
             val needed =
                 arrayOf(
                     Manifest.permission.BLUETOOTH_CONNECT,
+                    Manifest.permission.BLUETOOTH_SCAN,
                 ).filter { ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED }
             if (needed.isNotEmpty()) {
                 addAfterPermission = continueToAdd
@@ -522,16 +563,205 @@ class ConnectionsActivity : AppCompatActivity() {
         val names = profiles.map { it.profileName }.toTypedArray()
         MaterialAlertDialogBuilder(this)
             .setTitle(R.string.dialog_controller_profile_title)
-            .setItems(names) { _, which -> startBtRegistration(profiles[which]) }
+            .setItems(names) { _, which -> onBtProfileChosen(profiles[which]) }
             .setNegativeButton(R.string.action_cancel, null)
             .show()
     }
 
-    private fun startBtRegistration(profile: BluetoothGamepad.GamepadProfile) {
+    private fun onBtProfileChosen(profile: BluetoothGamepad.GamepadProfile) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            startBtRegistration(profile)
+            return
+        }
+        val tempId = "bt-pending-${System.currentTimeMillis()}"
+        requestDiscoverable { granted, durationSec ->
+            val discoverableUntilMs =
+                if (granted) {
+                    btRegistry.start(tempId, profile, autoConnectMac = null)
+                    armDiscoverabilityExpiryTimer(tempId)
+                    System.currentTimeMillis() + durationSec * 1000L
+                } else {
+                    null
+                }
+            showDevicePicker(profile, tempId, discoverableUntilMs)
+        }
+    }
+
+    private fun requestDiscoverable(onResult: (granted: Boolean, durationSec: Int) -> Unit) {
+        onDiscoverableResult = onResult
+        val intent =
+            Intent(BluetoothAdapter.ACTION_REQUEST_DISCOVERABLE).apply {
+                putExtra(BluetoothAdapter.EXTRA_DISCOVERABLE_DURATION, DISCOVERABLE_SECONDS)
+            }
+        btDiscoverableLauncher.launch(intent)
+    }
+
+    private fun showDevicePicker(
+        profile: BluetoothGamepad.GamepadProfile,
+        tempId: String,
+        initialDiscoverableUntilMs: Long?,
+    ) {
+        DevicePickerSession(profile, tempId, initialDiscoverableUntilMs).show()
+    }
+
+    private inner class DevicePickerSession(
+        private val profile: BluetoothGamepad.GamepadProfile,
+        private val tempId: String,
+        initialDiscoverableUntilMs: Long?,
+    ) {
+        private val view = layoutInflater.inflate(R.layout.dialog_bt_device_picker, null)
+        private val container = view.findViewById<LinearLayout>(R.id.deviceContainer)
+        private val progress = view.findViewById<TextView>(R.id.scanProgress)
+        private val empty = view.findViewById<TextView>(R.id.deviceEmpty)
+        private val canScan = !btPermissionState.state.value.scanMissing
+        private var discoverableUntilMs = initialDiscoverableUntilMs
+
+        // Hosts already linked before this attempt; a newly connected id means our host arrived.
+        private var baselineConnected = connectedIds()
+
+        private val dialog =
+            MaterialAlertDialogBuilder(this@ConnectionsActivity)
+                .setTitle(R.string.dialog_bt_device_title)
+                .setView(view)
+                .setNeutralButton(R.string.bt_wait_for_host, null)
+                .setNegativeButton(R.string.action_cancel, null)
+                .create()
+
+        fun show() {
+            view.findViewById<TextView>(R.id.scanNote).visibility =
+                if (canScan) View.GONE else View.VISIBLE
+            val job =
+                lifecycleScope.launch {
+                    launch { collectScan() }
+                    launch { tickCountdown() }
+                    launch { dismissOnConnect() }
+                }
+            dialog.setOnDismissListener { job.cancel() }
+            dialog.setOnShowListener {
+                refreshWaitButton()
+                dialog.getButton(AlertDialog.BUTTON_NEUTRAL)?.setOnClickListener { onWaitForHostClicked() }
+            }
+            dialog.show()
+        }
+
+        private fun connectedIds(): Set<String> {
+            val slots = btRegistry.states.value
+            return slots.filterValues { it.connected }.keys
+        }
+
+        private fun remainingSeconds(): Int {
+            val until = discoverableUntilMs ?: return 0
+            val remainingMs = until - System.currentTimeMillis()
+            return (remainingMs / 1000L).toInt().coerceAtLeast(0)
+        }
+
+        private fun refreshWaitButton() {
+            val button = dialog.getButton(AlertDialog.BUTTON_NEUTRAL) ?: return
+            if (remainingSeconds() > 0) {
+                button.isEnabled = false
+                button.text = getString(R.string.bt_waiting_for_host_timer, remainingSeconds())
+            } else {
+                discoverableUntilMs = null
+                button.isEnabled = true
+                button.text = getString(R.string.bt_wait_for_host)
+            }
+        }
+
+        private fun beginRegistration(
+            autoConnectMac: String?,
+            durationSec: Int,
+        ) {
+            discoverableUntilMs = System.currentTimeMillis() + durationSec * 1000L
+            btRegistry.start(tempId, profile, autoConnectMac)
+            armDiscoverabilityExpiryTimer(tempId)
+            baselineConnected = connectedIds()
+            refreshWaitButton()
+        }
+
+        private fun onWaitForHostClicked() {
+            requestDiscoverable { granted, durationSec ->
+                if (granted) beginRegistration(autoConnectMac = null, durationSec) else refreshWaitButton()
+            }
+        }
+
+        private fun onDevicePicked(mac: String) {
+            if (remainingSeconds() > 0) {
+                btRegistry.start(tempId, profile, mac)
+                dialog.dismiss()
+                return
+            }
+            requestDiscoverable { granted, durationSec ->
+                if (granted) {
+                    beginRegistration(mac, durationSec)
+                    dialog.dismiss()
+                } else {
+                    refreshWaitButton()
+                }
+            }
+        }
+
+        private suspend fun collectScan() {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                btScanner.start(canScan)
+                try {
+                    btScanner.state.collect { renderScan(it) }
+                } finally {
+                    btScanner.stop()
+                }
+            }
+        }
+
+        private fun renderScan(state: BluetoothDeviceScanner.State) {
+            progress.visibility = if (state.scanning) View.VISIBLE else View.GONE
+            empty.visibility = if (state.devices.isEmpty() && !state.scanning) View.VISIBLE else View.GONE
+            renderDeviceRows(container, state.devices) { onDevicePicked(it.mac) }
+        }
+
+        private suspend fun tickCountdown() {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                while (isActive) {
+                    refreshWaitButton()
+                    delay(COUNTDOWN_TICK_MS)
+                }
+            }
+        }
+
+        private suspend fun dismissOnConnect() {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                btRegistry.states.collect { states ->
+                    val connectedNow = states.filterValues { it.connected }.keys
+                    if ((connectedNow - baselineConnected).isNotEmpty()) dialog.dismiss()
+                }
+            }
+        }
+    }
+
+    private fun renderDeviceRows(
+        container: LinearLayout,
+        devices: List<BluetoothDeviceScanner.Device>,
+        onPick: (BluetoothDeviceScanner.Device) -> Unit,
+    ) {
+        container.removeAllViews()
+        for (device in devices) {
+            val row = layoutInflater.inflate(R.layout.row_bt_device, container, false)
+            row.findViewById<TextView>(R.id.tvDeviceName).text =
+                device.name?.takeIf { it.isNotBlank() } ?: device.mac
+            row.findViewById<TextView>(R.id.tvDeviceTag).setText(
+                if (device.bonded) R.string.bt_device_tag_paired else R.string.bt_device_tag_available,
+            )
+            row.setOnClickListener { onPick(device) }
+            container.addView(row)
+        }
+    }
+
+    private fun startBtRegistration(
+        profile: BluetoothGamepad.GamepadProfile,
+        autoConnectMac: String? = null,
+    ) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return
         val tempId = "bt-pending-${System.currentTimeMillis()}"
         // Defer HID registration until discoverability granted, else slot sits "Acquiring…" on deny.
-        pendingBtRegistration = PendingBtRegistration(tempId, profile)
+        pendingBtRegistration = PendingBtRegistration(tempId, profile, autoConnectMac)
         val intent =
             Intent(BluetoothAdapter.ACTION_REQUEST_DISCOVERABLE).apply {
                 putExtra(BluetoothAdapter.EXTRA_DISCOVERABLE_DURATION, DISCOVERABLE_SECONDS)
@@ -542,7 +772,65 @@ class ConnectionsActivity : AppCompatActivity() {
     private data class PendingBtRegistration(
         val tempId: String,
         val profile: BluetoothGamepad.GamepadProfile,
+        val autoConnectMac: String? = null,
     )
+
+    private fun showAddSatelliteDialog() {
+        val view = layoutInflater.inflate(R.layout.dialog_add_satellite, null)
+        val hostLayout = view.findViewById<TextInputLayout>(R.id.tilSatelliteHost)
+        val httpsLayout = view.findViewById<TextInputLayout>(R.id.tilSatelliteHttpsPort)
+        val udpLayout = view.findViewById<TextInputLayout>(R.id.tilSatelliteUdpPort)
+        val hostField = view.findViewById<TextInputEditText>(R.id.etSatelliteHost)
+        val httpsField = view.findViewById<TextInputEditText>(R.id.etSatelliteHttpsPort)
+        val udpField = view.findViewById<TextInputEditText>(R.id.etSatelliteUdpPort)
+        httpsField.setText(DEFAULT_HTTPS_PORT.toString())
+        udpField.setText(DEFAULT_UDP_PORT.toString())
+
+        val dialog =
+            MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.action_add_custom_satellite)
+                .setView(view)
+                .setPositiveButton(R.string.action_connect, null)
+                .setNegativeButton(R.string.action_cancel, null)
+                .create()
+        dialog.setOnShowListener {
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                val host =
+                    hostField.text
+                        ?.toString()
+                        ?.trim()
+                        .orEmpty()
+                val httpsPort = parsePort(httpsField)
+                val udpPort = parsePort(udpField)
+                hostLayout.error = if (host.isEmpty()) getString(R.string.add_satellite_error_host) else null
+                httpsLayout.error = if (httpsPort == null) getString(R.string.add_satellite_error_port) else null
+                udpLayout.error = if (udpPort == null) getString(R.string.add_satellite_error_port) else null
+                if (host.isNotEmpty() && httpsPort != null && udpPort != null) {
+                    satellite.connect(
+                        DiscoveredServer(
+                            name = host,
+                            ip = host,
+                            udpPort = udpPort,
+                            pairPort = httpsPort,
+                            httpPort = httpsPort,
+                            source = DiscoverySource.MANUAL,
+                        ),
+                    )
+                    dialog.dismiss()
+                }
+            }
+        }
+        dialog.show()
+    }
+
+    private fun parsePort(field: TextInputEditText): Int? {
+        val port =
+            field.text
+                ?.toString()
+                ?.trim()
+                ?.toIntOrNull() ?: return null
+        return if (port in 1..MAX_PORT) port else null
+    }
 
     private fun showPairingDialog(server: com.tinkernorth.dish.core.model.DiscoveredServer) {
         pinDialog?.dismiss()
@@ -654,23 +942,35 @@ class ConnectionsActivity : AppCompatActivity() {
             }
     }
 
-    private fun applyBtPermissionBanner(state: com.tinkernorth.dish.source.system.BluetoothPermissionState) {
+    private fun applyBtPermissionBanner(state: BluetoothPermissionState) {
         btPermissionBannerId?.let { notifications.dismiss(it) }
         btPermissionBannerId =
-            if (state == com.tinkernorth.dish.source.system.BluetoothPermissionState.DENIED) {
-                notifications.warn(
-                    glyph = R.drawable.ic_bluetooth_off,
-                    title = getString(R.string.notif_bt_permission_title),
-                    body = getString(R.string.notif_bt_permission_body),
-                    action =
-                        DishNotification.Action(
-                            label = getString(R.string.action_grant),
-                        ) { requestBtPermissions(continueToAdd = false) },
-                    key = "bt-permission-denied",
-                    durationMs = DishNotification.DURATION_PERSISTENT,
-                )
-            } else {
-                null
+            when {
+                state.connectMissing ->
+                    notifications.warn(
+                        glyph = R.drawable.ic_bluetooth_off,
+                        title = getString(R.string.notif_bt_permission_title),
+                        body = getString(R.string.notif_bt_permission_body),
+                        action =
+                            DishNotification.Action(
+                                label = getString(R.string.action_grant),
+                            ) { requestBtPermissions(continueToAdd = false) },
+                        key = "bt-permission-denied",
+                        durationMs = DishNotification.DURATION_PERSISTENT,
+                    )
+                state.scanMissing ->
+                    notifications.info(
+                        glyph = R.drawable.ic_bluetooth_off,
+                        title = getString(R.string.notif_bt_scan_permission_title),
+                        body = getString(R.string.notif_bt_scan_permission_body),
+                        action =
+                            DishNotification.Action(
+                                label = getString(R.string.action_grant),
+                            ) { requestBtPermissions(continueToAdd = false) },
+                        key = "bt-scan-permission-denied",
+                        durationMs = DishNotification.DURATION_PERSISTENT,
+                    )
+                else -> null
             }
     }
 
@@ -748,8 +1048,10 @@ class ConnectionsActivity : AppCompatActivity() {
         discoverabilityExpiryJob =
             lifecycleScope.launch {
                 kotlinx.coroutines.delay(DISCOVERABLE_SECONDS * 1000L)
-                val state = btRegistry.state(connId)
-                if (state.connected) return@launch
+                // The slot re-keys from the temp id to bt:<mac> on connect, so check the live
+                // session (single BT host at a time), not just connId.
+                val slots = btRegistry.states.value.values
+                if (slots.any { it.connected }) return@launch
                 notifications.warn(
                     glyph = R.drawable.ic_bluetooth_off,
                     title = getString(R.string.notif_discoverability_expired_title),
@@ -807,5 +1109,9 @@ class ConnectionsActivity : AppCompatActivity() {
         const val EXTRA_PAIR_PROMPT_FOR_ID = "extra_pair_prompt_for_id"
 
         private const val DISCOVERABLE_SECONDS = 120
+        private const val COUNTDOWN_TICK_MS = 500L
+        private const val DEFAULT_HTTPS_PORT = 9443
+        private const val DEFAULT_UDP_PORT = 9876
+        private const val MAX_PORT = 65535
     }
 }

--- a/app/src/main/res/layout/activity_gamepad_overlay.xml
+++ b/app/src/main/res/layout/activity_gamepad_overlay.xml
@@ -38,7 +38,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:paddingBottom="?attr/actionBarSize">
+            android:paddingBottom="@dimen/spacing_6xl">
 
             <com.tinkernorth.dish.ui.common.GamepadTouchView
                 android:id="@+id/gamepadTouchView"
@@ -48,9 +48,9 @@
                 android:paddingTop="@dimen/spacing_lg"
                 android:paddingBottom="@dimen/spacing_2xl" />
         </FrameLayout>
-
-        <include layout="@layout/overlay_low_power_chip" />
     </LinearLayout>
+
+    <include layout="@layout/overlay_low_power_chip" />
 
     <!-- Low-power overlays (countdown banner + dim screen). Included last
          so the dim FrameLayout sits on top of the gamepad and consumes

--- a/app/src/main/res/layout/activity_touchpad_overlay.xml
+++ b/app/src/main/res/layout/activity_touchpad_overlay.xml
@@ -43,8 +43,7 @@
             android:id="@+id/overlayContentFrame"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_weight="1"
-            android:paddingBottom="?attr/actionBarSize">
+            android:layout_weight="1">
 
             <!-- Trackpad row. Horizontal LinearLayout with weightSum=2
                  splits 50/50 between the two pads; margin_md on each
@@ -74,9 +73,9 @@
                     android:layout_marginStart="@dimen/spacing_md" />
             </LinearLayout>
         </FrameLayout>
-
-        <include layout="@layout/overlay_low_power_chip" />
     </LinearLayout>
+
+    <include layout="@layout/overlay_low_power_chip" />
 
     <!-- Low-power overlays (countdown banner + dim screen). Same include
          the gamepad overlay uses; the dim FrameLayout sits on top of the

--- a/app/src/main/res/layout/dialog_add_satellite.xml
+++ b/app/src/main/res/layout/dialog_add_satellite.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingHorizontal="@dimen/spacing_4xl"
+    android:paddingTop="@dimen/spacing_lg">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/tilSatelliteHost"
+        style="@style/Widget.Dish.TextInputLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/add_satellite_host_hint">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/etSatelliteHost"
+            style="@style/Widget.Dish.EditText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textUri"
+            android:singleLine="true"
+            android:imeOptions="actionNext"
+            android:importantForAutofill="no"
+            tools:targetApi="26" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/tilSatelliteHttpsPort"
+        style="@style/Widget.Dish.TextInputLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_lg"
+        android:hint="@string/add_satellite_https_hint">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/etSatelliteHttpsPort"
+            style="@style/Widget.Dish.EditText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="number"
+            android:maxLength="5"
+            android:singleLine="true"
+            android:imeOptions="actionNext"
+            android:importantForAutofill="no"
+            tools:targetApi="26" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/tilSatelliteUdpPort"
+        style="@style/Widget.Dish.TextInputLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_lg"
+        android:hint="@string/add_satellite_udp_hint">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/etSatelliteUdpPort"
+            style="@style/Widget.Dish.EditText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="number"
+            android:maxLength="5"
+            android:singleLine="true"
+            android:imeOptions="actionDone"
+            android:importantForAutofill="no"
+            tools:targetApi="26" />
+    </com.google.android.material.textfield.TextInputLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_bt_device_picker.xml
+++ b/app/src/main/res/layout/dialog_bt_device_picker.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingHorizontal="@dimen/spacing_4xl"
+    android:paddingTop="@dimen/spacing_lg">
+
+    <TextView
+        android:id="@+id/scanNote"
+        style="@style/TextAppearance.Dish.BodySmall"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/spacing_lg"
+        android:text="@string/bt_scan_permission_note"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/scanProgress"
+        style="@style/TextAppearance.Dish.Label.Accent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/spacing_sm"
+        android:text="@string/action_scanning"
+        android:visibility="gone" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <LinearLayout
+            android:id="@+id/deviceContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+    </ScrollView>
+
+    <TextView
+        android:id="@+id/deviceEmpty"
+        style="@style/TextAppearance.Dish.BodySmall"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingVertical="@dimen/spacing_xl"
+        android:text="@string/bt_device_empty"
+        android:visibility="gone" />
+</LinearLayout>

--- a/app/src/main/res/layout/overlay_low_power_chip.xml
+++ b/app/src/main/res/layout/overlay_low_power_chip.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Streaming hint + pre-dim countdown chip. Included in each screen's content
-     column (not the floating overlay) so it docks at the base and pushes
-     content up rather than covering it. View IDs preserved for LowPowerManager. -->
+<!-- Streaming hint + pre-dim countdown chip. On the dashboard it docks at the
+     base of the content column and pushes content up; on the input overlays it
+     is bottom-gravity so it floats over the controls without stealing height.
+     View IDs preserved for LowPowerManager. -->
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
@@ -9,7 +10,7 @@
         android:id="@+id/llStreamingHint"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
+        android:layout_gravity="bottom|center_horizontal"
         android:layout_marginTop="@dimen/spacing_2xl"
         android:layout_marginBottom="@dimen/spacing_2xl"
         android:background="@drawable/bg_pill"
@@ -39,7 +40,7 @@
         android:id="@+id/llCountdownBanner"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
+        android:layout_gravity="bottom|center_horizontal"
         android:layout_marginTop="@dimen/spacing_2xl"
         android:layout_marginBottom="@dimen/spacing_2xl"
         android:background="@drawable/bg_pill"

--- a/app/src/main/res/layout/row_bt_device.xml
+++ b/app/src/main/res/layout/row_bt_device.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:background="?attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:paddingVertical="@dimen/spacing_lg">
+
+    <TextView
+        android:id="@+id/tvDeviceName"
+        style="@style/TextAppearance.Dish.Body"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:singleLine="true"
+        android:ellipsize="end" />
+
+    <TextView
+        android:id="@+id/tvDeviceTag"
+        style="@style/Widget.Dish.MicroLabel"
+        android:layout_width="wrap_content"
+        android:layout_marginStart="@dimen/spacing_lg"
+        android:textColor="@color/colorMuted" />
+</LinearLayout>

--- a/app/src/main/res/menu/menu_connections.xml
+++ b/app/src/main/res/menu/menu_connections.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_add_satellite"
+        android:title="@string/action_add_custom_satellite"
+        app:showAsAction="never" />
+</menu>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -187,6 +187,22 @@
     <!-- Tekst Dish obavještenja. -->
     <string name="notif_bt_permission_title">Potrebna Bluetooth dozvola</string>
     <string name="notif_bt_permission_body">Dish-u treba pristup Bluetooth-u da registruje kontroler.</string>
+    <string name="notif_bt_scan_permission_title">Dozvoli Bluetooth skeniranje</string>
+    <string name="notif_bt_scan_permission_body">Dodijelite dozvolu za uređaje u blizini da pronađete nove hostove. Upareni uređaji rade i bez nje.</string>
+    <string name="discovery_source_manual">Ručno</string>
+    <string name="action_add_custom_satellite">Dodaj prilagođeni satelit</string>
+    <string name="add_satellite_host_hint">IP adresa ili naziv hosta</string>
+    <string name="add_satellite_https_hint">HTTPS port</string>
+    <string name="add_satellite_udp_hint">UDP port</string>
+    <string name="add_satellite_error_host">Unesite IP adresu ili naziv hosta</string>
+    <string name="add_satellite_error_port">Unesite port od 1 do 65535</string>
+    <string name="dialog_bt_device_title">Poveži se s uređajem</string>
+    <string name="bt_wait_for_host">Čekaj host</string>
+    <string name="bt_waiting_for_host_timer">Čekanje hosta (%1$ds)</string>
+    <string name="bt_device_empty">Još nema pronađenih uređaja</string>
+    <string name="bt_device_tag_paired">Uparen</string>
+    <string name="bt_device_tag_available">Dostupan</string>
+    <string name="bt_scan_permission_note">Skeniranje zahtijeva dozvolu za uređaje u blizini. Upareni uređaji se prikazuju i bez nje.</string>
     <string name="notif_bt_discoverability_denied_title">Vidljivost odbijena</string>
     <string name="notif_bt_discoverability_denied_body">Vaš host ne može vidjeti ovaj telefon dok ga ne učinite vidljivim.</string>
     <string name="notif_bt_adapter_off_title">Bluetooth je isključen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -188,6 +188,22 @@
     <!-- Text der Dish-Benachrichtigungen. -->
     <string name="notif_bt_permission_title">Bluetooth-Berechtigung nötig</string>
     <string name="notif_bt_permission_body">Dish braucht Bluetooth-Zugriff, um einen Controller zu registrieren.</string>
+    <string name="notif_bt_scan_permission_title">Bluetooth-Scannen erlauben</string>
+    <string name="notif_bt_scan_permission_body">Erteile die Berechtigung für Geräte in der Nähe, um neue Hosts zu finden. Gekoppelte Geräte funktionieren auch ohne sie.</string>
+    <string name="discovery_source_manual">Manuell</string>
+    <string name="action_add_custom_satellite">Eigenen Satelliten hinzufügen</string>
+    <string name="add_satellite_host_hint">IP-Adresse oder Hostname</string>
+    <string name="add_satellite_https_hint">HTTPS-Port</string>
+    <string name="add_satellite_udp_hint">UDP-Port</string>
+    <string name="add_satellite_error_host">IP-Adresse oder Hostname eingeben</string>
+    <string name="add_satellite_error_port">Port von 1 bis 65535 eingeben</string>
+    <string name="dialog_bt_device_title">Mit einem Gerät verbinden</string>
+    <string name="bt_wait_for_host">Auf Host warten</string>
+    <string name="bt_waiting_for_host_timer">Warte auf Host (%1$ds)</string>
+    <string name="bt_device_empty">Noch keine Geräte gefunden</string>
+    <string name="bt_device_tag_paired">Gekoppelt</string>
+    <string name="bt_device_tag_available">Verfügbar</string>
+    <string name="bt_scan_permission_note">Zum Scannen wird die Berechtigung für Geräte in der Nähe benötigt. Gekoppelte Geräte werden auch ohne sie angezeigt.</string>
     <string name="notif_bt_discoverability_denied_title">Sichtbarkeit abgelehnt</string>
     <string name="notif_bt_discoverability_denied_body">Dein Host kann dieses Telefon erst sehen, wenn du es sichtbar machst.</string>
     <string name="notif_bt_adapter_off_title">Bluetooth ist aus</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -190,6 +190,22 @@
     <!-- Texto de las notificaciones Dish. -->
     <string name="notif_bt_permission_title">Permiso de Bluetooth necesario</string>
     <string name="notif_bt_permission_body">Dish necesita acceso a Bluetooth para registrar un mando.</string>
+    <string name="notif_bt_scan_permission_title">Permitir el escaneo Bluetooth</string>
+    <string name="notif_bt_scan_permission_body">Concede el permiso de dispositivos cercanos para encontrar nuevos hosts. Los dispositivos vinculados siguen funcionando sin él.</string>
+    <string name="discovery_source_manual">Manual</string>
+    <string name="action_add_custom_satellite">Agregar satélite personalizado</string>
+    <string name="add_satellite_host_hint">Dirección IP o nombre de host</string>
+    <string name="add_satellite_https_hint">Puerto HTTPS</string>
+    <string name="add_satellite_udp_hint">Puerto UDP</string>
+    <string name="add_satellite_error_host">Introduce una dirección IP o un nombre de host</string>
+    <string name="add_satellite_error_port">Introduce un puerto del 1 al 65535</string>
+    <string name="dialog_bt_device_title">Conectar a un dispositivo</string>
+    <string name="bt_wait_for_host">Esperar al host</string>
+    <string name="bt_waiting_for_host_timer">Esperando al host (%1$ds)</string>
+    <string name="bt_device_empty">Aún no se encontraron dispositivos</string>
+    <string name="bt_device_tag_paired">Vinculado</string>
+    <string name="bt_device_tag_available">Disponible</string>
+    <string name="bt_scan_permission_note">El escaneo necesita el permiso de dispositivos cercanos. Los dispositivos vinculados se muestran sin él.</string>
     <string name="notif_bt_discoverability_denied_title">Visibilidad denegada</string>
     <string name="notif_bt_discoverability_denied_body">Tu host no puede ver este teléfono hasta que lo hagas visible.</string>
     <string name="notif_bt_adapter_off_title">Bluetooth desactivado</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -189,6 +189,22 @@
     <!-- Texte des notifications Dish. -->
     <string name="notif_bt_permission_title">Autorisation Bluetooth nécessaire</string>
     <string name="notif_bt_permission_body">Dish a besoin de l\'accès Bluetooth pour enregistrer une manette.</string>
+    <string name="notif_bt_scan_permission_title">Autoriser l\'analyse Bluetooth</string>
+    <string name="notif_bt_scan_permission_body">Accordez l\'autorisation Appareils à proximité pour trouver de nouveaux hôtes. Les appareils associés fonctionnent sans elle.</string>
+    <string name="discovery_source_manual">Manuel</string>
+    <string name="action_add_custom_satellite">Ajouter un satellite personnalisé</string>
+    <string name="add_satellite_host_hint">Adresse IP ou nom d\'hôte</string>
+    <string name="add_satellite_https_hint">Port HTTPS</string>
+    <string name="add_satellite_udp_hint">Port UDP</string>
+    <string name="add_satellite_error_host">Saisissez une adresse IP ou un nom d\'hôte</string>
+    <string name="add_satellite_error_port">Saisissez un port de 1 à 65535</string>
+    <string name="dialog_bt_device_title">Se connecter à un appareil</string>
+    <string name="bt_wait_for_host">Attendre l\'hôte</string>
+    <string name="bt_waiting_for_host_timer">En attente de l\'hôte (%1$ds)</string>
+    <string name="bt_device_empty">Aucun appareil trouvé pour l\'instant</string>
+    <string name="bt_device_tag_paired">Associé</string>
+    <string name="bt_device_tag_available">Disponible</string>
+    <string name="bt_scan_permission_note">L\'analyse nécessite l\'autorisation Appareils à proximité. Les appareils associés s\'affichent sans elle.</string>
     <string name="notif_bt_discoverability_denied_title">Visibilité refusée</string>
     <string name="notif_bt_discoverability_denied_body">Votre hôte ne peut pas voir ce téléphone tant que vous ne l\'avez pas rendu visible.</string>
     <string name="notif_bt_adapter_off_title">Bluetooth désactivé</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -190,6 +190,22 @@
     <!-- Texto das notificações Dish. -->
     <string name="notif_bt_permission_title">Permissão de Bluetooth necessária</string>
     <string name="notif_bt_permission_body">O Dish precisa de acesso ao Bluetooth para registrar um controle.</string>
+    <string name="notif_bt_scan_permission_title">Permitir busca por Bluetooth</string>
+    <string name="notif_bt_scan_permission_body">Conceda a permissão de dispositivos por perto para encontrar novos hosts. Dispositivos pareados continuam funcionando sem ela.</string>
+    <string name="discovery_source_manual">Manual</string>
+    <string name="action_add_custom_satellite">Adicionar satélite personalizado</string>
+    <string name="add_satellite_host_hint">Endereço IP ou nome do host</string>
+    <string name="add_satellite_https_hint">Porta HTTPS</string>
+    <string name="add_satellite_udp_hint">Porta UDP</string>
+    <string name="add_satellite_error_host">Digite um endereço IP ou nome do host</string>
+    <string name="add_satellite_error_port">Digite uma porta de 1 a 65535</string>
+    <string name="dialog_bt_device_title">Conectar a um dispositivo</string>
+    <string name="bt_wait_for_host">Aguardar host</string>
+    <string name="bt_waiting_for_host_timer">Aguardando host (%1$ds)</string>
+    <string name="bt_device_empty">Nenhum dispositivo encontrado ainda</string>
+    <string name="bt_device_tag_paired">Pareado</string>
+    <string name="bt_device_tag_available">Disponível</string>
+    <string name="bt_scan_permission_note">A busca precisa da permissão de dispositivos por perto. Dispositivos pareados aparecem sem ela.</string>
     <string name="notif_bt_discoverability_denied_title">Visibilidade recusada</string>
     <string name="notif_bt_discoverability_denied_body">Seu host não consegue ver este telefone até você torná-lo visível.</string>
     <string name="notif_bt_adapter_off_title">Bluetooth desativado</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,23 @@
     <!-- Bluetooth-profile picker dialog. -->
     <string name="dialog_controller_profile_title">Controller Profile</string>
 
+    <!-- Bluetooth device picker (paired + scanned hosts). -->
+    <string name="dialog_bt_device_title">Connect to a device</string>
+    <string name="bt_wait_for_host">Wait for host</string>
+    <string name="bt_waiting_for_host_timer">Waiting for host (%1$ds)</string>
+    <string name="bt_device_empty">No devices found yet</string>
+    <string name="bt_device_tag_paired">Paired</string>
+    <string name="bt_device_tag_available">Available</string>
+    <string name="bt_scan_permission_note">Scanning needs the Nearby devices permission. Paired devices are shown without it.</string>
+
+    <!-- Add-custom-satellite dialog (manual IP + ports). -->
+    <string name="action_add_custom_satellite">Add custom satellite</string>
+    <string name="add_satellite_host_hint">IP address or hostname</string>
+    <string name="add_satellite_https_hint">HTTPS port</string>
+    <string name="add_satellite_udp_hint">UDP port</string>
+    <string name="add_satellite_error_host">Enter an IP address or hostname</string>
+    <string name="add_satellite_error_port">Enter a port from 1 to 65535</string>
+
     <!-- Discoverability-expired banner posted from ConnectionsActivity. -->
     <string name="notif_discoverability_expired_title">Discoverability expired</string>
     <string name="notif_discoverability_expired_body">No host paired in time. Re-extend to keep trying.</string>
@@ -220,6 +237,7 @@
     <string name="discovery_source_broadcast">UDP broadcast</string>
     <string name="discovery_source_mdns">mDNS</string>
     <string name="discovery_source_both">mDNS + broadcast</string>
+    <string name="discovery_source_manual">Manual</string>
 
     <!-- DishNotification action labels. Short, imperative, sentence-case
          to match the modern (M3) button label convention. -->
@@ -234,6 +252,8 @@
          across data + UI sites. -->
     <string name="notif_bt_permission_title">Bluetooth permission needed</string>
     <string name="notif_bt_permission_body">Dish needs Bluetooth access to register a controller.</string>
+    <string name="notif_bt_scan_permission_title">Allow Bluetooth scanning</string>
+    <string name="notif_bt_scan_permission_body">Grant the Nearby devices permission to find new hosts. Paired devices still work without it.</string>
     <string name="notif_bt_discoverability_denied_title">Discoverability denied</string>
     <string name="notif_bt_discoverability_denied_body">Your host can\'t see this phone until you make it discoverable.</string>
     <string name="notif_bt_adapter_off_title">Bluetooth is off</string>

--- a/app/src/main/res/values/styles_widgets.xml
+++ b/app/src/main/res/values/styles_widgets.xml
@@ -208,6 +208,28 @@
         <item name="android:fontFamily">monospace</item>
     </style>
 
+    <style name="Widget.Dish.TextInputLayout" parent="Widget.Material3.TextInputLayout.OutlinedBox">
+        <item name="boxStrokeColor">@color/colorPrimary</item>
+        <item name="boxStrokeWidth">@dimen/border_thin</item>
+        <item name="boxStrokeWidthFocused">@dimen/border_thin</item>
+        <item name="boxStrokeErrorColor">@color/colorError</item>
+        <item name="boxBackgroundColor">@color/colorBackground</item>
+        <item name="boxCornerRadiusTopStart">@dimen/corner_picker_row</item>
+        <item name="boxCornerRadiusTopEnd">@dimen/corner_picker_row</item>
+        <item name="boxCornerRadiusBottomStart">@dimen/corner_picker_row</item>
+        <item name="boxCornerRadiusBottomEnd">@dimen/corner_picker_row</item>
+        <item name="hintTextColor">@color/colorPrimary</item>
+        <item name="android:textColorHint">@color/colorMuted</item>
+        <item name="errorEnabled">true</item>
+        <item name="errorIconDrawable">@null</item>
+        <item name="errorTextColor">@color/colorError</item>
+    </style>
+
+    <style name="Widget.Dish.EditText" parent="Widget.Material3.TextInputEditText.OutlinedBox">
+        <item name="android:textColor">@color/colorOnSurface</item>
+        <item name="android:textColorHint">@color/colorMuted</item>
+    </style>
+
     <!-- ============================================================
          CHIP — the pickable chip used by the controller card's inline
          pickers (Type: Xbox/PS, Touchpad mode: Off/Pad/Mouse). MaterialChip

--- a/app/src/test/java/com/tinkernorth/dish/hotpath/input/RumbleRouterTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/hotpath/input/RumbleRouterTest.kt
@@ -47,4 +47,49 @@ class RumbleRouterTest {
         assertEquals(RumbleTarget.None, classifyTarget("not-an-int"))
         assertEquals(RumbleTarget.None, classifyTarget(""))
     }
+
+    @Test
+    fun `combinedRumblePlan separates strong and weak across two actuators`() {
+        assertEquals(listOf(0 to 200, 1 to 100), combinedRumblePlan(vibratorCount = 2, strongAmp = 200, weakAmp = 100))
+    }
+
+    @Test
+    fun `combinedRumblePlan drops a zero-strong actuator on a dual target`() {
+        assertEquals(listOf(1 to 100), combinedRumblePlan(vibratorCount = 2, strongAmp = 0, weakAmp = 100))
+    }
+
+    @Test
+    fun `combinedRumblePlan drops a zero-weak actuator on a dual target`() {
+        assertEquals(listOf(0 to 200), combinedRumblePlan(vibratorCount = 2, strongAmp = 200, weakAmp = 0))
+    }
+
+    @Test
+    fun `combinedRumblePlan yields nothing when both amplitudes are zero on a dual target`() {
+        assertEquals(emptyList<Pair<Int, Int>>(), combinedRumblePlan(vibratorCount = 2, strongAmp = 0, weakAmp = 0))
+    }
+
+    @Test
+    fun `combinedRumblePlan folds a strong-dominant effect onto a single actuator`() {
+        assertEquals(listOf(0 to 200), combinedRumblePlan(vibratorCount = 1, strongAmp = 200, weakAmp = 50))
+    }
+
+    @Test
+    fun `combinedRumblePlan folds a weak-dominant effect onto a single actuator`() {
+        assertEquals(listOf(0 to 180), combinedRumblePlan(vibratorCount = 1, strongAmp = 40, weakAmp = 180))
+    }
+
+    @Test
+    fun `combinedRumblePlan drives the single actuator when only weak is set`() {
+        assertEquals(listOf(0 to 90), combinedRumblePlan(vibratorCount = 1, strongAmp = 0, weakAmp = 90))
+    }
+
+    @Test
+    fun `combinedRumblePlan yields nothing for a single actuator with no amplitude`() {
+        assertEquals(emptyList<Pair<Int, Int>>(), combinedRumblePlan(vibratorCount = 1, strongAmp = 0, weakAmp = 0))
+    }
+
+    @Test
+    fun `combinedRumblePlan yields nothing when there are no actuators`() {
+        assertEquals(emptyList<Pair<Int, Int>>(), combinedRumblePlan(vibratorCount = 0, strongAmp = 200, weakAmp = 100))
+    }
 }

--- a/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothDeviceScannerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothDeviceScannerTest.kt
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.bluetooth
+
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BluetoothDeviceScannerTest {
+    private lateinit var context: Context
+    private lateinit var adapter: BluetoothAdapter
+    private lateinit var scanner: BluetoothDeviceScanner
+
+    private val devices: List<BluetoothDeviceScanner.Device> get() = scanner.state.value.devices
+    private val scanning: Boolean get() = scanner.state.value.scanning
+
+    @Before
+    fun setUp() {
+        context = mockk(relaxed = true)
+        adapter = mockk(relaxed = true)
+        every { adapter.bondedDevices } returns emptySet()
+        every { adapter.startDiscovery() } returns true
+        every { adapter.cancelDiscovery() } returns true
+        scanner = BluetoothDeviceScanner(context) { adapter }
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    private fun deviceMock(
+        mac: String?,
+        name: String?,
+    ): BluetoothDevice {
+        val device = mockk<BluetoothDevice>(relaxed = true)
+        every { device.address } returns mac
+        every { device.name } returns name
+        return device
+    }
+
+    private fun foundIntent(device: BluetoothDevice?): Intent {
+        val intent = mockk<Intent>(relaxed = true)
+        every { intent.action } returns BluetoothDevice.ACTION_FOUND
+        every { intent.getParcelableExtra<BluetoothDevice>(BluetoothDevice.EXTRA_DEVICE) } returns device
+        every {
+            intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice::class.java)
+        } returns device
+        return intent
+    }
+
+    private fun discoveryFinishedIntent(): Intent {
+        val intent = mockk<Intent>(relaxed = true)
+        every { intent.action } returns BluetoothAdapter.ACTION_DISCOVERY_FINISHED
+        return intent
+    }
+
+    private fun receiverField(): BroadcastReceiver? {
+        val field = BluetoothDeviceScanner::class.java.getDeclaredField("receiver")
+        field.isAccessible = true
+        return field.get(scanner) as BroadcastReceiver?
+    }
+
+    private fun fire(intent: Intent) {
+        (receiverField() ?: error("no receiver registered")).onReceive(context, intent)
+    }
+
+    @Test
+    fun `initial state is empty and not scanning`() {
+        assertTrue(devices.isEmpty())
+        assertFalse(scanning)
+    }
+
+    @Test
+    fun `start with canScan false seeds bonded devices without scanning`() {
+        every { adapter.bondedDevices } returns setOf(deviceMock("AA", "Xbox"))
+
+        scanner.start(canScan = false)
+
+        assertEquals(1, devices.size)
+        val device = devices[0]
+        assertTrue(device.bonded)
+        assertEquals("Xbox", device.name)
+        assertFalse(scanning)
+        verify(exactly = 0) { adapter.startDiscovery() }
+    }
+
+    @Test
+    fun `start with canScan false does not register a receiver`() {
+        scanner.start(canScan = false)
+
+        assertNull(receiverField())
+    }
+
+    @Test
+    fun `start with canScan true starts discovery and reports scanning`() {
+        every { adapter.startDiscovery() } returns true
+
+        scanner.start(canScan = true)
+
+        assertTrue(scanning)
+        verify { adapter.startDiscovery() }
+    }
+
+    @Test
+    fun `start reports not scanning when startDiscovery returns false`() {
+        every { adapter.startDiscovery() } returns false
+
+        scanner.start(canScan = true)
+
+        assertFalse(scanning)
+    }
+
+    @Test
+    fun `start degrades to not scanning when startDiscovery throws`() {
+        every { adapter.startDiscovery() } throws SecurityException("scan permission revoked")
+
+        scanner.start(canScan = true)
+
+        assertFalse(scanning)
+    }
+
+    @Test
+    fun `start degrades to no bonded devices when bondedDevices throws`() {
+        every { adapter.bondedDevices } throws SecurityException("connect permission revoked")
+
+        scanner.start(canScan = true)
+
+        assertTrue(devices.isEmpty())
+    }
+
+    @Test
+    fun `start with no adapter does not crash and reports not scanning`() {
+        val noAdapter = BluetoothDeviceScanner(context) { null }
+
+        noAdapter.start(canScan = true)
+
+        val state = noAdapter.state.value
+        assertFalse(state.scanning)
+        assertTrue(state.devices.isEmpty())
+    }
+
+    @Test
+    fun `bonded devices are sorted before discovered and then by name`() {
+        every { adapter.bondedDevices } returns
+            linkedSetOf(deviceMock("BB", "Zeta"), deviceMock("AA", "Alpha"))
+
+        scanner.start(canScan = true)
+        fire(foundIntent(deviceMock("CC", "Mid")))
+
+        assertEquals(listOf("Alpha", "Zeta", "Mid"), devices.map { it.name })
+    }
+
+    @Test
+    fun `discovered device is appended as not bonded and keeps scanning true`() {
+        scanner.start(canScan = true)
+
+        fire(foundIntent(deviceMock("CC", "Controller")))
+
+        val device = devices.single { it.mac == "CC" }
+        assertFalse(device.bonded)
+        assertEquals("Controller", device.name)
+        assertTrue(scanning)
+    }
+
+    @Test
+    fun `discovery does not downgrade a bonded entry`() {
+        every { adapter.bondedDevices } returns setOf(deviceMock("AA", "Paired Xbox"))
+
+        scanner.start(canScan = true)
+        fire(foundIntent(deviceMock("AA", "AA")))
+
+        val device = devices.single { it.mac == "AA" }
+        assertTrue(device.bonded)
+        assertEquals("Paired Xbox", device.name)
+    }
+
+    @Test
+    fun `duplicate discovery keeps a single entry and updates the name`() {
+        scanner.start(canScan = true)
+
+        fire(foundIntent(deviceMock("CC", "First")))
+        fire(foundIntent(deviceMock("CC", "Second")))
+
+        val matches = devices.filter { it.mac == "CC" }
+        assertEquals(1, matches.size)
+        assertEquals("Second", matches[0].name)
+    }
+
+    @Test
+    fun `found intent without a device is ignored`() {
+        scanner.start(canScan = true)
+
+        fire(foundIntent(device = null))
+
+        assertTrue(devices.isEmpty())
+    }
+
+    @Test
+    fun `found intent with a null address is ignored`() {
+        scanner.start(canScan = true)
+
+        fire(foundIntent(deviceMock(mac = null, name = "Nameless")))
+
+        assertTrue(devices.isEmpty())
+    }
+
+    @Test
+    fun `discovered device with an unreadable name is added with a null name`() {
+        val device = mockk<BluetoothDevice>(relaxed = true)
+        every { device.address } returns "CC"
+        every { device.name } throws SecurityException("connect permission revoked")
+
+        scanner.start(canScan = true)
+        fire(foundIntent(device))
+
+        assertNull(devices.single { it.mac == "CC" }.name)
+    }
+
+    @Test
+    fun `discovery finished clears scanning but keeps devices`() {
+        scanner.start(canScan = true)
+        fire(foundIntent(deviceMock("CC", "Controller")))
+
+        fire(discoveryFinishedIntent())
+
+        assertFalse(scanning)
+        assertEquals(1, devices.size)
+    }
+
+    @Test
+    fun `stop clears devices and resets scanning`() {
+        every { adapter.bondedDevices } returns setOf(deviceMock("AA", "Xbox"))
+        scanner.start(canScan = true)
+
+        scanner.stop()
+
+        assertTrue(devices.isEmpty())
+        assertFalse(scanning)
+    }
+
+    @Test
+    fun `stop unregisters the receiver and cancels discovery`() {
+        scanner.start(canScan = true)
+        val registered = requireNotNull(receiverField())
+
+        scanner.stop()
+
+        verify { context.unregisterReceiver(registered) }
+        verify { adapter.cancelDiscovery() }
+        assertNull(receiverField())
+    }
+
+    @Test
+    fun `a broadcast delivered after stop is ignored`() {
+        scanner.start(canScan = true)
+        val stale = requireNotNull(receiverField())
+        scanner.stop()
+
+        stale.onReceive(context, foundIntent(deviceMock("CC", "Late")))
+
+        assertTrue(devices.isEmpty())
+    }
+
+    @Test
+    fun `start is idempotent and tears down the previous receiver`() {
+        scanner.start(canScan = true)
+        val first = requireNotNull(receiverField())
+
+        scanner.start(canScan = true)
+        val second = requireNotNull(receiverField())
+
+        verify { context.unregisterReceiver(first) }
+        assertNotSame(first, second)
+    }
+
+    @Test
+    fun `restart reseeds from the current bonded set`() {
+        every { adapter.bondedDevices } returns setOf(deviceMock("AA", "Xbox"))
+        scanner.start(canScan = true)
+        fire(foundIntent(deviceMock("CC", "Controller")))
+        assertEquals(2, devices.size)
+
+        every { adapter.bondedDevices } returns setOf(deviceMock("BB", "PlayStation"))
+        scanner.start(canScan = true)
+
+        assertEquals(listOf("BB"), devices.map { it.mac })
+    }
+
+    @Test
+    fun `state flow publishes updates to collectors`() =
+        runTest {
+            every { adapter.bondedDevices } returns setOf(deviceMock("AA", "Xbox"))
+            val seen = mutableListOf<BluetoothDeviceScanner.State>()
+            val job =
+                backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                    scanner.state.collect { seen += it }
+                }
+
+            scanner.start(canScan = true)
+            fire(foundIntent(deviceMock("CC", "Controller")))
+
+            val last = seen.last()
+            assertEquals(scanner.state.value, last)
+            assertTrue(last.devices.any { it.mac == "CC" })
+            job.cancel()
+        }
+}

--- a/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionTest.kt
@@ -4,6 +4,7 @@ package com.tinkernorth.dish.source.connection
 
 import com.tinkernorth.dish.core.jni.ControllerRepository
 import com.tinkernorth.dish.core.model.DiscoveredServer
+import com.tinkernorth.dish.source.store.SatelliteMotionBackendStatusStore
 import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.coVerify
@@ -185,7 +186,7 @@ class SatelliteConnectionTest {
             conn.attachSlot(slotId = "slot-1", controllerType = 0)
             assertEquals(0, conn.slots.value["slot-1"]?.controllerIndex)
             assertEquals(false, conn.slots.value["slot-1"]?.registered)
-            coVerify(exactly = 0) { repo.addController(any(), any(), any()) }
+            coVerify(exactly = 0) { repo.addController(any(), any(), any(), any()) }
         }
 
     @Test
@@ -200,7 +201,9 @@ class SatelliteConnectionTest {
             conn.markConnected(handle = 8, connectionId = "c") {}
             conn.attachSlot(slotId = "slot-1", controllerType = 0)
 
-            coVerify { repo.addController(8, 0, any()) }
+            // Type travels in the add (single-call connect)...
+            coVerify { repo.addController(8, 0, any(), 0) }
+            // ...and is re-sent as a backward-compat fallback for pre-extension receivers.
             verify { repo.sendControllerType(8, 0, 0) }
             assertEquals(true, conn.slots.value["slot-1"]?.registered)
         }
@@ -244,7 +247,7 @@ class SatelliteConnectionTest {
             conn.attachSlot(slotId = "slot-1", controllerType = 0)
 
             coVerify {
-                repo.addController(8, 0, match { (it and 0x0004) != 0 })
+                repo.addController(8, 0, match { (it and 0x0004) != 0 }, any())
             }
         }
 
@@ -269,10 +272,10 @@ class SatelliteConnectionTest {
             noMotion.attachSlot(slotId = "slot-1", controllerType = 0)
 
             coVerify {
-                repo.addController(8, 0, match { (it and 0x0004) == 0 })
+                repo.addController(8, 0, match { (it and 0x0004) == 0 }, any())
             }
             coVerify {
-                repo.addController(8, 0, match { (it and 0x0001) != 0 && (it and 0x0002) != 0 })
+                repo.addController(8, 0, match { (it and 0x0001) != 0 && (it and 0x0002) != 0 }, any())
             }
 
             noMotion.markDisconnected()
@@ -299,7 +302,7 @@ class SatelliteConnectionTest {
             withMotion.attachSlot(slotId = "slot-1", controllerType = 0)
 
             coVerify {
-                repo.addController(8, 0, match { (it and 0x0004) != 0 })
+                repo.addController(8, 0, match { (it and 0x0004) != 0 }, any())
             }
             withMotion.markDisconnected()
         }
@@ -331,8 +334,8 @@ class SatelliteConnectionTest {
 
             assertTrue(askedFor.contains("slot-A"))
             assertTrue(askedFor.contains("slot-B"))
-            coVerify { repo.addController(8, 0, match { (it and 0x0004) != 0 }) }
-            coVerify { repo.addController(8, 1, match { (it and 0x0004) == 0 }) }
+            coVerify { repo.addController(8, 0, match { (it and 0x0004) != 0 }, any()) }
+            coVerify { repo.addController(8, 1, match { (it and 0x0004) == 0 }, any()) }
             perSlot.markDisconnected()
         }
 
@@ -367,8 +370,8 @@ class SatelliteConnectionTest {
 
             assertEquals(0, conn.slots.value["slot-A"]?.controllerIndex)
             assertEquals(1, conn.slots.value["slot-B"]?.controllerIndex)
-            coVerify { repo.addController(4, 0, any()) }
-            coVerify { repo.addController(4, 1, any()) }
+            coVerify { repo.addController(4, 0, any(), any()) }
+            coVerify { repo.addController(4, 1, any(), any()) }
         }
 
     @Test
@@ -425,9 +428,49 @@ class SatelliteConnectionTest {
             conn.attachSlot("slot-A", controllerType = 0)
             conn.setControllerType("slot-A", controllerType = 1)
 
+            coVerify { repo.addController(6, 0, any(), 0) }
+            // registration re-sends the type as a compat fallback (type 0)...
             verify { repo.sendControllerType(6, 0, 0) }
+            // ...then the explicit change sends type 1.
             verify { repo.sendControllerType(6, 0, 1) }
             assertEquals(1, conn.slots.value["slot-A"]?.controllerType)
+        }
+
+    @Test
+    fun `setControllerType refreshes the motion backend status from the replug ACK`() =
+        runTest {
+            every { repo.resetControllerAck(any()) } just Runs
+            every { repo.startHeartbeat(any()) } just Runs
+            every { repo.isConnectionAlive(any()) } returns false
+            every { repo.getLastControllerAck(any()) } returns 0
+            every { repo.getLastControllerMotionFlags(any()) } returnsMany listOf(0x02, 0x03)
+
+            val store = SatelliteMotionBackendStatusStore()
+            val connId = SatelliteConnection.idFor(server)
+            val withStore =
+                SatelliteConnection(
+                    id = connId,
+                    server = server,
+                    scope = scope,
+                    controllerRepo = repo,
+                    motionBackendStatusStore = store,
+                )
+            withStore.markConnecting()
+            withStore.markConnected(handle = 6, connectionId = "c") {}
+            withStore.attachSlot("slot-A", controllerType = 0)
+
+            val afterAdd = store.statusFor(connId, "slot-A")
+            assertEquals(false, afterAdd?.sinkSupportedForType)
+            assertEquals(true, afterAdd?.backendOk)
+
+            withStore.setControllerType("slot-A", controllerType = 1)
+
+            val afterType = store.statusFor(connId, "slot-A")
+            assertEquals(true, afterType?.sinkSupportedForType)
+            assertEquals(true, afterType?.backendOk)
+            verify { repo.sendControllerType(6, 0, 1) }
+
+            withStore.markDisconnected()
         }
 
     @Test
@@ -461,7 +504,7 @@ class SatelliteConnectionTest {
             conn.attachSlot("slot-A", controllerType = 0)
             conn.attachSlot("slot-A", controllerType = 1)
 
-            coVerify(exactly = 1) { repo.addController(1, 0, any()) }
+            coVerify(exactly = 1) { repo.addController(1, 0, any(), any()) }
             assertEquals(0, conn.slots.value["slot-A"]?.controllerType)
         }
 
@@ -545,7 +588,7 @@ class SatelliteConnectionTest {
             reactive.attachSlot(slotId = "slot-1", controllerType = 0)
 
             coVerify {
-                repo.addController(8, 0, match { (it and 0x0004) != 0 })
+                repo.addController(8, 0, match { (it and 0x0004) != 0 }, any())
             }
 
             capsBit = 0

--- a/app/src/test/java/com/tinkernorth/dish/source/system/BluetoothPermissionStateTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/system/BluetoothPermissionStateTest.kt
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.system
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BluetoothPermissionStateTest {
+    @Test
+    fun `SATISFIED reports nothing missing`() {
+        val state = BluetoothPermissionState.SATISFIED
+        assertFalse(state.connectMissing)
+        assertFalse(state.scanMissing)
+        assertFalse(state.anyMissing)
+    }
+
+    @Test
+    fun `not required reports nothing missing even when grants are absent`() {
+        val state = BluetoothPermissionState(required = false, connectGranted = false, scanGranted = false)
+        assertFalse(state.connectMissing)
+        assertFalse(state.scanMissing)
+        assertFalse(state.anyMissing)
+    }
+
+    @Test
+    fun `required with both grants reports nothing missing`() {
+        val state = BluetoothPermissionState(required = true, connectGranted = true, scanGranted = true)
+        assertFalse(state.connectMissing)
+        assertFalse(state.scanMissing)
+        assertFalse(state.anyMissing)
+    }
+
+    @Test
+    fun `required with connect denied reports only connect missing`() {
+        val state = BluetoothPermissionState(required = true, connectGranted = false, scanGranted = true)
+        assertTrue(state.connectMissing)
+        assertFalse(state.scanMissing)
+        assertTrue(state.anyMissing)
+    }
+
+    @Test
+    fun `required with scan denied reports only scan missing`() {
+        val state = BluetoothPermissionState(required = true, connectGranted = true, scanGranted = false)
+        assertFalse(state.connectMissing)
+        assertTrue(state.scanMissing)
+        assertTrue(state.anyMissing)
+    }
+
+    @Test
+    fun `required with both denied reports both missing`() {
+        val state = BluetoothPermissionState(required = true, connectGranted = false, scanGranted = false)
+        assertTrue(state.connectMissing)
+        assertTrue(state.scanMissing)
+        assertTrue(state.anyMissing)
+    }
+}

--- a/docs/rumble.md
+++ b/docs/rumble.md
@@ -50,10 +50,10 @@ Mapping rules the client applies:
 - **Magnitude:** wire 0..65535 maps to amplitude 1..255, rounding up so
   any non-zero request is felt (`rumbleMagnitudeTo255`).
 - **Strong / weak:** sent to vibrator id 0 / id 1 when the target
-  exposes two actuators; single-actuator targets use one magnitude
-  (`max(strong, weak)` on the legacy path, strong-priority on the
-  combined path). Real dual-motor separation is only reachable on
-  USB-direct pads.
+  exposes two actuators; single-actuator targets fold to one magnitude
+  (`max(strong, weak)`) on both the legacy and combined paths, so a
+  weak-dominant effect is still felt. Real dual-motor separation is
+  only reachable on USB-direct pads.
 - **Duration:** clamped to `[1, 1500]` ms (`rumbleSafeDurationMs`) to
   bound a stranded buzz from a hung satellite.
 

--- a/docs/wire-format.md
+++ b/docs/wire-format.md
@@ -89,7 +89,7 @@ hot path takes no userspace lock.
 |---|---|---|---|
 | `0x0001` | `MSG_GAMEPAD_DATA` | 13 B | per-event XUSB report |
 | `0x0002` | `MSG_HEARTBEAT_PING` | 0 B | keepalive (250 ms cadence) |
-| `0x0004` | `MSG_CONTROLLER_ADD` | 3 B | register slot |
+| `0x0004` | `MSG_CONTROLLER_ADD` | 3–4 B | register slot |
 | `0x0005` | `MSG_CONTROLLER_REMOVE` | 1 B | unregister slot |
 | `0x0008` | `MSG_CONTROLLER_TYPE` | 2 B | Xbox vs PlayStation hint |
 | `0x000A` | `MSG_MOTION` | 17 B | IMU sample (rate-limited) |
@@ -134,12 +134,17 @@ Sticks follow the XInput convention: pushing up is **positive Y**.
 Android `AXIS_Y` is inverted (up is `-1.0f`), so the producer negates
 before scaling to `i16`.
 
-### `MSG_CONTROLLER_ADD` (0x0004) — 3 B
+### `MSG_CONTROLLER_ADD` (0x0004) — 3–4 B
 
 ```
-ctrlIdx       u8
-capabilities  u16 LE   (see "Capability bits" below)
+ctrlIdx        u8
+capabilities   u16 LE   (see "Capability bits" below)
+controllerType u8       optional: 0 = Xbox, 1 = PlayStation
 ```
+
+The optional trailing `controllerType` byte lets the receiver plug the correct
+virtual device on the first add (no follow-up `MSG_CONTROLLER_TYPE` / replug).
+Omitting it leaves the slot's existing type untouched on the receiver.
 
 ### `MSG_CONTROLLER_REMOVE` (0x0005) — 1 B
 


### PR DESCRIPTION
## Overview
Bundles the local work in the connections/input area into one branch: a new Bluetooth host-pairing flow, a single-call controller-type handshake, a rumble single-actuator fix, and a low-power chip overlay tweak. Reviewed for the repo's centralization conventions (colours, dimensions, XML layouts, why-only comments) and backed by unit tests. All CI tasks pass locally.

## Bluetooth host pairing (new)
Tapping **Add** now goes: permission, controller-type picker, discoverability prompt, then the device-list dialog. The dialog's neutral button morphs between **Wait for host** (idle, declined, or expired; tappable to re-request) and **Waiting for host (Ns)**, a live countdown from 120 to 0. It reverts at 0, and the dialog auto-dismisses once a host connects. Picking a device still connects directly.

- **`BluetoothDeviceScanner`** (new): `@Provides @Singleton`, exposes `StateFlow<State>`, registers its `BroadcastReceiver` against the application context with `RECEIVER_NOT_EXPORTED` (matching every other receiver in the repo), idempotent `start()`, drops stale post-`stop()` broadcasts, and degrades gracefully (no crash) when a BT permission is missing.
- `ConnectionsActivity` consumes it via `repeatOnLifecycle`, so the scan and receiver are torn down on dialog dismiss, background, and destroy. The picker lives in a small `DevicePickerSession` inner class so each method stays short and shallow (detekt limits).
- `BluetoothPermissionState` is now a data class with separate connect/scan grants (`connectMissing`, `scanMissing`, `anyMissing`). The manifest declares `BLUETOOTH_SCAN` with `neverForLocation`.
- Custom-satellite dialog (`dialog_add_satellite.xml` plus a menu item) for manual host/port entry, backed by `DiscoverySource.MANUAL`.

## Single-call controller type
`MSG_CONTROLLER_ADD` grows to a 4-byte payload (`idx`, `caps`, `type`) so the receiver plugs the correct virtual device on the first add with no replug. A backward-compat `MSG_CONTROLLER_TYPE` re-send keeps pre-extension satellites working. `setControllerType` now waits for the replug ACK and refreshes the motion-backend status. `docs/wire-format.md` updated.

## Rumble
Single-actuator targets now fold to `max(strong, weak)` so a weak-dominant effect is still felt (previously a weak-only effect on a single actuator could be dropped). Dual-actuator separation is unchanged. `docs/rumble.md` updated.

## UI
The low-power chip now docks over the input overlays (`bottom|center_horizontal`) instead of consuming column height. The `?attr/actionBarSize` padding was replaced with a semantic `@dimen`.

## Conventions checked
- Colours: all new views and styles reference `@color/*` (`colorMuted`, `colorPrimary`, `colorError`, and so on); no hardcoded hex.
- Dimensions: semantic `@dimen/*` throughout (`spacing_*`, `corner_picker_row`, `border_thin`); only idiomatic `0dp` weights remain.
- Layouts: all in XML; new `Widget.Dish.TextInputLayout` and `Widget.Dish.EditText` styles centralize the dialog look.
- Comments: why-only; narration removed.

## Tests
- `BluetoothDeviceScannerTest`: 22 cases (seeding, sort, dedup, bonded-not-downgraded, null device/address, unreadable name, discovery-finished, teardown and unregister, stale broadcast after stop, idempotent restart, no adapter, permission-throw degradation, flow emission).
- `BluetoothPermissionStateTest`: 6 cases covering all required/grant combinations.
- `RumbleRouterTest`: 9 new `combinedRumblePlan` cases (dual both/strong-only/weak-only/none, single strong-dominant/weak-dominant/weak-only/none, zero actuators).
- `SatelliteConnectionTest`: updated for the 4-arg add; new replug-ACK motion-status test.

## CI (all green locally)
clang-format (JNI), ktlintCheck, detekt, lint (including MissingTranslation across 6 locales), testDebugUnitTest, assembleDebug (arm64-v8a and x86_64).
