### PR TITLE
Architecture hardening: bugs, security, data-flow, and pattern fixes

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/architecture/abstracts/AbstractController.kt
+++ b/app/src/main/java/com/tinkernorth/dish/architecture/abstracts/AbstractController.kt
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.architecture.abstracts
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+// Lifecycle-actuator: collects an upstream [Flow] while STARTED and drives a side effect.
+// Subclasses keep their own [apply] and teardown; only the onStart/launchIn/job plumbing is shared.
+abstract class AbstractController<S>(
+    private val scope: CoroutineScope,
+) : DefaultLifecycleObserver {
+    private var job: Job? = null
+
+    protected abstract fun upstream(): Flow<S>
+
+    protected abstract fun apply(value: S)
+
+    // Runs once per actual (re)start, after the idempotency guard and before launch, so a subclass can
+    // re-arm post-stop state (e.g. a drop-late-emissions guard) under its own lock before collection.
+    protected open fun onStarting() = Unit
+
+    final override fun onStart(owner: LifecycleOwner) {
+        if (job != null) return
+        onStarting()
+        job = upstream().onEach(::apply).launchIn(scope)
+    }
+
+    // Default teardown stops collection; override to add teardown or to keep collecting (process-scoped).
+    override fun onStop(owner: LifecycleOwner) {
+        cancelCollection()
+    }
+
+    protected fun cancelCollection() {
+        job?.cancel()
+        job = null
+    }
+}

--- a/app/src/main/java/com/tinkernorth/dish/composer/ConnectionCoordinator.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/ConnectionCoordinator.kt
@@ -34,7 +34,7 @@ data class ConnectionSummary(
 )
 
 @Singleton
-class ConnectionHub
+class ConnectionCoordinator
     @Inject
     constructor(
         private val satellite: SatelliteConnectionManager,

--- a/app/src/main/java/com/tinkernorth/dish/composer/ConnectionCoordinator.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/ConnectionCoordinator.kt
@@ -92,6 +92,20 @@ class ConnectionCoordinator
             typeStore.clear(connId, slotId)
         }
 
+        // Forget a remembered connection and its local state. Unbind its slots (which drops their
+        // per-slot types), clear any orphaned type rows, then forget the backing host. Clearing the
+        // whole connection here is what stops a dead connection id leaking controller-type entries;
+        // it is done on forget, not on a transient disconnect, so a brief drop keeps the user's pick.
+        fun forgetConnection(connectionId: String) {
+            bindingStore.slotsFor(connectionId).toList().forEach(::unbind)
+            typeStore.clearConnection(connectionId)
+            if (store.rememberedBt().any { it.id == connectionId }) {
+                store.forgetBt(connectionId)
+            } else {
+                satellite.forget(connectionId)
+            }
+        }
+
         fun migrateSlotBinding(
             fromSlotId: String,
             toSlotId: String,

--- a/app/src/main/java/com/tinkernorth/dish/composer/ConnectionsComposer.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/ConnectionsComposer.kt
@@ -67,6 +67,12 @@ internal fun satelliteLinkState(
             }
     }
 
+private data class KnownSatellites(
+    val discovered: List<DiscoveredServer>,
+    val remembered: List<RememberedSatellite>,
+    val rememberedBt: List<RememberedBt>,
+)
+
 @Singleton
 class ConnectionsComposer
     @Inject
@@ -90,20 +96,33 @@ class ConnectionsComposer
                 }
             }
 
+        // The persisted "known" universe, folded into the combine so a remember/forget re-derives the
+        // list instead of an out-of-band store read that could leave a ghost or a missing row.
+        private val knownSatellites: Flow<KnownSatellites> =
+            combine(
+                satellite.discoveredServers,
+                store.rememberedSatellitesFlow,
+                store.rememberedBtFlow,
+            ) { discovered, remembered, rememberedBt ->
+                KnownSatellites(discovered, remembered, rememberedBt)
+            }
+
         override fun upstream(): Flow<List<ConnectionSummary>> =
             combine7(
                 flatSatConnections,
                 bt.states,
-                satellite.discoveredServers,
+                knownSatellites,
                 bindingStore.state,
                 typeStore.state,
                 satellite.staleSatelliteIds,
                 bt.staleBtIds,
-            ) { satMap, btStates, discovered, bindings, satTypes, staleSat, staleBt ->
+            ) { satMap, btStates, known, bindings, satTypes, staleSat, staleBt ->
                 buildSummaries(
                     satMap = satMap,
                     btStates = btStates,
-                    discoveredIds = discoveredIdSet(discovered),
+                    discoveredIds = discoveredIdSet(known.discovered),
+                    remembered = known.remembered,
+                    rememberedBt = known.rememberedBt,
                     bindings = bindings,
                     satTypes = satTypes,
                     staleSatIds = staleSat,
@@ -118,6 +137,8 @@ class ConnectionsComposer
             satMap: Map<String, SatelliteConnection>,
             btStates: Map<String, BluetoothGamepadRegistry.SlotState>,
             discoveredIds: Set<String>,
+            remembered: List<RememberedSatellite>,
+            rememberedBt: List<RememberedBt>,
             bindings: Map<String, String>,
             satTypes: Map<Pair<String, String>, Int>,
             staleSatIds: Set<String> = emptySet(),
@@ -125,13 +146,13 @@ class ConnectionsComposer
         ): List<ConnectionSummary> {
             val result = mutableListOf<ConnectionSummary>()
 
-            val remembered = store.remembered().associateBy { it.id }
-            val satIds = (remembered.keys + satMap.keys).toSet()
+            val rememberedById = remembered.associateBy { it.id }
+            val satIds = (rememberedById.keys + satMap.keys).toSet()
             for (id in satIds) {
                 buildSatelliteSummary(
                     id,
                     satMap[id],
-                    remembered[id],
+                    rememberedById[id],
                     bindings,
                     satTypes,
                     discoveredIds,
@@ -140,7 +161,7 @@ class ConnectionsComposer
             }
 
             val rememberedBtIds = mutableSetOf<String>()
-            for (entry in store.rememberedBt()) {
+            for (entry in rememberedBt) {
                 rememberedBtIds += entry.id
                 result +=
                     buildRememberedBtSummary(

--- a/app/src/main/java/com/tinkernorth/dish/composer/ConnectionsComposer.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/ConnectionsComposer.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import javax.inject.Inject
@@ -128,7 +129,7 @@ class ConnectionsComposer
                     staleSatIds = staleSat,
                     staleBtIds = staleBt.keys,
                 )
-            }
+            }.distinctUntilChanged()
 
         private fun discoveredIdSet(discovered: List<DiscoveredServer>): Set<String> =
             discovered.mapTo(mutableSetOf()) { SatelliteConnection.idFor(it) }

--- a/app/src/main/java/com/tinkernorth/dish/composer/CrashReportingController.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/CrashReportingController.kt
@@ -4,16 +4,14 @@ package com.tinkernorth.dish.composer
 
 import android.content.Context
 import android.util.Log
-import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.google.firebase.FirebaseApp
 import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.tinkernorth.dish.architecture.abstracts.AbstractController
 import com.tinkernorth.dish.source.store.CrashReportingStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -23,34 +21,25 @@ class CrashReportingController
     constructor(
         @ApplicationContext private val context: Context,
         private val store: CrashReportingStore,
-        private val scope: CoroutineScope,
-    ) : DefaultLifecycleObserver {
-        private var job: Job? = null
+        scope: CoroutineScope,
+    ) : AbstractController<Boolean>(scope) {
+        override fun upstream(): Flow<Boolean> = store.state
 
-        override fun onStart(owner: LifecycleOwner) {
-            if (job != null) return
-            job =
-                store.state
-                    .onEach(::applyToCrashlytics)
-                    .launchIn(scope)
-        }
+        // Process-scoped: do not cancel. Must propagate opt-in flips across activity restarts.
+        override fun onStop(owner: LifecycleOwner) = Unit
 
-        override fun onStop(owner: LifecycleOwner) {
-            // Process-scoped: do not cancel — must propagate opt-in flips across activity restarts.
-        }
-
-        private fun applyToCrashlytics(enabled: Boolean) {
+        override fun apply(value: Boolean) {
             if (FirebaseApp.getApps(context).isEmpty()) {
                 Log.i(
                     TAG,
-                    "Firebase not initialised (no google-services.json) — opt-in preference recorded but Crashlytics call skipped.",
+                    "Firebase not initialised (no google-services.json). Opt-in preference recorded but Crashlytics call skipped.",
                 )
                 return
             }
             runCatching {
-                FirebaseCrashlytics.getInstance().isCrashlyticsCollectionEnabled = enabled
+                FirebaseCrashlytics.getInstance().isCrashlyticsCollectionEnabled = value
             }.onFailure {
-                Log.e(TAG, "Failed to apply Crashlytics collection=$enabled", it)
+                Log.e(TAG, "Failed to apply Crashlytics collection=$value", it)
             }
         }
 

--- a/app/src/main/java/com/tinkernorth/dish/composer/MotionCapabilityComposer.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/MotionCapabilityComposer.kt
@@ -12,6 +12,8 @@ import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOf
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -62,14 +64,15 @@ class MotionCapabilityComposer
     constructor(
         private val phoneAvailability: PhoneMotionAvailability,
         private val registry: PhysicalGamepadRegistry,
-        private val hub: ConnectionHub,
+        private val hub: ConnectionCoordinator,
         private val motionEnabledStore: MotionEnabledStore,
         private val satelliteMotionBackendStatusStore: SatelliteMotionBackendStatusStore,
         scope: CoroutineScope,
     ) : AbstractComposer<Map<String, MotionCapability>>(scope, emptyMap()) {
         override fun upstream(): Flow<Map<String, MotionCapability>> =
             combine6(
-                phoneAvailability.state,
+                // Constant fact, lifted into the combine so the per-slot shape stays uniform.
+                flowOf(phoneAvailability.hasGyro),
                 registry.devices,
                 hub.bindings,
                 hub.connections,
@@ -102,7 +105,7 @@ class MotionCapabilityComposer
                         )
                 }
                 out
-            }
+            }.distinctUntilChanged()
 
         fun capabilityFor(slotId: String): MotionCapability = state.value[slotId] ?: MotionCapability.Off
 

--- a/app/src/main/java/com/tinkernorth/dish/composer/PhysicalReachabilityComposer.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/PhysicalReachabilityComposer.kt
@@ -20,7 +20,7 @@ class PhysicalReachabilityComposer
     @Inject
     constructor(
         private val registry: PhysicalGamepadRegistry,
-        private val hub: ConnectionHub,
+        private val hub: ConnectionCoordinator,
         private val satellite: SatelliteConnectionManager,
         scope: CoroutineScope,
     ) : AbstractComposer<Map<String, SatelliteConnection>>(scope, emptyMap()) {

--- a/app/src/main/java/com/tinkernorth/dish/composer/StreamingService.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/StreamingService.kt
@@ -30,7 +30,7 @@ import javax.inject.Inject
 class StreamingService : Service() {
     @Inject lateinit var wakeState: WakeStateController
 
-    @Inject lateinit var hub: ConnectionHub
+    @Inject lateinit var hub: ConnectionCoordinator
 
     @Inject lateinit var satellite: SatelliteConnectionManager
 

--- a/app/src/main/java/com/tinkernorth/dish/composer/StreamingServiceController.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/StreamingServiceController.kt
@@ -5,8 +5,8 @@ package com.tinkernorth.dish.composer
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import com.tinkernorth.dish.architecture.abstracts.AbstractStateSource
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -22,7 +22,7 @@ class StreamingServiceController
         @ApplicationContext private val context: Context,
         private val wakeState: WakeStateController,
         private val scope: CoroutineScope,
-    ) : AbstractStateSource<Unit>(Unit) {
+    ) : DefaultLifecycleObserver {
         private var job: Job? = null
         private var running = false
 

--- a/app/src/main/java/com/tinkernorth/dish/composer/StreamingServiceController.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/StreamingServiceController.kt
@@ -5,13 +5,11 @@ package com.tinkernorth.dish.composer
 import android.content.Context
 import android.content.Intent
 import android.os.Build
-import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import com.tinkernorth.dish.architecture.abstracts.AbstractController
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -21,28 +19,23 @@ class StreamingServiceController
     constructor(
         @ApplicationContext private val context: Context,
         private val wakeState: WakeStateController,
-        private val scope: CoroutineScope,
-    ) : DefaultLifecycleObserver {
-        private var job: Job? = null
+        scope: CoroutineScope,
+    ) : AbstractController<Int>(scope) {
         private var running = false
 
-        override fun onStart(owner: LifecycleOwner) {
-            if (job != null) return
-            job =
-                wakeState.streamingSlotCount
-                    .onEach { count ->
-                        val shouldRun = count > 0
-                        if (shouldRun && !running) {
-                            startService()
-                        } else if (!shouldRun && running) {
-                            stopService()
-                        }
-                    }.launchIn(scope)
+        override fun upstream(): Flow<Int> = wakeState.streamingSlotCount
+
+        override fun apply(value: Int) {
+            val shouldRun = value > 0
+            if (shouldRun && !running) {
+                startService()
+            } else if (!shouldRun && running) {
+                stopService()
+            }
         }
 
         override fun onStop(owner: LifecycleOwner) {
-            job?.cancel()
-            job = null
+            cancelCollection()
             if (running) stopService()
         }
 

--- a/app/src/main/java/com/tinkernorth/dish/composer/WakeStateComposer.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/WakeStateComposer.kt
@@ -6,6 +6,7 @@ import com.tinkernorth.dish.architecture.abstracts.AbstractComposer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -22,7 +23,7 @@ data class WakeState(
 class WakeStateComposer
     @Inject
     constructor(
-        private val hub: ConnectionHub,
+        private val hub: ConnectionCoordinator,
         scope: CoroutineScope,
     ) : AbstractComposer<WakeState>(scope, WakeState.Idle) {
         override fun upstream(): Flow<WakeState> =
@@ -33,5 +34,5 @@ class WakeStateComposer
                         byId[cid]?.live == LinkState.Connected
                     }
                 WakeState(streamingSlotCount = count, shouldKeepScreenOn = count > 0)
-            }
+            }.distinctUntilChanged()
     }

--- a/app/src/main/java/com/tinkernorth/dish/composer/WakeStateController.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/WakeStateController.kt
@@ -61,10 +61,12 @@ class WakeStateController
         }
 
         private fun apply(wake: WakeState) {
-            setState(wake)
-            _streamingSlotCount.value = wake.streamingSlotCount
             synchronized(lock) {
+                // Drop a composer emission that lands after onStop: publishing the count here would let
+                // StreamingServiceController restart the foreground service while the app is stopped.
                 if (stopped) return
+                setState(wake)
+                _streamingSlotCount.value = wake.streamingSlotCount
                 val keep = wake.shouldKeepScreenOn
                 if (keep == _shouldKeepScreenOn.value) return
                 _shouldKeepScreenOn.value = keep

--- a/app/src/main/java/com/tinkernorth/dish/composer/WakeStateController.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/WakeStateController.kt
@@ -5,15 +5,13 @@ package com.tinkernorth.dish.composer
 import android.content.Context
 import android.os.PowerManager
 import androidx.lifecycle.LifecycleOwner
-import com.tinkernorth.dish.architecture.abstracts.AbstractStateSource
+import com.tinkernorth.dish.architecture.abstracts.AbstractController
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -23,8 +21,8 @@ class WakeStateController
     constructor(
         @ApplicationContext context: Context,
         private val composer: WakeStateComposer,
-        private val scope: CoroutineScope,
-    ) : AbstractStateSource<WakeState>(WakeState.Idle) {
+        scope: CoroutineScope,
+    ) : AbstractController<WakeState>(scope) {
         private val powerManager =
             context.getSystemService(Context.POWER_SERVICE) as PowerManager
 
@@ -37,15 +35,12 @@ class WakeStateController
         private val lock = Any()
         private var wakeLock: PowerManager.WakeLock? = null
         private var stopped = false
-        private var job: Job? = null
 
-        override fun onStart(owner: LifecycleOwner) {
-            if (job != null) return
+        override fun upstream(): Flow<WakeState> = composer.state
+
+        // Re-arm the stopped guard under [lock] before the base launches the collector.
+        override fun onStarting() {
             synchronized(lock) { stopped = false }
-            job =
-                composer.state
-                    .onEach(::apply)
-                    .launchIn(scope)
         }
 
         override fun onStop(owner: LifecycleOwner) {
@@ -53,21 +48,18 @@ class WakeStateController
                 stopped = true
                 release()
             }
-            job?.cancel()
-            job = null
-            setState(WakeState.Idle)
+            cancelCollection()
             _streamingSlotCount.value = 0
             _shouldKeepScreenOn.value = false
         }
 
-        private fun apply(wake: WakeState) {
+        override fun apply(value: WakeState) {
             synchronized(lock) {
                 // Drop a composer emission that lands after onStop: publishing the count here would let
                 // StreamingServiceController restart the foreground service while the app is stopped.
                 if (stopped) return
-                setState(wake)
-                _streamingSlotCount.value = wake.streamingSlotCount
-                val keep = wake.shouldKeepScreenOn
+                _streamingSlotCount.value = value.streamingSlotCount
+                val keep = value.shouldKeepScreenOn
                 if (keep == _shouldKeepScreenOn.value) return
                 _shouldKeepScreenOn.value = keep
                 if (keep) acquire() else release()

--- a/app/src/main/java/com/tinkernorth/dish/core/net/DiscoveryGateway.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/net/DiscoveryGateway.kt
@@ -8,6 +8,7 @@ import com.tinkernorth.dish.core.model.DiscoveredServer
 import com.tinkernorth.dish.core.model.DiscoverySource
 import com.tinkernorth.dish.core.model.stableKey
 import com.tinkernorth.dish.di.IoDispatcher
+import com.tinkernorth.dish.repository.SatellitePinRepository
 import com.tinkernorth.dish.source.connection.MdnsDiscovery
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
@@ -19,20 +20,23 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class DiscoveryRepository
+class DiscoveryGateway
     @Inject
     constructor(
         private val mdns: MdnsDiscovery,
+        private val pins: SatellitePinRepository,
         @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     ) {
-        private val mutex = Mutex()
+        // Guards ONLY the native+mDNS discovery single-flight. Per-host HTTP is deliberately
+        // left off this lock: a hung satellite must not block HTTP to a healthy one.
+        private val discoveryMutex = Mutex()
 
         suspend fun discoverServers(
             port: Int,
             timeoutMs: Int,
         ): List<DiscoveredServer> =
             withContext(ioDispatcher) {
-                mutex.withLock {
+                discoveryMutex.withLock {
                     coroutineScope {
                         val broadcast =
                             async { parseServers(SatelliteNative.discoverServers(port, timeoutMs)) }
@@ -50,6 +54,9 @@ class DiscoveryRepository
                 }
             }
 
+        // satelliteId is an optional trailing param (constant "" default, resolved to the host
+        // in-body) so existing positional callers stay source-compatible. The cert pin protects
+        // "the box at this address", which is the right key for TLS pinning on a CA-less LAN.
         suspend fun pair(
             ip: String,
             port: Int,
@@ -57,33 +64,30 @@ class DiscoveryRepository
             deviceName: String,
             pin: String,
             clientPin: String = "",
+            satelliteId: String = "",
         ): String =
             withContext(ioDispatcher) {
-                mutex.withLock {
-                    SatelliteHttpClient.pair(ip, port, deviceId, deviceName, pin, clientPin)
-                }
+                SatelliteHttpClient.pair(ip, port, deviceId, deviceName, pin, pinId(satelliteId, ip), pins, clientPin)
             }
 
         suspend fun pairStatus(
             ip: String,
             port: Int,
             deviceId: String,
+            satelliteId: String = "",
         ): String =
             withContext(ioDispatcher) {
-                mutex.withLock {
-                    SatelliteHttpClient.pairStatus(ip, port, deviceId)
-                }
+                SatelliteHttpClient.pairStatus(ip, port, deviceId, pinId(satelliteId, ip), pins)
             }
 
         suspend fun connect(
             ip: String,
             port: Int,
             deviceId: String,
+            satelliteId: String = "",
         ): String =
             withContext(ioDispatcher) {
-                mutex.withLock {
-                    SatelliteHttpClient.connect(ip, port, deviceId)
-                }
+                SatelliteHttpClient.connect(ip, port, deviceId, pinId(satelliteId, ip), pins)
             }
 
         suspend fun disconnect(
@@ -91,11 +95,10 @@ class DiscoveryRepository
             port: Int,
             connectionId: String,
             deviceId: String,
+            satelliteId: String = "",
         ): String =
             withContext(ioDispatcher) {
-                mutex.withLock {
-                    SatelliteHttpClient.disconnect(ip, port, connectionId, deviceId)
-                }
+                SatelliteHttpClient.disconnect(ip, port, connectionId, deviceId, pinId(satelliteId, ip), pins)
             }
 
         suspend fun setTouchpadMode(
@@ -103,15 +106,20 @@ class DiscoveryRepository
             port: Int,
             deviceId: String,
             mode: String,
+            satelliteId: String = "",
         ): String =
             withContext(ioDispatcher) {
-                mutex.withLock {
-                    SatelliteHttpClient.setTouchpadMode(ip, port, deviceId, mode)
-                }
+                SatelliteHttpClient.setTouchpadMode(ip, port, deviceId, mode, pinId(satelliteId, ip), pins)
             }
 
         companion object {
-            private const val TAG = "DiscoveryRepository"
+            private const val TAG = "DiscoveryGateway"
+
+            // Empty satelliteId means "caller didn't override": key the pin on the host.
+            internal fun pinId(
+                satelliteId: String,
+                ip: String,
+            ): String = satelliteId.ifEmpty { ip }
 
             internal fun mergeDiscovered(
                 broadcast: List<DiscoveredServer>,

--- a/app/src/main/java/com/tinkernorth/dish/core/net/IpLiterals.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/net/IpLiterals.kt
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.core.net
+
+/**
+ * True only for a numeric IP literal in a private/local range, parsed without
+ * DNS resolution. Hostnames, public IPs, and malformed literals all return
+ * false. Intended to vet mDNS/broadcast-discovered addresses before a caller
+ * opens a socket to them.
+ */
+fun isPrivateHostLiteral(host: String): Boolean {
+    // IPv6 literals may arrive bracketed (e.g. from a URL authority).
+    val candidate =
+        if (host.startsWith("[") && host.endsWith("]")) {
+            host.substring(1, host.length - 1)
+        } else {
+            host
+        }
+    parseIpv4(candidate)?.let { return isPrivateIpv4(it) }
+    parseIpv6(candidate)?.let { return isPrivateIpv6(it) }
+    return false
+}
+
+private fun parseIpv4(host: String): IntArray? {
+    val parts = host.split('.')
+    if (parts.size != 4) return null
+    val octets = IntArray(4)
+    for (i in 0 until 4) {
+        val p = parts[i]
+        if (p.isEmpty() || p.length > 3 || !p.all { it in '0'..'9' }) return null
+        val v = p.toIntOrNull() ?: return null
+        if (v > 255) return null
+        octets[i] = v
+    }
+    return octets
+}
+
+private fun isPrivateIpv4(o: IntArray): Boolean =
+    when {
+        o[0] == 10 -> true // 10.0.0.0/8
+        o[0] == 172 && o[1] in 16..31 -> true // 172.16.0.0/12 (172.16 .. 172.31 inclusive)
+        o[0] == 192 && o[1] == 168 -> true // 192.168.0.0/16
+        o[0] == 169 && o[1] == 254 -> true // 169.254.0.0/16 link-local
+        o[0] == 127 -> true // 127.0.0.0/8 loopback
+        else -> false
+    }
+
+private fun parseIpv6(host: String): IntArray? {
+    val groups = ipv6Groups(host) ?: return null
+    val bytes = IntArray(16)
+    for (i in 0 until 8) {
+        bytes[i * 2] = (groups[i] ushr 8) and 0xFF
+        bytes[i * 2 + 1] = groups[i] and 0xFF
+    }
+    return bytes
+}
+
+private fun ipv6Groups(host: String): IntArray? {
+    val doubleColon = host.indexOf("::")
+    if (
+        host.isEmpty() ||
+        host.contains('%') ||
+        (doubleColon != -1 && host.indexOf("::", doubleColon + 1) != -1)
+    ) {
+        return null
+    }
+    val headStr = if (doubleColon == -1) host else host.substring(0, doubleColon)
+    val tailStr = if (doubleColon == -1) "" else host.substring(doubleColon + 2)
+    val head = splitHextets(headStr) ?: return null
+    val tail = splitHextets(tailStr) ?: return null
+    val groups = ArrayList<Int>(8)
+    groups.addAll(head)
+    if (doubleColon != -1) {
+        val missing = 8 - head.size - tail.size
+        if (missing < 1) return null // "::" must stand for at least one group
+        repeat(missing) { groups.add(0) }
+    }
+    groups.addAll(tail)
+    return if (groups.size == 8) groups.toIntArray() else null
+}
+
+private fun splitHextets(fragment: String): List<Int>? {
+    if (fragment.isEmpty()) return emptyList()
+    val tokens = fragment.split(':')
+    val groups = ArrayList<Int>(tokens.size + 1)
+    for ((index, token) in tokens.withIndex()) {
+        if (token.contains('.')) {
+            // Embedded IPv4 is only legal as the final token.
+            if (index != tokens.size - 1) return null
+            val v4 = parseIpv4(token) ?: return null
+            groups.add((v4[0] shl 8) or v4[1])
+            groups.add((v4[2] shl 8) or v4[3])
+        } else {
+            if (token.isEmpty() || token.length > 4 || !token.all { it.isHexDigit() }) return null
+            groups.add(token.toInt(16))
+        }
+    }
+    return groups
+}
+
+private fun isPrivateIpv6(b: IntArray): Boolean =
+    when {
+        b.copyOfRange(0, 15).all { it == 0 } && b[15] == 1 -> true // ::1 loopback
+        b[0] == 0xfc || b[0] == 0xfd -> true // fc00::/7 unique local
+        b[0] == 0xfe && (b[1] and 0xc0) == 0x80 -> true // fe80::/10 link-local
+        else -> false
+    }

--- a/app/src/main/java/com/tinkernorth/dish/core/net/NetworkUtils.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/net/NetworkUtils.kt
@@ -24,6 +24,10 @@ fun jsonGet(
     }
 
 fun hexToBytes(hex: String): ByteArray {
+    // Validate up front: an odd length would read past the end mid-loop, and a
+    // non-hex char makes Character.digit return -1 and silently corrupt a byte.
+    require(hex.length % 2 == 0) { "hex string must have even length" }
+    require(hex.all { it.isHexDigit() }) { "hex string contains a non-hex character" }
     val data = ByteArray(hex.length / 2)
     var i = 0
     while (i < hex.length) {
@@ -32,6 +36,8 @@ fun hexToBytes(hex: String): ByteArray {
     }
     return data
 }
+
+internal fun Char.isHexDigit(): Boolean = this in '0'..'9' || this in 'a'..'f' || this in 'A'..'F'
 
 fun parseServers(jsonString: String): List<DiscoveredServer> =
     try {

--- a/app/src/main/java/com/tinkernorth/dish/core/net/SatelliteHttpClient.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/net/SatelliteHttpClient.kt
@@ -3,6 +3,10 @@
 package com.tinkernorth.dish.core.net
 
 import android.util.Log
+import com.tinkernorth.dish.repository.SatellitePinRepository
+import com.tinkernorth.dish.repository.TofuVerdict
+import com.tinkernorth.dish.repository.sha256FingerprintHex
+import com.tinkernorth.dish.repository.tofuVerdict
 import java.io.IOException
 import java.net.URL
 import java.security.SecureRandom
@@ -14,8 +18,10 @@ import javax.net.ssl.SSLSession
 import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
 
-// Satellite presents a self-signed cert on a LAN IP; approved decision to skip TLS validation
-// (curl --insecure equivalent). UDP gamepad channel has its own ChaCha20-Poly1305 auth.
+// Satellite presents a self-signed cert on a LAN IP (no CA to validate against), so the
+// X509TrustManager stays permissive to let the handshake complete. MITM protection instead
+// comes from trust-on-first-use cert PINNING in the hostname verifier below.
+// UDP gamepad channel has its own ChaCha20-Poly1305 auth.
 // All methods BLOCK — call from Dispatchers.IO.
 internal object SatelliteHttpClient {
     private const val TAG = "SatelliteHttpClient"
@@ -48,13 +54,39 @@ internal object SatelliteHttpClient {
             }.socketFactory
     }
 
-    private val allowAllHostnames =
-        HostnameVerifier { _: String?, _: SSLSession? -> true }
+    // Per-call TOFU verifier: the X509TrustManager accepts any (self-signed) cert, so this
+    // is the sole MITM gate. It fingerprints the negotiated peer cert and pins it to this
+    // satellite id on first contact, then rejects any future cert that doesn't match.
+    // TRADEOFF: pairing's FIRST contact has no prior pin, so that one handshake is
+    // unauthenticated (an attacker already on-path at pairing time can still impersonate).
+    // internal (not private) so the verifier decision is unit-testable with a mocked session.
+    internal fun tofuHostnameVerifier(
+        satelliteId: String,
+        pins: SatellitePinRepository,
+    ): HostnameVerifier =
+        HostnameVerifier { _: String?, session: SSLSession? ->
+            val cert = session?.peerCertificates?.firstOrNull() ?: return@HostnameVerifier false
+            val presented = sha256FingerprintHex(cert.encoded)
+            when (tofuVerdict(pins.pinnedFingerprint(satelliteId), presented)) {
+                TofuVerdict.TRUST_FIRST_USE -> {
+                    pins.pin(satelliteId, presented)
+                    Log.i(TAG, "pinned cert for $satelliteId on first use")
+                    true
+                }
+                TofuVerdict.MATCH -> true
+                TofuVerdict.MISMATCH -> {
+                    Log.e(TAG, "cert pin MISMATCH for $satelliteId — aborting (possible MITM)")
+                    false
+                }
+            }
+        }
 
     fun connect(
         ip: String,
         port: Int,
         deviceId: String,
+        satelliteId: String,
+        pins: SatellitePinRepository,
     ): String =
         request(
             method = "POST",
@@ -63,6 +95,8 @@ internal object SatelliteHttpClient {
             path = "/api/connections",
             deviceId = deviceId,
             body = """{"deviceId":"${jsonEscape(deviceId)}"}""",
+            satelliteId = satelliteId,
+            pins = pins,
         )
 
     fun disconnect(
@@ -70,6 +104,8 @@ internal object SatelliteHttpClient {
         port: Int,
         connectionId: String,
         deviceId: String,
+        satelliteId: String,
+        pins: SatellitePinRepository,
     ): String =
         request(
             method = "DELETE",
@@ -78,6 +114,8 @@ internal object SatelliteHttpClient {
             path = "/api/connections/$connectionId",
             deviceId = deviceId,
             body = """{"deviceId":"${jsonEscape(deviceId)}"}""",
+            satelliteId = satelliteId,
+            pins = pins,
         )
 
     // Body field is "id" (matches handler route-param); device id for auth goes in X-Device-Id header.
@@ -86,6 +124,8 @@ internal object SatelliteHttpClient {
         port: Int,
         deviceId: String,
         mode: String,
+        satelliteId: String,
+        pins: SatellitePinRepository,
     ): String =
         request(
             method = "POST",
@@ -96,6 +136,8 @@ internal object SatelliteHttpClient {
             body =
                 """{"id":"${jsonEscape(deviceId)}",""" +
                     """"mode":"${jsonEscape(mode)}"}""",
+            satelliteId = satelliteId,
+            pins = pins,
         )
 
     // No X-Device-Id — /api/pair is the only client route that bypasses clientAuthorized.
@@ -108,6 +150,8 @@ internal object SatelliteHttpClient {
         deviceId: String,
         deviceName: String,
         pin: String,
+        satelliteId: String,
+        pins: SatellitePinRepository,
         clientPin: String = "",
     ): String =
         request(
@@ -121,6 +165,8 @@ internal object SatelliteHttpClient {
                     """"deviceName":"${jsonEscape(deviceName)}",""" +
                     """"pin":"${jsonEscape(pin)}",""" +
                     """"clientPin":"${jsonEscape(clientPin)}"}""",
+            satelliteId = satelliteId,
+            pins = pins,
         )
 
     // Poll for the operator's accept/deny decision on a Path-B request.
@@ -128,6 +174,8 @@ internal object SatelliteHttpClient {
         ip: String,
         port: Int,
         deviceId: String,
+        satelliteId: String,
+        pins: SatellitePinRepository,
     ): String =
         request(
             method = "GET",
@@ -136,6 +184,8 @@ internal object SatelliteHttpClient {
             path = "/api/pair/status?deviceId=" + java.net.URLEncoder.encode(deviceId, "UTF-8"),
             deviceId = null,
             body = null,
+            satelliteId = satelliteId,
+            pins = pins,
         )
 
     // Never throws — transport failure surfaces as a JSON {error} body so callers' decode path stays unchanged.
@@ -147,6 +197,8 @@ internal object SatelliteHttpClient {
         path: String,
         deviceId: String?,
         body: String?,
+        satelliteId: String,
+        pins: SatellitePinRepository,
     ): String {
         val url = URL("https", ip, port, path)
         Log.i(TAG, "$method https://$ip:$port$path")
@@ -155,7 +207,7 @@ internal object SatelliteHttpClient {
             conn =
                 (url.openConnection() as HttpsURLConnection).apply {
                     sslSocketFactory = insecureSocketFactory
-                    hostnameVerifier = allowAllHostnames
+                    hostnameVerifier = tofuHostnameVerifier(satelliteId, pins)
                     requestMethod = method
                     connectTimeout = CONNECT_TIMEOUT_MS
                     readTimeout = READ_TIMEOUT_MS

--- a/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistry.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistry.kt
@@ -70,6 +70,27 @@ class PhysicalGamepadRegistry
             val hasRumble: Boolean,
         )
 
+        // Build the pure transient projection of a Device. restoreStuck is gated on isUsbSynthetic, so
+        // that identity flag rides along for the reducer's guards.
+        private fun Device.placeholderState(): PlaceholderState =
+            PlaceholderState(
+                transitioning = transitioning,
+                needsReplug = needsReplug,
+                restoreStuck = restoreStuck,
+                disconnectingTimeLeftSec = disconnectingTimeLeftSec,
+                isUsbSynthetic = isUsbSynthetic,
+            )
+
+        // Copy a reducer result back onto a Device. Only the transient fields move; identity and the
+        // hot-path fields are untouched.
+        private fun Device.withPlaceholder(state: PlaceholderState): Device =
+            copy(
+                transitioning = state.transitioning,
+                needsReplug = state.needsReplug,
+                restoreStuck = state.restoreStuck,
+                disconnectingTimeLeftSec = state.disconnectingTimeLeftSec,
+            )
+
         private val inputManager =
             context.getSystemService(Context.INPUT_SERVICE) as InputManager
 
@@ -268,7 +289,7 @@ class PhysicalGamepadRegistry
             _devices.update { map ->
                 map.mapValues { (_, d) ->
                     if (d.transitioning && !d.isUsbSynthetic && d.vendorId == vendorId && d.productId == productId) {
-                        d.copy(transitioning = false, needsReplug = true)
+                        d.withPlaceholder(placeholderTransition(d.placeholderState(), PlaceholderEvent.MarkNeedsReplug))
                     } else {
                         d
                     }
@@ -285,7 +306,7 @@ class PhysicalGamepadRegistry
             _devices.update { map ->
                 map.mapValues { (_, d) ->
                     if (d.isUsbSynthetic && d.vendorId == vendorId && d.productId == productId) {
-                        d.copy(transitioning = false, restoreStuck = true)
+                        d.withPlaceholder(placeholderTransition(d.placeholderState(), PlaceholderEvent.MarkRestoreStuck))
                     } else {
                         d
                     }
@@ -301,7 +322,7 @@ class PhysicalGamepadRegistry
             _devices.update { map ->
                 map.mapValues { (_, d) ->
                     if (d.isUsbSynthetic && d.vendorId == vendorId && d.productId == productId) {
-                        d.copy(restoreStuck = false, transitioning = true)
+                        d.withPlaceholder(placeholderTransition(d.placeholderState(), PlaceholderEvent.ClearRestoreStuck))
                     } else {
                         d
                     }
@@ -315,7 +336,16 @@ class PhysicalGamepadRegistry
         ) {
             _devices.update { map ->
                 val cur = map[deviceId] ?: return@update map
-                if (cur.transitioning == value) map else map + (deviceId to cur.copy(transitioning = value))
+                // Same idempotent short-circuit as before: if the flag is unchanged, do not re-emit.
+                if (cur.transitioning == value) {
+                    map
+                } else {
+                    val next =
+                        cur.withPlaceholder(
+                            placeholderTransition(cur.placeholderState(), PlaceholderEvent.SetSyntheticTransitioning(value)),
+                        )
+                    map + (deviceId to next)
+                }
             }
         }
 
@@ -327,7 +357,8 @@ class PhysicalGamepadRegistry
             disconnectJobs.remove(deviceId)?.cancel()
             _devices.update { map ->
                 val cur = map[deviceId] ?: return@update map
-                map + (deviceId to cur.copy(transitioning = true, disconnectingTimeLeftSec = null))
+                val next = cur.withPlaceholder(placeholderTransition(cur.placeholderState(), PlaceholderEvent.HoldAsTransitioning))
+                map + (deviceId to next)
             }
         }
 
@@ -522,3 +553,73 @@ internal fun isGamepadDeviceFromCapabilities(
     return (sources and InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD ||
         (sources and InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK
 }
+
+// Pure projection of a device's transient ("placeholder") fields plus the identity flag that gates
+// them. Mutators compute the next value via placeholderTransition and copy it back onto the Device
+// unchanged. Keeping the booleans (not a single enum) is deliberate: transitioning, needsReplug,
+// restoreStuck and the disconnect countdown are independent fields on Device that consumers read
+// directly, so collapsing them would be lossy.
+internal data class PlaceholderState(
+    val transitioning: Boolean,
+    val needsReplug: Boolean,
+    val restoreStuck: Boolean,
+    val disconnectingTimeLeftSec: Int?,
+    val isUsbSynthetic: Boolean,
+)
+
+internal sealed interface PlaceholderEvent {
+    // A removed framework device held as a loader placeholder rather than reaped.
+    data object HoldAsTransitioning : PlaceholderEvent
+
+    // setUsbSyntheticTransitioning(value): flips only the loader flag.
+    data class SetSyntheticTransitioning(
+        val value: Boolean,
+    ) : PlaceholderEvent
+
+    // The OS never returned a held framework device: settle the loader into a replug card.
+    data object MarkNeedsReplug : PlaceholderEvent
+
+    // A held synthetic's return-to-Standard never re-enumerated: keep it actionable.
+    data object MarkRestoreStuck : PlaceholderEvent
+
+    // Retry: drop the stuck look and go back to the held-loader look.
+    data object ClearRestoreStuck : PlaceholderEvent
+}
+
+// Pure (state, event) -> state for the per-device placeholder phase. No StateFlow, native, or map
+// access. Each imperative mutator matches the same device subset it did before and applies this
+// result; events are never dispatched to a device the mutator's filter excludes.
+internal fun placeholderTransition(
+    current: PlaceholderState,
+    event: PlaceholderEvent,
+): PlaceholderState =
+    when (event) {
+        // Entering the loader look also clears any in-flight disconnect countdown, exactly as
+        // holdAsTransitioning did inline.
+        PlaceholderEvent.HoldAsTransitioning ->
+            current.copy(transitioning = true, disconnectingTimeLeftSec = null)
+
+        is PlaceholderEvent.SetSyntheticTransitioning ->
+            current.copy(transitioning = event.value)
+
+        // Contradictory-combo guard: a device cannot be both transitioning and needsReplug, so
+        // settling to needsReplug clears the loader flag.
+        PlaceholderEvent.MarkNeedsReplug ->
+            current.copy(transitioning = false, needsReplug = true)
+
+        // restoreStuck only applies to a synthetic; on anything else this is a no-op. Callers already
+        // filter to synthetics, the guard makes the invariant explicit in the reducer.
+        PlaceholderEvent.MarkRestoreStuck ->
+            if (current.isUsbSynthetic) {
+                current.copy(transitioning = false, restoreStuck = true)
+            } else {
+                current
+            }
+
+        PlaceholderEvent.ClearRestoreStuck ->
+            if (current.isUsbSynthetic) {
+                current.copy(restoreStuck = false, transitioning = true)
+            } else {
+                current
+            }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalSlotBindingObserver.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalSlotBindingObserver.kt
@@ -4,7 +4,7 @@ package com.tinkernorth.dish.hotpath.input
 
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import com.tinkernorth.dish.composer.ConnectionHub
+import com.tinkernorth.dish.composer.ConnectionCoordinator
 import com.tinkernorth.dish.composer.ConnectionKind
 import com.tinkernorth.dish.composer.ConnectionSummary
 import com.tinkernorth.dish.composer.LinkState
@@ -117,7 +117,7 @@ class PhysicalSlotBindingObserver
     @Inject
     constructor(
         private val registry: PhysicalGamepadRegistry,
-        private val hub: ConnectionHub,
+        private val hub: ConnectionCoordinator,
         private val satellite: SatelliteConnectionManager,
         private val bt: BluetoothGamepadRegistry,
         private val scope: CoroutineScope,

--- a/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalSlotBindingObserver.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalSlotBindingObserver.kt
@@ -9,6 +9,8 @@ import com.tinkernorth.dish.composer.ConnectionKind
 import com.tinkernorth.dish.composer.ConnectionSummary
 import com.tinkernorth.dish.composer.LinkState
 import com.tinkernorth.dish.core.jni.SatelliteNative
+import com.tinkernorth.dish.source.bluetooth.BluetoothGamepadRegistry
+import com.tinkernorth.dish.source.connection.SatelliteConnection
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -22,6 +24,93 @@ import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 import javax.inject.Singleton
 
+// The ordered native/hub effects reconcileSlots resolves from one snapshot. Kept a pure value type so
+// the routing decision (which physical device id lands on which server-side controller) is testable
+// without the JNI side effects; getting it wrong routes input to the wrong controller.
+sealed interface BindOp {
+    data class BindSatellite(
+        val deviceId: Int,
+        val handle: Int,
+        val controllerIndex: Int,
+    ) : BindOp
+
+    data class BindBluetooth(
+        val deviceId: Int,
+        val connectionId: String,
+    ) : BindOp
+
+    data class Unbind(
+        val deviceId: Int,
+    ) : BindOp
+
+    data class Forget(
+        val deviceId: Int,
+    ) : BindOp
+
+    // The departed-id path also drops the hub binding for the slot, so a re-added id re-binds cleanly.
+    data class ReleaseHubBinding(
+        val deviceId: Int,
+    ) : BindOp
+}
+
+// Flat, immutable view of one satellite connection captured once per push so reconcileSlots stays pure.
+// Absence of a key means the connection is unknown locally (the old `satellite.get(cid) == null`).
+data class SatelliteSlotSnapshot(
+    val handle: Int,
+    val slots: Map<String, SatelliteConnection.SlotBinding>,
+)
+
+// Pure reconciler. Ordering guarantee: every departed-id op (Unbind, Forget for a framework id, then
+// ReleaseHubBinding) precedes every present-id bind, so a re-added device id cannot bind onto a
+// controller index a stale entry still owns. A present device only emits BindSatellite when its
+// session is known with a live handle and its slot is registered, and BindBluetooth only when the
+// connection is actually connected now; otherwise it emits Unbind.
+fun reconcileSlots(
+    present: Set<Int>,
+    lastBound: Set<Int>,
+    bindings: Map<String, String>,
+    summaries: List<ConnectionSummary>,
+    perConnectionSlotInfo: Map<String, SatelliteSlotSnapshot>,
+    btConnectedIds: Set<String>,
+): List<BindOp> {
+    val ops = mutableListOf<BindOp>()
+    for (id in lastBound - present) {
+        ops += BindOp.Unbind(id)
+        // A claimed USB synthetic (negative id) is freed by detachUsbDevice, not forgetPhysicalDevice.
+        if (id >= 0) ops += BindOp.Forget(id)
+        ops += BindOp.ReleaseHubBinding(id)
+    }
+    for (id in present) {
+        val slotId = id.toString()
+        val cid = bindings[slotId]
+        val summary = cid?.let { lookup -> summaries.firstOrNull { it.id == lookup } }
+        if (cid == null || summary == null || summary.live != LinkState.Connected) {
+            ops += BindOp.Unbind(id)
+            continue
+        }
+        when (summary.kind) {
+            ConnectionKind.SATELLITE -> {
+                val sat = perConnectionSlotInfo[cid]
+                val info = sat?.slots?.get(slotId)
+                if (sat == null || sat.handle < 0 || info == null || !info.registered) {
+                    ops += BindOp.Unbind(id)
+                } else {
+                    ops += BindOp.BindSatellite(id, sat.handle, info.controllerIndex)
+                }
+            }
+            ConnectionKind.BLUETOOTH ->
+                // The summary's Connected is a composer-snapshot read; re-check the registry's live
+                // connected state (as the satellite branch re-checks handle/registered) before binding.
+                if (cid in btConnectedIds) {
+                    ops += BindOp.BindBluetooth(id, cid)
+                } else {
+                    ops += BindOp.Unbind(id)
+                }
+        }
+    }
+    return ops
+}
+
 // Process-scoped (not activity-scoped) so bindings survive MainActivity → GamepadOverlayActivity hand-off.
 @Singleton
 class PhysicalSlotBindingObserver
@@ -30,6 +119,7 @@ class PhysicalSlotBindingObserver
         private val registry: PhysicalGamepadRegistry,
         private val hub: ConnectionHub,
         private val satellite: SatelliteConnectionManager,
+        private val bt: BluetoothGamepadRegistry,
         private val scope: CoroutineScope,
     ) : DefaultLifecycleObserver {
         private data class BindingState(
@@ -70,41 +160,36 @@ class PhysicalSlotBindingObserver
 
         private fun push(state: BindingState) {
             val present = state.devices.keys
-            // Without this, re-added device ids could land on the wrong server-side controller index.
-            val disappeared = lastBoundDeviceIds - present
-            for (id in disappeared) {
-                SatelliteNative.unbindPhysicalSlot(id)
-                // Reclaim the native input-state entry for a departed framework device; a claimed
-                // USB synthetic (negative id) is freed by detachUsbDevice instead.
-                if (id >= 0) SatelliteNative.forgetPhysicalDevice(id)
-                hub.unbind(id.toString())
-            }
-            for (id in present) {
-                val slotId = id.toString()
-                val cid = state.bindings[slotId]
-                val summary = cid?.let { lookup -> state.summaries.firstOrNull { it.id == lookup } }
-                if (cid == null || summary == null || summary.live != LinkState.Connected) {
-                    SatelliteNative.unbindPhysicalSlot(id)
-                    continue
-                }
-                when (summary.kind) {
-                    ConnectionKind.SATELLITE -> {
-                        val sat = satellite.get(cid)
-                        val info = sat?.slots?.value?.get(slotId)
-                        if (sat == null || sat.handle < 0 || info == null || !info.registered) {
-                            SatelliteNative.unbindPhysicalSlot(id)
-                        } else {
-                            SatelliteNative.bindPhysicalSlotSatellite(
-                                id,
-                                sat.handle,
-                                info.controllerIndex,
-                            )
-                        }
-                    }
-                    ConnectionKind.BLUETOOTH ->
-                        SatelliteNative.bindPhysicalSlotBluetooth(id, cid)
-                }
-            }
+            // Read each live source once into a flat snapshot so reconcileSlots is pure; the resolved
+            // ops are then executed against the native/hub side effects exactly as before.
+            val referencedConnIds = state.bindings.values.toSet()
+            val slotInfo =
+                referencedConnIds
+                    .mapNotNull { cid ->
+                        satellite.get(cid)?.let { conn -> cid to SatelliteSlotSnapshot(conn.handle, conn.slots.value) }
+                    }.toMap()
+            val btConnectedIds = referencedConnIds.filterTo(mutableSetOf()) { bt.isConnected(it) }
+            val ops =
+                reconcileSlots(
+                    present = present,
+                    lastBound = lastBoundDeviceIds,
+                    bindings = state.bindings,
+                    summaries = state.summaries,
+                    perConnectionSlotInfo = slotInfo,
+                    btConnectedIds = btConnectedIds,
+                )
+            for (op in ops) execute(op)
             lastBoundDeviceIds = present
+        }
+
+        private fun execute(op: BindOp) {
+            when (op) {
+                is BindOp.Unbind -> SatelliteNative.unbindPhysicalSlot(op.deviceId)
+                is BindOp.Forget -> SatelliteNative.forgetPhysicalDevice(op.deviceId)
+                is BindOp.ReleaseHubBinding -> hub.unbind(op.deviceId.toString())
+                is BindOp.BindSatellite ->
+                    SatelliteNative.bindPhysicalSlotSatellite(op.deviceId, op.handle, op.controllerIndex)
+                is BindOp.BindBluetooth -> SatelliteNative.bindPhysicalSlotBluetooth(op.deviceId, op.connectionId)
+            }
         }
     }

--- a/app/src/main/java/com/tinkernorth/dish/hotpath/input/RumbleRouter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/input/RumbleRouter.kt
@@ -13,6 +13,7 @@ import androidx.annotation.RequiresApi
 import com.tinkernorth.dish.core.jni.PhysicalInputNative
 import com.tinkernorth.dish.source.connection.SatelliteConnection
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
+import com.tinkernorth.dish.source.connection.SatelliteSessionState
 import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
@@ -74,7 +75,7 @@ class RumbleRouter
         ) {
             val target = resolveTarget(sessionHandle, controllerIndex)
             if (target is RumbleTarget.None) return
-            if (durationMs == 0 || (strongMagnitude == 0 && weakMagnitude == 0)) {
+            if (isRumbleStop(strongMagnitude, weakMagnitude, durationMs)) {
                 cancel(target)
                 return
             }
@@ -86,13 +87,17 @@ class RumbleRouter
             sessionHandle: Int,
             controllerIndex: Int,
         ): RumbleTarget {
-            if (sessionHandle < 0) return RumbleTarget.None
-            val conn =
-                satellite.connections.value.values
-                    .firstOrNull { it.handle == sessionHandle }
-                    ?: return RumbleTarget.None
-            val slotId = resolveSlotId(conn.slots.value, controllerIndex) ?: return RumbleTarget.None
-            return classifyTarget(slotId)
+            // Read each StateFlow once into a flat snapshot so the routing decision is pure and
+            // testable; the native receive thread never re-reads the live manager mid-resolve.
+            val snapshot =
+                satellite.connections.value.values.map { conn ->
+                    RumbleConnectionSnapshot(
+                        handle = conn.handle,
+                        connected = conn.state.value == SatelliteSessionState.Live,
+                        slots = conn.slots.value,
+                    )
+                }
+            return resolveRumble(snapshot, sessionHandle, controllerIndex)
         }
 
         private fun actuate(
@@ -197,6 +202,35 @@ class RumbleRouter
             }
         }
     }
+
+// Flat, immutable view of one connection captured once per dispatch so resolveRumble stays pure.
+data class RumbleConnectionSnapshot(
+    val handle: Int,
+    val connected: Boolean,
+    val slots: Map<String, SatelliteConnection.SlotBinding>,
+)
+
+// Pure target resolver. Collision rule: a connected match wins over a non-connected one with the
+// same handle so a stale session can't steal a live controller's rumble; among equally-connected
+// matches the first wins (deterministic over the snapshot order).
+fun resolveRumble(
+    connections: List<RumbleConnectionSnapshot>,
+    sessionHandle: Int,
+    controllerIndex: Int,
+): RumbleTarget {
+    if (sessionHandle < 0) return RumbleTarget.None
+    val matches = connections.filter { it.handle == sessionHandle }
+    val conn = matches.firstOrNull { it.connected } ?: matches.firstOrNull() ?: return RumbleTarget.None
+    val slotId = resolveSlotId(conn.slots, controllerIndex) ?: return RumbleTarget.None
+    return classifyTarget(slotId)
+}
+
+// Zero duration or zero strong+weak means stop/cancel, never a positive vibration.
+internal fun isRumbleStop(
+    strongMagnitude: Int,
+    weakMagnitude: Int,
+    durationMs: Int,
+): Boolean = durationMs == 0 || (strongMagnitude == 0 && weakMagnitude == 0)
 
 internal fun resolveSlotId(
     slots: Map<String, SatelliteConnection.SlotBinding>,

--- a/app/src/main/java/com/tinkernorth/dish/repository/ConnectionStore.kt
+++ b/app/src/main/java/com/tinkernorth/dish/repository/ConnectionStore.kt
@@ -4,6 +4,7 @@ package com.tinkernorth.dish.repository
 
 import com.tinkernorth.dish.core.model.DiscoveredServer
 import com.tinkernorth.dish.source.connection.SatelliteConnection
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.Serializable
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -16,6 +17,11 @@ class ConnectionStore
         val bt: RememberedBtRepository,
         val satelliteKeys: SatelliteSharedKeyRepository,
     ) {
+        // Observable projections so the connections composer derives purely from flows, with no
+        // out-of-band prefs read that a remember/forget could leave stale.
+        val rememberedSatellitesFlow: StateFlow<List<RememberedSatellite>> = satellites.entries
+        val rememberedBtFlow: StateFlow<List<RememberedBt>> = bt.entries
+
         fun remembered(): List<RememberedSatellite> = satellites.all()
 
         fun rememberSatellite(server: DiscoveredServer) {
@@ -51,15 +57,18 @@ class ConnectionStore
             id: String,
         ) {
             val legacyId = "satellite:${server.ip}:${server.udpPort}"
-            if (satelliteKeys.get(id) == null) {
-                satelliteKeys.get(legacyId)?.let { satelliteKeys.put(id, it) }
-            }
             for (entry in satellites.all()) {
                 if (entry.id == id) continue
                 val isGhostOfThisBox =
                     entry.machineId.isBlank() &&
                         (entry.id == legacyId || entry.name == server.name)
-                if (isGhostOfThisBox) forgetSatellite(entry.id)
+                if (!isGhostOfThisBox) continue
+                // Adopt the ghost's key before dropping its row: a box that only just gained a machineId
+                // (or moved IP) must keep its pairing rather than be silently forced to re-pair.
+                if (satelliteKeys.get(id) == null) {
+                    satelliteKeys.get(entry.id)?.let { satelliteKeys.put(id, it) }
+                }
+                forgetSatellite(entry.id)
             }
         }
 

--- a/app/src/main/java/com/tinkernorth/dish/repository/RememberedBtRepository.kt
+++ b/app/src/main/java/com/tinkernorth/dish/repository/RememberedBtRepository.kt
@@ -6,6 +6,9 @@ import android.content.Context
 import androidx.core.content.edit
 import com.tinkernorth.dish.architecture.interfaces.KeyedRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
@@ -23,6 +26,11 @@ class RememberedBtRepository
         }
 
         private val writeLock = Any()
+
+        private val _entries = MutableStateFlow(all())
+
+        // Observable mirror so derived state reacts to remember/forget instead of re-reading prefs on a tick.
+        val entries: StateFlow<List<RememberedBt>> = _entries.asStateFlow()
 
         override fun keyOf(value: RememberedBt): String = value.id
 
@@ -44,6 +52,7 @@ class RememberedBtRepository
                 list.removeAll { it.id == key }
                 list += value
                 persist(list)
+                _entries.value = list.toList()
             }
         }
 
@@ -51,12 +60,14 @@ class RememberedBtRepository
             synchronized(writeLock) {
                 val list = all().filterNot { it.id == key }
                 persist(list)
+                _entries.value = list
             }
         }
 
         override fun clear() {
             synchronized(writeLock) {
                 prefs.edit { remove(KEY_BT) }
+                _entries.value = emptyList()
             }
         }
 

--- a/app/src/main/java/com/tinkernorth/dish/repository/RememberedBtRepository.kt
+++ b/app/src/main/java/com/tinkernorth/dish/repository/RememberedBtRepository.kt
@@ -3,6 +3,7 @@
 package com.tinkernorth.dish.repository
 
 import android.content.Context
+import android.util.Log
 import androidx.core.content.edit
 import com.tinkernorth.dish.architecture.interfaces.KeyedRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -40,7 +41,16 @@ class RememberedBtRepository
             val raw = prefs.getString(KEY_BT, null) ?: return emptyList()
             return runCatching {
                 json.decodeFromString(ListSerializer(RememberedBt.serializer()), raw)
-            }.getOrDefault(emptyList())
+            }.getOrElse { err ->
+                // Fall back to empty on parse failure: forgetting paired controllers beats crashing on corrupt prefs.
+                Log.w(
+                    TAG,
+                    "Failed to decode remembered-Bluetooth list; treating as empty. " +
+                        "User-facing impact: every paired controller is forgotten. " +
+                        "Cause: ${err.javaClass.simpleName}: ${err.message}",
+                )
+                emptyList()
+            }
         }
 
         override fun put(
@@ -77,6 +87,7 @@ class RememberedBtRepository
         }
 
         private companion object {
+            const val TAG = "RememberedBtRepository"
             const val PREFS_NAME = "connection_store"
             const val KEY_BT = "bt_list"
         }

--- a/app/src/main/java/com/tinkernorth/dish/repository/RememberedSatelliteRepository.kt
+++ b/app/src/main/java/com/tinkernorth/dish/repository/RememberedSatelliteRepository.kt
@@ -3,6 +3,7 @@
 package com.tinkernorth.dish.repository
 
 import android.content.Context
+import android.util.Log
 import androidx.core.content.edit
 import com.tinkernorth.dish.architecture.interfaces.KeyedRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -41,7 +42,16 @@ class RememberedSatelliteRepository
             val raw = prefs.getString(KEY_SATELLITES, null) ?: return emptyList()
             return runCatching {
                 json.decodeFromString(ListSerializer(RememberedSatellite.serializer()), raw)
-            }.getOrDefault(emptyList())
+            }.getOrElse { err ->
+                // Fall back to empty on parse failure: forgetting satellites beats crashing on corrupt prefs.
+                Log.w(
+                    TAG,
+                    "Failed to decode satellite list; treating as empty. " +
+                        "User-facing impact: every remembered satellite is forgotten. " +
+                        "Cause: ${err.javaClass.simpleName}: ${err.message}",
+                )
+                emptyList()
+            }
         }
 
         override fun put(
@@ -78,6 +88,7 @@ class RememberedSatelliteRepository
         }
 
         private companion object {
+            const val TAG = "RememberedSatelliteRepo"
             const val PREFS_NAME = "connection_store"
             const val KEY_SATELLITES = "satellite_list"
         }

--- a/app/src/main/java/com/tinkernorth/dish/repository/RememberedSatelliteRepository.kt
+++ b/app/src/main/java/com/tinkernorth/dish/repository/RememberedSatelliteRepository.kt
@@ -6,6 +6,9 @@ import android.content.Context
 import androidx.core.content.edit
 import com.tinkernorth.dish.architecture.interfaces.KeyedRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
@@ -24,6 +27,11 @@ class RememberedSatelliteRepository
 
         // SharedPreferences is atomic per key; read-modify-write of the list is not.
         private val writeLock = Any()
+
+        private val _entries = MutableStateFlow(all())
+
+        // Observable mirror so derived state reacts to remember/forget instead of re-reading prefs on a tick.
+        val entries: StateFlow<List<RememberedSatellite>> = _entries.asStateFlow()
 
         override fun keyOf(value: RememberedSatellite): String = value.id
 
@@ -45,6 +53,7 @@ class RememberedSatelliteRepository
                 list.removeAll { it.id == key }
                 list += value
                 persist(list)
+                _entries.value = list.toList()
             }
         }
 
@@ -52,12 +61,14 @@ class RememberedSatelliteRepository
             synchronized(writeLock) {
                 val list = all().filterNot { it.id == key }
                 persist(list)
+                _entries.value = list
             }
         }
 
         override fun clear() {
             synchronized(writeLock) {
                 prefs.edit { remove(KEY_SATELLITES) }
+                _entries.value = emptyList()
             }
         }
 

--- a/app/src/main/java/com/tinkernorth/dish/repository/SatellitePinRepository.kt
+++ b/app/src/main/java/com/tinkernorth/dish/repository/SatellitePinRepository.kt
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.repository
+
+import android.content.Context
+import androidx.core.content.edit
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.security.MessageDigest
+import javax.inject.Inject
+import javax.inject.Singleton
+
+// Result of comparing a presented cert fingerprint against the pinned one.
+enum class TofuVerdict { TRUST_FIRST_USE, MATCH, MISMATCH }
+
+// Pure TOFU decision: no prior pin trusts this first contact; otherwise the
+// presented fingerprint must equal the stored one (hex, case-insensitive).
+fun tofuVerdict(
+    stored: String?,
+    presented: String,
+): TofuVerdict =
+    when {
+        stored == null -> TofuVerdict.TRUST_FIRST_USE
+        stored.equals(presented, ignoreCase = true) -> TofuVerdict.MATCH
+        else -> TofuVerdict.MISMATCH
+    }
+
+// Lowercase hex SHA-256 of a DER-encoded cert. Pure so the verifier and tests share it.
+fun sha256FingerprintHex(certDer: ByteArray): String =
+    MessageDigest
+        .getInstance("SHA-256")
+        .digest(certDer)
+        .joinToString("") { "%02x".format(it) }
+
+// One SHA-256 cert fingerprint per satellite id (TOFU pin). Per-key storage (vs. one
+// JSON list) so forget is a single prefs edit and per-key writes are atomic. Co-tenants
+// the connection_store prefs with SatelliteSharedKeyRepository.
+@Singleton
+class SatellitePinRepository
+    @Inject
+    constructor(
+        @ApplicationContext context: Context,
+    ) {
+        private val prefs by lazy {
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        }
+
+        fun pinnedFingerprint(satelliteId: String): String? = prefs.getString(keyPref(satelliteId), null)
+
+        fun pin(
+            satelliteId: String,
+            fingerprintHex: String,
+        ) {
+            prefs.edit { putString(keyPref(satelliteId), fingerprintHex) }
+        }
+
+        fun forget(satelliteId: String) {
+            prefs.edit { remove(keyPref(satelliteId)) }
+        }
+
+        private fun keyPref(id: String): String = "$KEY_PREFIX$id"
+
+        private companion object {
+            const val PREFS_NAME = "connection_store"
+            const val KEY_PREFIX = "satellite_cert_pin:"
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/repository/TouchpadModeRepository.kt
+++ b/app/src/main/java/com/tinkernorth/dish/repository/TouchpadModeRepository.kt
@@ -55,6 +55,11 @@ class TouchpadModeRepository
             key: String,
             value: TouchpadModePreference,
         ) {
+            // Reject unknown modes so a typo never persists a value the satellite cannot route.
+            if (!TouchpadModeValue.isValid(value.mode)) {
+                Log.w(TAG, "Ignoring put of invalid touchpad mode '${value.mode}' for $key")
+                return
+            }
             synchronized(writeLock) {
                 val list = all().toMutableList()
                 list.removeAll { it.satelliteId == key }

--- a/app/src/main/java/com/tinkernorth/dish/source/bluetooth/AndroidHidProxyClient.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/bluetooth/AndroidHidProxyClient.kt
@@ -22,8 +22,12 @@ class AndroidHidProxyClient(
     private val context: Context,
 ) : HidProxyClient {
     private var events: HidProxyClient.Events? = null
-    private var hidDevice: BluetoothHidDevice? = null
-    private var connectedDevice: BluetoothDevice? = null
+
+    // Read on the JNI report thread (sendReport) but mutated on the binder callback thread
+    // (onConnectionStateChanged / onServiceDisconnected); volatile publishes those writes.
+    @Volatile private var hidDevice: BluetoothHidDevice? = null
+
+    @Volatile private var connectedDevice: BluetoothDevice? = null
     private var currentProfile: BluetoothGamepad.GamepadProfile? = null
 
     override fun isAdapterEnabled(): Boolean {
@@ -105,10 +109,15 @@ class AndroidHidProxyClient(
     }
 
     override fun sendReport(report: ByteArray): Boolean {
-        val hid = hidDevice ?: return false
-        val device = connectedDevice ?: return false
-        // Strip report-id byte: BluetoothHidDevice.sendReport takes it separately from the payload.
-        return hid.sendReport(device, REPORT_ID, report.sliceArray(1 until report.size))
+        // runCatching: a concurrent teardown can null the stack out from under us, so hid.sendReport
+        // may throw IllegalStateException after the proxy closed. This runs on the JNI report thread,
+        // which must never crash; swallow and report failure instead.
+        return runCatching {
+            val hid = hidDevice ?: return false
+            val device = connectedDevice ?: return false
+            // Strip report-id byte: BluetoothHidDevice.sendReport takes it separately from the payload.
+            hid.sendReport(device, REPORT_ID, report.sliceArray(1 until report.size))
+        }.getOrDefault(false)
     }
 
     override fun unregisterAndRelease() {

--- a/app/src/main/java/com/tinkernorth/dish/source/bluetooth/BluetoothHidSession.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/bluetooth/BluetoothHidSession.kt
@@ -133,8 +133,13 @@ class BluetoothHidSession(
                 mac: String,
                 name: String?,
             ) = ifCurrent(gen) {
-                val profile = currentProfileLocked() ?: return@ifCurrent
-                emitLocked(BluetoothSessionState.Connected(profile, mac, name))
+                // Only accept inbound connections from a state that is awaiting one (Registered).
+                // When started for a specific host, reject any other mac the OS reports, mirroring
+                // the onHostDisconnected mac guard so a stray/foreign host cannot hijack the session.
+                val registered = _state.value as? BluetoothSessionState.Registered ?: return@ifCurrent
+                val intendedMac = registered.autoConnectMac
+                if (intendedMac != null && !intendedMac.equals(mac, ignoreCase = true)) return@ifCurrent
+                emitLocked(BluetoothSessionState.Connected(registered.profile, mac, name))
             }
 
             override fun onHostDisconnected(mac: String) =
@@ -149,14 +154,6 @@ class BluetoothHidSession(
                     teardownLocked()
                     emitLocked(BluetoothSessionState.Failed(message))
                 }
-        }
-
-    private fun currentProfileLocked(): BluetoothGamepad.GamepadProfile? =
-        when (val s = _state.value) {
-            is BluetoothSessionState.Acquiring -> s.profile
-            is BluetoothSessionState.Registered -> s.profile
-            is BluetoothSessionState.Connected -> s.profile
-            else -> null
         }
 
     private inline fun ifCurrent(

--- a/app/src/main/java/com/tinkernorth/dish/source/connection/PairingApproval.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/connection/PairingApproval.kt
@@ -38,7 +38,9 @@ internal object PairingApproval {
         val status = jsonGet(json, "status")
         val key = jsonGet(json, "sharedKey")
         return when {
-            status == "approved" && key != null && key.length == SHARED_KEY_HEX_LEN ->
+            // Require the hex alphabet, not just the length: a 64-char non-hex
+            // key would otherwise decode to garbage downstream in hexToBytes.
+            status == "approved" && key != null && SHARED_KEY_HEX.matches(key) ->
                 Status.Approved(key)
             status == "pending" -> Status.Pending
             else -> Status.Declined
@@ -46,5 +48,5 @@ internal object PairingApproval {
     }
 
     private const val PIN_DIGITS = 4
-    private const val SHARED_KEY_HEX_LEN = 64
+    private val SHARED_KEY_HEX = Regex("[0-9a-fA-F]{64}")
 }

--- a/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManager.kt
@@ -9,8 +9,9 @@ import com.tinkernorth.dish.core.jni.ControllerRepository
 import com.tinkernorth.dish.core.model.ConnectResponse
 import com.tinkernorth.dish.core.model.DiscoveredServer
 import com.tinkernorth.dish.core.model.PairResponse
-import com.tinkernorth.dish.core.net.DiscoveryRepository
+import com.tinkernorth.dish.core.net.DiscoveryGateway
 import com.tinkernorth.dish.core.net.hexToBytes
+import com.tinkernorth.dish.core.net.isPrivateHostLiteral
 import com.tinkernorth.dish.di.IoDispatcher
 import com.tinkernorth.dish.repository.ConnectionStore
 import com.tinkernorth.dish.repository.RememberedSatellite
@@ -18,6 +19,7 @@ import com.tinkernorth.dish.source.store.SatelliteMotionBackendStatusStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -55,7 +57,7 @@ class SatelliteConnectionManager
     constructor(
         @ApplicationContext private val context: Context,
         private val scope: CoroutineScope,
-        private val discoveryRepo: DiscoveryRepository,
+        private val discoveryRepo: DiscoveryGateway,
         val controllerRepo: ControllerRepository,
         private val store: ConnectionStore,
         private val json: Json,
@@ -90,6 +92,11 @@ class SatelliteConnectionManager
 
         private val deviceId by lazy { getOrCreateDeviceId() }
         private val deviceName by lazy { android.os.Build.MODEL ?: "Android" }
+
+        // Path-B approval polls run up to APPROVAL_TIMEOUT_MS and can call openSession
+        // long after the user forgot the satellite. Keyed by id so disconnect/forget
+        // (and a re-issued request) can cancel the in-flight poll.
+        private val approvalPollJobs = java.util.concurrent.ConcurrentHashMap<String, Job>()
 
         init {
             // Project to cap-bits-by-slot so unrelated composer emissions don't fire no-op wire updates.
@@ -310,71 +317,84 @@ class SatelliteConnectionManager
                     }[id] ?: return
             conn.updateServer(server)
             conn.markConnecting()
-            scope.launch {
-                val raw =
-                    runCatching {
-                        discoveryRepo.pair(
-                            server.ip,
-                            server.pairPort,
-                            deviceId,
-                            deviceName,
-                            pin = "",
-                            clientPin = clientPin,
-                        )
-                    }.getOrNull()
-                if (raw.isNullOrBlank()) {
-                    conn.markDisconnected()
-                    _events.emit(ConnectionEvent.Error(SERVER_UNREACHABLE_MSG))
-                    return@launch
-                }
-                // An already-paired short-circuit hands a key straight back, skipping the operator step.
-                val immediate =
-                    runCatching { json.decodeFromString(PairResponse.serializer(), raw) }.getOrNull()
-                if (immediate?.ok == true && immediate.sharedKey != null) {
-                    clearStale(id)
-                    store.setSatelliteSharedKey(id, immediate.sharedKey)
-                    openSession(conn, server, ConnectIntent.USER_INITIATED)
-                    return@launch
-                }
-                // Otherwise wait for the operator: poll until accept / deny / timeout.
-                // The satellite-PIN path (pairWithPin) shares this connection, so
-                // once it reaches Live we bail without touching it. Otherwise this
-                // poll's terminal paths (esp. the timeout) would tear down a live
-                // session the user just established by typing the PIN.
-                var waited = 0L
-                while (waited < APPROVAL_TIMEOUT_MS) {
-                    if (conn.state.value == SatelliteSessionState.Live) return@launch
-                    kotlinx.coroutines.delay(APPROVAL_POLL_INTERVAL_MS)
-                    waited += APPROVAL_POLL_INTERVAL_MS
-                    val statusRaw =
-                        runCatching { discoveryRepo.pairStatus(server.ip, server.httpPort, deviceId) }
-                            .getOrNull()
-                    // A transient null reply is treated as still-pending, not a refusal.
-                    val st =
-                        if (statusRaw.isNullOrBlank()) {
-                            PairingApproval.Status.Pending
-                        } else {
-                            PairingApproval.classifyStatus(statusRaw)
-                        }
-                    // Re-check: Live may have flipped during the poll round-trip.
-                    if (conn.state.value == SatelliteSessionState.Live) return@launch
-                    if (st is PairingApproval.Status.Approved) {
+            // A re-issued request supersedes any prior poll for this id; cancel it
+            // so two polls can't race to openSession on the same satellite.
+            cancelApprovalPoll(id)
+            val job =
+                scope.launch {
+                    val raw =
+                        runCatching {
+                            discoveryRepo.pair(
+                                server.ip,
+                                server.pairPort,
+                                deviceId,
+                                deviceName,
+                                pin = "",
+                                clientPin = clientPin,
+                            )
+                        }.getOrNull()
+                    if (raw.isNullOrBlank()) {
+                        conn.markDisconnected()
+                        _events.emit(ConnectionEvent.Error(SERVER_UNREACHABLE_MSG))
+                        return@launch
+                    }
+                    // An already-paired short-circuit hands a key straight back, skipping the operator step.
+                    val immediate =
+                        runCatching { json.decodeFromString(PairResponse.serializer(), raw) }.getOrNull()
+                    if (immediate?.ok == true && immediate.sharedKey != null) {
                         clearStale(id)
-                        store.setSatelliteSharedKey(id, st.sharedKeyHex)
+                        store.setSatelliteSharedKey(id, immediate.sharedKey)
                         openSession(conn, server, ConnectIntent.USER_INITIATED)
                         return@launch
                     }
-                    if (st is PairingApproval.Status.Declined) {
+                    // Otherwise wait for the operator: poll until accept / deny / timeout.
+                    // The satellite-PIN path (pairWithPin) shares this connection, so
+                    // once it reaches Live we bail without touching it. Otherwise this
+                    // poll's terminal paths (esp. the timeout) would tear down a live
+                    // session the user just established by typing the PIN.
+                    var waited = 0L
+                    while (waited < APPROVAL_TIMEOUT_MS) {
+                        if (conn.state.value == SatelliteSessionState.Live) return@launch
+                        kotlinx.coroutines.delay(APPROVAL_POLL_INTERVAL_MS)
+                        waited += APPROVAL_POLL_INTERVAL_MS
+                        val statusRaw =
+                            runCatching { discoveryRepo.pairStatus(server.ip, server.httpPort, deviceId) }
+                                .getOrNull()
+                        // A transient null reply is treated as still-pending, not a refusal.
+                        val st =
+                            if (statusRaw.isNullOrBlank()) {
+                                PairingApproval.Status.Pending
+                            } else {
+                                PairingApproval.classifyStatus(statusRaw)
+                            }
+                        // Re-check: Live may have flipped during the poll round-trip.
+                        if (conn.state.value == SatelliteSessionState.Live) return@launch
+                        if (st is PairingApproval.Status.Approved) {
+                            clearStale(id)
+                            store.setSatelliteSharedKey(id, st.sharedKeyHex)
+                            openSession(conn, server, ConnectIntent.USER_INITIATED)
+                            return@launch
+                        }
+                        if (st is PairingApproval.Status.Declined) {
+                            conn.markDisconnected()
+                            _events.emit(ConnectionEvent.Error(APPROVAL_DECLINED_MSG))
+                            return@launch
+                        }
+                    }
+                    if (conn.state.value != SatelliteSessionState.Live) {
                         conn.markDisconnected()
-                        _events.emit(ConnectionEvent.Error(APPROVAL_DECLINED_MSG))
-                        return@launch
+                        _events.emit(ConnectionEvent.Error(APPROVAL_TIMEOUT_MSG))
                     }
                 }
-                if (conn.state.value != SatelliteSessionState.Live) {
-                    conn.markDisconnected()
-                    _events.emit(ConnectionEvent.Error(APPROVAL_TIMEOUT_MSG))
-                }
-            }
+            approvalPollJobs[id] = job
+            // Self-remove so a completed/cancelled poll doesn't linger in the map;
+            // guarded so we never evict a newer poll that already replaced this id.
+            job.invokeOnCompletion { approvalPollJobs.remove(id, job) }
+        }
+
+        // Cancels and deregisters an in-flight Path-B approval poll for [id], if any.
+        private fun cancelApprovalPoll(id: String) {
+            approvalPollJobs.remove(id)?.cancel()
         }
 
         private suspend fun openSession(
@@ -383,18 +403,28 @@ class SatelliteConnectionManager
             intent: ConnectIntent,
         ) = withContext(ioDispatcher) {
             val id = SatelliteConnection.idFor(server)
-            val keyHex = sharedKeyFor(server) ?: ""
-            if (keyHex.length != 64) {
+            // Vet the discovered address before any socket: an unauthenticated
+            // mDNS/broadcast beacon must not steer us at a public or non-literal
+            // host. Every connect path funnels through here, so both discovery
+            // transports are covered at one choke point.
+            if (!isPrivateHostLiteral(server.ip)) {
                 conn.markDisconnected()
-                // The local key is bogus — drop it so a subsequent
-                // user-initiated Connect goes through the pair handshake fresh
-                // rather than re-trying with the same broken value.
+                emitErrorIfUserInitiated(intent, SERVER_UNREACHABLE_MSG)
+                return@withContext
+            }
+            val keyHex = sharedKeyFor(server) ?: ""
+            // A 64-char value can still be non-hex (hexToBytes throws), so decode
+            // here and treat a decode failure as the same bogus-key case as a
+            // wrong length: drop the local key and re-pair on the next user tap
+            // rather than retrying the broken value.
+            val key = if (keyHex.length == 64) runCatching { hexToBytes(keyHex) }.getOrNull() else null
+            if (key == null) {
+                conn.markDisconnected()
                 store.forgetSatelliteSharedKey(id)
                 markStale(id)
                 emitErrorIfUserInitiated(intent, "No shared key — re-pair needed")
                 return@withContext
             }
-            val key = hexToBytes(keyHex)
             val rawConn = runCatching { discoveryRepo.connect(server.ip, server.httpPort, deviceId) }
             val rawConnText = rawConn.getOrNull()
             if (rawConn.isFailure || rawConnText.isNullOrBlank()) {
@@ -429,8 +459,10 @@ class SatelliteConnectionManager
                 )
                 return@withContext
             }
-            val token = hexToBytes(tokenHex)
-            if (token.size != 4 || key.size != 32) {
+            // Token is server-supplied: a malformed (non-hex) value must degrade
+            // like a wrong-size token, not crash the coroutine.
+            val token = runCatching { hexToBytes(tokenHex) }.getOrNull()
+            if (token == null || token.size != 4 || key.size != 32) {
                 conn.markDisconnected()
                 return@withContext
             }
@@ -515,6 +547,9 @@ class SatelliteConnectionManager
         }
 
         fun disconnect(id: String) {
+            // Stop any reverse-pairing poll first: otherwise it could call
+            // openSession seconds after the user tore the connection down.
+            cancelApprovalPoll(id)
             val conn = _connections.value[id] ?: return
             val srv = conn.server.value
             val cid = conn.connectionId

--- a/app/src/main/java/com/tinkernorth/dish/source/lowpower/LowPowerManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/lowpower/LowPowerManager.kt
@@ -10,7 +10,6 @@ import android.view.Window
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.TextView
-import androidx.lifecycle.LifecycleOwner
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.architecture.abstracts.AbstractStateSource
 import java.util.Calendar
@@ -72,13 +71,11 @@ class LowPowerManager(
         }
     }
 
+    // Teardown is driven explicitly by the host activity via cancel(); this is not a registered
+    // lifecycle observer, so it deliberately does not override onStop.
     fun cancel() {
         inactivityHandler.removeCallbacks(inactivityRunnable)
         exit()
-    }
-
-    override fun onStop(owner: LifecycleOwner) {
-        cancel()
     }
 
     private fun resetInactivityTimer() {

--- a/app/src/main/java/com/tinkernorth/dish/source/sensor/PhoneMotionAvailability.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/sensor/PhoneMotionAvailability.kt
@@ -5,20 +5,19 @@ package com.tinkernorth.dish.source.sensor
 import android.content.Context
 import android.hardware.Sensor
 import android.hardware.SensorManager
-import com.tinkernorth.dish.architecture.abstracts.AbstractStateSource
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
+// Gyro presence is a fixed hardware fact, resolved once at construction. Not reactive, so it is a
+// plain holder rather than a state source.
 @Singleton
 class PhoneMotionAvailability
     @Inject
     constructor(
         @ApplicationContext context: Context,
-    ) : AbstractStateSource<Boolean>(initialState = false) {
-        init {
-            val sm = context.getSystemService(Context.SENSOR_SERVICE) as? SensorManager
-            val hasGyro = sm?.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null
-            setState(hasGyro)
-        }
+    ) {
+        val hasGyro: Boolean =
+            (context.getSystemService(Context.SENSOR_SERVICE) as? SensorManager)
+                ?.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null
     }

--- a/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalBatterySource.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalBatterySource.kt
@@ -12,7 +12,7 @@ import android.view.InputDevice
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import com.tinkernorth.dish.composer.ConnectionHub
+import com.tinkernorth.dish.composer.ConnectionCoordinator
 import com.tinkernorth.dish.composer.PhysicalReachability
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.source.connection.SatelliteConnection
@@ -36,7 +36,7 @@ class PhysicalBatterySource
     constructor(
         @ApplicationContext private val context: Context,
         private val registry: PhysicalGamepadRegistry,
-        private val hub: ConnectionHub,
+        private val hub: ConnectionCoordinator,
         private val satellite: SatelliteConnectionManager,
         private val statusStore: BatteryStatusStore,
         private val scope: CoroutineScope,

--- a/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalMotionSource.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/sensor/PhysicalMotionSource.kt
@@ -12,7 +12,7 @@ import android.util.Log
 import android.view.InputDevice
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import com.tinkernorth.dish.composer.ConnectionHub
+import com.tinkernorth.dish.composer.ConnectionCoordinator
 import com.tinkernorth.dish.composer.MotionCapability
 import com.tinkernorth.dish.composer.MotionCapabilityComposer
 import com.tinkernorth.dish.composer.PhysicalReachability
@@ -32,7 +32,7 @@ class PhysicalMotionSource
     @Inject
     constructor(
         private val registry: PhysicalGamepadRegistry,
-        private val hub: ConnectionHub,
+        private val hub: ConnectionCoordinator,
         private val satellite: SatelliteConnectionManager,
         private val motionCapability: MotionCapabilityComposer,
         private val scope: CoroutineScope,

--- a/app/src/main/java/com/tinkernorth/dish/source/store/ControllerTypeStore.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/store/ControllerTypeStore.kt
@@ -44,6 +44,10 @@ class ControllerTypeStore
             }
         }
 
+        fun clearConnection(connectionId: String) {
+            setState { current -> current.filterNot { (k, _) -> k.first == connectionId } }
+        }
+
         fun slotTypesFor(
             connectionId: String,
             boundSlotIds: List<String>,

--- a/app/src/main/java/com/tinkernorth/dish/source/system/ConnectionForegroundObserver.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/system/ConnectionForegroundObserver.kt
@@ -2,8 +2,8 @@
 
 package com.tinkernorth.dish.source.system
 
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import com.tinkernorth.dish.architecture.abstracts.AbstractStateSource
 import com.tinkernorth.dish.composer.ConnectionHub
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -13,7 +13,7 @@ class ConnectionForegroundObserver
     @Inject
     constructor(
         private val hub: ConnectionHub,
-    ) : AbstractStateSource<Unit>(Unit) {
+    ) : DefaultLifecycleObserver {
         override fun onStart(owner: LifecycleOwner) {
             hub.autoReconnectAll()
         }

--- a/app/src/main/java/com/tinkernorth/dish/source/system/ConnectionForegroundObserver.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/system/ConnectionForegroundObserver.kt
@@ -4,7 +4,7 @@ package com.tinkernorth.dish.source.system
 
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import com.tinkernorth.dish.composer.ConnectionHub
+import com.tinkernorth.dish.composer.ConnectionCoordinator
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -12,7 +12,7 @@ import javax.inject.Singleton
 class ConnectionForegroundObserver
     @Inject
     constructor(
-        private val hub: ConnectionHub,
+        private val hub: ConnectionCoordinator,
     ) : DefaultLifecycleObserver {
         override fun onStart(owner: LifecycleOwner) {
             hub.autoReconnectAll()

--- a/app/src/main/java/com/tinkernorth/dish/source/usb/UsbGamepadManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/usb/UsbGamepadManager.kt
@@ -17,7 +17,7 @@ import android.os.Build
 import android.util.Log
 import androidx.core.content.ContextCompat
 import com.tinkernorth.dish.R
-import com.tinkernorth.dish.composer.ConnectionHub
+import com.tinkernorth.dish.composer.ConnectionCoordinator
 import com.tinkernorth.dish.core.jni.PhysicalInputNative
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.source.notification.DishNotifications
@@ -50,7 +50,7 @@ class UsbGamepadManager
     constructor(
         @ApplicationContext private val context: Context,
         private val registry: PhysicalGamepadRegistry,
-        private val connectionHubProvider: Provider<ConnectionHub>,
+        private val connectionHubProvider: Provider<ConnectionCoordinator>,
         private val notifications: DishNotifications,
         private val scope: CoroutineScope,
         private val native: PhysicalInputNative,

--- a/app/src/main/java/com/tinkernorth/dish/source/usb/UsbGamepadManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/usb/UsbGamepadManager.kt
@@ -432,16 +432,11 @@ class UsbGamepadManager
             vendorId: Int,
             productId: Int,
         ): PathChoice =
-            pathPrefs.choiceFor(vendorId, productId)
-                ?: if (native.isKnownFastLaneModel(vendorId, productId) &&
-                    registry.directFailureFor(vendorId, productId) == null
-                ) {
-                    // No stored pick: auto-Direct a verified model, but not one that just failed to claim
-                    // (an explicit user pick still routes through Choose and claims regardless).
-                    PathChoice.Direct
-                } else {
-                    PathChoice.Standard
-                }
+            resolvePathChoice(
+                stored = pathPrefs.choiceFor(vendorId, productId),
+                isFastLaneModel = native.isKnownFastLaneModel(vendorId, productId),
+                priorFailure = registry.directFailureFor(vendorId, productId),
+            )
 
         private fun requestPermission(device: UsbDevice) {
             val intent = Intent(ACTION_USB_PERMISSION).setPackage(context.packageName)
@@ -544,3 +539,11 @@ class UsbGamepadManager
             const val TRANSITION_TIMEOUT_MS = 4000L
         }
     }
+
+// An explicit stored pick always wins; absent one, auto-Direct only a verified fast-lane model
+// that has not just failed to claim.
+internal fun resolvePathChoice(
+    stored: PathChoice?,
+    isFastLaneModel: Boolean,
+    priorFailure: DirectClaimFailure?,
+): PathChoice = stored ?: if (isFastLaneModel && priorFailure == null) PathChoice.Direct else PathChoice.Standard

--- a/app/src/main/java/com/tinkernorth/dish/source/usb/UsbPathMachine.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/usb/UsbPathMachine.kt
@@ -237,11 +237,14 @@ private fun reduceClaiming(
                 )
             } else {
                 // Open/claim was rejected without ever stealing the interface, so the framework slot is
-                // still live; drop straight back to Standard and say why Direct didn't happen.
+                // still live; drop straight back to Standard and say why Direct didn't happen. Persist
+                // Standard too, or the failed pick is silently re-attempted on every reconnect (mirrors
+                // the permission-denied path).
                 Reduction(
                     c.copy(phase = UsbPhase.Routed, desired = PathChoice.Standard, syntheticId = null, failure = event.reason),
                     buildList {
                         add(UsbEffect.EndHold)
+                        add(UsbEffect.SetPref(PathChoice.Standard))
                         add(UsbEffect.MarkFailure(event.reason))
                         if (c.userInitiated) add(UsbEffect.Notify(UsbNotice.SwitchToDirectFailed))
                     },
@@ -311,10 +314,16 @@ private fun reduceAwaiting(
                 )
             } else {
                 // Failed claim never recovered; the device is gone from the OS. Keep the held placeholder
-                // visible as a "needs replug" card rather than letting it disappear.
+                // visible as a "needs replug" card, and mark the reason Dropped so the card asks for a
+                // physical replug instead of echoing the stale claim error.
                 Reduction(
-                    c.copy(phase = UsbPhase.NeedsReplug, desired = PathChoice.Standard),
-                    listOf(UsbEffect.MarkNeedsReplug, UsbEffect.SetPref(PathChoice.Standard), UsbEffect.Notify(UsbNotice.NeedsReplug)),
+                    c.copy(phase = UsbPhase.NeedsReplug, desired = PathChoice.Standard, failure = DirectClaimFailure.Dropped),
+                    listOf(
+                        UsbEffect.MarkNeedsReplug,
+                        UsbEffect.MarkFailure(DirectClaimFailure.Dropped),
+                        UsbEffect.SetPref(PathChoice.Standard),
+                        UsbEffect.Notify(UsbNotice.NeedsReplug),
+                    ),
                 )
             }
         is UsbEvent.PermissionGranted -> stay(c.copy(hasPermission = true))
@@ -349,11 +358,11 @@ private fun reduceRestoreStuck(
                 listOf(UsbEffect.SetPref(PathChoice.Direct), UsbEffect.ClearFailure, UsbEffect.Notify(UsbNotice.RolledBackToDirect)),
             )
         // Reclaim failed too: the device is gone. The synthetic placeholder is dropped by the Reclaim
-        // effector, so there is nothing left to mark; the banner carries the news.
+        // effector; surface a Dropped reason so the NeedsReplug card asks for a physical replug.
         is UsbEvent.ClaimFailed ->
             Reduction(
-                c.copy(phase = UsbPhase.NeedsReplug, syntheticId = null),
-                listOf(UsbEffect.Notify(UsbNotice.RestoreFailed)),
+                c.copy(phase = UsbPhase.NeedsReplug, syntheticId = null, failure = DirectClaimFailure.Dropped),
+                listOf(UsbEffect.MarkFailure(DirectClaimFailure.Dropped), UsbEffect.Notify(UsbNotice.RestoreFailed)),
             )
         // The framework finally came back on its own: settle on Standard.
         is UsbEvent.FrameworkUp -> {

--- a/app/src/main/java/com/tinkernorth/dish/ui/common/StaticViewAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/StaticViewAdapter.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.common
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.LayoutRes
+import androidx.recyclerview.widget.RecyclerView
+
+class StaticViewAdapter(
+    @LayoutRes private val layoutRes: Int,
+) : RecyclerView.Adapter<StaticViewAdapter.VH>() {
+    class VH(
+        view: View,
+    ) : RecyclerView.ViewHolder(view)
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): VH = VH(LayoutInflater.from(parent.context).inflate(layoutRes, parent, false))
+
+    override fun onBindViewHolder(
+        holder: VH,
+        position: Int,
+    ) = Unit
+
+    override fun getItemCount(): Int = 1
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/BluetoothListAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/BluetoothListAdapter.kt
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.connections
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.tinkernorth.dish.R
+import com.tinkernorth.dish.composer.ConnectionKind
+import com.tinkernorth.dish.composer.ConnectionSummary
+import com.tinkernorth.dish.composer.LinkState
+import com.tinkernorth.dish.databinding.RowConnectionBinding
+import com.tinkernorth.dish.ui.common.setLoading
+import com.tinkernorth.dish.ui.common.statusChipText
+
+data class BtRowUi(
+    val summary: ConnectionSummary,
+    val connectingLabel: String?,
+    val secondaryIsForget: Boolean,
+)
+
+sealed interface BluetoothRow {
+    data class Item(
+        val ui: BtRowUi,
+    ) : BluetoothRow
+
+    data class Empty(
+        val message: String,
+    ) : BluetoothRow
+}
+
+interface BluetoothRowListener {
+    fun onConnect(id: String)
+
+    fun onDisconnect(id: String)
+
+    fun onRepair(id: String)
+
+    fun onSecondary(summary: ConnectionSummary)
+}
+
+class BluetoothListAdapter(
+    private val listener: BluetoothRowListener,
+) : ListAdapter<BluetoothRow, RecyclerView.ViewHolder>(Diff) {
+    override fun getItemViewType(position: Int): Int = if (getItem(position) is BluetoothRow.Empty) TYPE_EMPTY else TYPE_ROW
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): RecyclerView.ViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return if (viewType == TYPE_EMPTY) {
+            EmptyVH(inflater.inflate(R.layout.item_connection_empty, parent, false))
+        } else {
+            RowVH(RowConnectionBinding.inflate(inflater, parent, false), listener)
+        }
+    }
+
+    override fun onBindViewHolder(
+        holder: RecyclerView.ViewHolder,
+        position: Int,
+    ) {
+        when (val row = getItem(position)) {
+            is BluetoothRow.Empty -> (holder as EmptyVH).bind(row.message)
+            is BluetoothRow.Item -> (holder as RowVH).bind(row.ui)
+        }
+    }
+
+    class EmptyVH(
+        view: View,
+    ) : RecyclerView.ViewHolder(view) {
+        fun bind(message: String) {
+            (itemView as TextView).text = message
+        }
+    }
+
+    class RowVH(
+        private val b: RowConnectionBinding,
+        private val listener: BluetoothRowListener,
+    ) : RecyclerView.ViewHolder(b.root) {
+        private val ctx get() = b.root.context
+
+        fun bind(ui: BtRowUi) {
+            val c = ui.summary
+            b.paintConnection(c.label, c.detail, statusChipText(ctx, c.live), ConnectionKind.BLUETOOTH, c.live)
+            when (c.live) {
+                LinkState.Connected, LinkState.Unstable -> {
+                    b.btnRowAction.setLoading(false, "", ctx.getString(R.string.action_disconnect))
+                    b.btnRowAction.setOnClickListener { listener.onDisconnect(c.id) }
+                }
+                LinkState.Connecting -> {
+                    b.btnRowAction.setLoading(true, ui.connectingLabel.orEmpty(), ctx.getString(R.string.action_connect))
+                    b.btnRowAction.setOnClickListener(null)
+                }
+                LinkState.Stale -> {
+                    b.btnRowAction.setLoading(false, "", ctx.getString(R.string.action_repair_short))
+                    b.btnRowAction.setOnClickListener { listener.onRepair(c.id) }
+                }
+                LinkState.Saved, LinkState.Ready, LinkState.Found -> {
+                    b.btnRowAction.setLoading(false, "", ctx.getString(R.string.action_connect))
+                    b.btnRowAction.setOnClickListener { listener.onConnect(c.id) }
+                }
+            }
+            b.btnRowSecondary.visibility = View.VISIBLE
+            b.btnRowSecondary.text =
+                ctx.getString(if (ui.secondaryIsForget) R.string.action_forget_short else R.string.action_cancel)
+            b.btnRowSecondary.setOnClickListener { listener.onSecondary(c) }
+        }
+    }
+
+    companion object {
+        private const val TYPE_ROW = 0
+        private const val TYPE_EMPTY = 1
+
+        private val Diff =
+            object : DiffUtil.ItemCallback<BluetoothRow>() {
+                override fun areItemsTheSame(
+                    o: BluetoothRow,
+                    n: BluetoothRow,
+                ): Boolean =
+                    when {
+                        o is BluetoothRow.Item && n is BluetoothRow.Item -> o.ui.summary.id == n.ui.summary.id
+                        o is BluetoothRow.Empty && n is BluetoothRow.Empty -> true
+                        else -> false
+                    }
+
+                override fun areContentsTheSame(
+                    o: BluetoothRow,
+                    n: BluetoothRow,
+                ): Boolean = o == n
+            }
+    }
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionRows.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionRows.kt
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.connections
+
+import android.graphics.drawable.GradientDrawable
+import com.tinkernorth.dish.composer.ConnectionKind
+import com.tinkernorth.dish.composer.LinkState
+import com.tinkernorth.dish.databinding.RowConnectionBinding
+import com.tinkernorth.dish.ui.common.dotColorForState
+import com.tinkernorth.dish.ui.common.glyphForConnection
+
+internal fun RowConnectionBinding.paintConnection(
+    title: String,
+    detail: String,
+    status: String,
+    kind: ConnectionKind,
+    state: LinkState,
+) {
+    tvRowTitle.text = title
+    tvRowDetail.text = detail
+    tvRowStatus.text = status
+    (dotRow.background as GradientDrawable).setColor(root.context.getColor(dotColorForState(state)))
+    ivRowGlyph.setImageResource(glyphForConnection(kind, state))
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
@@ -7,7 +7,6 @@ import android.app.Activity
 import android.bluetooth.BluetoothAdapter
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.graphics.drawable.GradientDrawable
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
@@ -16,7 +15,6 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.MotionEvent
 import android.view.View
-import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
@@ -24,10 +22,13 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
-import androidx.core.view.isNotEmpty
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.ConcatAdapter
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.SimpleItemAnimator
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
@@ -42,7 +43,6 @@ import com.tinkernorth.dish.core.model.DiscoveredServer
 import com.tinkernorth.dish.core.model.DiscoverySource
 import com.tinkernorth.dish.core.model.DishNotification
 import com.tinkernorth.dish.databinding.ActivityConnectionsBinding
-import com.tinkernorth.dish.databinding.RowConnectionBinding
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.hotpath.overlay.GamepadActivityHost
 import com.tinkernorth.dish.repository.ConnectionStore
@@ -61,15 +61,12 @@ import com.tinkernorth.dish.source.system.BluetoothPermissionState
 import com.tinkernorth.dish.source.system.BluetoothPermissionStateObserver
 import com.tinkernorth.dish.source.system.NetworkState
 import com.tinkernorth.dish.source.system.NetworkStateObserver
+import com.tinkernorth.dish.ui.common.StaticViewAdapter
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.attachDonatePill
 import com.tinkernorth.dish.ui.common.attachGamepadHost
-import com.tinkernorth.dish.ui.common.dotColorForState
-import com.tinkernorth.dish.ui.common.glyphForConnection
-import com.tinkernorth.dish.ui.common.setLoading
 import com.tinkernorth.dish.ui.common.setupDishToolbar
-import com.tinkernorth.dish.ui.common.statusChipText
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -102,6 +99,64 @@ class ConnectionsActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityConnectionsBinding
     private lateinit var gamepadHost: GamepadActivityHost
+
+    private lateinit var satelliteHeader: SectionHeaderAdapter
+    private lateinit var bluetoothHeader: SectionHeaderAdapter
+    private lateinit var satelliteList: SatelliteListAdapter
+    private lateinit var bluetoothList: BluetoothListAdapter
+
+    private val satelliteRowListener =
+        object : SatelliteRowListener {
+            override fun onConnect(row: SatelliteRow) {
+                when (row) {
+                    is SatelliteRow.Known -> {
+                        val remembered = satellite.remembered().firstOrNull { it.id == row.summary.id } ?: return
+                        satellite.connect(remembered.toDiscovered())
+                    }
+                    is SatelliteRow.Discovered -> satellite.connect(row.server)
+                    is SatelliteRow.Empty -> Unit
+                }
+            }
+
+            override fun onDisconnect(id: String) {
+                satellite.disconnect(id)
+            }
+
+            override fun onRepair(id: String) {
+                val remembered = satellite.remembered().firstOrNull { it.id == id } ?: return
+                showPairingDialog(remembered.toDiscovered())
+            }
+
+            override fun onForget(id: String) {
+                hub.forgetConnection(id)
+            }
+        }
+
+    private val bluetoothRowListener =
+        object : BluetoothRowListener {
+            override fun onConnect(id: String) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) btRegistry.tryAutoReconnect(id)
+            }
+
+            override fun onDisconnect(id: String) {
+                btRegistry.stop(id)
+            }
+
+            override fun onRepair(id: String) {
+                val entry = store.rememberedBt().firstOrNull { it.id == id } ?: return
+                openBluetoothDeviceDetails(entry.mac)
+            }
+
+            override fun onSecondary(summary: ConnectionSummary) {
+                val remembered = store.rememberedBt().firstOrNull { it.id == summary.id }
+                if (remembered != null) {
+                    confirmForgetBt(summary.id, remembered)
+                } else {
+                    btRegistry.stop(summary.id)
+                    render()
+                }
+            }
+        }
 
     private var btAdapterBannerId: Long? = null
     private var btPermissionBannerId: Long? = null
@@ -167,7 +222,7 @@ class ConnectionsActivity : AppCompatActivity() {
         applyDishSystemBars(binding.root)
         applyDishActivityTransitions()
         attachDonatePill()
-        bindSectionHeaders()
+        setupList()
 
         observeSatelliteHub()
         observeSystemStateBanners()
@@ -194,7 +249,7 @@ class ConnectionsActivity : AppCompatActivity() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 hub.connections.collect { conns ->
-                    render(conns)
+                    render()
                     // Success path emits no ConnectionEvent, so observe state directly to dismiss PIN dialog.
                     val pairing = pairingServer
                     if (pairing != null) {
@@ -209,23 +264,19 @@ class ConnectionsActivity : AppCompatActivity() {
         }
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                satellite.discoveredServers.collect { render(hub.connections.value) }
+                satellite.discoveredServers.collect { render() }
             }
         }
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 satellite.isScanning.collect { scanning ->
-                    binding.sectionSatellites.btnSectionAction.setLoading(
-                        loading = scanning,
-                        loadingText = getString(R.string.action_scanning),
-                        restingText = getString(R.string.action_scan),
-                    )
+                    satelliteHeader.setLoading(scanning, getString(R.string.action_scanning))
                 }
             }
         }
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                satellite.lastScanAtMs.collect { _ -> renderEmptyState() }
+                satellite.lastScanAtMs.collect { render() }
             }
         }
         lifecycleScope.launch {
@@ -298,60 +349,92 @@ class ConnectionsActivity : AppCompatActivity() {
         gamepadHost.cancelDimOnStop()
     }
 
-    private fun bindSectionHeaders() {
-        with(binding.sectionSatellites) {
-            iconSection.visibility = View.VISIBLE
-            iconSection.setImageResource(R.drawable.ic_satellite)
-            labelSection.setText(R.string.section_satellites)
-            btnSectionAction.visibility = View.VISIBLE
-            btnSectionAction.setText(R.string.action_scan)
-            btnSectionAction.setOnClickListener { satellite.startDiscovery() }
-        }
-        with(binding.sectionBluetooth) {
-            iconSection.visibility = View.VISIBLE
-            iconSection.setImageResource(R.drawable.ic_bluetooth)
-            labelSection.setText(R.string.section_bluetooth_hosts)
-            btnSectionAction.visibility = View.VISIBLE
-            btnSectionAction.setText(R.string.action_add)
-            btnSectionAction.setOnClickListener { requestBtPermissions(continueToAdd = true) }
-        }
-    }
-
-    private fun render(conns: List<ConnectionSummary>) {
-        val satConns = conns.filter { it.kind == ConnectionKind.SATELLITE }
-        val discovered = satellite.discoveredServers.value
-        val knownIds = satConns.map { it.id }.toSet()
-        val list = binding.llSatelliteList
-        list.removeAllViews()
-        satConns.forEach { list.addView(satelliteRow(it)) }
-        for (s in discovered) {
-            val id = SatelliteConnection.idFor(s)
-            if (id !in knownIds) list.addView(discoveredSatelliteRow(s))
-        }
-        renderEmptyState()
-
-        val btConns = conns.filter { it.kind == ConnectionKind.BLUETOOTH }
-        binding.llBtList.removeAllViews()
-        btConns.forEach { binding.llBtList.addView(btRow(it)) }
-        binding.tvBtEmpty.visibility =
-            if (btConns.isEmpty()) View.VISIBLE else View.GONE
-    }
-
-    private fun renderEmptyState() {
-        val hasRows = binding.llSatelliteList.isNotEmpty()
-        if (hasRows) {
-            binding.tvSatelliteEmpty.visibility = View.GONE
+    private fun setupList() {
+        satelliteHeader =
+            SectionHeaderAdapter(
+                R.drawable.ic_satellite,
+                R.string.section_satellites,
+                R.string.action_scan,
+            ) { satellite.startDiscovery() }
+        bluetoothHeader =
+            SectionHeaderAdapter(
+                R.drawable.ic_bluetooth,
+                R.string.section_bluetooth_hosts,
+                R.string.action_add,
+            ) { requestBtPermissions(continueToAdd = true) }
+        satelliteList = SatelliteListAdapter(satelliteRowListener)
+        bluetoothList = BluetoothListAdapter(bluetoothRowListener)
+        val single = binding.rvConnections
+        if (single != null) {
+            single.bindConnectionColumn(
+                ConcatAdapter(
+                    satelliteHeader,
+                    satelliteList,
+                    StaticViewAdapter(R.layout.item_connection_divider),
+                    bluetoothHeader,
+                    bluetoothList,
+                ),
+            )
             return
         }
-        binding.tvSatelliteEmpty.visibility = View.VISIBLE
-        val lastScan = satellite.lastScanAtMs.value
-        binding.tvSatelliteEmpty.text =
-            if (lastScan == null) {
-                getString(R.string.discovery_empty_never_scanned)
-            } else {
-                val time = formatClock(lastScan)
-                getString(R.string.discovery_empty_no_results, time)
+        binding.rvSatellites?.bindConnectionColumn(ConcatAdapter(satelliteHeader, satelliteList))
+        binding.rvBluetooth?.bindConnectionColumn(ConcatAdapter(bluetoothHeader, bluetoothList))
+    }
+
+    private fun RecyclerView.bindConnectionColumn(concat: ConcatAdapter) {
+        layoutManager = LinearLayoutManager(this@ConnectionsActivity)
+        adapter = concat
+        setHasFixedSize(true)
+        (itemAnimator as? SimpleItemAnimator)?.supportsChangeAnimations = false
+    }
+
+    private fun render() {
+        val conns = hub.connections.value
+        renderSatellites(conns)
+        renderBluetooth(conns)
+    }
+
+    private fun renderSatellites(conns: List<ConnectionSummary>) {
+        val satConns = conns.filter { it.kind == ConnectionKind.SATELLITE }
+        val knownIds = satConns.mapTo(mutableSetOf()) { it.id }
+        val rows =
+            buildList {
+                satConns.forEach { add(SatelliteRow.Known(it)) }
+                satellite.discoveredServers.value.forEach { server ->
+                    if (SatelliteConnection.idFor(server) !in knownIds) add(SatelliteRow.Discovered(server))
+                }
             }
+        satelliteList.submitList(rows.ifEmpty { listOf(SatelliteRow.Empty(satelliteEmptyMessage())) })
+    }
+
+    private fun satelliteEmptyMessage(): String {
+        val lastScan = satellite.lastScanAtMs.value ?: return getString(R.string.discovery_empty_never_scanned)
+        return getString(R.string.discovery_empty_no_results, formatClock(lastScan))
+    }
+
+    private fun renderBluetooth(conns: List<ConnectionSummary>) {
+        val rows =
+            conns
+                .filter { it.kind == ConnectionKind.BLUETOOTH }
+                .map { c ->
+                    BluetoothRow.Item(
+                        BtRowUi(
+                            summary = c,
+                            connectingLabel = if (c.live == LinkState.Connecting) btConnectingLabel(c.id) else null,
+                            secondaryIsForget = store.rememberedBt().any { it.id == c.id },
+                        ),
+                    )
+                }
+        bluetoothList.submitList(rows.ifEmpty { listOf(BluetoothRow.Empty(getString(R.string.bt_hosts_empty))) })
+    }
+
+    private fun btConnectingLabel(id: String): String {
+        val state = btRegistry.state(id)
+        return when {
+            state.registered -> getString(R.string.bt_row_pair_from_host)
+            state.acquiring -> getString(R.string.bt_row_acquiring)
+            else -> getString(R.string.bt_row_waiting)
+        }
     }
 
     private fun formatClock(epochMs: Long): String {
@@ -363,125 +446,6 @@ class ConnectionsActivity : AppCompatActivity() {
             cal.get(java.util.Calendar.HOUR_OF_DAY),
             cal.get(java.util.Calendar.MINUTE),
         )
-    }
-
-    private fun satelliteRow(c: ConnectionSummary): View {
-        val rb =
-            inflateRow(
-                binding.llSatelliteList,
-                c.label,
-                c.detail,
-                statusChipText(this, c.live),
-                kind = ConnectionKind.SATELLITE,
-                state = c.live,
-            )
-        when (c.live) {
-            LinkState.Connected, LinkState.Unstable -> {
-                rb.btnRowAction.setLoading(loading = false, loadingText = "", restingText = getString(R.string.action_disconnect))
-                rb.btnRowAction.setOnClickListener { satellite.disconnect(c.id) }
-            }
-            LinkState.Connecting -> {
-                rb.btnRowAction.setLoading(
-                    loading = true,
-                    loadingText = getString(R.string.chip_status_connecting),
-                    restingText = getString(R.string.action_connect),
-                )
-                rb.btnRowAction.setOnClickListener(null)
-            }
-            LinkState.Stale -> {
-                rb.btnRowAction.setLoading(loading = false, loadingText = "", restingText = getString(R.string.action_repair_short))
-                rb.btnRowAction.setOnClickListener {
-                    val remembered =
-                        satellite.remembered().firstOrNull { it.id == c.id } ?: return@setOnClickListener
-                    showPairingDialog(remembered.toDiscovered())
-                }
-            }
-            LinkState.Saved, LinkState.Ready, LinkState.Found -> {
-                rb.btnRowAction.setLoading(loading = false, loadingText = "", restingText = getString(R.string.action_connect))
-                rb.btnRowAction.setOnClickListener {
-                    val remembered = satellite.remembered().firstOrNull { it.id == c.id } ?: return@setOnClickListener
-                    satellite.connect(remembered.toDiscovered())
-                }
-            }
-        }
-        rb.btnRowSecondary.visibility = View.VISIBLE
-        rb.btnRowSecondary.text = getString(R.string.action_forget_short)
-        rb.btnRowSecondary.setOnClickListener { hub.forgetConnection(c.id) }
-        return rb.root
-    }
-
-    private fun discoveredSatelliteRow(s: com.tinkernorth.dish.core.model.DiscoveredServer): View {
-        val rb =
-            inflateRow(
-                binding.llSatelliteList,
-                s.name.ifEmpty { s.ip },
-                getString(R.string.discovered_row_detail, s.ip, s.udpPort),
-                getString(R.string.discovered_row_status, getString(s.source.labelRes)),
-                kind = ConnectionKind.SATELLITE,
-                state = LinkState.Found,
-            )
-        rb.btnRowAction.setLoading(loading = false, loadingText = "", restingText = getString(R.string.action_connect))
-        rb.btnRowAction.setOnClickListener { satellite.connect(s) }
-        return rb.root
-    }
-
-    private fun btRow(c: ConnectionSummary): View {
-        val rb =
-            inflateRow(
-                binding.llBtList,
-                c.label,
-                c.detail,
-                statusChipText(this, c.live),
-                kind = ConnectionKind.BLUETOOTH,
-                state = c.live,
-            )
-        when (c.live) {
-            LinkState.Connected, LinkState.Unstable -> {
-                rb.btnRowAction.setLoading(loading = false, loadingText = "", restingText = getString(R.string.action_disconnect))
-                rb.btnRowAction.setOnClickListener { btRegistry.stop(c.id) }
-            }
-            LinkState.Connecting -> {
-                val state = btRegistry.state(c.id)
-                val label =
-                    when {
-                        state.registered -> getString(R.string.bt_row_pair_from_host)
-                        state.acquiring -> getString(R.string.bt_row_acquiring)
-                        else -> getString(R.string.bt_row_waiting)
-                    }
-                rb.btnRowAction.setLoading(
-                    loading = true,
-                    loadingText = label,
-                    restingText = getString(R.string.action_connect),
-                )
-                rb.btnRowAction.setOnClickListener(null)
-            }
-            LinkState.Stale -> {
-                rb.btnRowAction.setLoading(loading = false, loadingText = "", restingText = getString(R.string.action_repair_short))
-                rb.btnRowAction.setOnClickListener {
-                    val entry = store.rememberedBt().firstOrNull { it.id == c.id } ?: return@setOnClickListener
-                    openBluetoothDeviceDetails(entry.mac)
-                }
-            }
-            LinkState.Saved, LinkState.Ready, LinkState.Found -> {
-                rb.btnRowAction.setLoading(loading = false, loadingText = "", restingText = getString(R.string.action_connect))
-                rb.btnRowAction.setOnClickListener {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) btRegistry.tryAutoReconnect(c.id)
-                }
-            }
-        }
-        rb.btnRowSecondary.visibility = View.VISIBLE
-        val rememberedEntry = store.rememberedBt().firstOrNull { it.id == c.id }
-        val isRemembered = rememberedEntry != null
-        rb.btnRowSecondary.text = getString(if (isRemembered) R.string.action_forget_short else R.string.action_cancel)
-        rb.btnRowSecondary.setOnClickListener {
-            if (isRemembered) {
-                confirmForgetBt(c.id, rememberedEntry)
-            } else {
-                btRegistry.stop(c.id)
-                render(hub.connections.value)
-            }
-        }
-        return rb.root
     }
 
     private fun confirmForgetBt(
@@ -503,7 +467,7 @@ class ConnectionsActivity : AppCompatActivity() {
     private fun commitForgetBt(id: String) {
         btRegistry.stop(id)
         hub.forgetConnection(id)
-        render(hub.connections.value)
+        render()
     }
 
     private fun openBluetoothDeviceDetails(mac: String) {
@@ -519,23 +483,6 @@ class ConnectionsActivity : AppCompatActivity() {
             }
         runCatching { startActivity(deepLink) }
             .onFailure { startActivity(fallback) }
-    }
-
-    private fun inflateRow(
-        parent: ViewGroup,
-        title: String,
-        detail: String,
-        status: String,
-        kind: ConnectionKind,
-        state: LinkState,
-    ): RowConnectionBinding {
-        val rb = RowConnectionBinding.inflate(layoutInflater, parent, false)
-        rb.tvRowTitle.text = title
-        rb.tvRowDetail.text = detail
-        rb.tvRowStatus.text = status
-        (rb.dotRow.background as GradientDrawable).setColor(getColor(dotColorForState(state)))
-        rb.ivRowGlyph.setImageResource(glyphForConnection(kind, state))
-        return rb
     }
 
     private fun requestBtPermissions(continueToAdd: Boolean) {

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
@@ -32,7 +32,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import com.tinkernorth.dish.R
-import com.tinkernorth.dish.composer.ConnectionHub
+import com.tinkernorth.dish.composer.ConnectionCoordinator
 import com.tinkernorth.dish.composer.ConnectionKind
 import com.tinkernorth.dish.composer.ConnectionSummary
 import com.tinkernorth.dish.composer.LinkState
@@ -84,7 +84,7 @@ class ConnectionsActivity : AppCompatActivity() {
 
     @Inject lateinit var btScanner: BluetoothDeviceScanner
 
-    @Inject lateinit var hub: ConnectionHub
+    @Inject lateinit var hub: ConnectionCoordinator
 
     @Inject lateinit var store: com.tinkernorth.dish.repository.ConnectionStore
 

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
@@ -406,7 +406,7 @@ class ConnectionsActivity : AppCompatActivity() {
         }
         rb.btnRowSecondary.visibility = View.VISIBLE
         rb.btnRowSecondary.text = getString(R.string.action_forget_short)
-        rb.btnRowSecondary.setOnClickListener { satellite.forget(c.id) }
+        rb.btnRowSecondary.setOnClickListener { hub.forgetConnection(c.id) }
         return rb.root
     }
 
@@ -502,7 +502,7 @@ class ConnectionsActivity : AppCompatActivity() {
 
     private fun commitForgetBt(id: String) {
         btRegistry.stop(id)
-        store.forgetBt(id)
+        hub.forgetConnection(id)
         render(hub.connections.value)
     }
 

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/SatelliteListAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/SatelliteListAdapter.kt
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.connections
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.tinkernorth.dish.R
+import com.tinkernorth.dish.composer.ConnectionKind
+import com.tinkernorth.dish.composer.ConnectionSummary
+import com.tinkernorth.dish.composer.LinkState
+import com.tinkernorth.dish.core.model.DiscoveredServer
+import com.tinkernorth.dish.databinding.RowConnectionBinding
+import com.tinkernorth.dish.source.connection.SatelliteConnection
+import com.tinkernorth.dish.ui.common.setLoading
+import com.tinkernorth.dish.ui.common.statusChipText
+
+sealed interface SatelliteRow {
+    data class Known(
+        val summary: ConnectionSummary,
+    ) : SatelliteRow
+
+    data class Discovered(
+        val server: DiscoveredServer,
+    ) : SatelliteRow
+
+    data class Empty(
+        val message: String,
+    ) : SatelliteRow
+}
+
+interface SatelliteRowListener {
+    fun onConnect(row: SatelliteRow)
+
+    fun onDisconnect(id: String)
+
+    fun onRepair(id: String)
+
+    fun onForget(id: String)
+}
+
+class SatelliteListAdapter(
+    private val listener: SatelliteRowListener,
+) : ListAdapter<SatelliteRow, RecyclerView.ViewHolder>(Diff) {
+    override fun getItemViewType(position: Int): Int = if (getItem(position) is SatelliteRow.Empty) TYPE_EMPTY else TYPE_ROW
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): RecyclerView.ViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return if (viewType == TYPE_EMPTY) {
+            EmptyVH(inflater.inflate(R.layout.item_connection_empty, parent, false))
+        } else {
+            RowVH(RowConnectionBinding.inflate(inflater, parent, false), listener)
+        }
+    }
+
+    override fun onBindViewHolder(
+        holder: RecyclerView.ViewHolder,
+        position: Int,
+    ) {
+        when (val row = getItem(position)) {
+            is SatelliteRow.Empty -> (holder as EmptyVH).bind(row.message)
+            else -> (holder as RowVH).bind(row)
+        }
+    }
+
+    class EmptyVH(
+        view: View,
+    ) : RecyclerView.ViewHolder(view) {
+        fun bind(message: String) {
+            (itemView as TextView).text = message
+        }
+    }
+
+    class RowVH(
+        private val b: RowConnectionBinding,
+        private val listener: SatelliteRowListener,
+    ) : RecyclerView.ViewHolder(b.root) {
+        private val ctx get() = b.root.context
+
+        fun bind(row: SatelliteRow) {
+            when (row) {
+                is SatelliteRow.Known -> bindKnown(row)
+                is SatelliteRow.Discovered -> bindDiscovered(row)
+                is SatelliteRow.Empty -> Unit
+            }
+        }
+
+        private fun bindKnown(row: SatelliteRow.Known) {
+            val c = row.summary
+            b.paintConnection(c.label, c.detail, statusChipText(ctx, c.live), ConnectionKind.SATELLITE, c.live)
+            when (c.live) {
+                LinkState.Connected, LinkState.Unstable -> {
+                    b.btnRowAction.setLoading(false, "", ctx.getString(R.string.action_disconnect))
+                    b.btnRowAction.setOnClickListener { listener.onDisconnect(c.id) }
+                }
+                LinkState.Connecting -> {
+                    b.btnRowAction.setLoading(
+                        true,
+                        ctx.getString(R.string.chip_status_connecting),
+                        ctx.getString(R.string.action_connect),
+                    )
+                    b.btnRowAction.setOnClickListener(null)
+                }
+                LinkState.Stale -> {
+                    b.btnRowAction.setLoading(false, "", ctx.getString(R.string.action_repair_short))
+                    b.btnRowAction.setOnClickListener { listener.onRepair(c.id) }
+                }
+                LinkState.Saved, LinkState.Ready, LinkState.Found -> {
+                    b.btnRowAction.setLoading(false, "", ctx.getString(R.string.action_connect))
+                    b.btnRowAction.setOnClickListener { listener.onConnect(row) }
+                }
+            }
+            b.btnRowSecondary.visibility = View.VISIBLE
+            b.btnRowSecondary.text = ctx.getString(R.string.action_forget_short)
+            b.btnRowSecondary.setOnClickListener { listener.onForget(c.id) }
+        }
+
+        private fun bindDiscovered(row: SatelliteRow.Discovered) {
+            val s = row.server
+            b.paintConnection(
+                s.name.ifEmpty { s.ip },
+                ctx.getString(R.string.discovered_row_detail, s.ip, s.udpPort),
+                ctx.getString(R.string.discovered_row_status, ctx.getString(s.source.labelRes)),
+                ConnectionKind.SATELLITE,
+                LinkState.Found,
+            )
+            b.btnRowAction.setLoading(false, "", ctx.getString(R.string.action_connect))
+            b.btnRowAction.setOnClickListener { listener.onConnect(row) }
+            b.btnRowSecondary.visibility = View.GONE
+            b.btnRowSecondary.setOnClickListener(null)
+        }
+    }
+
+    companion object {
+        private const val TYPE_ROW = 0
+        private const val TYPE_EMPTY = 1
+
+        private val Diff =
+            object : DiffUtil.ItemCallback<SatelliteRow>() {
+                override fun areItemsTheSame(
+                    o: SatelliteRow,
+                    n: SatelliteRow,
+                ): Boolean =
+                    when {
+                        o is SatelliteRow.Known && n is SatelliteRow.Known -> o.summary.id == n.summary.id
+                        o is SatelliteRow.Discovered && n is SatelliteRow.Discovered ->
+                            SatelliteConnection.idFor(o.server) == SatelliteConnection.idFor(n.server)
+                        o is SatelliteRow.Empty && n is SatelliteRow.Empty -> true
+                        else -> false
+                    }
+
+                override fun areContentsTheSame(
+                    o: SatelliteRow,
+                    n: SatelliteRow,
+                ): Boolean = o == n
+            }
+    }
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/SectionHeaderAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/SectionHeaderAdapter.kt
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.connections
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.core.view.updateLayoutParams
+import androidx.recyclerview.widget.RecyclerView
+import com.tinkernorth.dish.R
+import com.tinkernorth.dish.databinding.SectionHeaderBinding
+import com.tinkernorth.dish.ui.common.setLoading
+
+class SectionHeaderAdapter(
+    @DrawableRes private val icon: Int,
+    @StringRes private val label: Int,
+    @StringRes private val actionLabel: Int,
+    private val onAction: () -> Unit,
+) : RecyclerView.Adapter<SectionHeaderAdapter.VH>() {
+    private var loading = false
+    private var loadingText = ""
+
+    fun setLoading(
+        loading: Boolean,
+        loadingText: String,
+    ) {
+        if (this.loading == loading && this.loadingText == loadingText) return
+        this.loading = loading
+        this.loadingText = loadingText
+        notifyItemChanged(0)
+    }
+
+    class VH(
+        val binding: SectionHeaderBinding,
+    ) : RecyclerView.ViewHolder(binding.root)
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): VH {
+        val binding = SectionHeaderBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        binding.root.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+            bottomMargin = parent.resources.getDimensionPixelSize(R.dimen.spacing_md)
+        }
+        return VH(binding)
+    }
+
+    override fun onBindViewHolder(
+        holder: VH,
+        position: Int,
+    ) {
+        val b = holder.binding
+        b.iconSection.visibility = View.VISIBLE
+        b.iconSection.setImageResource(icon)
+        b.labelSection.setText(label)
+        b.btnSectionAction.visibility = View.VISIBLE
+        b.btnSectionAction.setLoading(loading, loadingText, b.root.context.getString(actionLabel))
+        b.btnSectionAction.setOnClickListener { onAction() }
+    }
+
+    override fun getItemCount(): Int = 1
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/BaseInputOverlayActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/BaseInputOverlayActivity.kt
@@ -19,7 +19,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.tinkernorth.dish.R
-import com.tinkernorth.dish.composer.ConnectionHub
+import com.tinkernorth.dish.composer.ConnectionCoordinator
 import com.tinkernorth.dish.composer.ConnectionSummary
 import com.tinkernorth.dish.composer.WakeStateController
 import com.tinkernorth.dish.core.model.DishNotification
@@ -41,7 +41,7 @@ import javax.inject.Inject
 import kotlin.math.max
 
 abstract class BaseInputOverlayActivity : AppCompatActivity() {
-    @Inject lateinit var hub: ConnectionHub
+    @Inject lateinit var hub: ConnectionCoordinator
 
     @Inject lateinit var satellite: SatelliteConnectionManager
 

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsViewModel.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.composer.CONTROLLER_TYPE_PLAYSTATION
 import com.tinkernorth.dish.composer.CONTROLLER_TYPE_XBOX
-import com.tinkernorth.dish.composer.ConnectionHub
+import com.tinkernorth.dish.composer.ConnectionCoordinator
 import com.tinkernorth.dish.composer.ConnectionKind
 import com.tinkernorth.dish.composer.LinkState
 import com.tinkernorth.dish.composer.MotionCapabilityComposer
@@ -118,7 +118,7 @@ class ConfigureBindingsViewModel
     @Inject
     constructor(
         @ApplicationContext private val context: Context,
-        private val hub: ConnectionHub,
+        private val hub: ConnectionCoordinator,
         private val gamepadRegistry: PhysicalGamepadRegistry,
         private val motionEnabledStore: MotionEnabledStore,
         private val motionCapability: MotionCapabilityComposer,
@@ -337,18 +337,6 @@ class ConfigureBindingsViewModel
                 else ->
                     context.getString(R.string.touchpad_mode_error_unknown, err ?: reply)
             }
-        }
-
-        private fun extractJsonErrorField(json: String): String? {
-            val keyIdx = json.indexOf("\"error\"")
-            if (keyIdx < 0) return null
-            val colon = json.indexOf(':', startIndex = keyIdx + "\"error\"".length)
-            if (colon < 0) return null
-            val openQuote = json.indexOf('"', startIndex = colon + 1)
-            if (openQuote < 0) return null
-            val closeQuote = json.indexOf('"', startIndex = openQuote + 1)
-            if (closeQuote < 0) return null
-            return json.substring(openQuote + 1, closeQuote)
         }
 
         private fun buildSnapshot(slotId: String): BindingSnapshot {

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
@@ -7,6 +7,7 @@ import android.content.res.ColorStateList
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.recyclerview.widget.DiffUtil
@@ -21,6 +22,7 @@ import com.tinkernorth.dish.composer.ConnectionSummary
 import com.tinkernorth.dish.composer.LinkState
 import com.tinkernorth.dish.composer.MotionCapability
 import com.tinkernorth.dish.databinding.BindingDecisionRowBinding
+import com.tinkernorth.dish.databinding.BindingPillBinding
 import com.tinkernorth.dish.databinding.BindingValueMonoBinding
 import com.tinkernorth.dish.databinding.BindingValueNoneBinding
 import com.tinkernorth.dish.databinding.BindingValueNotBoundBinding
@@ -98,6 +100,40 @@ class ControllerAdapter(
         private val ctx: Context get() = b.root.context
         private val inflater: LayoutInflater get() = LayoutInflater.from(ctx)
 
+        private val connectionRow = decisionRow(R.string.binding_label_connection)
+        private val destinationRow = decisionRow(R.string.binding_label_destination)
+        private val emulateRow = decisionRow(R.string.binding_label_emulate)
+        private val functionRow = decisionRow(null)
+
+        private val connectionPills = PillPool(connectionRow.valueContainer)
+        private val emulatePills = PillPool(emulateRow.valueContainer)
+        private val functionPills = PillPool(functionRow.valueContainer)
+
+        private val destinationMono = BindingValueMonoBinding.inflate(inflater, destinationRow.valueContainer, true)
+        private val destinationNotBound = BindingValueNotBoundBinding.inflate(inflater, destinationRow.valueContainer, true)
+        private val functionNone = BindingValueNoneBinding.inflate(inflater, functionRow.valueContainer, true)
+
+        private val filledActions =
+            List(MAX_FILLED_ACTIONS) {
+                inflater.inflate(R.layout.binding_action_button, b.llActions, false) as MaterialButton
+            }
+        private val outlinedAction =
+            inflater.inflate(R.layout.binding_action_button_outlined, b.llActions, false) as MaterialButton
+
+        init {
+            listOf(connectionRow, destinationRow, emulateRow, functionRow).forEach { b.llDecisions.addView(it.root) }
+            filledActions.forEach { b.llActions.addView(it) }
+            b.llActions.addView(outlinedAction)
+        }
+
+        private fun decisionRow(
+            @StringRes labelRes: Int?,
+        ): BindingDecisionRowBinding {
+            val row = BindingDecisionRowBinding.inflate(inflater, b.llDecisions, false)
+            if (labelRes != null) row.tvRowLabel.setText(labelRes) else row.tvRowLabel.visibility = View.GONE
+            return row
+        }
+
         fun bind(row: Row) {
             val slot = row.slot
             val isVirtual = slot.inputType == SlotInputType.VIRTUAL
@@ -113,52 +149,62 @@ class ControllerAdapter(
                 edge != EdgeState.NONE && !(edge == EdgeState.UNSTEADY && slot.id in dismissedUnsteady)
             b.root.alpha = if (!showEdge && slot.isDisconnecting) 0.5f else 1f
 
-            b.llDecisions.removeAllViews()
-            b.llActions.removeAllViews()
-
             if (slot.boundStatus == null || slot.boundConnectionId == null) {
-                buildUnboundDecisions(row)
+                bindUnbound(row)
             } else {
-                buildBoundDecisions(row, slot.boundStatus)
+                bindBound(row, slot.boundStatus)
             }
-            buildActions(row)
+            bindActions(row)
             bindEdge(if (showEdge) edge else EdgeState.NONE, row)
         }
 
-        private fun buildBoundDecisions(
+        private fun bindBound(
             row: Row,
             bound: ConnectionSummary,
         ) {
-            addDecisionRow(R.string.binding_label_connection) { c -> connectionPills(c, row, bound.kind) }
-            addDecisionRow(R.string.binding_label_destination) { c -> c.addView(monoValue(c, bound.label)) }
-            typePillLabel(row, bound)?.let { label ->
-                addDecisionRow(R.string.binding_label_emulate) { c -> c.addView(c.inflateBindingPill(label, null, PillTone.FACT)) }
+            connectionRow.root.visibility = View.VISIBLE
+            connectionPills.bind(connectionSpecs(row, bound.kind))
+
+            destinationRow.root.visibility = View.VISIBLE
+            showDestination(bound.label)
+
+            val emulate = typePillLabel(row, bound)
+            if (emulate != null) {
+                emulateRow.root.visibility = View.VISIBLE
+                emulatePills.bind(listOf(PillSpec(emulate, null, PillTone.FACT)))
+            } else {
+                emulateRow.root.visibility = View.GONE
             }
-            // Function chips render label-less (full-width row), so pass no row label.
-            addDecisionRow(null) { c -> functionPills(c, row, bound) }
+
+            functionRow.root.visibility = View.VISIBLE
+            bindFunctionPills(functionSpecs(row, bound))
         }
 
-        private fun buildUnboundDecisions(row: Row) {
+        private fun bindUnbound(row: Row) {
             // Unbound shows the connection without a mode chip; Direct/Standard is only chosen at bind time.
-            addDecisionRow(R.string.binding_label_connection) { c -> connectionPills(c, row, null) }
-            addDecisionRow(R.string.binding_label_destination) { c -> c.addView(notBoundValue(c)) }
+            connectionRow.root.visibility = View.VISIBLE
+            connectionPills.bind(connectionSpecs(row, kind = null))
+            destinationRow.root.visibility = View.VISIBLE
+            showDestination(null)
+            emulateRow.root.visibility = View.GONE
+            functionRow.root.visibility = View.GONE
         }
 
-        private fun addDecisionRow(
-            labelRes: Int?,
-            buildValues: (ViewGroup) -> Unit,
-        ) {
-            val rowB = BindingDecisionRowBinding.inflate(inflater, b.llDecisions, false)
-            if (labelRes != null) rowB.tvRowLabel.setText(labelRes) else rowB.tvRowLabel.visibility = View.GONE
-            buildValues(rowB.valueContainer)
-            b.llDecisions.addView(rowB.root)
+        private fun showDestination(monoText: String?) {
+            if (monoText != null) {
+                destinationMono.root.text = monoText
+                destinationMono.root.visibility = View.VISIBLE
+                destinationNotBound.root.visibility = View.GONE
+            } else {
+                destinationMono.root.visibility = View.GONE
+                destinationNotBound.root.visibility = View.VISIBLE
+            }
         }
 
-        private fun connectionPills(
-            container: ViewGroup,
+        private fun connectionSpecs(
             row: Row,
             kind: ConnectionKind?,
-        ) {
+        ): List<PillSpec> {
             val card = row.pathCard
             val virtual = row.slot.inputType == SlotInputType.VIRTUAL
             val isUsb = !virtual && card?.transport == Transport.Usb
@@ -169,31 +215,19 @@ class ControllerAdapter(
                     isBt -> R.string.binding_link_bluetooth to R.drawable.ic_bluetooth
                     else -> R.string.binding_link_usb to R.drawable.ic_usb
                 }
-            addPill(container, label, icon, PillTone.FACT)
+            val specs = mutableListOf(PillSpec(ctx.getString(label), icon, PillTone.FACT))
             // The Direct/Standard mode chip only applies once a USB controller is on a known path.
-            if (isUsb && kind != null && card != null) addUsbModePill(container, card)
+            if (isUsb && kind != null && card != null) specs.add(usbModeSpec(card))
+            return specs
         }
 
-        private fun addPill(
-            container: ViewGroup,
-            @StringRes label: Int,
-            @DrawableRes icon: Int,
-            tone: PillTone,
-        ) {
-            container.addView(container.inflateBindingPill(ctx.getString(label), icon, tone))
-        }
-
-        private fun addUsbModePill(
-            container: ViewGroup,
-            card: PathCard,
-        ) {
+        private fun usbModeSpec(card: PathCard): PillSpec =
             if (card.currentMode == InputPathMode.Direct) {
                 val tone = if (card.risk == PathRisk.GuessedLayout) PillTone.WARN else PillTone.ON
-                addPill(container, R.string.binding_mode_direct, R.drawable.ic_bolt, tone)
+                PillSpec(ctx.getString(R.string.binding_mode_direct), R.drawable.ic_bolt, tone)
             } else {
-                addPill(container, R.string.binding_mode_standard, R.drawable.ic_cable, PillTone.CAP)
+                PillSpec(ctx.getString(R.string.binding_mode_standard), R.drawable.ic_cable, PillTone.CAP)
             }
-        }
 
         private fun typePillLabel(
             row: Row,
@@ -207,26 +241,29 @@ class ControllerAdapter(
                 ConnectionKind.BLUETOOTH -> bound.btProfile
             }
 
+        private fun bindFunctionPills(specs: List<PillSpec>) {
+            if (specs.isEmpty()) {
+                functionPills.hideAll()
+                functionNone.root.visibility = View.VISIBLE
+            } else {
+                functionNone.root.visibility = View.GONE
+                functionPills.bind(specs)
+            }
+        }
+
         // Reports the configured (not live-gated) routing: motion only carries on a Satellite host
         // emulating PlayStation; touchpad only on a Satellite host.
-        private fun functionPills(
-            container: ViewGroup,
+        private fun functionSpecs(
             row: Row,
             bound: ConnectionSummary,
-        ) {
-            val before = container.childCount
+        ): List<PillSpec> {
+            val specs = mutableListOf<PillSpec>()
             val card = row.pathCard
             val rumblePresent =
                 card != null &&
                     (if (card.currentMode == InputPathMode.Direct) card.direct.rumble else card.standard.rumble)
             if (rumblePresent) {
-                container.addView(
-                    container.inflateBindingPill(
-                        funcValue(R.string.binding_func_rumble, R.string.binding_state_on),
-                        R.drawable.ic_rumble,
-                        PillTone.ON,
-                    ),
-                )
+                specs.add(PillSpec(funcValue(R.string.binding_func_rumble, R.string.binding_state_on), R.drawable.ic_rumble, PillTone.ON))
             }
 
             val type = bound.satelliteControllerTypes[row.slot.id] ?: CONTROLLER_TYPE_XBOX
@@ -238,7 +275,7 @@ class ControllerAdapter(
                 val on = row.motionCap.userEnabled
                 val state = if (on) R.string.binding_state_on else R.string.binding_state_off
                 val tone = if (on) PillTone.ON else PillTone.OFF
-                container.addView(container.inflateBindingPill(funcValue(R.string.binding_func_motion, state), R.drawable.ic_motion, tone))
+                specs.add(PillSpec(funcValue(R.string.binding_func_motion, state), R.drawable.ic_motion, tone))
             }
 
             if (bound.kind == ConnectionKind.SATELLITE) {
@@ -257,10 +294,9 @@ class ControllerAdapter(
                     )
                 val icon = if (mode == TouchpadModeValue.MOUSE) R.drawable.ic_mouse else R.drawable.ic_touchpad
                 val tone = if (mode == TouchpadModeValue.OFF) PillTone.OFF else PillTone.ON
-                container.addView(container.inflateBindingPill(label, icon, tone))
+                specs.add(PillSpec(label, icon, tone))
             }
-
-            if (container.childCount == before) container.addView(noneValue(container))
+            return specs
         }
 
         private fun funcValue(
@@ -268,25 +304,25 @@ class ControllerAdapter(
             valueRes: Int,
         ): String = ctx.getString(R.string.binding_func_value, ctx.getString(nameRes), ctx.getString(valueRes))
 
-        private fun monoValue(
-            parent: ViewGroup,
-            text: String,
-        ): View {
-            val mono = BindingValueMonoBinding.inflate(inflater, parent, false)
-            mono.root.text = text
-            return mono.root
+        private fun bindActions(row: Row) {
+            val actions = computeActions(row)
+            filledActions.forEach { it.visibility = View.GONE }
+            outlinedAction.visibility = View.GONE
+            var filledIndex = 0
+            for (action in actions) {
+                val btn = if (action.outlined) outlinedAction else filledActions[filledIndex++]
+                btn.visibility = View.VISIBLE
+                btn.text = action.label
+                btn.setIconResource(action.icon)
+                btn.setOnClickListener { dispatch(action.kind, row.slot.id) }
+            }
         }
 
-        private fun notBoundValue(parent: ViewGroup): View = BindingValueNotBoundBinding.inflate(inflater, parent, false).root
-
-        private fun noneValue(parent: ViewGroup): View = BindingValueNoneBinding.inflate(inflater, parent, false).root
-
-        private fun buildActions(row: Row) {
+        private fun computeActions(row: Row): List<CardAction> {
             val slot = row.slot
-            val actions = mutableListOf<CardAction>()
             val bound = slot.boundStatus
             if (bound == null || slot.boundConnectionId == null) {
-                actions +=
+                return listOf(
                     if (row.connections.isEmpty()) {
                         CardAction(
                             R.drawable.ic_satellite,
@@ -301,45 +337,38 @@ class ControllerAdapter(
                             outlined = true,
                             kind = ActionKind.CONFIGURE,
                         )
-                    }
-            } else {
-                val connected = bound.live == LinkState.Connected
-                if (slot.inputType == SlotInputType.VIRTUAL && connected) {
-                    actions +=
-                        CardAction(
-                            R.drawable.ic_open_gamepad,
-                            ctx.getString(R.string.action_open_gamepad),
-                            outlined = false,
-                            kind = ActionKind.GAMEPAD,
-                        )
-                }
-                val touchpadMode = row.touchpadModes[slot.boundConnectionId] ?: TouchpadModeValue.OFF
-                if (bound.kind == ConnectionKind.SATELLITE && connected && touchpadMode != TouchpadModeValue.OFF) {
-                    actions +=
-                        CardAction(
-                            R.drawable.ic_open_touchpad,
-                            ctx.getString(R.string.action_open_touchpad),
-                            outlined = false,
-                            kind = ActionKind.TOUCHPAD,
-                        )
-                }
+                    },
+                )
+            }
+            val actions = mutableListOf<CardAction>()
+            val connected = bound.live == LinkState.Connected
+            if (slot.inputType == SlotInputType.VIRTUAL && connected) {
                 actions +=
                     CardAction(
-                        R.drawable.ic_tune,
-                        ctx.getString(R.string.binding_action_configure),
-                        outlined = true,
-                        kind = ActionKind.CONFIGURE,
+                        R.drawable.ic_open_gamepad,
+                        ctx.getString(R.string.action_open_gamepad),
+                        outlined = false,
+                        kind = ActionKind.GAMEPAD,
                     )
             }
-
-            for (action in actions) {
-                val layoutRes = if (action.outlined) R.layout.binding_action_button_outlined else R.layout.binding_action_button
-                val btn = inflater.inflate(layoutRes, b.llActions, false) as MaterialButton
-                btn.text = action.label
-                btn.setIconResource(action.icon)
-                btn.setOnClickListener { dispatch(action.kind, slot.id) }
-                b.llActions.addView(btn)
+            val touchpadMode = row.touchpadModes[slot.boundConnectionId] ?: TouchpadModeValue.OFF
+            if (bound.kind == ConnectionKind.SATELLITE && connected && touchpadMode != TouchpadModeValue.OFF) {
+                actions +=
+                    CardAction(
+                        R.drawable.ic_open_touchpad,
+                        ctx.getString(R.string.action_open_touchpad),
+                        outlined = false,
+                        kind = ActionKind.TOUCHPAD,
+                    )
             }
+            actions +=
+                CardAction(
+                    R.drawable.ic_tune,
+                    ctx.getString(R.string.binding_action_configure),
+                    outlined = true,
+                    kind = ActionKind.CONFIGURE,
+                )
+            return actions
         }
 
         private fun dispatch(
@@ -479,5 +508,34 @@ class ControllerAdapter(
             o: Row,
             n: Row,
         ) = o == n
+    }
+}
+
+private const val MAX_FILLED_ACTIONS = 2
+
+private class PillPool(
+    private val container: LinearLayout,
+) {
+    private val pills = mutableListOf<BindingPillBinding>()
+
+    fun bind(specs: List<PillSpec>) {
+        specs.forEachIndexed { i, spec ->
+            obtain(i).also { pill ->
+                pill.bindPill(spec)
+                pill.root.visibility = View.VISIBLE
+            }
+        }
+        for (i in specs.size until pills.size) pills[i].root.visibility = View.GONE
+    }
+
+    fun hideAll() {
+        for (pill in pills) pill.root.visibility = View.GONE
+    }
+
+    private fun obtain(index: Int): BindingPillBinding {
+        while (pills.size <= index) {
+            pills.add(BindingPillBinding.inflate(LayoutInflater.from(container.context), container, true))
+        }
+        return pills[index]
     }
 }

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
@@ -250,31 +250,8 @@ class GamepadOverlayActivity :
         MenuItemCompat.setIconTintList(item, ColorStateList.valueOf(getColor(state.dotColorRes)))
     }
 
-    private fun motionStateOf(paint: OverlayMotionPaint): MotionIndicatorState {
-        val summary = paint.summary
-        // A null summary (connection not resolved yet) is treated as motion-capable but
-        // not-yet-connected: PAUSED is rendered until the kind + liveness resolve, then the next
-        // paint self-corrects.
-        val carriesMotion = summary?.kind != ConnectionKind.BLUETOOTH
-        val connected = summary?.live == LinkState.Connected
-        val cap = paint.capability
-        val sourceState = paint.sourceState
-        val isAvailable = sourceState != MotionStreamState.Disabled
-        val isStreaming =
-            sourceState == MotionStreamState.Streaming ||
-                sourceState == MotionStreamState.Stalled
-        val isStalled = sourceState == MotionStreamState.Stalled
-        return MotionIndicatorState.of(
-            isAvailable = isAvailable,
-            isStreaming = isStreaming,
-            connectionCarriesMotion = carriesMotion,
-            connectionConnected = connected,
-            userEnabled = cap.userEnabled,
-            hostHasSinkForType = cap.hostHasSinkForType,
-            satelliteBackendOk = cap.satelliteBackendStatus?.backendOk,
-            isStalled = isStalled,
-        )
-    }
+    private fun motionStateOf(paint: OverlayMotionPaint): MotionIndicatorState =
+        motionIndicatorFor(paint.summary, paint.capability, paint.sourceState)
 
     private fun showMotionDialog() {
         val state = currentMotionState ?: currentPaint?.let(::motionStateOf) ?: return

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
@@ -128,6 +128,7 @@ class MainActivity :
         binding.sectionControllers.labelSection.setText(R.string.section_controllers)
         binding.ivConnectionsLoading.setImageDrawable(connectionsSpinner)
         binding.rvControllers.adapter = controllerAdapter
+        binding.rvControllers.setHasFixedSize(true)
         (binding.rvControllers.itemAnimator as? androidx.recyclerview.widget.SimpleItemAnimator)
             ?.supportsChangeAnimations = false
         binding.btnManageConnections.setOnClickListener { nav.toConnections() }

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
@@ -14,7 +14,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.google.androidgamesdk.GameActivity
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.composer.CONTROLLER_TYPE_PLAYSTATION
-import com.tinkernorth.dish.composer.ConnectionHub
+import com.tinkernorth.dish.composer.ConnectionCoordinator
 import com.tinkernorth.dish.composer.WakeStateController
 import com.tinkernorth.dish.core.model.DishNotification
 import com.tinkernorth.dish.databinding.ActivityMainBinding
@@ -46,7 +46,7 @@ class MainActivity :
 
     @Inject lateinit var satellite: SatelliteConnectionManager
 
-    @Inject lateinit var hub: ConnectionHub
+    @Inject lateinit var hub: ConnectionCoordinator
 
     @Inject lateinit var wakeState: WakeStateController
 

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
@@ -6,7 +6,7 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tinkernorth.dish.R
-import com.tinkernorth.dish.composer.ConnectionHub
+import com.tinkernorth.dish.composer.ConnectionCoordinator
 import com.tinkernorth.dish.composer.ConnectionKind
 import com.tinkernorth.dish.composer.ConnectionSummary
 import com.tinkernorth.dish.composer.MotionCapability
@@ -45,7 +45,7 @@ class MainViewModel
     constructor(
         @ApplicationContext private val context: Context,
         val satellite: SatelliteConnectionManager,
-        val hub: ConnectionHub,
+        val hub: ConnectionCoordinator,
         private val gamepadRegistry: PhysicalGamepadRegistry,
         private val batteryStatusStore: BatteryStatusStore,
         private val motionEnabledStore: MotionEnabledStore,
@@ -228,19 +228,6 @@ class MainViewModel
             }
         }
 
-        // Avoids a JSON dep; server always emits `{"error":"…"}` as first key with no nesting/escapes.
-        private fun extractJsonErrorField(json: String): String? {
-            val keyIdx = json.indexOf("\"error\"")
-            if (keyIdx < 0) return null
-            val colon = json.indexOf(':', startIndex = keyIdx + "\"error\"".length)
-            if (colon < 0) return null
-            val openQuote = json.indexOf('"', startIndex = colon + 1)
-            if (openQuote < 0) return null
-            val closeQuote = json.indexOf('"', startIndex = openQuote + 1)
-            if (closeQuote < 0) return null
-            return json.substring(openQuote + 1, closeQuote)
-        }
-
         private fun pathCardFor(
             slot: ControllerSlot,
             devices: Map<Int, PhysicalGamepadRegistry.Device>,
@@ -306,3 +293,17 @@ class MainViewModel
             val ASSUMED_SUPPORTED_TOUCHPAD_MODES: Set<String> = TouchpadModeValue.ALL.toSet()
         }
     }
+
+// Avoids a JSON dep; server always emits `{"error":"…"}` as first key with no nesting/escapes.
+// Shared by MainViewModel and ConfigureBindingsViewModel so the two touchpad-error mappers parse identically.
+fun extractJsonErrorField(json: String): String? {
+    val keyIdx = json.indexOf("\"error\"")
+    if (keyIdx < 0) return null
+    val colon = json.indexOf(':', startIndex = keyIdx + "\"error\"".length)
+    if (colon < 0) return null
+    val openQuote = json.indexOf('"', startIndex = colon + 1)
+    if (openQuote < 0) return null
+    val closeQuote = json.indexOf('"', startIndex = openQuote + 1)
+    if (closeQuote < 0) return null
+    return json.substring(openQuote + 1, closeQuote)
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MotionIndicatorState.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MotionIndicatorState.kt
@@ -5,6 +5,11 @@ package com.tinkernorth.dish.ui.main
 import androidx.annotation.ColorRes
 import androidx.annotation.StringRes
 import com.tinkernorth.dish.R
+import com.tinkernorth.dish.composer.ConnectionKind
+import com.tinkernorth.dish.composer.ConnectionSummary
+import com.tinkernorth.dish.composer.LinkState
+import com.tinkernorth.dish.composer.MotionCapability
+import com.tinkernorth.dish.source.sensor.MotionStreamState
 
 enum class MotionIndicatorState(
     @param:StringRes val labelRes: Int,
@@ -53,4 +58,36 @@ enum class MotionIndicatorState(
                 else -> PAUSED
             }
     }
+}
+
+/**
+ * Translate the three live overlay inputs into the boolean flags of
+ * [MotionIndicatorState.of]. Pure so the toolbar-paint decision is testable
+ * outside the Activity.
+ */
+fun motionIndicatorFor(
+    summary: ConnectionSummary?,
+    capability: MotionCapability,
+    source: MotionStreamState,
+): MotionIndicatorState {
+    // A null summary (connection not resolved yet) is treated as motion-capable but
+    // not-yet-connected: PAUSED is rendered until the kind + liveness resolve, then the next
+    // paint self-corrects.
+    val carriesMotion = summary?.kind != ConnectionKind.BLUETOOTH
+    val connected = summary?.live == LinkState.Connected
+    val isAvailable = source != MotionStreamState.Disabled
+    val isStreaming =
+        source == MotionStreamState.Streaming ||
+            source == MotionStreamState.Stalled
+    val isStalled = source == MotionStreamState.Stalled
+    return MotionIndicatorState.of(
+        isAvailable = isAvailable,
+        isStreaming = isStreaming,
+        connectionCarriesMotion = carriesMotion,
+        connectionConnected = connected,
+        userEnabled = capability.userEnabled,
+        hostHasSinkForType = capability.hostHasSinkForType,
+        satelliteBackendOk = capability.satelliteBackendStatus?.backendOk,
+        isStalled = isStalled,
+    )
 }

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/PillTone.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/PillTone.kt
@@ -22,7 +22,28 @@ internal enum class PillTone(
     OFF(R.drawable.bg_binding_pill_off, R.color.colorMuted),
 }
 
+internal data class PillSpec(
+    val text: String,
+    @DrawableRes val icon: Int?,
+    val tone: PillTone,
+)
+
 private const val PILL_ALPHA_OFF = 0.6f
+
+internal fun BindingPillBinding.bindPill(spec: PillSpec) {
+    val fg = root.context.getColor(spec.tone.foreground)
+    tvPillText.text = spec.text
+    tvPillText.setTextColor(fg)
+    root.setBackgroundResource(spec.tone.background)
+    if (spec.icon != null) {
+        ivPillIcon.visibility = View.VISIBLE
+        ivPillIcon.setImageResource(spec.icon)
+        ivPillIcon.imageTintList = ColorStateList.valueOf(fg)
+    } else {
+        ivPillIcon.visibility = View.GONE
+    }
+    root.alpha = if (spec.tone == PillTone.OFF) PILL_ALPHA_OFF else 1f
+}
 
 internal fun ViewGroup.inflateBindingPill(
     text: String,
@@ -30,16 +51,6 @@ internal fun ViewGroup.inflateBindingPill(
     tone: PillTone,
 ): View {
     val b = BindingPillBinding.inflate(LayoutInflater.from(context), this, false)
-    b.tvPillText.text = text
-    b.root.setBackgroundResource(tone.background)
-    val fg = context.getColor(tone.foreground)
-    b.tvPillText.setTextColor(fg)
-    if (icon != null) {
-        b.ivPillIcon.setImageResource(icon)
-        b.ivPillIcon.imageTintList = ColorStateList.valueOf(fg)
-    } else {
-        b.ivPillIcon.visibility = View.GONE
-    }
-    b.root.alpha = if (tone == PillTone.OFF) PILL_ALPHA_OFF else 1f
+    b.bindPill(PillSpec(text, icon, tone))
     return b.root
 }

--- a/app/src/main/res/layout-sw600dp/activity_connections.xml
+++ b/app/src/main/res/layout-sw600dp/activity_connections.xml
@@ -23,67 +23,18 @@
             android:paddingHorizontal="@dimen/spacing_5xl"
             android:paddingVertical="@dimen/spacing_3xl">
 
-            <androidx.core.widget.NestedScrollView
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rvSatellites"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:layout_marginEnd="@dimen/spacing_5xl">
+                android:layout_marginEnd="@dimen/spacing_5xl" />
 
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical">
-
-                    <include
-                        android:id="@+id/sectionSatellites"
-                        layout="@layout/section_header"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
-
-                    <LinearLayout
-                        android:id="@+id/llSatelliteList"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical"
-                        android:paddingTop="@dimen/spacing_md" />
-
-                    <TextView
-                        android:id="@+id/tvSatelliteEmpty"
-                        style="@style/Widget.Dish.EmptyStateText.Section"
-                        android:text="@string/discovery_empty_never_scanned"
-                        android:visibility="gone" />
-                </LinearLayout>
-            </androidx.core.widget.NestedScrollView>
-
-            <androidx.core.widget.NestedScrollView
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rvBluetooth"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
-                android:layout_weight="1">
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical">
-
-                    <include
-                        android:id="@+id/sectionBluetooth"
-                        layout="@layout/section_header"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
-
-                    <LinearLayout
-                        android:id="@+id/llBtList"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical"
-                        android:paddingTop="@dimen/spacing_md" />
-
-                    <TextView
-                        android:id="@+id/tvBtEmpty"
-                        style="@style/Widget.Dish.EmptyStateText.Section"
-                        android:text="@string/bt_hosts_empty" />
-                </LinearLayout>
-            </androidx.core.widget.NestedScrollView>
+                android:layout_weight="1" />
         </LinearLayout>
     </LinearLayout>
 

--- a/app/src/main/res/layout/activity_connections.xml
+++ b/app/src/main/res/layout/activity_connections.xml
@@ -32,71 +32,13 @@
             android:layout_height="0dp"
             android:layout_weight="1">
 
-            <androidx.core.widget.NestedScrollView
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rvConnections"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:clipToPadding="false"
                 android:paddingHorizontal="@dimen/spacing_5xl"
-                android:paddingVertical="@dimen/spacing_3xl">
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical">
-
-                    <!-- ── Satellite section ──
-                         Icon, label, and scan-button content live in
-                         ConnectionsActivity.onCreate (the include's children are
-                         reachable via View Binding on `sectionSatellites`). v6
-                         brand satellite glyph (`ic_satellite`) keeps parity with
-                         the web dashboard and dish-mac SectionHeader. -->
-                    <include
-                        android:id="@+id/sectionSatellites"
-                        layout="@layout/section_header"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
-
-                    <LinearLayout
-                        android:id="@+id/llSatelliteList"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical"
-                        android:paddingTop="@dimen/spacing_md" />
-
-                    <TextView
-                        android:id="@+id/tvSatelliteEmpty"
-                        style="@style/Widget.Dish.EmptyStateText.Section"
-                        android:text="@string/discovery_empty_never_scanned"
-                        android:visibility="gone" />
-
-                    <View
-                        android:layout_width="match_parent"
-                        android:layout_height="@dimen/divider_height"
-                        android:layout_marginVertical="@dimen/spacing_5xl"
-                        android:background="@color/colorOutline" />
-
-                    <!-- ── Bluetooth section ──
-                         Icon, label, and add-button content live in
-                         ConnectionsActivity.onCreate. -->
-                    <include
-                        android:id="@+id/sectionBluetooth"
-                        layout="@layout/section_header"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
-
-                    <LinearLayout
-                        android:id="@+id/llBtList"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical"
-                        android:paddingTop="@dimen/spacing_md" />
-
-                    <TextView
-                        android:id="@+id/tvBtEmpty"
-                        style="@style/Widget.Dish.EmptyStateText.Section"
-                        android:text="@string/bt_hosts_empty" />
-
-                </LinearLayout>
-            </androidx.core.widget.NestedScrollView>
+                android:paddingVertical="@dimen/spacing_3xl" />
 
             <include
                 layout="@layout/view_donate_pill"

--- a/app/src/main/res/layout/item_connection_divider.xml
+++ b/app/src/main/res/layout/item_connection_divider.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<View xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/divider_height"
+    android:layout_marginVertical="@dimen/spacing_5xl"
+    android:background="@color/colorOutline" />

--- a/app/src/main/res/layout/item_connection_empty.xml
+++ b/app/src/main/res/layout/item_connection_empty.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/Widget.Dish.EmptyStateText.Section"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />

--- a/app/src/test/java/com/tinkernorth/dish/architecture/testing/ControllerProbe.kt
+++ b/app/src/test/java/com/tinkernorth/dish/architecture/testing/ControllerProbe.kt
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.architecture.testing
+
+import com.tinkernorth.dish.architecture.abstracts.AbstractController
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+
+class ControllerProbe<S> internal constructor(
+    private val controller: AbstractController<S>,
+) {
+    val owner = TestLifecycleOwner()
+
+    fun start() {
+        owner.start()
+        controller.onStart(owner)
+    }
+
+    fun stop() {
+        controller.onStop(owner)
+        owner.stop()
+    }
+}
+
+fun <S> AbstractController<S>.probe(): ControllerProbe<S> = ControllerProbe(this)
+
+fun controllerTest(block: suspend TestScope.() -> Unit) = runTest(testBody = block)

--- a/app/src/test/java/com/tinkernorth/dish/composer/ConnectionCoordinatorTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/ConnectionCoordinatorTest.kt
@@ -29,7 +29,7 @@ import org.junit.Before
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class ConnectionHubTest {
+class ConnectionCoordinatorTest {
     private lateinit var satellite: SatelliteConnectionManager
     private lateinit var bt: BluetoothGamepadRegistry
     private lateinit var store: ConnectionStore
@@ -92,7 +92,7 @@ class ConnectionHubTest {
         return ctx
     }
 
-    private fun buildHub(): ConnectionHub {
+    private fun buildHub(): ConnectionCoordinator {
         val bindingStore =
             com.tinkernorth.dish.source.store
                 .SlotBindingStore()
@@ -110,7 +110,7 @@ class ConnectionHubTest {
                 scope = scope,
             )
         val hub =
-            ConnectionHub(
+            ConnectionCoordinator(
                 satellite = satellite,
                 bt = bt,
                 store = store,

--- a/app/src/test/java/com/tinkernorth/dish/composer/ConnectionCoordinatorTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/ConnectionCoordinatorTest.kt
@@ -132,6 +132,33 @@ class ConnectionCoordinatorTest {
         }
 
     @Test
+    fun `forgetConnection clears the binding and type then forgets the satellite`() {
+        val hub = buildHub()
+        hub.bind("slot-A", "sat:1")
+        hub.setSatelliteControllerType("sat:1", "slot-A", CONTROLLER_TYPE_PLAYSTATION)
+        scope.testScheduler.runCurrent()
+        assertEquals(CONTROLLER_TYPE_PLAYSTATION, hub.satTypes.value["sat:1" to "slot-A"])
+
+        hub.forgetConnection("sat:1")
+        scope.testScheduler.runCurrent()
+
+        assertNull(hub.bindings.value["slot-A"])
+        assertNull(hub.satTypes.value["sat:1" to "slot-A"])
+        verify { satellite.forget("sat:1") }
+    }
+
+    @Test
+    fun `forgetConnection forgets a remembered bluetooth host`() {
+        btEntriesFlow.value =
+            listOf(RememberedBt(id = "bt:AA", name = "Pad", mac = "AA", profileName = "XBOX"))
+        val hub = buildHub()
+
+        hub.forgetConnection("bt:AA")
+
+        verify { store.forgetBt("bt:AA") }
+    }
+
+    @Test
     fun `remembered satellite entries appear as IDLE summaries`() {
         satEntriesFlow.value =
             listOf(

--- a/app/src/test/java/com/tinkernorth/dish/composer/ConnectionHubTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/ConnectionHubTest.kt
@@ -44,18 +44,27 @@ class ConnectionHubTest {
     private val staleSatFlow = MutableStateFlow<Set<String>>(emptySet())
     private val staleBtFlow = MutableStateFlow<Map<String, com.tinkernorth.dish.source.bluetooth.BtStaleReason>>(emptyMap())
 
+    private val satEntriesFlow = MutableStateFlow<List<RememberedSatellite>>(emptyList())
+    private val btEntriesFlow = MutableStateFlow<List<RememberedBt>>(emptyList())
+
     @Before
     fun setUp() {
         satellite = mockk(relaxed = true)
         bt = mockk(relaxed = true)
         store = mockk(relaxed = true)
+        satEntriesFlow.value = emptyList()
+        btEntriesFlow.value = emptyList()
         every { satellite.connections } returns satConnsFlow
         every { satellite.discoveredServers } returns discoveredFlow
         every { satellite.staleSatelliteIds } returns staleSatFlow
         every { bt.states } returns btStatesFlow
         every { bt.staleBtIds } returns staleBtFlow
-        every { store.remembered() } returns emptyList()
-        every { store.rememberedBt() } returns emptyList()
+        // The composer derives from the observable flows; the hub still reads remembered() directly,
+        // so both are backed by the same per-test flow value.
+        every { store.rememberedSatellitesFlow } returns satEntriesFlow
+        every { store.rememberedBtFlow } returns btEntriesFlow
+        every { store.remembered() } answers { satEntriesFlow.value }
+        every { store.rememberedBt() } answers { btEntriesFlow.value }
         scope = TestScope(StandardTestDispatcher())
     }
 
@@ -124,7 +133,7 @@ class ConnectionHubTest {
 
     @Test
     fun `remembered satellite entries appear as IDLE summaries`() {
-        every { store.remembered() } returns
+        satEntriesFlow.value =
             listOf(
                 RememberedSatellite(
                     id = "satellite:10.0.0.1:9876",
@@ -147,7 +156,7 @@ class ConnectionHubTest {
 
     @Test
     fun `remembered bt entries surface their profile in detail`() {
-        every { store.rememberedBt() } returns
+        btEntriesFlow.value =
             listOf(
                 RememberedBt(id = "bt:AA:BB", name = "PS5", mac = "AA:BB", profileName = "PLAYSTATION"),
             )
@@ -161,7 +170,7 @@ class ConnectionHubTest {
 
     @Test
     fun `bt connected state propagates from registry`() {
-        every { store.rememberedBt() } returns
+        btEntriesFlow.value =
             listOf(
                 RememberedBt(id = "bt:X", name = "Xbox", mac = "X", profileName = "XBOX"),
             )
@@ -177,7 +186,7 @@ class ConnectionHubTest {
 
     @Test
     fun `acquiring on a remembered bt host shows CONNECTING`() {
-        every { store.rememberedBt() } returns
+        btEntriesFlow.value =
             listOf(
                 RememberedBt(id = "bt:X", name = "Xbox", mac = "X", profileName = "Xbox"),
             )
@@ -248,7 +257,7 @@ class ConnectionHubTest {
 
     @Test
     fun `transient slot disappears once registry re-keys to bt-mac and host is remembered`() {
-        every { store.rememberedBt() } returns
+        btEntriesFlow.value =
             listOf(
                 RememberedBt(id = "bt:AA:BB", name = "PS5", mac = "AA:BB", profileName = "PlayStation"),
             )
@@ -275,7 +284,7 @@ class ConnectionHubTest {
 
     @Test
     fun `idle remembered bt host with no registry state stays IDLE`() {
-        every { store.rememberedBt() } returns
+        btEntriesFlow.value =
             listOf(
                 RememberedBt(id = "bt:Z", name = "Pad", mac = "Z", profileName = "Xbox"),
             )
@@ -288,7 +297,7 @@ class ConnectionHubTest {
 
     @Test
     fun `bind sets slot to connection and binding is reflected in summary`() {
-        every { store.remembered() } returns
+        satEntriesFlow.value =
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
             )
@@ -310,7 +319,7 @@ class ConnectionHubTest {
     fun `binding two slots to the same satellite keeps both attached`() {
         val satConn = mockk<SatelliteConnection>(relaxed = true)
         every { satellite.get("s:1") } returns satConn
-        every { store.remembered() } returns
+        satEntriesFlow.value =
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
             )
@@ -331,7 +340,7 @@ class ConnectionHubTest {
 
     @Test
     fun `bind evicts the prior slot for a bluetooth host`() {
-        every { store.rememberedBt() } returns
+        btEntriesFlow.value =
             listOf(
                 RememberedBt(id = "bt:X", name = "Xbox", mac = "X", profileName = "XBOX"),
             )
@@ -350,7 +359,7 @@ class ConnectionHubTest {
         val sat2 = mockk<SatelliteConnection>(relaxed = true)
         every { satellite.get("s:1") } returns sat1
         every { satellite.get("s:2") } returns sat2
-        every { store.remembered() } returns
+        satEntriesFlow.value =
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
                 RememberedSatellite(id = "s:2", name = "B", ip = "2", udpPort = 4, pairPort = 5, httpPort = 6),
@@ -368,7 +377,7 @@ class ConnectionHubTest {
     fun `unbind removes the binding and detaches the satellite slot by id`() {
         val satConn = mockk<SatelliteConnection>(relaxed = true)
         every { satellite.get("s:1") } returns satConn
-        every { store.remembered() } returns
+        satEntriesFlow.value =
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
             )
@@ -383,7 +392,7 @@ class ConnectionHubTest {
 
     @Test
     fun `bind seeds a default Xbox controller type for new satellite slots`() {
-        every { store.remembered() } returns
+        satEntriesFlow.value =
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
             )
@@ -400,7 +409,7 @@ class ConnectionHubTest {
     fun `setSatelliteControllerType updates the summary and pushes to the connection`() {
         val satConn = mockk<SatelliteConnection>(relaxed = true)
         every { satellite.get("s:1") } returns satConn
-        every { store.remembered() } returns
+        satEntriesFlow.value =
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
             )
@@ -416,7 +425,7 @@ class ConnectionHubTest {
 
     @Test
     fun `summary returns the entry matching id or null`() {
-        every { store.remembered() } returns
+        satEntriesFlow.value =
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
             )
@@ -430,7 +439,7 @@ class ConnectionHubTest {
     fun `autoReconnectAll connects each remembered satellite that is not live`() {
         val live = RememberedSatellite(id = "s:live", name = "L", ip = "1.1.1.1", udpPort = 1, pairPort = 2, httpPort = 3)
         val idle = RememberedSatellite(id = "s:idle", name = "I", ip = "2.2.2.2", udpPort = 4, pairPort = 5, httpPort = 6)
-        every { store.remembered() } returns listOf(live, idle)
+        satEntriesFlow.value = listOf(live, idle)
         val liveConn =
             mockk<SatelliteConnection>(relaxed = true) {
                 every { state } returns MutableStateFlow(SatelliteSessionState.Live)
@@ -451,7 +460,7 @@ class ConnectionHubTest {
 
     @Test
     fun `autoReconnectAll tries the first remembered bt host when none are live`() {
-        every { store.rememberedBt() } returns
+        btEntriesFlow.value =
             listOf(
                 RememberedBt(id = "bt:A", name = "A", mac = "A", profileName = "XBOX"),
                 RememberedBt(id = "bt:B", name = "B", mac = "B", profileName = "XBOX"),
@@ -466,7 +475,7 @@ class ConnectionHubTest {
 
     @Test
     fun `connections re-emits when an inner SatelliteConnection state transitions`() {
-        every { store.remembered() } returns
+        satEntriesFlow.value =
             listOf(
                 RememberedSatellite(
                     id = "satellite:1.1.1.1:9876",
@@ -517,7 +526,7 @@ class ConnectionHubTest {
 
     @Test
     fun `connections re-emits when an inner SatelliteConnection drops back to IDLE`() {
-        every { store.remembered() } returns
+        satEntriesFlow.value =
             listOf(
                 RememberedSatellite(
                     id = "satellite:1.1.1.1:9876",
@@ -560,7 +569,7 @@ class ConnectionHubTest {
 
     @Test
     fun `autoReconnectAll skips bt when a remembered host is already registered`() {
-        every { store.rememberedBt() } returns
+        btEntriesFlow.value =
             listOf(
                 RememberedBt(id = "bt:A", name = "A", mac = "A", profileName = "XBOX"),
             )
@@ -574,7 +583,7 @@ class ConnectionHubTest {
 
     @Test
     fun `stale satellite id lifts an idle remembered satellite to LinkState Stale`() {
-        every { store.remembered() } returns
+        satEntriesFlow.value =
             listOf(
                 RememberedSatellite(
                     id = "satellite:10.0.0.1:9876",
@@ -629,7 +638,7 @@ class ConnectionHubTest {
 
     @Test
     fun `stale bt id lifts an idle remembered host to LinkState Stale`() {
-        every { store.rememberedBt() } returns
+        btEntriesFlow.value =
             listOf(RememberedBt(id = "bt:AA", name = "Xbox", mac = "AA", profileName = "Xbox"))
         every { bt.state(any()) } returns BluetoothGamepadRegistry.SlotState()
         staleBtFlow.value = mapOf("bt:AA" to com.tinkernorth.dish.source.bluetooth.BtStaleReason.KEY_MISSING)
@@ -648,7 +657,7 @@ class ConnectionHubTest {
         val satConn = mockk<SatelliteConnection>(relaxed = true)
         every { satellite.get("s:1") } returns satConn
         every { satConn.renameSlot("slot-fw", "slot-usb") } returns true
-        every { store.remembered() } returns
+        satEntriesFlow.value =
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
             )
@@ -687,7 +696,7 @@ class ConnectionHubTest {
         val satConn = mockk<SatelliteConnection>(relaxed = true)
         every { satellite.get("s:1") } returns satConn
         every { satConn.renameSlot("slot-fw", "slot-usb") } returns false
-        every { store.remembered() } returns
+        satEntriesFlow.value =
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
             )
@@ -705,7 +714,7 @@ class ConnectionHubTest {
 
     @Test
     fun `stale bt marker does not override a connected bt host`() {
-        every { store.rememberedBt() } returns
+        btEntriesFlow.value =
             listOf(RememberedBt(id = "bt:AA", name = "Xbox", mac = "AA", profileName = "Xbox"))
         every { bt.state(any()) } returns
             BluetoothGamepadRegistry.SlotState(
@@ -750,7 +759,7 @@ class ConnectionHubTest {
         val satConn = mockk<SatelliteConnection>(relaxed = true)
         every { satellite.get("s:1") } returns satConn
         every { satConn.renameSlot("slot-fw", "-1000") } returns true
-        every { store.remembered() } returns
+        satEntriesFlow.value =
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
             )
@@ -794,7 +803,7 @@ class ConnectionHubTest {
 
     @Test
     fun `bindClaimedSynthetic leaves the device unbound when no satellite is live`() {
-        every { store.remembered() } returns
+        satEntriesFlow.value =
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
             )

--- a/app/src/test/java/com/tinkernorth/dish/composer/CrashReportingControllerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/CrashReportingControllerTest.kt
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.composer
+
+import android.content.Context
+import android.util.Log
+import com.google.firebase.FirebaseApp
+import com.tinkernorth.dish.architecture.testing.probe
+import com.tinkernorth.dish.source.store.CrashReportingStore
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CrashReportingControllerTest {
+    private lateinit var context: Context
+    private lateinit var store: CrashReportingStore
+    private lateinit var scope: TestScope
+
+    private val enabledFlow = MutableStateFlow(false)
+
+    @Before
+    fun setUp() {
+        mockkStatic(Log::class, FirebaseApp::class)
+        every { Log.i(any<String>(), any<String>()) } returns 0
+        every { Log.e(any<String>(), any<String>(), any<Throwable>()) } returns 0
+        // Drives apply down the "Firebase not initialised" branch: no real Crashlytics on the JVM
+        // classpath, yet getApps(context) still proves apply ran for each emission.
+        every { FirebaseApp.getApps(any()) } returns emptyList()
+
+        context = mockk(relaxed = true)
+        enabledFlow.value = false
+        store = mockk(relaxed = true) { every { state } returns enabledFlow }
+        scope = TestScope(StandardTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Log::class, FirebaseApp::class)
+    }
+
+    private fun controller() = CrashReportingController(context, store, scope)
+
+    @Test
+    fun `opt-in flips propagate to apply on each emission`() {
+        val probe = controller().probe()
+        probe.start()
+        scope.testScheduler.runCurrent()
+        verify(exactly = 1) { FirebaseApp.getApps(context) }
+
+        enabledFlow.value = true
+        scope.testScheduler.runCurrent()
+        verify(exactly = 2) { FirebaseApp.getApps(context) }
+    }
+
+    @Test
+    fun `onStop does not cancel the collection so a later emission still applies`() {
+        val probe = controller().probe()
+        probe.start()
+        scope.testScheduler.runCurrent()
+        verify(exactly = 1) { FirebaseApp.getApps(context) }
+
+        probe.stop()
+        scope.testScheduler.runCurrent()
+
+        // Process-scoped controller keeps collecting after ON_STOP, so the flip must still reach apply.
+        enabledFlow.value = true
+        scope.testScheduler.runCurrent()
+        verify(exactly = 2) { FirebaseApp.getApps(context) }
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/composer/MotionCapabilityComposerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/MotionCapabilityComposerTest.kt
@@ -51,11 +51,12 @@ class MotionCapabilityComposerTest {
         satelliteBackendStatus: MutableStateFlow<Map<Pair<String, String>, SatelliteMotionBackendStatus>> =
             MutableStateFlow(emptyMap()),
     ): MotionCapabilityComposer {
+        // hasGyro is a constant hardware fact; snapshot the flow's current value at construction.
         val availability: PhoneMotionAvailability =
-            mockk { every { state } returns phoneAvailable }
+            mockk { every { hasGyro } returns phoneAvailable.value }
         val registry: PhysicalGamepadRegistry =
             mockk { every { this@mockk.devices } returns devices }
-        val hub: ConnectionHub =
+        val hub: ConnectionCoordinator =
             mockk {
                 every { this@mockk.bindings } returns bindings
                 every { this@mockk.connections } returns connections
@@ -125,21 +126,22 @@ class MotionCapabilityComposerTest {
             )
         }
 
+    // hasGyro is fixed hardware, resolved once: assert the constant rides through, both values.
     @Test
     fun `virtual slot hasGyro mirrors PhoneMotionAvailability`() =
         composerTest {
-            val phoneAvail = MutableStateFlow(true)
             val devices = MutableStateFlow<Map<Int, PhysicalGamepadRegistry.Device>>(emptyMap())
             val bindings = MutableStateFlow<Map<String, String>>(emptyMap())
             val conns = MutableStateFlow<List<ConnectionSummary>>(emptyList())
 
-            val probe = composerFor(phoneAvail, devices, bindings, conns, backgroundScope).probe(this)
+            val present =
+                composerFor(MutableStateFlow(true), devices, bindings, conns, backgroundScope).probe(this)
+            val absent =
+                composerFor(MutableStateFlow(false), devices, bindings, conns, backgroundScope).probe(this)
             testScheduler.runCurrent()
-            assertEquals(true, probe.latest[VIRTUAL_SLOT_ID]?.hasGyro)
 
-            phoneAvail.value = false
-            testScheduler.runCurrent()
-            assertEquals(false, probe.latest[VIRTUAL_SLOT_ID]?.hasGyro)
+            assertEquals(true, present.latest[VIRTUAL_SLOT_ID]?.hasGyro)
+            assertEquals(false, absent.latest[VIRTUAL_SLOT_ID]?.hasGyro)
         }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/composer/WakeStateComposerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/WakeStateComposerTest.kt
@@ -29,7 +29,7 @@ class WakeStateComposerTest {
         connections: MutableStateFlow<List<ConnectionSummary>>,
         scope: kotlinx.coroutines.CoroutineScope,
     ): WakeStateComposer {
-        val hub: ConnectionHub =
+        val hub: ConnectionCoordinator =
             mockk {
                 every { this@mockk.bindings } returns bindings
                 every { this@mockk.connections } returns connections

--- a/app/src/test/java/com/tinkernorth/dish/composer/WakeStateControllerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/WakeStateControllerTest.kt
@@ -240,4 +240,25 @@ class WakeStateControllerTest {
             verify(exactly = 0) { wakeLock.acquire() }
             verify(exactly = 0) { wakeLock.release() }
         }
+
+    @Test
+    fun `an upstream change after ON_STOP does not repopulate the streaming count`() =
+        runTest(scope.testScheduler) {
+            val (controller, owner) = buildAndStart()
+            connectionsFlow.value = listOf(summary("s:1", LinkState.Connected))
+            bindingsFlow.value = mapOf("virtual" to "s:1")
+            scope.testScheduler.runCurrent()
+            assertEquals(1, controller.streamingSlotCount.value)
+
+            owner.registry.currentState = Lifecycle.State.CREATED
+            scope.testScheduler.runCurrent()
+            assertEquals(0, controller.streamingSlotCount.value)
+
+            // Once stopped, a late upstream change must keep the count at zero so the foreground service
+            // is not restarted while the app is backgrounded.
+            connectionsFlow.value = listOf(summary("s:1", LinkState.Connected))
+            bindingsFlow.value = mapOf("virtual" to "s:1", "5" to "s:1")
+            scope.testScheduler.runCurrent()
+            assertEquals(0, controller.streamingSlotCount.value)
+        }
 }

--- a/app/src/test/java/com/tinkernorth/dish/composer/WakeStateControllerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/WakeStateControllerTest.kt
@@ -31,7 +31,7 @@ class WakeStateControllerTest {
     private lateinit var context: Context
     private lateinit var powerManager: PowerManager
     private lateinit var wakeLock: PowerManager.WakeLock
-    private lateinit var hub: ConnectionHub
+    private lateinit var hub: ConnectionCoordinator
     private lateinit var scope: TestScope
 
     private val bindingsFlow = MutableStateFlow<Map<String, String>>(emptyMap())

--- a/app/src/test/java/com/tinkernorth/dish/core/net/DiscoveryGatewayTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/core/net/DiscoveryGatewayTest.kt
@@ -8,7 +8,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class DiscoveryRepositoryTest {
+class DiscoveryGatewayTest {
     private fun server(
         name: String,
         ip: String,
@@ -18,7 +18,7 @@ class DiscoveryRepositoryTest {
     @Test
     fun broadcastOnlyServerIsTaggedBroadcast() {
         val merged =
-            DiscoveryRepository.mergeDiscovered(
+            DiscoveryGateway.mergeDiscovered(
                 broadcast = listOf(server("A", "10.0.0.1")),
                 mdns = emptyList(),
             )
@@ -29,7 +29,7 @@ class DiscoveryRepositoryTest {
     @Test
     fun mdnsOnlyServerIsTaggedMdns() {
         val merged =
-            DiscoveryRepository.mergeDiscovered(
+            DiscoveryGateway.mergeDiscovered(
                 broadcast = emptyList(),
                 mdns = listOf(server("B", "10.0.0.2")),
             )
@@ -40,7 +40,7 @@ class DiscoveryRepositoryTest {
     @Test
     fun serverHeardOnBothPathsIsTaggedBoth() {
         val merged =
-            DiscoveryRepository.mergeDiscovered(
+            DiscoveryGateway.mergeDiscovered(
                 broadcast = listOf(server("Sat", "10.0.0.9")),
                 mdns = listOf(server("Sat", "10.0.0.9")),
             )
@@ -51,7 +51,7 @@ class DiscoveryRepositoryTest {
     @Test
     fun distinctServersFromEachPathAreKept() {
         val merged =
-            DiscoveryRepository.mergeDiscovered(
+            DiscoveryGateway.mergeDiscovered(
                 broadcast = listOf(server("Alpha", "10.0.0.1")),
                 mdns = listOf(server("Bravo", "10.0.0.2")),
             )
@@ -63,7 +63,7 @@ class DiscoveryRepositoryTest {
     @Test
     fun samePairIpDifferentPortAreDistinctEntries() {
         val merged =
-            DiscoveryRepository.mergeDiscovered(
+            DiscoveryGateway.mergeDiscovered(
                 broadcast = listOf(server("One", "10.0.0.1", udp = 9876)),
                 mdns = listOf(server("Two", "10.0.0.1", udp = 9900)),
             )
@@ -73,7 +73,7 @@ class DiscoveryRepositoryTest {
     @Test
     fun resultIsSortedByName() {
         val merged =
-            DiscoveryRepository.mergeDiscovered(
+            DiscoveryGateway.mergeDiscovered(
                 broadcast = listOf(server("Zulu", "10.0.0.3"), server("Alpha", "10.0.0.1")),
                 mdns = listOf(server("Mike", "10.0.0.2")),
             )
@@ -83,7 +83,7 @@ class DiscoveryRepositoryTest {
     @Test
     fun emptyInputsYieldEmptyResult() {
         assertTrue(
-            DiscoveryRepository.mergeDiscovered(emptyList(), emptyList()).isEmpty(),
+            DiscoveryGateway.mergeDiscovered(emptyList(), emptyList()).isEmpty(),
         )
     }
 
@@ -97,5 +97,18 @@ class DiscoveryRepositoryTest {
             )
         assertTrue("a discovery-source label resource is unset", labels.all { it != 0 })
         assertEquals("each discovery source needs its own label", labels.size, labels.toSet().size)
+    }
+
+    @Test
+    fun pinIdFallsBackToHostWhenCallerPassesNoSatelliteId() {
+        assertEquals("10.0.0.7", DiscoveryGateway.pinId(satelliteId = "", ip = "10.0.0.7"))
+    }
+
+    @Test
+    fun pinIdPrefersExplicitSatelliteIdOverHost() {
+        assertEquals(
+            "satellite:mid:abc",
+            DiscoveryGateway.pinId(satelliteId = "satellite:mid:abc", ip = "10.0.0.7"),
+        )
     }
 }

--- a/app/src/test/java/com/tinkernorth/dish/core/net/NetworkUtilsTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/core/net/NetworkUtilsTest.kt
@@ -5,7 +5,10 @@ package com.tinkernorth.dish.core.net
 import com.tinkernorth.dish.core.model.DiscoveredServer
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 class NetworkUtilsTest {
@@ -78,6 +81,72 @@ class NetworkUtilsTest {
         val hex = "0123456789abcdef".repeat(4)
         val bytes = hexToBytes(hex)
         assertEquals(32, bytes.size)
+    }
+
+    @Test
+    fun `hexToBytes rejects a non-hex character`() {
+        try {
+            hexToBytes("0g")
+            fail("expected IllegalArgumentException for non-hex input")
+        } catch (e: IllegalArgumentException) {
+            // expected
+        }
+    }
+
+    @Test
+    fun `hexToBytes rejects odd-length input`() {
+        try {
+            hexToBytes("abc")
+            fail("expected IllegalArgumentException for odd-length input")
+        } catch (e: IllegalArgumentException) {
+            // expected
+        }
+    }
+
+    @Test
+    fun `hexToBytes decodes valid mixed-case hex correctly`() {
+        assertArrayEquals(
+            byteArrayOf(0x00, 0x1F.toByte(), 0xA0.toByte(), 0xFf.toByte()),
+            hexToBytes("001fA0fF"),
+        )
+    }
+
+    @Test
+    fun `isPrivateHostLiteral accepts private and local literals`() {
+        val privateHosts =
+            listOf(
+                "10.0.0.5",
+                "172.16.0.1",
+                "172.31.255.255",
+                "192.168.1.1",
+                "169.254.1.1",
+                "127.0.0.1",
+                "::1",
+                "fe80::1",
+                "[fe80::1]",
+                "fc00::1",
+            )
+        for (h in privateHosts) {
+            assertTrue("expected $h to be private", isPrivateHostLiteral(h))
+        }
+    }
+
+    @Test
+    fun `isPrivateHostLiteral rejects public, out-of-range, and non-literals`() {
+        val nonPrivateHosts =
+            listOf(
+                "8.8.8.8",
+                "172.32.0.1", // just past the 172.16/12 upper bound
+                "11.0.0.1", // only 10.0.0.0/8 is private, not 11.x
+                "172.15.0.1", // just below the 172.16/12 lower bound
+                "example.com",
+                "",
+                "999.1.1.1", // octet out of range
+                "1.2.3", // too few octets
+            )
+        for (h in nonPrivateHosts) {
+            assertFalse("expected $h to be non-private", isPrivateHostLiteral(h))
+        }
     }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/core/net/SatelliteHttpClientVerifierTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/core/net/SatelliteHttpClientVerifierTest.kt
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.core.net
+
+import android.util.Log
+import com.tinkernorth.dish.repository.SatellitePinRepository
+import com.tinkernorth.dish.repository.mapBackedPrefs
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.security.cert.Certificate
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLSession
+
+// Exercises the real TOFU hostname verifier end to end (peer-cert read -> fingerprint ->
+// pin/match/mismatch) against a real pin repo, with only the SSLSession + cert mocked.
+// The live-socket handshake path remains integration-only.
+class SatelliteHttpClientVerifierTest {
+    private val sat = "satellite:mid:test"
+
+    @Before
+    fun stubAndroidLog() {
+        // SatelliteHttpClient logs via android.util.Log, which is unmocked under plain JUnit.
+        mockkStatic(Log::class)
+        every { Log.i(any<String>(), any<String>()) } returns 0
+        every { Log.e(any<String>(), any<String>()) } returns 0
+    }
+
+    @After
+    fun unstub() {
+        unmockkStatic(Log::class)
+    }
+
+    private fun sessionWith(der: ByteArray): SSLSession {
+        val cert = mockk<X509Certificate>()
+        every { cert.encoded } returns der
+        val session = mockk<SSLSession>()
+        every { session.peerCertificates } returns arrayOf<Certificate>(cert)
+        return session
+    }
+
+    private fun pinRepo(): SatellitePinRepository = SatellitePinRepository(mapBackedPrefs().first)
+
+    @Test
+    fun `first contact pins the presented cert and accepts`() {
+        val pins = pinRepo()
+        val verifier = SatelliteHttpClient.tofuHostnameVerifier(sat, pins)
+
+        assertTrue(verifier.verify("1.2.3.4", sessionWith(byteArrayOf(1, 2, 3))))
+        assertEquals(
+            "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+            pins.pinnedFingerprint(sat),
+        )
+    }
+
+    @Test
+    fun `same cert on a later contact matches and accepts without re-pinning`() {
+        val pins = pinRepo()
+        val verifier = SatelliteHttpClient.tofuHostnameVerifier(sat, pins)
+        verifier.verify("1.2.3.4", sessionWith(byteArrayOf(1, 2, 3)))
+        val firstPin = pins.pinnedFingerprint(sat)
+
+        assertTrue(verifier.verify("1.2.3.4", sessionWith(byteArrayOf(1, 2, 3))))
+        assertEquals("pin must be unchanged on a match", firstPin, pins.pinnedFingerprint(sat))
+    }
+
+    @Test
+    fun `a different cert after pinning is rejected and the pin is left intact`() {
+        val pins = pinRepo()
+        val verifier = SatelliteHttpClient.tofuHostnameVerifier(sat, pins)
+        verifier.verify("1.2.3.4", sessionWith(byteArrayOf(1, 2, 3)))
+        val firstPin = pins.pinnedFingerprint(sat)
+
+        assertFalse(
+            "an attacker cert must fail the verifier",
+            verifier.verify("1.2.3.4", sessionWith(byteArrayOf(9, 9, 9))),
+        )
+        assertEquals("a mismatch must not overwrite the trusted pin", firstPin, pins.pinnedFingerprint(sat))
+    }
+
+    @Test
+    fun `a session without peer certificates is rejected`() {
+        val pins = pinRepo()
+        val session = mockk<SSLSession>()
+        every { session.peerCertificates } returns emptyArray()
+
+        assertFalse(SatelliteHttpClient.tofuHostnameVerifier(sat, pins).verify("1.2.3.4", session))
+    }
+
+    @Test
+    fun `pins are keyed per satellite id`() {
+        val pins = pinRepo()
+        SatelliteHttpClient.tofuHostnameVerifier("a", pins).verify("h", sessionWith(byteArrayOf(1, 2, 3)))
+        // Same cert presented for a different id is still a first-use pin, not a cross-id match.
+        assertTrue(SatelliteHttpClient.tofuHostnameVerifier("b", pins).verify("h", sessionWith(byteArrayOf(4, 5, 6))))
+
+        // Both were first-use accepts on different ids: no mismatch was logged.
+        verify(exactly = 0) { Log.e(any<String>(), any<String>()) }
+        assertEquals(64, pins.pinnedFingerprint("a")?.length)
+        assertEquals(64, pins.pinnedFingerprint("b")?.length)
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistryPlaceholderTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistryPlaceholderTest.kt
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.hotpath.input
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+// Exhaustive table tests for the pure placeholderTransition reducer extracted from
+// PhysicalGamepadRegistry. The reducer is the single source of truth for how the transient
+// placeholder booleans evolve; the imperative mutators only pick which devices it is applied to.
+class PhysicalGamepadRegistryPlaceholderTest {
+    private fun live(isUsbSynthetic: Boolean = false) =
+        PlaceholderState(
+            transitioning = false,
+            needsReplug = false,
+            restoreStuck = false,
+            disconnectingTimeLeftSec = null,
+            isUsbSynthetic = isUsbSynthetic,
+        )
+
+    // HoldAsTransitioning
+
+    @Test
+    fun `hold sets transitioning and clears the disconnect countdown`() {
+        val start = live().copy(disconnectingTimeLeftSec = 3)
+        val next = placeholderTransition(start, PlaceholderEvent.HoldAsTransitioning)
+        assertTrue(next.transitioning)
+        assertNull(next.disconnectingTimeLeftSec)
+        assertFalse(next.needsReplug)
+        assertFalse(next.restoreStuck)
+    }
+
+    @Test
+    fun `hold from a clean live state just raises transitioning`() {
+        val next = placeholderTransition(live(), PlaceholderEvent.HoldAsTransitioning)
+        assertEquals(
+            live().copy(transitioning = true),
+            next,
+        )
+    }
+
+    @Test
+    fun `hold leaves needsReplug untouched`() {
+        val start = live().copy(needsReplug = true)
+        val next = placeholderTransition(start, PlaceholderEvent.HoldAsTransitioning)
+        assertTrue(next.needsReplug)
+        assertTrue(next.transitioning)
+    }
+
+    // SetSyntheticTransitioning
+
+    @Test
+    fun `setSyntheticTransitioning true raises only the loader flag`() {
+        val next = placeholderTransition(live(isUsbSynthetic = true), PlaceholderEvent.SetSyntheticTransitioning(true))
+        assertEquals(
+            live(isUsbSynthetic = true).copy(transitioning = true),
+            next,
+        )
+    }
+
+    @Test
+    fun `setSyntheticTransitioning false lowers only the loader flag`() {
+        val start = live(isUsbSynthetic = true).copy(transitioning = true)
+        val next = placeholderTransition(start, PlaceholderEvent.SetSyntheticTransitioning(false))
+        assertFalse(next.transitioning)
+    }
+
+    @Test
+    fun `setSyntheticTransitioning does not disturb restoreStuck`() {
+        val start = live(isUsbSynthetic = true).copy(restoreStuck = true)
+        val next = placeholderTransition(start, PlaceholderEvent.SetSyntheticTransitioning(true))
+        assertTrue(next.restoreStuck)
+        assertTrue(next.transitioning)
+    }
+
+    // MarkNeedsReplug
+
+    @Test
+    fun `markNeedsReplug settles transitioning into needsReplug`() {
+        val start = live().copy(transitioning = true)
+        val next = placeholderTransition(start, PlaceholderEvent.MarkNeedsReplug)
+        assertFalse(next.transitioning)
+        assertTrue(next.needsReplug)
+    }
+
+    @Test
+    fun `markNeedsReplug guards the contradictory transitioning plus needsReplug combo`() {
+        // Even if a caller somehow applied this to an already-stuck state, the result is never both
+        // transitioning and needsReplug.
+        val start = live().copy(transitioning = true, needsReplug = true)
+        val next = placeholderTransition(start, PlaceholderEvent.MarkNeedsReplug)
+        assertFalse(next.transitioning)
+        assertTrue(next.needsReplug)
+    }
+
+    // MarkRestoreStuck (synthetic-only)
+
+    @Test
+    fun `markRestoreStuck on a synthetic clears transitioning and raises restoreStuck`() {
+        val start = live(isUsbSynthetic = true).copy(transitioning = true)
+        val next = placeholderTransition(start, PlaceholderEvent.MarkRestoreStuck)
+        assertFalse(next.transitioning)
+        assertTrue(next.restoreStuck)
+    }
+
+    @Test
+    fun `markRestoreStuck on a non-synthetic is a no-op`() {
+        val start = live(isUsbSynthetic = false).copy(transitioning = true)
+        val next = placeholderTransition(start, PlaceholderEvent.MarkRestoreStuck)
+        // restoreStuck must never appear on a framework device.
+        assertSame(start, next)
+        assertFalse(next.restoreStuck)
+    }
+
+    // ClearRestoreStuck (synthetic-only)
+
+    @Test
+    fun `clearRestoreStuck on a synthetic returns to the held-loader look`() {
+        val start = live(isUsbSynthetic = true).copy(restoreStuck = true)
+        val next = placeholderTransition(start, PlaceholderEvent.ClearRestoreStuck)
+        assertFalse(next.restoreStuck)
+        assertTrue(next.transitioning)
+    }
+
+    @Test
+    fun `clearRestoreStuck on a non-synthetic is a no-op`() {
+        val start = live(isUsbSynthetic = false).copy(restoreStuck = true)
+        val next = placeholderTransition(start, PlaceholderEvent.ClearRestoreStuck)
+        assertSame(start, next)
+        assertFalse(next.transitioning)
+    }
+
+    // Round trips that mirror the real call sequences.
+
+    @Test
+    fun `hold then markNeedsReplug matches the framework loader to replug path`() {
+        val held = placeholderTransition(live().copy(disconnectingTimeLeftSec = 4), PlaceholderEvent.HoldAsTransitioning)
+        val replug = placeholderTransition(held, PlaceholderEvent.MarkNeedsReplug)
+        assertEquals(
+            live().copy(needsReplug = true),
+            replug,
+        )
+    }
+
+    @Test
+    fun `markRestoreStuck then clearRestoreStuck round-trips a synthetic back to transitioning`() {
+        val base = live(isUsbSynthetic = true).copy(transitioning = true)
+        val stuck = placeholderTransition(base, PlaceholderEvent.MarkRestoreStuck)
+        val cleared = placeholderTransition(stuck, PlaceholderEvent.ClearRestoreStuck)
+        assertEquals(base, cleared)
+    }
+
+    // Identity preservation: the reducer never flips isUsbSynthetic.
+
+    @Test
+    fun `every event preserves the isUsbSynthetic identity flag`() {
+        val events =
+            listOf(
+                PlaceholderEvent.HoldAsTransitioning,
+                PlaceholderEvent.SetSyntheticTransitioning(true),
+                PlaceholderEvent.SetSyntheticTransitioning(false),
+                PlaceholderEvent.MarkNeedsReplug,
+                PlaceholderEvent.MarkRestoreStuck,
+                PlaceholderEvent.ClearRestoreStuck,
+            )
+        for (synthetic in listOf(true, false)) {
+            for (event in events) {
+                val next = placeholderTransition(live(isUsbSynthetic = synthetic), event)
+                assertEquals(
+                    "event $event must not change isUsbSynthetic",
+                    synthetic,
+                    next.isUsbSynthetic,
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/hotpath/input/PhysicalSlotBindingObserverTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/hotpath/input/PhysicalSlotBindingObserverTest.kt
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.hotpath.input
+
+import com.tinkernorth.dish.composer.ConnectionKind
+import com.tinkernorth.dish.composer.ConnectionSummary
+import com.tinkernorth.dish.composer.LinkState
+import com.tinkernorth.dish.source.connection.SatelliteConnection
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+// Locks the physical-slot reconciliation: which device id binds to which server-side controller, and
+// the departed-before-bind ordering that keeps a re-added id off a stale entry's controller index.
+class PhysicalSlotBindingObserverTest {
+    private fun satSummary(
+        id: String,
+        live: LinkState = LinkState.Connected,
+    ) = ConnectionSummary(
+        id = id,
+        kind = ConnectionKind.SATELLITE,
+        label = id,
+        detail = "",
+        live = live,
+        boundSlotIds = emptyList(),
+    )
+
+    private fun btSummary(
+        id: String,
+        live: LinkState = LinkState.Connected,
+    ) = ConnectionSummary(
+        id = id,
+        kind = ConnectionKind.BLUETOOTH,
+        label = id,
+        detail = "",
+        live = live,
+        boundSlotIds = emptyList(),
+    )
+
+    private fun slot(
+        index: Int,
+        registered: Boolean = true,
+    ) = SatelliteConnection.SlotBinding(controllerIndex = index, controllerType = 0, registered = registered)
+
+    private fun reconcile(
+        present: Set<Int> = emptySet(),
+        lastBound: Set<Int> = emptySet(),
+        bindings: Map<String, String> = emptyMap(),
+        summaries: List<ConnectionSummary> = emptyList(),
+        slotInfo: Map<String, SatelliteSlotSnapshot> = emptyMap(),
+        btConnectedIds: Set<String> = emptySet(),
+    ) = reconcileSlots(present, lastBound, bindings, summaries, slotInfo, btConnectedIds)
+
+    @Test
+    fun `a departed device is unbound then forgotten then released, before any binds`() {
+        // Device 7 left; device 5 is present and bound to a live satellite slot 0.
+        val ops =
+            reconcile(
+                present = setOf(5),
+                lastBound = setOf(5, 7),
+                bindings = mapOf("5" to "sat:a"),
+                summaries = listOf(satSummary("sat:a")),
+                slotInfo = mapOf("sat:a" to SatelliteSlotSnapshot(handle = 9, slots = mapOf("5" to slot(0)))),
+            )
+        assertEquals(
+            listOf(
+                BindOp.Unbind(7),
+                BindOp.Forget(7),
+                BindOp.ReleaseHubBinding(7),
+                BindOp.BindSatellite(deviceId = 5, handle = 9, controllerIndex = 0),
+            ),
+            ops,
+        )
+    }
+
+    @Test
+    fun `a departed synthetic negative id is unbound and released but not forgotten`() {
+        // detachUsbDevice frees a claimed synthetic, so the negative id must skip Forget.
+        val ops = reconcile(lastBound = setOf(-1000))
+        assertEquals(listOf(BindOp.Unbind(-1000), BindOp.ReleaseHubBinding(-1000)), ops)
+    }
+
+    @Test
+    fun `a present device on a live registered satellite slot binds to that controller index`() {
+        val ops =
+            reconcile(
+                present = setOf(5),
+                lastBound = setOf(5),
+                bindings = mapOf("5" to "sat:a"),
+                summaries = listOf(satSummary("sat:a")),
+                slotInfo = mapOf("sat:a" to SatelliteSlotSnapshot(handle = 9, slots = mapOf("5" to slot(2)))),
+            )
+        assertEquals(listOf(BindOp.BindSatellite(deviceId = 5, handle = 9, controllerIndex = 2)), ops)
+    }
+
+    @Test
+    fun `a present device on an unregistered satellite slot is unbound not bound`() {
+        val ops =
+            reconcile(
+                present = setOf(5),
+                lastBound = setOf(5),
+                bindings = mapOf("5" to "sat:a"),
+                summaries = listOf(satSummary("sat:a")),
+                slotInfo = mapOf("sat:a" to SatelliteSlotSnapshot(handle = 9, slots = mapOf("5" to slot(0, registered = false)))),
+            )
+        assertEquals(listOf(BindOp.Unbind(5)), ops)
+    }
+
+    @Test
+    fun `a present device on a satellite with a negative handle is unbound not bound`() {
+        // handle < 0 means the session is not live, mirroring the registered re-check.
+        val ops =
+            reconcile(
+                present = setOf(5),
+                lastBound = setOf(5),
+                bindings = mapOf("5" to "sat:a"),
+                summaries = listOf(satSummary("sat:a")),
+                slotInfo = mapOf("sat:a" to SatelliteSlotSnapshot(handle = -1, slots = mapOf("5" to slot(0)))),
+            )
+        assertEquals(listOf(BindOp.Unbind(5)), ops)
+    }
+
+    @Test
+    fun `a present device bound to an unknown satellite connection is unbound not bound`() {
+        // No slotInfo entry for the connection => the old satellite.get(cid) == null branch.
+        val ops =
+            reconcile(
+                present = setOf(5),
+                lastBound = setOf(5),
+                bindings = mapOf("5" to "sat:a"),
+                summaries = listOf(satSummary("sat:a")),
+            )
+        assertEquals(listOf(BindOp.Unbind(5)), ops)
+    }
+
+    @Test
+    fun `a present device on an actually-connected bluetooth connection binds bluetooth`() {
+        val ops =
+            reconcile(
+                present = setOf(5),
+                lastBound = setOf(5),
+                bindings = mapOf("5" to "bt:aa"),
+                summaries = listOf(btSummary("bt:aa")),
+                btConnectedIds = setOf("bt:aa"),
+            )
+        assertEquals(listOf(BindOp.BindBluetooth(deviceId = 5, connectionId = "bt:aa")), ops)
+    }
+
+    @Test
+    fun `a bluetooth summary that says connected but whose registry is not connected is unbound`() {
+        // The fix: the satellite-only liveness re-check now also guards the BT branch.
+        val ops =
+            reconcile(
+                present = setOf(5),
+                lastBound = setOf(5),
+                bindings = mapOf("5" to "bt:aa"),
+                summaries = listOf(btSummary("bt:aa", live = LinkState.Connected)),
+                btConnectedIds = emptySet(),
+            )
+        assertEquals(listOf(BindOp.Unbind(5)), ops)
+    }
+
+    @Test
+    fun `a present device whose summary is not connected is unbound regardless of kind`() {
+        val ops =
+            reconcile(
+                present = setOf(5),
+                lastBound = setOf(5),
+                bindings = mapOf("5" to "sat:a"),
+                summaries = listOf(satSummary("sat:a", live = LinkState.Connecting)),
+                slotInfo = mapOf("sat:a" to SatelliteSlotSnapshot(handle = 9, slots = mapOf("5" to slot(0)))),
+            )
+        assertEquals(listOf(BindOp.Unbind(5)), ops)
+    }
+
+    @Test
+    fun `a present device with no binding is unbound`() {
+        val ops = reconcile(present = setOf(5), lastBound = setOf(5))
+        assertEquals(listOf(BindOp.Unbind(5)), ops)
+    }
+
+    @Test
+    fun `with no bindings only departed unbinds and releases are emitted`() {
+        // Two ids left, none present and none bound: each departed framework id is unbound, forgotten
+        // and released; no bind ops at all.
+        val ops = reconcile(lastBound = setOf(3, 8))
+        assertEquals(
+            listOf(
+                BindOp.Unbind(3),
+                BindOp.Forget(3),
+                BindOp.ReleaseHubBinding(3),
+                BindOp.Unbind(8),
+                BindOp.Forget(8),
+                BindOp.ReleaseHubBinding(8),
+            ),
+            ops,
+        )
+    }
+
+    @Test
+    fun `an empty snapshot yields no ops`() {
+        assertEquals(emptyList<BindOp>(), reconcile())
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/hotpath/input/RumbleRouterTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/hotpath/input/RumbleRouterTest.kt
@@ -5,7 +5,9 @@ package com.tinkernorth.dish.hotpath.input
 import com.tinkernorth.dish.source.connection.SatelliteConnection
 import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class RumbleRouterTest {
@@ -91,5 +93,76 @@ class RumbleRouterTest {
     @Test
     fun `combinedRumblePlan yields nothing when there are no actuators`() {
         assertEquals(emptyList<Pair<Int, Int>>(), combinedRumblePlan(vibratorCount = 0, strongAmp = 200, weakAmp = 100))
+    }
+
+    private fun conn(
+        handle: Int,
+        connected: Boolean = true,
+        slots: Map<String, SatelliteConnection.SlotBinding> = emptyMap(),
+    ) = RumbleConnectionSnapshot(handle = handle, connected = connected, slots = slots)
+
+    @Test
+    fun `resolveRumble routes to the framework slot bound at the controller index`() {
+        val snapshot = listOf(conn(handle = 7, slots = mapOf("1234" to slot(0))))
+        assertEquals(RumbleTarget.Framework(1234), resolveRumble(snapshot, sessionHandle = 7, controllerIndex = 0))
+    }
+
+    @Test
+    fun `resolveRumble routes the virtual slot to the phone`() {
+        val snapshot = listOf(conn(handle = 7, slots = mapOf(VIRTUAL_SLOT_ID to slot(0))))
+        assertEquals(RumbleTarget.Phone, resolveRumble(snapshot, sessionHandle = 7, controllerIndex = 0))
+    }
+
+    @Test
+    fun `resolveRumble routes a synthetic slot to the USB-direct path`() {
+        val snapshot = listOf(conn(handle = 7, slots = mapOf("-1000" to slot(2))))
+        assertEquals(RumbleTarget.DirectUsb(-1000), resolveRumble(snapshot, sessionHandle = 7, controllerIndex = 2))
+    }
+
+    @Test
+    fun `resolveRumble yields None when no connection has the session handle`() {
+        val snapshot = listOf(conn(handle = 7, slots = mapOf("1234" to slot(0))))
+        assertEquals(RumbleTarget.None, resolveRumble(snapshot, sessionHandle = 99, controllerIndex = 0))
+        assertEquals(RumbleTarget.None, resolveRumble(emptyList(), sessionHandle = 7, controllerIndex = 0))
+    }
+
+    @Test
+    fun `resolveRumble yields None for a negative session handle`() {
+        val snapshot = listOf(conn(handle = -1, slots = mapOf("1234" to slot(0))))
+        assertEquals(RumbleTarget.None, resolveRumble(snapshot, sessionHandle = -1, controllerIndex = 0))
+    }
+
+    @Test
+    fun `resolveRumble yields None when the matched connection has no slot at the index`() {
+        val snapshot = listOf(conn(handle = 7, slots = mapOf("1234" to slot(0))))
+        assertEquals(RumbleTarget.None, resolveRumble(snapshot, sessionHandle = 7, controllerIndex = 5))
+    }
+
+    @Test
+    fun `resolveRumble prefers the connected connection when two share a handle`() {
+        val stale = conn(handle = 7, connected = false, slots = mapOf("1111" to slot(0)))
+        val live = conn(handle = 7, connected = true, slots = mapOf("2222" to slot(0)))
+        // Stale listed first: the connected match must still win, not first-match.
+        assertEquals(RumbleTarget.Framework(2222), resolveRumble(listOf(stale, live), sessionHandle = 7, controllerIndex = 0))
+        assertEquals(RumbleTarget.Framework(2222), resolveRumble(listOf(live, stale), sessionHandle = 7, controllerIndex = 0))
+    }
+
+    @Test
+    fun `resolveRumble falls back to the first match when no sharing connection is connected`() {
+        val first = conn(handle = 7, connected = false, slots = mapOf("1111" to slot(0)))
+        val second = conn(handle = 7, connected = false, slots = mapOf("2222" to slot(0)))
+        assertEquals(RumbleTarget.Framework(1111), resolveRumble(listOf(first, second), sessionHandle = 7, controllerIndex = 0))
+    }
+
+    @Test
+    fun `isRumbleStop is true when both magnitudes are zero or duration is zero`() {
+        assertTrue(isRumbleStop(strongMagnitude = 0, weakMagnitude = 0, durationMs = 100))
+        assertTrue(isRumbleStop(strongMagnitude = 500, weakMagnitude = 500, durationMs = 0))
+    }
+
+    @Test
+    fun `isRumbleStop is false when there is a positive magnitude and duration`() {
+        assertFalse(isRumbleStop(strongMagnitude = 500, weakMagnitude = 0, durationMs = 100))
+        assertFalse(isRumbleStop(strongMagnitude = 0, weakMagnitude = 500, durationMs = 100))
     }
 }

--- a/app/src/test/java/com/tinkernorth/dish/repository/ConnectionStoreFlowTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/ConnectionStoreFlowTest.kt
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.repository
+
+import com.tinkernorth.dish.core.model.DiscoveredServer
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+// Guards the observable seam that lets ConnectionsComposer derive the connections list purely from
+// flows. Before this, the composer read store.remembered()/rememberedBt() out of band, so a
+// remember/forget with no coincident upstream tick left a stale or ghost row.
+class ConnectionStoreFlowTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun newStore(): ConnectionStore {
+        val (ctx, _) = mapBackedPrefs()
+        return ConnectionStore(
+            RememberedSatelliteRepository(ctx, json),
+            RememberedBtRepository(ctx, json),
+            SatelliteSharedKeyRepository(ctx),
+        )
+    }
+
+    private fun discovered(
+        ip: String,
+        name: String,
+        machineId: String,
+    ) = DiscoveredServer(name = name, ip = ip, udpPort = 9876, machineId = machineId)
+
+    @Test
+    fun `rememberedSatellitesFlow tracks remember and forget`() {
+        val store = newStore()
+        assertEquals(emptyList<RememberedSatellite>(), store.rememberedSatellitesFlow.value)
+
+        store.rememberSatellite(discovered("10.0.0.1", "Box", "abc"))
+        assertEquals(listOf("satellite:mid:abc"), store.rememberedSatellitesFlow.value.map { it.id })
+
+        store.forgetSatellite("satellite:mid:abc")
+        assertEquals(emptyList<RememberedSatellite>(), store.rememberedSatellitesFlow.value)
+    }
+
+    @Test
+    fun `rememberedBtFlow tracks remember and forget`() {
+        val store = newStore()
+        assertEquals(emptyList<RememberedBt>(), store.rememberedBtFlow.value)
+
+        store.rememberBt(RememberedBt(id = "bt:AA", name = "Pad", mac = "AA", profileName = "XBOX"))
+        assertEquals(listOf("bt:AA"), store.rememberedBtFlow.value.map { it.id })
+
+        store.forgetBt("bt:AA")
+        assertEquals(emptyList<RememberedBt>(), store.rememberedBtFlow.value)
+    }
+
+    @Test
+    fun `the satellite flow reflects a reconciliation that collapses a ghost`() {
+        val store = newStore()
+        store.rememberSatellite(discovered("10.0.0.1", "Box", "")) // legacy per-ip row
+        assertEquals(1, store.rememberedSatellitesFlow.value.size)
+
+        store.rememberSatellite(discovered("10.0.0.1", "Box", "abc")) // same box, now with a machineId
+        assertEquals(listOf("satellite:mid:abc"), store.rememberedSatellitesFlow.value.map { it.id })
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/repository/ConnectionStoreReconciliationTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/ConnectionStoreReconciliationTest.kt
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.repository
+
+import com.tinkernorth.dish.core.model.DiscoveredServer
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+// Exercises ConnectionStore.reconcileLegacyGhosts, the machineId migration that collapses
+// per-IP "ghost" rows (the duplicate-connection bug) into one stable id. All three repositories
+// share a single backing prefs map, the way they share the real connection_store file.
+class ConnectionStoreReconciliationTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun newStore(): Pair<ConnectionStore, MutableMap<String, Any?>> {
+        val (ctx, backing) = mapBackedPrefs()
+        val satellites = RememberedSatelliteRepository(ctx, json)
+        val bt = RememberedBtRepository(ctx, json)
+        val keys = SatelliteSharedKeyRepository(ctx)
+        return ConnectionStore(satellites, bt, keys) to backing
+    }
+
+    private fun legacy(
+        ip: String,
+        name: String,
+        udpPort: Int = 9876,
+    ) = RememberedSatellite(
+        id = "satellite:$ip:$udpPort",
+        name = name,
+        ip = ip,
+        udpPort = udpPort,
+        pairPort = 9443,
+        httpPort = 9443,
+        machineId = "",
+    )
+
+    private fun discovered(
+        ip: String,
+        name: String,
+        machineId: String,
+        udpPort: Int = 9876,
+    ) = DiscoveredServer(name = name, ip = ip, udpPort = udpPort, machineId = machineId)
+
+    @Test
+    fun `remembering the same box under its machineId adopts the legacy shared key and drops the ghost`() {
+        val (store, _) = newStore()
+        store.satellites.put(legacy(ip = "10.0.0.1", name = "Box"))
+        store.setSatelliteSharedKey("satellite:10.0.0.1:9876", "OLDKEY")
+
+        store.rememberSatellite(discovered(ip = "10.0.0.1", name = "Box", machineId = "abc"))
+
+        val all = store.remembered()
+        assertEquals(1, all.size)
+        assertEquals("satellite:mid:abc", all.single().id)
+        assertEquals("OLDKEY", store.satelliteSharedKey("satellite:mid:abc"))
+        assertNull(store.satelliteSharedKey("satellite:10.0.0.1:9876"))
+    }
+
+    @Test
+    fun `a name-matched ghost stranded at a dead IP is collapsed into the stable id`() {
+        val (store, _) = newStore()
+        store.satellites.put(legacy(ip = "192.168.1.50", name = "Box"))
+
+        store.rememberSatellite(discovered(ip = "10.0.0.1", name = "Box", machineId = "abc"))
+
+        val all = store.remembered()
+        assertEquals(1, all.size)
+        assertEquals("satellite:mid:abc", all.single().id)
+    }
+
+    @Test
+    fun `reconciliation never removes a different, stably-identified satellite that shares a name`() {
+        val (store, _) = newStore()
+        store.satellites.put(
+            RememberedSatellite(
+                id = "satellite:mid:other",
+                name = "Box",
+                ip = "1.2.3.4",
+                udpPort = 9876,
+                pairPort = 9443,
+                httpPort = 9443,
+                machineId = "other",
+            ),
+        )
+
+        store.rememberSatellite(discovered(ip = "10.0.0.1", name = "Box", machineId = "abc"))
+
+        val ids = store.remembered().map { it.id }.toSet()
+        assertEquals(setOf("satellite:mid:other", "satellite:mid:abc"), ids)
+    }
+
+    @Test
+    fun `an existing key on the stable id is not overwritten by the legacy key`() {
+        val (store, _) = newStore()
+        store.satellites.put(legacy(ip = "10.0.0.1", name = "Box"))
+        store.setSatelliteSharedKey("satellite:10.0.0.1:9876", "OLDKEY")
+        store.setSatelliteSharedKey("satellite:mid:abc", "NEWKEY")
+
+        store.rememberSatellite(discovered(ip = "10.0.0.1", name = "Box", machineId = "abc"))
+
+        assertEquals("NEWKEY", store.satelliteSharedKey("satellite:mid:abc"))
+    }
+
+    @Test
+    fun `remembering a satellite without a machineId never reconciles, so legacy per-IP rows still accrue`() {
+        val (store, _) = newStore()
+        store.satellites.put(legacy(ip = "10.0.0.1", name = "Box"))
+
+        // No machineId: the migration is skipped entirely, reproducing the original per-IP duplication.
+        store.rememberSatellite(discovered(ip = "10.0.0.2", name = "Box", machineId = ""))
+
+        assertEquals(2, store.remembered().size)
+    }
+
+    @Test
+    fun `KNOWN RISK a legacy row sharing only a display name is forgotten even if it is a different box`() {
+        val (store, _) = newStore()
+        // A genuinely different machine the user happened to name the same before machineIds existed.
+        store.satellites.put(legacy(ip = "172.16.0.9", name = "Living Room PC"))
+
+        store.rememberSatellite(discovered(ip = "10.0.0.1", name = "Living Room PC", machineId = "abc"))
+
+        // The unrelated legacy entry is collapsed purely on the name match. See summary: over-forget risk.
+        assertTrue(store.remembered().none { it.id == "satellite:172.16.0.9:9876" })
+        assertEquals(1, store.remembered().size)
+    }
+
+    @Test
+    fun `a name-matched ghost at a stale IP is collapsed and its key is adopted onto the stable id`() {
+        val (store, _) = newStore()
+        // The remembered row (and its key) live at an OLD ip, different from where the box is seen now.
+        store.satellites.put(legacy(ip = "192.168.1.50", name = "Box"))
+        store.setSatelliteSharedKey("satellite:192.168.1.50:9876", "OLDKEY")
+
+        // The box now advertises a machineId at a NEW ip. Reconciliation adopts the ghost's key onto the
+        // stable id before dropping the row, so the already-paired box is not forced to re-pair.
+        store.rememberSatellite(discovered(ip = "10.0.0.1", name = "Box", machineId = "abc"))
+
+        assertEquals(1, store.remembered().size)
+        assertEquals("satellite:mid:abc", store.remembered().single().id)
+        assertEquals("OLDKEY", store.satelliteSharedKey("satellite:mid:abc"))
+        assertNull(store.satelliteSharedKey("satellite:192.168.1.50:9876"))
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/repository/MapBackedPrefs.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/MapBackedPrefs.kt
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+
+// Map-backed SharedPreferences double shared by the connection_store repository tests.
+// One backing map per Context models the single connection_store prefs file that
+// RememberedSatelliteRepository, RememberedBtRepository and SatelliteSharedKeyRepository co-tenant.
+internal fun mapBackedPrefs(seed: MutableMap<String, Any?>? = null): Pair<Context, MutableMap<String, Any?>> {
+    val store: MutableMap<String, Any?> = seed ?: mutableMapOf()
+
+    val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+    val keySlot = slot<String>()
+    val strSlot = slot<String?>()
+    every { editor.putString(capture(keySlot), captureNullable(strSlot)) } answers {
+        store[keySlot.captured] = strSlot.captured
+        editor
+    }
+    every { editor.remove(capture(keySlot)) } answers {
+        store.remove(keySlot.captured)
+        editor
+    }
+    every { editor.apply() } answers { }
+
+    val prefs = mockk<SharedPreferences>(relaxed = true)
+    every { prefs.getString(any(), any()) } answers {
+        val k = firstArg<String>()
+        val default = secondArg<String?>()
+        (store[k] as? String) ?: default
+    }
+    every { prefs.edit() } returns editor
+    every { prefs.all } answers { store.toMap() }
+
+    val ctx = mockk<Context>(relaxed = true)
+    every { ctx.getSharedPreferences(any(), any()) } returns prefs
+    return ctx to store
+}

--- a/app/src/test/java/com/tinkernorth/dish/repository/RememberedBtRepositoryContractTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/RememberedBtRepositoryContractTest.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.repository
+
+import com.tinkernorth.dish.architecture.interfaces.Repository
+import com.tinkernorth.dish.architecture.testing.AbstractRepositoryContract
+import kotlinx.serialization.json.Json
+import kotlin.random.Random
+
+class RememberedBtRepositoryContractTest : AbstractRepositoryContract<String, RememberedBt>() {
+    override fun newRepository(): Repository<String, RememberedBt> =
+        RememberedBtRepository(
+            context = mapBackedPrefs().first,
+            json = Json { ignoreUnknownKeys = true },
+        )
+
+    override fun newKey(): String = "bt:${Random.nextInt(0, 256)}:${Random.nextInt(0, 256)}"
+
+    // Must be deterministic for a given key: the contract recomputes expected via newValue(k).
+    override fun newValue(key: String): RememberedBt {
+        val seed = key.hashCode()
+        return RememberedBt(
+            id = key,
+            name = "Pad-${key.takeLast(4)}",
+            mac = key.removePrefix("bt:"),
+            profileName = if (seed and 1 == 0) "XBOX" else "PLAYSTATION",
+        )
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/repository/RememberedBtRepositoryTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/RememberedBtRepositoryTest.kt
@@ -90,15 +90,20 @@ class RememberedBtRepositoryTest {
     }
 
     @Test
-    fun `corrupt JSON is dropped silently with no WARN breadcrumb`() {
+    fun `corrupt JSON logs a WARN breadcrumb`() {
         val (ctx, store) = mapBackedPrefs()
         store["bt_list"] = "{not valid json"
         val repo = RememberedBtRepository(ctx, json)
         repo.all()
 
-        // Unlike MotionPreferenceRepository, this repo logs nothing on a decode failure.
-        // See summary: a corrupt blob forgets every paired controller with no trace.
-        verify(exactly = 0) { Log.w(any<String>(), any<String>()) }
-        verify(exactly = 0) { Log.w(any<String>(), any<String>(), any<Throwable>()) }
+        // Parity with MotionPreferenceRepository: a corrupt blob forgets every paired controller, so
+        // leave a trace instead of failing silently. The eager observable mirror reads once at
+        // construction too, so this is at-least-one rather than exactly-one.
+        verify(atLeast = 1) {
+            Log.w(
+                any<String>(),
+                match<String> { it.contains("Failed to decode remembered-Bluetooth list") },
+            )
+        }
     }
 }

--- a/app/src/test/java/com/tinkernorth/dish/repository/RememberedBtRepositoryTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/RememberedBtRepositoryTest.kt
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.repository
+
+import android.util.Log
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class RememberedBtRepositoryTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun entry(
+        id: String,
+        name: String = "Pad",
+        mac: String = "AA:BB",
+        profile: String = "XBOX",
+    ) = RememberedBt(id = id, name = name, mac = mac, profileName = profile)
+
+    @Before
+    fun mockLog() {
+        mockkStatic(Log::class)
+        every { Log.w(any<String>(), any<String>()) } returns 0
+        every { Log.w(any<String>(), any<String>(), any<Throwable>()) } returns 0
+    }
+
+    @After
+    fun unmockLog() {
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun `put then get round-trips an entry by id`() {
+        val (ctx, _) = mapBackedPrefs()
+        val repo = RememberedBtRepository(ctx, json)
+        repo.put(entry(id = "bt:AA:BB", profile = "PLAYSTATION"))
+        assertEquals("PLAYSTATION", repo.get("bt:AA:BB")?.profileName)
+    }
+
+    @Test
+    fun `keyOf reads the id off the value`() {
+        val repo = RememberedBtRepository(mapBackedPrefs().first, json)
+        assertEquals("bt:Z", repo.keyOf(entry(id = "bt:Z")))
+    }
+
+    @Test
+    fun `put with the same id replaces in place so the list never grows`() {
+        val (ctx, _) = mapBackedPrefs()
+        val repo = RememberedBtRepository(ctx, json)
+        repo.put(entry(id = "bt:AA:BB", name = "First"))
+        repo.put(entry(id = "bt:AA:BB", name = "Second"))
+        assertEquals(1, repo.all().size)
+        assertEquals("Second", repo.get("bt:AA:BB")?.name)
+    }
+
+    @Test
+    fun `remove of one host leaves the others`() {
+        val (ctx, _) = mapBackedPrefs()
+        val repo = RememberedBtRepository(ctx, json)
+        repo.put(entry(id = "bt:A"))
+        repo.put(entry(id = "bt:B"))
+        repo.remove("bt:A")
+        assertNull(repo.get("bt:A"))
+        assertEquals(listOf("bt:B"), repo.all().map { it.id })
+    }
+
+    @Test
+    fun `entries survive into a fresh repo over the same prefs`() {
+        val (_, store) = mapBackedPrefs()
+        RememberedBtRepository(mapBackedPrefs(store).first, json).put(entry(id = "bt:A", name = "Durable"))
+        val repo2 = RememberedBtRepository(mapBackedPrefs(store).first, json)
+        assertEquals("Durable", repo2.get("bt:A")?.name)
+    }
+
+    @Test
+    fun `corrupt JSON falls back to empty without crashing`() {
+        val (ctx, store) = mapBackedPrefs()
+        store["bt_list"] = "{not valid json"
+        val repo = RememberedBtRepository(ctx, json)
+        assertTrue(repo.all().isEmpty())
+        assertNull(repo.get("anything"))
+    }
+
+    @Test
+    fun `corrupt JSON is dropped silently with no WARN breadcrumb`() {
+        val (ctx, store) = mapBackedPrefs()
+        store["bt_list"] = "{not valid json"
+        val repo = RememberedBtRepository(ctx, json)
+        repo.all()
+
+        // Unlike MotionPreferenceRepository, this repo logs nothing on a decode failure.
+        // See summary: a corrupt blob forgets every paired controller with no trace.
+        verify(exactly = 0) { Log.w(any<String>(), any<String>()) }
+        verify(exactly = 0) { Log.w(any<String>(), any<String>(), any<Throwable>()) }
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/repository/RememberedSatelliteRepositoryTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/RememberedSatelliteRepositoryTest.kt
@@ -16,8 +16,8 @@ import org.junit.Before
 import org.junit.Test
 
 // Behavioral coverage for the satellite list repository beyond the generic AbstractRepositoryContract:
-// in particular the corrupt-decode fallback and its (current) silence. Mirrors RememberedBtRepositoryTest
-// so the two list repositories document the same trace-less-loss behavior side by side.
+// in particular the corrupt-decode fallback and its WARN breadcrumb. Mirrors RememberedBtRepositoryTest
+// so the two list repositories document the same loss-with-a-trace behavior side by side.
 class RememberedSatelliteRepositoryTest {
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -73,16 +73,20 @@ class RememberedSatelliteRepositoryTest {
     }
 
     @Test
-    fun `corrupt JSON is dropped silently with no WARN breadcrumb`() {
+    fun `corrupt JSON logs a WARN breadcrumb`() {
         val (ctx, store) = mapBackedPrefs()
         store["satellite_list"] = "{not valid json"
         val repo = RememberedSatelliteRepository(ctx, json)
         repo.all()
 
-        // Unlike MotionPreferenceRepository / TouchpadModeRepository, this repo logs nothing on a
-        // decode failure, so a corrupt blob forgets every remembered satellite with no trace.
-        // See summary: add a WARN breadcrumb for parity.
-        verify(exactly = 0) { Log.w(any<String>(), any<String>()) }
-        verify(exactly = 0) { Log.w(any<String>(), any<String>(), any<Throwable>()) }
+        // Parity with MotionPreferenceRepository / TouchpadModeRepository: a corrupt blob forgets
+        // every remembered satellite, so leave a trace instead of failing silently. The eager
+        // observable mirror reads once at construction too, so this is at-least-one, not exactly-one.
+        verify(atLeast = 1) {
+            Log.w(
+                any<String>(),
+                match<String> { it.contains("Failed to decode satellite list") },
+            )
+        }
     }
 }

--- a/app/src/test/java/com/tinkernorth/dish/repository/RememberedSatelliteRepositoryTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/RememberedSatelliteRepositoryTest.kt
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.repository
+
+import android.util.Log
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+// Behavioral coverage for the satellite list repository beyond the generic AbstractRepositoryContract:
+// in particular the corrupt-decode fallback and its (current) silence. Mirrors RememberedBtRepositoryTest
+// so the two list repositories document the same trace-less-loss behavior side by side.
+class RememberedSatelliteRepositoryTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun sat(
+        id: String,
+        name: String = "Box",
+        ip: String = "10.0.0.1",
+    ) = RememberedSatellite(
+        id = id,
+        name = name,
+        ip = ip,
+        udpPort = 9876,
+        pairPort = 9443,
+        httpPort = 9443,
+        machineId = "",
+    )
+
+    @Before
+    fun mockLog() {
+        mockkStatic(Log::class)
+        every { Log.w(any<String>(), any<String>()) } returns 0
+        every { Log.w(any<String>(), any<String>(), any<Throwable>()) } returns 0
+    }
+
+    @After
+    fun unmockLog() {
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun `put then get round-trips by id`() {
+        val (ctx, _) = mapBackedPrefs()
+        val repo = RememberedSatelliteRepository(ctx, json)
+        repo.put(sat(id = "satellite:mid:abc", name = "Den"))
+        assertEquals("Den", repo.get("satellite:mid:abc")?.name)
+    }
+
+    @Test
+    fun `entries survive into a fresh repo over the same prefs`() {
+        val (_, store) = mapBackedPrefs()
+        RememberedSatelliteRepository(mapBackedPrefs(store).first, json).put(sat(id = "satellite:mid:abc"))
+        val repo2 = RememberedSatelliteRepository(mapBackedPrefs(store).first, json)
+        assertEquals("Box", repo2.get("satellite:mid:abc")?.name)
+    }
+
+    @Test
+    fun `corrupt JSON falls back to empty without crashing`() {
+        val (ctx, store) = mapBackedPrefs()
+        store["satellite_list"] = "{not valid json"
+        val repo = RememberedSatelliteRepository(ctx, json)
+        assertTrue(repo.all().isEmpty())
+        assertNull(repo.get("anything"))
+    }
+
+    @Test
+    fun `corrupt JSON is dropped silently with no WARN breadcrumb`() {
+        val (ctx, store) = mapBackedPrefs()
+        store["satellite_list"] = "{not valid json"
+        val repo = RememberedSatelliteRepository(ctx, json)
+        repo.all()
+
+        // Unlike MotionPreferenceRepository / TouchpadModeRepository, this repo logs nothing on a
+        // decode failure, so a corrupt blob forgets every remembered satellite with no trace.
+        // See summary: add a WARN breadcrumb for parity.
+        verify(exactly = 0) { Log.w(any<String>(), any<String>()) }
+        verify(exactly = 0) { Log.w(any<String>(), any<String>(), any<Throwable>()) }
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/repository/SatellitePinRepositoryTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/SatellitePinRepositoryTest.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.repository
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SatellitePinRepositoryTest {
+    @Test
+    fun `pin then read round-trips a fingerprint by satellite id`() {
+        val (ctx, _) = mapBackedPrefs()
+        val repo = SatellitePinRepository(ctx)
+        repo.pin("satellite:mid:abc", "deadbeef")
+        assertEquals("deadbeef", repo.pinnedFingerprint("satellite:mid:abc"))
+    }
+
+    @Test
+    fun `pinnedFingerprint for an unknown satellite is null`() {
+        val (ctx, _) = mapBackedPrefs()
+        val repo = SatellitePinRepository(ctx)
+        assertNull(repo.pinnedFingerprint("satellite:mid:nope"))
+    }
+
+    @Test
+    fun `pins survive into a fresh repo over the same prefs`() {
+        val (ctx, store) = mapBackedPrefs()
+        SatellitePinRepository(ctx).pin("satellite:mid:abc", "AABB")
+
+        val repo2 = SatellitePinRepository(mapBackedPrefs(store).first)
+        assertEquals("AABB", repo2.pinnedFingerprint("satellite:mid:abc"))
+    }
+
+    @Test
+    fun `forget drops one pin and leaves the others`() {
+        val (ctx, _) = mapBackedPrefs()
+        val repo = SatellitePinRepository(ctx)
+        repo.pin("satellite:mid:a", "AA")
+        repo.pin("satellite:mid:b", "BB")
+
+        repo.forget("satellite:mid:a")
+
+        assertNull(repo.pinnedFingerprint("satellite:mid:a"))
+        assertEquals("BB", repo.pinnedFingerprint("satellite:mid:b"))
+    }
+
+    @Test
+    fun `distinct satellites keep isolated pins`() {
+        val (ctx, _) = mapBackedPrefs()
+        val repo = SatellitePinRepository(ctx)
+        repo.pin("10.0.0.1", "1111")
+        repo.pin("10.0.0.2", "2222")
+
+        assertEquals("1111", repo.pinnedFingerprint("10.0.0.1"))
+        assertEquals("2222", repo.pinnedFingerprint("10.0.0.2"))
+    }
+
+    @Test
+    fun `pin does not leak into a sibling shared-key repo over the same prefs`() {
+        // Both repos co-tenant the connection_store prefs file under different key prefixes.
+        val (ctx, store) = mapBackedPrefs()
+        SatellitePinRepository(ctx).pin("satellite:mid:a", "CAFE")
+
+        val keys = SatelliteSharedKeyRepository(mapBackedPrefs(store).first)
+        assertNull("cert pin must not surface as a shared key", keys.get("satellite:mid:a"))
+        assertNotNull(SatellitePinRepository(mapBackedPrefs(store).first).pinnedFingerprint("satellite:mid:a"))
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/repository/SatelliteSharedKeyRepositoryTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/SatelliteSharedKeyRepositoryTest.kt
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.repository
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SatelliteSharedKeyRepositoryTest {
+    @Test
+    fun `put then get round-trips a key by id`() {
+        val (ctx, _) = mapBackedPrefs()
+        val repo = SatelliteSharedKeyRepository(ctx)
+        repo.put("satellite:mid:abc", "DEADBEEF")
+        assertEquals("DEADBEEF", repo.get("satellite:mid:abc"))
+    }
+
+    @Test
+    fun `get for an unknown id is null`() {
+        val (ctx, _) = mapBackedPrefs()
+        val repo = SatelliteSharedKeyRepository(ctx)
+        assertNull(repo.get("satellite:mid:nope"))
+    }
+
+    @Test
+    fun `keys survive into a fresh repo over the same prefs`() {
+        val (ctx, store) = mapBackedPrefs()
+        SatelliteSharedKeyRepository(ctx).put("satellite:mid:abc", "KEY1")
+
+        val repo2 = SatelliteSharedKeyRepository(mapBackedPrefs(store).first)
+        assertEquals("KEY1", repo2.get("satellite:mid:abc"))
+    }
+
+    @Test
+    fun `remove drops one key and leaves the others`() {
+        val (ctx, _) = mapBackedPrefs()
+        val repo = SatelliteSharedKeyRepository(ctx)
+        repo.put("satellite:mid:a", "A")
+        repo.put("satellite:mid:b", "B")
+
+        repo.remove("satellite:mid:a")
+
+        assertNull(repo.get("satellite:mid:a"))
+        assertEquals("B", repo.get("satellite:mid:b"))
+    }
+
+    @Test
+    fun `all returns only shared-key values and ignores sibling prefs entries`() {
+        val (ctx, store) = mapBackedPrefs()
+        // Co-tenant keys in the same connection_store prefs file must not leak into all().
+        store["satellite_list"] = """[{"id":"x"}]"""
+        store["bt_list"] = """[{"id":"y"}]"""
+        val repo = SatelliteSharedKeyRepository(ctx)
+        repo.put("satellite:mid:a", "A")
+        repo.put("satellite:mid:b", "B")
+
+        assertEquals(setOf("A", "B"), repo.all().toSet())
+    }
+
+    @Test
+    fun `clear removes every shared key but preserves co-tenant prefs entries`() {
+        val (ctx, store) = mapBackedPrefs()
+        store["satellite_list"] = "preserved"
+        val repo = SatelliteSharedKeyRepository(ctx)
+        repo.put("satellite:mid:a", "A")
+        repo.put("satellite:mid:b", "B")
+
+        repo.clear()
+
+        assertTrue(repo.all().isEmpty())
+        assertEquals("preserved", store["satellite_list"])
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/repository/TofuPinningTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/TofuPinningTest.kt
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.repository
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TofuPinningTest {
+    @Test
+    fun `no prior pin trusts first use`() {
+        assertEquals(TofuVerdict.TRUST_FIRST_USE, tofuVerdict(stored = null, presented = "aabb"))
+    }
+
+    @Test
+    fun `equal fingerprint is a match`() {
+        assertEquals(TofuVerdict.MATCH, tofuVerdict(stored = "aabb", presented = "aabb"))
+    }
+
+    @Test
+    fun `match is case-insensitive on hex`() {
+        assertEquals(TofuVerdict.MATCH, tofuVerdict(stored = "AABBcc", presented = "aabbCC"))
+    }
+
+    @Test
+    fun `different fingerprint is a mismatch`() {
+        assertEquals(TofuVerdict.MISMATCH, tofuVerdict(stored = "aabb", presented = "ccdd"))
+    }
+
+    @Test
+    fun `empty stored string is not treated as absent and can mismatch`() {
+        // Only null means "never pinned"; an empty stored value is a present, non-matching pin.
+        assertEquals(TofuVerdict.MISMATCH, tofuVerdict(stored = "", presented = "aabb"))
+    }
+
+    @Test
+    fun `sha256 of empty array matches the known vector`() {
+        assertEquals(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            sha256FingerprintHex(ByteArray(0)),
+        )
+    }
+
+    @Test
+    fun `sha256 of abc matches the known vector`() {
+        assertEquals(
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            sha256FingerprintHex(byteArrayOf('a'.code.toByte(), 'b'.code.toByte(), 'c'.code.toByte())),
+        )
+    }
+
+    @Test
+    fun `sha256 output is lowercase and 64 hex chars`() {
+        val hex = sha256FingerprintHex(byteArrayOf(0x00, 0x7F, 0xFF.toByte()))
+        assertEquals(64, hex.length)
+        assertEquals(hex.lowercase(), hex)
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/repository/TouchpadModeRepositoryContractTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/TouchpadModeRepositoryContractTest.kt
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.repository
+
+import com.tinkernorth.dish.architecture.interfaces.Repository
+import com.tinkernorth.dish.architecture.testing.AbstractRepositoryContract
+import kotlinx.serialization.json.Json
+import kotlin.random.Random
+
+class TouchpadModeRepositoryContractTest : AbstractRepositoryContract<String, TouchpadModePreference>() {
+    override fun newRepository(): Repository<String, TouchpadModePreference> =
+        TouchpadModeRepository(
+            context = mapBackedPrefs().first,
+            json = Json { ignoreUnknownKeys = true },
+        )
+
+    override fun newKey(): String = "sat-${Random.nextLong()}"
+
+    // Must be deterministic AND a valid wire mode: put() now rejects unknown modes,
+    // so a garbage value here would silently make the contract's round-trip assertions fail.
+    override fun newValue(key: String): TouchpadModePreference {
+        val mode = TouchpadModeValue.ALL[(key.hashCode().mod(TouchpadModeValue.ALL.size))]
+        return TouchpadModePreference(satelliteId = key, mode = mode)
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/repository/TouchpadModeRepositoryTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/repository/TouchpadModeRepositoryTest.kt
@@ -82,6 +82,26 @@ class TouchpadModeRepositoryTest {
     }
 
     @Test
+    fun `put of an invalid mode does not round-trip`() {
+        val (ctx, _) = fakePrefs()
+        val repo = TouchpadModeRepository(ctx, json)
+        repo.put(TouchpadModePreference("sat-a", "garbage"))
+
+        // Rejected at the door: nothing persisted, so a typo cannot survive a reload.
+        assertNull(repo.get("sat-a"))
+        assertTrue(repo.all().isEmpty())
+    }
+
+    @Test
+    fun `put of an invalid mode does not overwrite an existing valid mode`() {
+        val (ctx, _) = fakePrefs()
+        val repo = TouchpadModeRepository(ctx, json)
+        repo.put(TouchpadModePreference("sat-a", TouchpadModeValue.DS4))
+        repo.put(TouchpadModePreference("sat-a", "garbage"))
+        assertEquals(TouchpadModeValue.DS4, repo.get("sat-a")?.mode)
+    }
+
+    @Test
     fun `remove of one satellite does not disturb other satellites' modes`() {
         val (ctx, _) = fakePrefs()
         val repo = TouchpadModeRepository(ctx, json)

--- a/app/src/test/java/com/tinkernorth/dish/source/bluetooth/AndroidHidProxyClientReportTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/bluetooth/AndroidHidProxyClientReportTest.kt
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.bluetooth
+
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothHidDevice
+import android.content.Context
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AndroidHidProxyClientReportTest {
+    private val context = mockk<Context>(relaxed = true)
+    private val client = AndroidHidProxyClient(context)
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // sendReport reads @Volatile hidDevice/connectedDevice set by the binder thread; the tests
+    // inject them directly since there is no Android adapter to drive the real callbacks here.
+    private fun setField(
+        name: String,
+        value: Any?,
+    ) {
+        AndroidHidProxyClient::class.java
+            .getDeclaredField(name)
+            .apply { isAccessible = true }
+            .set(client, value)
+    }
+
+    @Test
+    fun `sendReport returns false without crashing when the proxy throws after teardown`() {
+        val hid =
+            mockk<BluetoothHidDevice> {
+                every { sendReport(any(), any(), any()) } throws IllegalStateException("proxy closed")
+            }
+        setField("hidDevice", hid)
+        setField("connectedDevice", mockk<BluetoothDevice>(relaxed = true))
+
+        assertFalse(client.sendReport(ByteArray(14)))
+    }
+
+    @Test
+    fun `sendReport delegates to the proxy and returns its result on the happy path`() {
+        val device = mockk<BluetoothDevice>(relaxed = true)
+        val hid =
+            mockk<BluetoothHidDevice> {
+                every { sendReport(any(), any(), any()) } returns true
+            }
+        setField("hidDevice", hid)
+        setField("connectedDevice", device)
+
+        assertTrue(client.sendReport(ByteArray(14).also { it[0] = 1 }))
+        verify { hid.sendReport(device, 1, any()) }
+    }
+
+    @Test
+    fun `sendReport returns false when nothing is connected`() {
+        assertFalse(client.sendReport(ByteArray(14)))
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothHidSessionTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothHidSessionTest.kt
@@ -4,6 +4,7 @@ package com.tinkernorth.dish.source.bluetooth
 
 import com.tinkernorth.dish.core.input.BluetoothGamepad.GamepadProfile
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -116,5 +117,43 @@ class BluetoothHidSessionTest {
         fake.fireHostDisconnected("OTHER")
 
         assertTrue(session.state.value is BluetoothSessionState.Connected)
+    }
+
+    @Test
+    fun `onHostConnected for a foreign mac is ignored when started for a specific host`() {
+        session.start(GamepadProfile.XBOX, autoConnectMac = "AA:BB")
+        fake.fireAcquired()
+        fake.fireAppRegistered()
+
+        fake.fireHostConnected("CC:DD", "Stranger PC")
+
+        val s = session.state.value as BluetoothSessionState.Registered
+        assertEquals("AA:BB", s.autoConnectMac)
+        assertFalse(session.sendReport(ByteArray(14)))
+        assertTrue(fake.calls.none { it is FakeHidProxyClient.Call.SendReport })
+    }
+
+    @Test
+    fun `onHostConnected for the intended mac is accepted when started for a specific host`() {
+        session.start(GamepadProfile.XBOX, autoConnectMac = "AA:BB")
+        fake.fireAcquired()
+        fake.fireAppRegistered()
+
+        fake.fireHostConnected("aa:bb", "My PC")
+
+        val s = session.state.value as BluetoothSessionState.Connected
+        assertEquals("aa:bb", s.mac)
+        assertEquals("My PC", s.name)
+        assertEquals(GamepadProfile.XBOX, s.profile)
+    }
+
+    @Test
+    fun `onHostConnected is rejected before the app is registered`() {
+        session.start(GamepadProfile.XBOX, autoConnectMac = null)
+        fake.fireAcquired()
+
+        fake.fireHostConnected("11:22", "Premature PC")
+
+        assertTrue(session.state.value is BluetoothSessionState.Acquiring)
     }
 }

--- a/app/src/test/java/com/tinkernorth/dish/source/connection/PairingApprovalTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/connection/PairingApprovalTest.kt
@@ -57,4 +57,14 @@ class PairingApprovalTest {
     fun `an unparseable body is Declined`() {
         assertEquals(PairingApproval.Status.Declined, PairingApproval.classifyStatus("not json"))
     }
+
+    @Test
+    fun `a 64-char non-hex sharedKey is Declined`() {
+        // Right length but wrong alphabet: must not be trusted as a session key.
+        val notHex = "g".repeat(64)
+        assertEquals(
+            PairingApproval.Status.Declined,
+            PairingApproval.classifyStatus("""{"status":"approved","sharedKey":"$notHex"}"""),
+        )
+    }
 }

--- a/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManagerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManagerTest.kt
@@ -8,13 +8,14 @@ import com.tinkernorth.dish.composer.MotionCapability
 import com.tinkernorth.dish.composer.MotionCapabilityComposer
 import com.tinkernorth.dish.core.jni.ControllerRepository
 import com.tinkernorth.dish.core.model.DiscoveredServer
-import com.tinkernorth.dish.core.net.DiscoveryRepository
+import com.tinkernorth.dish.core.net.DiscoveryGateway
 import com.tinkernorth.dish.repository.ConnectionStore
 import com.tinkernorth.dish.source.store.SatelliteMotionBackendStatusStore
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.launch
@@ -31,7 +32,7 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class SatelliteConnectionManagerTest {
     private lateinit var context: Context
-    private lateinit var discoveryRepo: DiscoveryRepository
+    private lateinit var discoveryRepo: DiscoveryGateway
     private lateinit var controllerRepo: ControllerRepository
     private lateinit var store: ConnectionStore
     private lateinit var prefs: SharedPreferences
@@ -349,5 +350,98 @@ class SatelliteConnectionManagerTest {
                 "second subscriber must see no replayed events: $secondEvents",
                 secondEvents.isEmpty(),
             )
+        }
+
+    @Test
+    fun `forget cancels an in-flight reverse-pairing poll`() =
+        runMgrTest { mgr, _ ->
+            // Pair accepts the request (no immediate key), then status stays pending.
+            coEvery { discoveryRepo.pair(any(), any(), any(), any(), any(), any()) } returns
+                """{"status":"pending"}"""
+            var pollCount = 0
+            coEvery { discoveryRepo.pairStatus(any(), any(), any()) } coAnswers {
+                pollCount++
+                """{"status":"pending"}"""
+            }
+
+            mgr.requestApproval(server, "4242")
+            // Let a couple of poll rounds run so we know the loop is live before we forget.
+            scope.testScheduler.advanceTimeBy(5000)
+            scope.testScheduler.runCurrent()
+            assertTrue("poll should have run at least once before forget", pollCount > 0)
+
+            mgr.forget(serverId)
+            val afterForget = pollCount
+            // Advance well past the 2-minute timeout: a leaked poll would keep calling pairStatus.
+            scope.testScheduler.advanceUntilIdle()
+
+            assertEquals("no pairStatus calls after forget", afterForget, pollCount)
+            coVerify(exactly = 0) { discoveryRepo.connect(any(), any(), any()) }
+            verify(exactly = 0) { controllerRepo.openSocket(any(), any()) }
+        }
+
+    @Test
+    fun `disconnect cancels an in-flight reverse-pairing poll`() =
+        runMgrTest { mgr, _ ->
+            coEvery { discoveryRepo.pair(any(), any(), any(), any(), any(), any()) } returns
+                """{"status":"pending"}"""
+            var pollCount = 0
+            coEvery { discoveryRepo.pairStatus(any(), any(), any()) } coAnswers {
+                pollCount++
+                """{"status":"pending"}"""
+            }
+
+            mgr.requestApproval(server, "4242")
+            scope.testScheduler.advanceTimeBy(5000)
+            scope.testScheduler.runCurrent()
+            assertTrue("poll should have run at least once before disconnect", pollCount > 0)
+
+            mgr.disconnect(serverId)
+            val afterDisconnect = pollCount
+            scope.testScheduler.advanceUntilIdle()
+
+            assertEquals("no pairStatus calls after disconnect", afterDisconnect, pollCount)
+            coVerify(exactly = 0) { discoveryRepo.connect(any(), any(), any()) }
+            verify(exactly = 0) { controllerRepo.openSocket(any(), any()) }
+        }
+
+    @Test
+    fun `malformed (non-hex) server token degrades gracefully without crashing`() =
+        runMgrTest { mgr, _ ->
+            every { store.satelliteSharedKey(serverId) } returns "aa".repeat(32)
+            // Auth-shape OK (connectionId + token present) but the token is non-hex,
+            // so hexToBytes throws. The session must fail closed, not crash the coroutine.
+            coEvery { discoveryRepo.connect(any(), any(), any()) } returns
+                """{"connectionId":"c1","token":"zzzz"}"""
+
+            mgr.connect(server)
+            scope.testScheduler.advanceUntilIdle()
+
+            assertEquals(SatelliteSessionState.Idle, mgr.get(serverId)?.state?.value)
+            verify(exactly = 0) { controllerRepo.openSocket(any(), any()) }
+        }
+
+    @Test
+    fun `connect to a public ip is refused before any socket is opened`() =
+        runMgrTest { mgr, _ ->
+            val publicServer = server.copy(ip = "8.8.8.8")
+            val publicId = SatelliteConnection.idFor(publicServer)
+            // Stored key routes both straight to openSession (the IP choke point).
+            every { store.satelliteSharedKey(publicId) } returns "aa".repeat(32)
+            every { store.satelliteSharedKey(serverId) } returns "aa".repeat(32)
+            coEvery { discoveryRepo.connect(any(), any(), any()) } returns ""
+
+            mgr.connect(publicServer)
+            scope.testScheduler.advanceUntilIdle()
+
+            // Public address: rejected before contacting the host or opening a socket.
+            coVerify(exactly = 0) { discoveryRepo.connect("8.8.8.8", any(), any()) }
+            verify(exactly = 0) { controllerRepo.openSocket("8.8.8.8", any()) }
+            assertEquals(SatelliteSessionState.Idle, mgr.get(publicId)?.state?.value)
+
+            // Private address: passes the guard and proceeds to the connect call.
+            mgr.connect(server)
+            scope.testScheduler.advanceUntilIdle()
+            coVerify(exactly = 1) { discoveryRepo.connect("10.0.0.5", any(), any()) }
         }
 }

--- a/app/src/test/java/com/tinkernorth/dish/source/sensor/PhoneMotionAvailabilityTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/sensor/PhoneMotionAvailabilityTest.kt
@@ -7,7 +7,6 @@ import android.hardware.Sensor
 import android.hardware.SensorManager
 import io.mockk.every
 import io.mockk.mockk
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -24,13 +23,13 @@ class PhoneMotionAvailabilityTest {
     @Test
     fun `phone with a gyroscope is motion-available`() {
         val src = PhoneMotionAvailability(contextWithSensor(mockk()))
-        assertTrue(src.state.value)
+        assertTrue(src.hasGyro)
     }
 
     @Test
     fun `phone without a gyroscope is not motion-available`() {
         val src = PhoneMotionAvailability(contextWithSensor(sensor = null))
-        assertFalse(src.state.value)
+        assertFalse(src.hasGyro)
     }
 
     @Test
@@ -40,13 +39,6 @@ class PhoneMotionAvailabilityTest {
                 every { getSystemService(Context.SENSOR_SERVICE) } returns null
             }
         val src = PhoneMotionAvailability(ctx)
-        assertFalse(src.state.value)
-    }
-
-    @Test
-    fun `state flow exposes the same boolean as state value`() {
-        val src = PhoneMotionAvailability(contextWithSensor(mockk()))
-        assertEquals(src.state.value, src.state.value)
-        assertTrue(src.state.value)
+        assertFalse(src.hasGyro)
     }
 }

--- a/app/src/test/java/com/tinkernorth/dish/source/store/ControllerTypeStoreTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/store/ControllerTypeStoreTest.kt
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.store
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ControllerTypeStoreTest {
+    private val xbox = 0
+    private val playstation = 1
+
+    @Test
+    fun `setType then typeFor round-trips the value`() {
+        val store = ControllerTypeStore()
+        store.setType("conn-1", "slot-A", playstation)
+        assertEquals(playstation, store.typeFor("conn-1", "slot-A"))
+    }
+
+    @Test
+    fun `typeFor an unset connection-slot is null`() {
+        val store = ControllerTypeStore()
+        assertNull(store.typeFor("conn-1", "slot-A"))
+    }
+
+    @Test
+    fun `setType overwrites an existing value`() {
+        val store = ControllerTypeStore()
+        store.setType("conn-1", "slot-A", xbox)
+        store.setType("conn-1", "slot-A", playstation)
+        assertEquals(playstation, store.typeFor("conn-1", "slot-A"))
+    }
+
+    @Test
+    fun `setTypeIfAbsent writes when the key is unset`() {
+        val store = ControllerTypeStore()
+        store.setTypeIfAbsent("conn-1", "slot-A", playstation)
+        assertEquals(playstation, store.typeFor("conn-1", "slot-A"))
+    }
+
+    @Test
+    fun `setTypeIfAbsent keeps the existing value when present`() {
+        val store = ControllerTypeStore()
+        store.setType("conn-1", "slot-A", playstation)
+        store.setTypeIfAbsent("conn-1", "slot-A", xbox)
+        assertEquals(playstation, store.typeFor("conn-1", "slot-A"))
+    }
+
+    @Test
+    fun `the same slot id under different connections does not collide`() {
+        val store = ControllerTypeStore()
+        store.setType("conn-1", "slot-A", xbox)
+        store.setType("conn-2", "slot-A", playstation)
+        assertEquals(xbox, store.typeFor("conn-1", "slot-A"))
+        assertEquals(playstation, store.typeFor("conn-2", "slot-A"))
+    }
+
+    @Test
+    fun `slotTypesFor returns only bound slots that carry a type`() {
+        val store = ControllerTypeStore()
+        store.setType("conn-1", "slot-A", xbox)
+        store.setType("conn-1", "slot-B", playstation)
+        store.setType("conn-2", "slot-A", playstation)
+
+        val types = store.slotTypesFor("conn-1", listOf("slot-A", "slot-B", "slot-unbound"))
+
+        assertEquals(mapOf("slot-A" to xbox, "slot-B" to playstation), types)
+    }
+
+    @Test
+    fun `clear removes only the exact connection-slot entry, leaving the connection's other slots`() {
+        val store = ControllerTypeStore()
+        store.setType("conn-1", "slot-A", xbox)
+        store.setType("conn-1", "slot-B", playstation)
+
+        store.clear("conn-1", "slot-A")
+
+        assertNull(store.typeFor("conn-1", "slot-A"))
+        // No bulk clearConnection(connectionId) exists, so slot-B's type survives the connection going away.
+        assertEquals(playstation, store.typeFor("conn-1", "slot-B"))
+    }
+
+    @Test
+    fun `clear of an unset connection-slot is a no-op`() {
+        val store = ControllerTypeStore()
+        store.setType("conn-1", "slot-A", xbox)
+        store.clear("conn-1", "slot-missing")
+        assertEquals(xbox, store.typeFor("conn-1", "slot-A"))
+        assertEquals(1, store.state.value.size)
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/source/store/ControllerTypeStoreTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/store/ControllerTypeStoreTest.kt
@@ -76,8 +76,22 @@ class ControllerTypeStoreTest {
         store.clear("conn-1", "slot-A")
 
         assertNull(store.typeFor("conn-1", "slot-A"))
-        // No bulk clearConnection(connectionId) exists, so slot-B's type survives the connection going away.
+        // clear is per-slot: slot-B survives. clearConnection drops a whole connection at once.
         assertEquals(playstation, store.typeFor("conn-1", "slot-B"))
+    }
+
+    @Test
+    fun `clearConnection drops every slot for a connection and leaves other connections`() {
+        val store = ControllerTypeStore()
+        store.setType("conn-1", "slot-A", xbox)
+        store.setType("conn-1", "slot-B", playstation)
+        store.setType("conn-2", "slot-A", playstation)
+
+        store.clearConnection("conn-1")
+
+        assertNull(store.typeFor("conn-1", "slot-A"))
+        assertNull(store.typeFor("conn-1", "slot-B"))
+        assertEquals(playstation, store.typeFor("conn-2", "slot-A"))
     }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/source/store/SlotBindingStoreTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/store/SlotBindingStoreTest.kt
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.store
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.concurrent.CyclicBarrier
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SlotBindingStoreTest {
+    @Test
+    fun `bind records the slot to connection mapping`() {
+        val store = SlotBindingStore()
+        store.bind("slot-A", "conn-1")
+        assertEquals("conn-1", store.connectionFor("slot-A"))
+        assertEquals(mapOf("slot-A" to "conn-1"), store.bindings.value)
+    }
+
+    @Test
+    fun `connectionFor an unbound slot is null`() {
+        val store = SlotBindingStore()
+        assertNull(store.connectionFor("ghost"))
+    }
+
+    @Test
+    fun `slotsFor returns every slot bound to a connection`() {
+        val store = SlotBindingStore()
+        store.bind("slot-A", "conn-1")
+        store.bind("slot-B", "conn-1")
+        store.bind("slot-C", "conn-2")
+        assertEquals(setOf("slot-A", "slot-B"), store.slotsFor("conn-1").toSet())
+        assertEquals(listOf("slot-C"), store.slotsFor("conn-2"))
+        assertEquals(emptyList<String>(), store.slotsFor("conn-unknown"))
+    }
+
+    @Test
+    fun `binding the same slot to a new connection overwrites the prior connection`() {
+        val store = SlotBindingStore()
+        store.bind("slot-A", "conn-1")
+        store.bind("slot-A", "conn-2")
+        assertEquals("conn-2", store.connectionFor("slot-A"))
+        assertEquals(emptyList<String>(), store.slotsFor("conn-1"))
+    }
+
+    @Test
+    fun `unbind removes the slot`() {
+        val store = SlotBindingStore()
+        store.bind("slot-A", "conn-1")
+        store.unbind("slot-A")
+        assertNull(store.connectionFor("slot-A"))
+        assertEquals(emptyMap<String, String>(), store.bindings.value)
+    }
+
+    @Test
+    fun `unbind of an unbound slot is a no-op`() {
+        val store = SlotBindingStore()
+        store.bind("slot-A", "conn-1")
+        store.unbind("ghost")
+        assertEquals(mapOf("slot-A" to "conn-1"), store.bindings.value)
+    }
+
+    @Test
+    fun `replace returns the prior connection and installs the new one`() {
+        val store = SlotBindingStore()
+        store.bind("slot-A", "conn-1")
+        val prior = store.replace("slot-A", "conn-2")
+        assertEquals("conn-1", prior)
+        assertEquals("conn-2", store.connectionFor("slot-A"))
+    }
+
+    @Test
+    fun `replace on an unbound slot returns null`() {
+        val store = SlotBindingStore()
+        val prior = store.replace("slot-A", "conn-1")
+        assertNull(prior)
+        assertEquals("conn-1", store.connectionFor("slot-A"))
+    }
+
+    @Test
+    fun `re-binding a slot to the identical connection does not emit a new state`() =
+        runTest {
+            val store = SlotBindingStore()
+            val seen = mutableListOf<Map<String, String>>()
+            val job = launch(UnconfinedTestDispatcher(testScheduler)) { store.state.collect { seen += it } }
+
+            store.bind("slot-A", "conn-1")
+            store.bind("slot-A", "conn-1")
+            runCurrent()
+            job.cancel()
+
+            // StateFlow conflates structurally-equal values, so the redundant bind is dropped.
+            assertEquals(listOf(emptyMap(), mapOf("slot-A" to "conn-1")), seen)
+        }
+
+    @Test
+    fun `concurrent binds for distinct slots never lose an update`() {
+        val store = SlotBindingStore()
+        val threads = 16
+        val perThread = 500
+        val barrier = CyclicBarrier(threads)
+
+        val workers =
+            (0 until threads).map { t ->
+                Thread {
+                    runCatching { barrier.await() }
+                    repeat(perThread) { i -> store.bind("slot-$t-$i", "conn-$t") }
+                }
+            }
+        workers.forEach(Thread::start)
+        workers.forEach(Thread::join)
+
+        assertEquals(
+            "a concurrent bind was lost: read-modify-write is not atomic",
+            threads * perThread,
+            store.bindings.value.size,
+        )
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/source/store/UsbPathPreferenceStoreTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/store/UsbPathPreferenceStoreTest.kt
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.store
+
+import com.tinkernorth.dish.repository.mapBackedPrefs
+import com.tinkernorth.dish.source.usb.PathChoice
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+// First coverage for the persisted USB path override (the store had no test). Exercises the
+// per-(vid,pid) round-trip, durability across re-construction, the unchanged-write short-circuit,
+// and the corrupt/forward-incompatible blob fallbacks in readInitial. Uses the shared map-backed
+// SharedPreferences double so one backing map models the on-disk user_preferences file.
+class UsbPathPreferenceStoreTest {
+    @Test
+    fun `setChoice then choiceFor round-trips per vid and pid`() {
+        val (ctx, _) = mapBackedPrefs()
+        val store = UsbPathPreferenceStore(ctx)
+
+        store.setChoice(0x045E, 0x028E, PathChoice.Direct)
+
+        assertEquals(PathChoice.Direct, store.choiceFor(0x045E, 0x028E))
+        assertNull(store.choiceFor(0x054C, 0x05C4)) // an unrelated pad is unaffected
+    }
+
+    @Test
+    fun `choices survive into a fresh store over the same prefs`() {
+        val (_, backing) = mapBackedPrefs()
+        UsbPathPreferenceStore(mapBackedPrefs(backing).first)
+            .setChoice(0x045E, 0x028E, PathChoice.Standard)
+
+        val reopened = UsbPathPreferenceStore(mapBackedPrefs(backing).first)
+
+        assertEquals(PathChoice.Standard, reopened.choiceFor(0x045E, 0x028E))
+    }
+
+    @Test
+    fun `clear removes only the targeted pad`() {
+        val (ctx, _) = mapBackedPrefs()
+        val store = UsbPathPreferenceStore(ctx)
+        store.setChoice(0x045E, 0x028E, PathChoice.Direct)
+        store.setChoice(0x054C, 0x05C4, PathChoice.Standard)
+
+        store.clear(0x045E, 0x028E)
+
+        assertNull(store.choiceFor(0x045E, 0x028E))
+        assertEquals(PathChoice.Standard, store.choiceFor(0x054C, 0x05C4))
+    }
+
+    @Test
+    fun `setChoice to the current value does not churn the state map`() {
+        val (ctx, _) = mapBackedPrefs()
+        val store = UsbPathPreferenceStore(ctx)
+        store.setChoice(0x045E, 0x028E, PathChoice.Direct)
+        val before = store.state.value
+
+        store.setChoice(0x045E, 0x028E, PathChoice.Direct)
+
+        // The store short-circuits an unchanged write, so the same map instance is retained (no emission).
+        assertSame(before, store.state.value)
+    }
+
+    @Test
+    fun `a corrupt choices blob falls back to an empty map without crashing`() {
+        val (ctx, backing) = mapBackedPrefs()
+        backing[UsbPathPreferenceStore.KEY_CHOICES] = "{not valid json"
+
+        val store = UsbPathPreferenceStore(ctx)
+
+        assertNull(store.choiceFor(0x045E, 0x028E))
+    }
+
+    @Test
+    fun `an unknown stored path value is dropped on read for forward-compat`() {
+        val (ctx, backing) = mapBackedPrefs()
+        // A value written by a newer build (an enum constant this build does not know) is ignored.
+        backing[UsbPathPreferenceStore.KEY_CHOICES] = """{"045e:028e":"teleport"}"""
+
+        val store = UsbPathPreferenceStore(ctx)
+
+        assertNull(store.choiceFor(0x045E, 0x028E))
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/source/system/ConnectionForegroundObserverTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/system/ConnectionForegroundObserverTest.kt
@@ -5,7 +5,7 @@ package com.tinkernorth.dish.source.system
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
-import com.tinkernorth.dish.composer.ConnectionHub
+import com.tinkernorth.dish.composer.ConnectionCoordinator
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Test
@@ -19,7 +19,7 @@ class ConnectionForegroundObserverTest {
 
     @Test
     fun `ON_START triggers autoReconnectAll on the hub`() {
-        val hub = mockk<ConnectionHub>(relaxed = true)
+        val hub = mockk<ConnectionCoordinator>(relaxed = true)
         val owner = TestOwner()
         val observer = ConnectionForegroundObserver(hub)
         owner.registry.addObserver(observer)
@@ -31,7 +31,7 @@ class ConnectionForegroundObserverTest {
 
     @Test
     fun `ON_STOP does not call autoReconnectAll`() {
-        val hub = mockk<ConnectionHub>(relaxed = true)
+        val hub = mockk<ConnectionCoordinator>(relaxed = true)
         val owner = TestOwner()
         val observer = ConnectionForegroundObserver(hub)
         owner.registry.addObserver(observer)
@@ -44,7 +44,7 @@ class ConnectionForegroundObserverTest {
 
     @Test
     fun `repeated ON_START triggers autoReconnectAll each time the app comes back`() {
-        val hub = mockk<ConnectionHub>(relaxed = true)
+        val hub = mockk<ConnectionCoordinator>(relaxed = true)
         val owner = TestOwner()
         val observer = ConnectionForegroundObserver(hub)
         owner.registry.addObserver(observer)

--- a/app/src/test/java/com/tinkernorth/dish/source/usb/UsbGamepadManagerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/usb/UsbGamepadManagerTest.kt
@@ -11,7 +11,7 @@ import android.hardware.usb.UsbEndpoint
 import android.hardware.usb.UsbInterface
 import android.hardware.usb.UsbManager
 import android.util.Log
-import com.tinkernorth.dish.composer.ConnectionHub
+import com.tinkernorth.dish.composer.ConnectionCoordinator
 import com.tinkernorth.dish.core.jni.PhysicalInputNative
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.source.notification.DishNotifications
@@ -46,7 +46,7 @@ class UsbGamepadManagerTest {
     private val registry = mockk<PhysicalGamepadRegistry>(relaxed = true)
     private val native = mockk<PhysicalInputNative>(relaxed = true)
     private val notifications = mockk<DishNotifications>(relaxed = true)
-    private val hub = mockk<ConnectionHub>(relaxed = true)
+    private val hub = mockk<ConnectionCoordinator>(relaxed = true)
     private val pathPrefs = mockk<UsbPathPreferenceStore>(relaxed = true)
     private val device = gamepadDevice()
 

--- a/app/src/test/java/com/tinkernorth/dish/source/usb/UsbPathMachineEdgeCasesTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/usb/UsbPathMachineEdgeCasesTest.kt
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.usb
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+// Characterization tests for transitions that are intentionally inert or fall through to `stay`.
+// They document the current contract so a future change to these corners is a visible diff, and
+// they back the two FSM observations called out in the architecture summary.
+class UsbPathMachineEdgeCasesTest {
+    private fun controller(
+        phase: UsbPhase,
+        frameworkId: Int? = null,
+        syntheticId: Int? = null,
+        desired: PathChoice = PathChoice.Standard,
+        userInitiated: Boolean = false,
+        failure: DirectClaimFailure? = null,
+    ) = UsbController(
+        vendorId = 0x045E,
+        productId = 0x028E,
+        name = "Pad",
+        phase = phase,
+        frameworkId = frameworkId,
+        syntheticId = syntheticId,
+        desired = desired,
+        userInitiated = userInitiated,
+        failure = failure,
+    )
+
+    @Test
+    fun `needs replug plus choose direct records the desire but emits no recovery effect`() {
+        val r = reduce(controller(UsbPhase.NeedsReplug), UsbEvent.Choose(PathChoice.Direct, userInitiated = true))
+        assertEquals(UsbPhase.NeedsReplug, r.next?.phase)
+        assertEquals(PathChoice.Direct, r.next?.desired)
+        // The live toggle on a NeedsReplug card produces no Reclaim/RequestPermission: only a physical
+        // replug (FrameworkUp) recovers. Contrast RestoreStuck + Choose(Direct), which emits Reclaim.
+        assertTrue(r.effects.isEmpty())
+    }
+
+    @Test
+    fun `needs replug plus choose standard is equally inert`() {
+        val r = reduce(controller(UsbPhase.NeedsReplug), UsbEvent.Choose(PathChoice.Standard, userInitiated = true))
+        assertEquals(UsbPhase.NeedsReplug, r.next?.phase)
+        assertTrue(r.effects.isEmpty())
+    }
+
+    @Test
+    fun `needs replug recovers only when the framework device re-enumerates`() {
+        val r = reduce(controller(UsbPhase.NeedsReplug), UsbEvent.FrameworkUp(12))
+        assertEquals(UsbPhase.Routed, r.next?.phase)
+        assertEquals(listOf(UsbEffect.BindFramework(12), UsbEffect.ClearFailure), r.effects)
+    }
+
+    @Test
+    fun `claiming plus framework down is ignored, leaning on the coordinator having forgotten the framework`() {
+        val r = reduce(controller(UsbPhase.Claiming), UsbEvent.FrameworkDown)
+        assertEquals(UsbPhase.Claiming, r.next?.phase)
+        assertTrue(r.effects.isEmpty())
+    }
+
+    @Test
+    fun `direct plus framework down is ignored`() {
+        val r = reduce(controller(UsbPhase.Direct, syntheticId = -1000), UsbEvent.FrameworkDown)
+        assertEquals(UsbPhase.Direct, r.next?.phase)
+        assertTrue(r.effects.isEmpty())
+    }
+
+    // ── Persistence-rollback asymmetry (see summary, USB bug B1) ──────────────
+    // UsbGamepadManager.setPathChoice persists the user's Direct pick eagerly, BEFORE the claim runs.
+    // Every transition that settles a controller on Standard is expected to roll that pref back with a
+    // SetPref(Standard) effect, except this one: a non-stolen claim failure (Busy / open rejected).
+
+    @Test
+    fun `a non-stolen claim failure settles on Standard and persists Standard`() {
+        val r =
+            reduce(
+                controller(UsbPhase.Claiming, userInitiated = true),
+                UsbEvent.ClaimFailed(DirectClaimFailure.Busy, frameworkStolen = false),
+            )
+        assertEquals(UsbPhase.Routed, r.next?.phase)
+        assertEquals(PathChoice.Standard, r.next?.desired)
+        // The failed Direct pick is rolled back in storage, so resolvePath() does not auto-retry Direct
+        // on every reconnect. Matches the permission-denied path below.
+        assertTrue(r.effects.contains(UsbEffect.SetPref(PathChoice.Standard)))
+    }
+
+    @Test
+    fun `by contrast the permission-denied fallback does persist Standard`() {
+        // The sibling "Direct failed" transition rolls the pref back. The divergence is the smell.
+        val r =
+            reduce(
+                controller(UsbPhase.Routed, desired = PathChoice.Direct, userInitiated = true),
+                UsbEvent.PermissionDenied,
+            )
+        assertTrue(r.effects.contains(UsbEffect.SetPref(PathChoice.Standard)))
+    }
+
+    // ── Dead failure reason (see summary, USB bug B2) ─────────────────────────
+
+    @Test
+    fun `the timeout into NeedsReplug marks the reason as Dropped`() {
+        // Dropped has a dedicated card string (path_needs_replug). The timeout that strands a failed
+        // claim in NeedsReplug now sets it, so the card asks for a physical replug instead of echoing
+        // the prior claim error.
+        val r =
+            reduce(
+                controller(UsbPhase.AwaitingFramework, syntheticId = null, failure = DirectClaimFailure.InitFailed),
+                UsbEvent.Timeout,
+            )
+        assertEquals(UsbPhase.NeedsReplug, r.next?.phase)
+        assertEquals(DirectClaimFailure.Dropped, r.next?.failure)
+        assertTrue(r.effects.contains(UsbEffect.MarkFailure(DirectClaimFailure.Dropped)))
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/source/usb/UsbPathMachineTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/usb/UsbPathMachineTest.kt
@@ -125,6 +125,7 @@ class UsbPathMachineTest {
         assertEquals(
             listOf(
                 UsbEffect.EndHold,
+                UsbEffect.SetPref(PathChoice.Standard),
                 UsbEffect.MarkFailure(DirectClaimFailure.Busy),
                 UsbEffect.Notify(UsbNotice.SwitchToDirectFailed),
             ),
@@ -140,7 +141,10 @@ class UsbPathMachineTest {
                 UsbEvent.ClaimFailed(DirectClaimFailure.Busy, frameworkStolen = false),
             )
         assertEquals(UsbPhase.Routed, r.next?.phase)
-        assertEquals(listOf(UsbEffect.EndHold, UsbEffect.MarkFailure(DirectClaimFailure.Busy)), r.effects)
+        assertEquals(
+            listOf(UsbEffect.EndHold, UsbEffect.SetPref(PathChoice.Standard), UsbEffect.MarkFailure(DirectClaimFailure.Busy)),
+            r.effects,
+        )
     }
 
     @Test
@@ -237,8 +241,14 @@ class UsbPathMachineTest {
     fun `awaiting from claim-fail + timeout needs replug`() {
         val r = reduce(controller(UsbPhase.AwaitingFramework, syntheticId = null), UsbEvent.Timeout)
         assertEquals(UsbPhase.NeedsReplug, r.next?.phase)
+        assertEquals(DirectClaimFailure.Dropped, r.next?.failure)
         assertEquals(
-            listOf(UsbEffect.MarkNeedsReplug, UsbEffect.SetPref(PathChoice.Standard), UsbEffect.Notify(UsbNotice.NeedsReplug)),
+            listOf(
+                UsbEffect.MarkNeedsReplug,
+                UsbEffect.MarkFailure(DirectClaimFailure.Dropped),
+                UsbEffect.SetPref(PathChoice.Standard),
+                UsbEffect.Notify(UsbNotice.NeedsReplug),
+            ),
             r.effects,
         )
     }
@@ -276,7 +286,11 @@ class UsbPathMachineTest {
                 UsbEvent.ClaimFailed(DirectClaimFailure.InitFailed, frameworkStolen = true),
             )
         assertEquals(UsbPhase.NeedsReplug, r.next?.phase)
-        assertEquals(listOf(UsbEffect.Notify(UsbNotice.RestoreFailed)), r.effects)
+        assertEquals(DirectClaimFailure.Dropped, r.next?.failure)
+        assertEquals(
+            listOf(UsbEffect.MarkFailure(DirectClaimFailure.Dropped), UsbEffect.Notify(UsbNotice.RestoreFailed)),
+            r.effects,
+        )
     }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/source/usb/UsbPathResolutionTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/usb/UsbPathResolutionTest.kt
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.usb
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+// The path-resolution policy, lifted out of UsbGamepadManager so each branch is checkable directly.
+class UsbPathResolutionTest {
+    @Test
+    fun `an explicit stored pick always wins`() {
+        assertEquals(
+            PathChoice.Direct,
+            resolvePathChoice(stored = PathChoice.Direct, isFastLaneModel = false, priorFailure = null),
+        )
+        assertEquals(
+            PathChoice.Standard,
+            resolvePathChoice(stored = PathChoice.Standard, isFastLaneModel = true, priorFailure = null),
+        )
+    }
+
+    @Test
+    fun `with no stored pick a verified fast-lane model auto-selects Direct`() {
+        assertEquals(
+            PathChoice.Direct,
+            resolvePathChoice(stored = null, isFastLaneModel = true, priorFailure = null),
+        )
+    }
+
+    @Test
+    fun `a fast-lane model that just failed to claim is not auto-Directed`() {
+        assertEquals(
+            PathChoice.Standard,
+            resolvePathChoice(stored = null, isFastLaneModel = true, priorFailure = DirectClaimFailure.Busy),
+        )
+    }
+
+    @Test
+    fun `an unknown model with no stored pick defaults to Standard`() {
+        assertEquals(
+            PathChoice.Standard,
+            resolvePathChoice(stored = null, isFastLaneModel = false, priorFailure = null),
+        )
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/ExtractJsonErrorFieldTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/ExtractJsonErrorFieldTest.kt
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.main
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+// Guards the hand-rolled extractor shared by MainViewModel and ConfigureBindingsViewModel:
+// it stands in for a real JSON parser, so its happy path and every bail-out branch are pinned here.
+class ExtractJsonErrorFieldTest {
+    @Test
+    fun `reads the error string from a well-formed reply`() {
+        assertEquals("device not paired", extractJsonErrorField("""{"error":"device not paired"}"""))
+    }
+
+    @Test
+    fun `reads the error even when it is not the first key`() {
+        assertEquals("unauthorized", extractJsonErrorField("""{"ok":false,"error":"unauthorized"}"""))
+    }
+
+    @Test
+    fun `returns null when there is no error field`() {
+        assertNull(extractJsonErrorField("""{"ok":true}"""))
+    }
+
+    @Test
+    fun `returns null on empty input`() {
+        assertNull(extractJsonErrorField(""))
+    }
+
+    @Test
+    fun `returns null when the error value is malformed and never closes its quote`() {
+        // Open quote but no closing quote: the extractor must bail rather than read past the end.
+        assertNull(extractJsonErrorField("""{"error":"unterminated"""))
+    }
+
+    @Test
+    fun `returns null when the error value is missing entirely`() {
+        assertNull(extractJsonErrorField("""{"error":}"""))
+    }
+
+    @Test
+    fun `extracts an empty error string as empty - not null`() {
+        assertEquals("", extractJsonErrorField("""{"error":""}"""))
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
@@ -3,7 +3,7 @@
 package com.tinkernorth.dish.ui.main
 
 import android.content.Context
-import com.tinkernorth.dish.composer.ConnectionHub
+import com.tinkernorth.dish.composer.ConnectionCoordinator
 import com.tinkernorth.dish.composer.ConnectionKind
 import com.tinkernorth.dish.composer.ConnectionSummary
 import com.tinkernorth.dish.composer.LinkState
@@ -43,7 +43,7 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainViewModelTest {
     private val dispatcher: TestDispatcher = StandardTestDispatcher()
-    private lateinit var hub: ConnectionHub
+    private lateinit var hub: ConnectionCoordinator
     private lateinit var satellite: SatelliteConnectionManager
     private lateinit var gamepadRegistry: PhysicalGamepadRegistry
     private lateinit var batteryStore: BatteryStatusStore

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/MotionIndicatorStateTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/MotionIndicatorStateTest.kt
@@ -2,6 +2,12 @@
 
 package com.tinkernorth.dish.ui.main
 
+import com.tinkernorth.dish.composer.ConnectionKind
+import com.tinkernorth.dish.composer.ConnectionSummary
+import com.tinkernorth.dish.composer.LinkState
+import com.tinkernorth.dish.composer.MotionCapability
+import com.tinkernorth.dish.source.sensor.MotionStreamState
+import com.tinkernorth.dish.source.store.SatelliteMotionBackendStatus
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -438,6 +444,191 @@ class MotionIndicatorStateTest {
                 hostHasSinkForType = true,
                 satelliteBackendOk = false,
                 isStalled = true,
+            ),
+        )
+    }
+
+    // ---- motionIndicatorFor: the Activity-extracted input translation ----
+
+    private fun summary(
+        kind: ConnectionKind,
+        live: LinkState,
+    ): ConnectionSummary =
+        ConnectionSummary(
+            id = "c1",
+            kind = kind,
+            label = "label",
+            detail = "detail",
+            live = live,
+            boundSlotIds = emptyList(),
+        )
+
+    private val fullCapability =
+        MotionCapability(
+            hasGyro = true,
+            carriesOnConnection = true,
+            userEnabled = true,
+            hostHasSinkForType = true,
+            satelliteBackendStatus = null,
+        )
+
+    @Test
+    fun `motionIndicatorFor null summary with a streaming source maps to PAUSED`() {
+        // Null summary is treated as motion-capable (carries) but not-yet-connected, so a started
+        // source still reads PAUSED until liveness resolves.
+        assertEquals(
+            MotionIndicatorState.PAUSED,
+            motionIndicatorFor(
+                summary = null,
+                capability = fullCapability,
+                source = MotionStreamState.Streaming,
+            ),
+        )
+    }
+
+    @Test
+    fun `motionIndicatorFor connected satellite streaming maps to STREAMING`() {
+        assertEquals(
+            MotionIndicatorState.STREAMING,
+            motionIndicatorFor(
+                summary = summary(ConnectionKind.SATELLITE, LinkState.Connected),
+                capability = fullCapability,
+                source = MotionStreamState.Streaming,
+            ),
+        )
+    }
+
+    @Test
+    fun `motionIndicatorFor bluetooth summary streaming maps to NOT_FORWARDED`() {
+        assertEquals(
+            MotionIndicatorState.NOT_FORWARDED,
+            motionIndicatorFor(
+                summary = summary(ConnectionKind.BLUETOOTH, LinkState.Connected),
+                capability = fullCapability,
+                source = MotionStreamState.Streaming,
+            ),
+        )
+    }
+
+    @Test
+    fun `motionIndicatorFor stalled source over a connected satellite maps to STALLED`() {
+        // Stalled is folded into isStreaming, and also raises the isStalled flag.
+        assertEquals(
+            MotionIndicatorState.STALLED,
+            motionIndicatorFor(
+                summary = summary(ConnectionKind.SATELLITE, LinkState.Connected),
+                capability = fullCapability,
+                source = MotionStreamState.Stalled,
+            ),
+        )
+    }
+
+    @Test
+    fun `motionIndicatorFor disabled source maps to UNAVAILABLE`() {
+        // The no-gyro / off condition reaches this function as a Disabled source, not via
+        // capability.hasGyro (which this translation never reads).
+        assertEquals(
+            MotionIndicatorState.UNAVAILABLE,
+            motionIndicatorFor(
+                summary = summary(ConnectionKind.SATELLITE, LinkState.Connected),
+                capability = fullCapability,
+                source = MotionStreamState.Disabled,
+            ),
+        )
+    }
+
+    @Test
+    fun `motionIndicatorFor a Disabled source dominates regardless of summary and capability`() {
+        // Mirrors the existing precedence test: UNAVAILABLE wins. Note the dominating input here is
+        // the source being Disabled, not MotionCapability.hasGyro, which motionIndicatorFor ignores.
+        val richCapability =
+            MotionCapability(
+                hasGyro = true,
+                carriesOnConnection = true,
+                userEnabled = false,
+                hostHasSinkForType = false,
+                satelliteBackendStatus =
+                    SatelliteMotionBackendStatus(sinkSupportedForType = false, backendOk = false),
+            )
+        for (kind in ConnectionKind.entries) {
+            for (live in LinkState.entries) {
+                assertEquals(
+                    "kind=$kind live=$live must stay UNAVAILABLE when source is Disabled",
+                    MotionIndicatorState.UNAVAILABLE,
+                    motionIndicatorFor(
+                        summary = summary(kind, live),
+                        capability = richCapability,
+                        source = MotionStreamState.Disabled,
+                    ),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `motionIndicatorFor a Stopped source over a connected satellite maps to PAUSED`() {
+        // Stopped is neither Disabled (so available) nor Streaming/Stalled (so not streaming).
+        assertEquals(
+            MotionIndicatorState.PAUSED,
+            motionIndicatorFor(
+                summary = summary(ConnectionKind.SATELLITE, LinkState.Connected),
+                capability = fullCapability,
+                source = MotionStreamState.Stopped,
+            ),
+        )
+    }
+
+    @Test
+    fun `motionIndicatorFor a not-yet-connected satellite reads PAUSED, not STREAMING`() {
+        assertEquals(
+            MotionIndicatorState.PAUSED,
+            motionIndicatorFor(
+                summary = summary(ConnectionKind.SATELLITE, LinkState.Connecting),
+                capability = fullCapability,
+                source = MotionStreamState.Streaming,
+            ),
+        )
+    }
+
+    @Test
+    fun `motionIndicatorFor passes through capability userEnabled to USER_DISABLED`() {
+        assertEquals(
+            MotionIndicatorState.USER_DISABLED,
+            motionIndicatorFor(
+                summary = summary(ConnectionKind.SATELLITE, LinkState.Connected),
+                capability = fullCapability.copy(userEnabled = false),
+                source = MotionStreamState.Streaming,
+            ),
+        )
+    }
+
+    @Test
+    fun `motionIndicatorFor passes through capability hostHasSinkForType to NO_HOST_SINK`() {
+        assertEquals(
+            MotionIndicatorState.NO_HOST_SINK,
+            motionIndicatorFor(
+                summary = summary(ConnectionKind.SATELLITE, LinkState.Connected),
+                capability = fullCapability.copy(hostHasSinkForType = false),
+                source = MotionStreamState.Streaming,
+            ),
+        )
+    }
+
+    @Test
+    fun `motionIndicatorFor passes through satellite backend status to BACKEND_BROKEN`() {
+        assertEquals(
+            MotionIndicatorState.BACKEND_BROKEN,
+            motionIndicatorFor(
+                summary = summary(ConnectionKind.SATELLITE, LinkState.Connected),
+                capability =
+                    fullCapability.copy(
+                        satelliteBackendStatus =
+                            SatelliteMotionBackendStatus(
+                                sinkSupportedForType = true,
+                                backendOk = false,
+                            ),
+                    ),
+                source = MotionStreamState.Streaming,
             ),
         )
     }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,9 +102,12 @@ classes own their own `SharedFlow`s directly
 (`SatelliteConnectionManager`, `DishNotifications`). Keep the base
 tight: state + optional lifecycle.
 
-`S = Unit` is allowed when the class is purely a lifecycle hook with
-no observable state (e.g. `ConnectionForegroundObserver`). Most
-subclasses have a meaningful `S`.
+A class that is purely a lifecycle hook with no observable state
+(e.g. `ConnectionForegroundObserver`, `StreamingServiceController`)
+implements `DefaultLifecycleObserver` directly rather than
+`AbstractStateSource<Unit>`: a state holder that holds no state is
+just noise. Every `AbstractStateSource` subclass therefore has a
+meaningful `S`.
 
 ### `AbstractComposer<S>`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,12 +134,6 @@ The combine runs on whichever dispatcher `upstream` is collected on
 (by default the composer's `scope` dispatcher). UI consumers `collect`
 on `Main`.
 
-`ConnectionHub` is the coordinator over `SlotBindingStore`,
-`ControllerTypeStore`, and `ConnectionsComposer`. Its
-`connections` field is `composer.state` *directly* — no hub-local
-mirror, which would create a two-writer race between the composer's
-`onEach` and the hub's imperative `bind`/`unbind` paths.
-
 ### `Repository<K, V>` / `KeyedRepository<K, V>`
 
 Synchronous CRUD over a single durable backing store. Lives in
@@ -167,6 +161,114 @@ for older satellites (see `DiscoveredServer.stableKey`). Keying on the stable
 id is what stops a receiver's DHCP address change spawning a duplicate row. The
 Bluetooth id is `bt:<MAC>`. The distinct `removeValue` name is
 deliberate: it avoids a JVM-erasure clash with `remove(K)`.
+
+## Patterns beyond the base classes
+
+The three base classes cover owned state, derived state, and storage.
+Five more patterns recur often enough to name, even though four are
+conventions (plus one small base class) rather than a shared
+supertype. Pick the one that matches what a class actually does: most
+architectural drift is a class wearing the wrong one of these.
+
+### Coordinator
+
+Imperative orchestration over several sources, stores, or gateways. A
+coordinator owns the cross-cutting commands (bind a slot, connect a
+satellite, auto-reconnect) and the invariants that span more than one
+store. It does not derive state (that is a composer) and it is not a
+lifecycle actuator (that is a controller).
+
+- `ConnectionCoordinator` sequences `SlotBindingStore`,
+  `ControllerTypeStore`, and each `SatelliteConnection`, and re-exposes
+  `ConnectionsComposer.state` as `connections` directly: no
+  coordinator-local mirror, which would create a two-writer race with
+  the composer's `onEach`.
+- `SatelliteConnectionManager` owns the connect/pair/retry lifecycle
+  and the live `SatelliteConnection` map.
+
+Rule: a coordinator may read flows and call commands, but it never
+becomes the source of truth for state another class already owns.
+
+### Gateway
+
+The boundary to something outside the process (a socket, an HTTP
+endpoint, the native library) behind a narrow Kotlin surface. A
+gateway holds no domain state and never derives: it translates a call
+into IO and back.
+
+- `DiscoveryGateway` serializes native discovery and per-host HTTP.
+- `SatelliteHttpClient` is the HTTPS gateway. The self-signed-cert
+  trust manager and trust-on-first-use pinning live here, not in
+  callers.
+- The JNI wrappers (`ControllerRepository`, `PhysicalInputNative`) are
+  gateways over `SatelliteNative`.
+
+A gateway is mockable by construction: callers depend on the gateway
+type, never on the raw socket or JNI object, so a test injects a fake.
+Name it `*Gateway` or `*Client`, never `*Repository`: a repository is
+keyed local storage, not an IO boundary.
+
+### Reducer (pure transition or decision function)
+
+A pure `(state, event) -> result` (or `(inputs) -> decision`) function
+with sealed input and output types and no side effects, so the whole
+decision space is unit-testable without standing up the machine.
+Effects are returned as data and executed by the caller.
+
+- `UsbPathMachine.reduce(UsbController, UsbEvent): Reduction` is the
+  canonical full state machine: every `(phase x event)` pair is total,
+  and effects (`Claim`, `SetPref`, `MarkFailure`, and so on) are a
+  returned list the coordinator runs.
+- `reconcileSlots`, `resolveRumble`, `resolvePathChoice`, and the
+  registry's placeholder-lifecycle transition are smaller pure decision
+  functions lifted out of Android- or JNI-coupled coordinators for the
+  same reason.
+
+Rule: keep the transition pure. If you need a socket or a StateFlow
+read inside the function, you are writing a coordinator, not a reducer:
+read the live state once at the call site and pass it in.
+
+### Mapper
+
+A pure function from domain state to a UI or value shape, with no
+Android view types. Mappers are the testable seam under the
+humble-object Activities and Views.
+
+- `PathCardMapper`, `motionIndicatorFor`, `satelliteLinkState`,
+  `connectionsVisibleInPicker`.
+
+Rule: a mapper takes data in and returns data out. The moment it
+touches a `View`, a `Context` for anything but `getString`, or a
+StateFlow, it has stopped being a mapper.
+
+### `AbstractController<S>`
+
+A lifecycle actuator: it subscribes to one upstream `Flow<S>` and
+turns each value into a side effect (a wakelock, a foreground service,
+a Crashlytics opt-in). It is the mirror image of a composer: a composer
+derives state from inputs, a controller drives effects from state.
+
+The base (`architecture/abstracts/AbstractController.kt`) provides:
+
+- `protected abstract fun upstream(): Flow<S>` and
+  `protected abstract fun apply(value: S)`.
+- an idempotent `onStart` (re-entrant lifecycle callbacks do not stack
+  collectors), an `onStarting()` hook for setup a subclass must run
+  under its own lock before the collector launches, and a
+  `cancelCollection()` helper.
+- an open `onStop`, because teardown genuinely differs:
+  `WakeStateController` cancels and releases its wakelock under the
+  `stopped` guard that drops a post-stop emission;
+  `StreamingServiceController` cancels and stops the service;
+  `CrashReportingController` deliberately does not cancel, so the
+  opt-in survives an Activity restart.
+
+Harness: `ControllerProbe` (`architecture/testing/`), the controller
+analogue of `ComposerProbe` and `StateSourceProbe`.
+
+Rule: if a class both derives a value and effects something, split it
+(derive in a composer, effect in a controller) rather than collapsing
+the two.
 
 ## Multi-session model
 
@@ -225,7 +327,7 @@ Key invariants:
   entry. The UI sees a single stable row.
 - **Stale markers.** `BluetoothBondMonitor` reports `KEY_MISSING` or
   unexpected `BOND_NONE` for remembered MACs; the registry surfaces
-  these as a `Stale` lift on `ConnectionHub`. `KEY_MISSING` is the
+  these as a `Stale` lift on `ConnectionCoordinator`. `KEY_MISSING` is the
   more specific signal — if both arrive for the same host, the
   registry promotes `BOND_REMOVED` to `KEY_MISSING` so the user
   copy reads *"Re-pair X"* instead of the weaker *"X was unpaired"*.

--- a/play/SCREENSHOT-STRATEGY.md
+++ b/play/SCREENSHOT-STRATEGY.md
@@ -143,7 +143,7 @@ The test cannot drive these screens by mutating production `@Singleton` classes 
 |---|---|---|---|
 | `MainUiStateProvider` | `DefaultMainUiStateProvider` | `FakeMainUiStateProvider` | `MainActivity` dashboard state |
 | `WakeStateSource` | `WakeStateController` | `FakeWakeStateSource` | Streaming pill, screen-on flag |
-| `ConnectionsSource` | `ConnectionHub` (implements directly) | `FakeConnectionsSource` | `ConnectionsActivity` list, overlay connection chip |
+| `ConnectionsSource` | `ConnectionCoordinator` (implements directly) | `FakeConnectionsSource` | `ConnectionsActivity` list, overlay connection chip |
 
 Each interface exposes only the read-only `StateFlow` surface the consumer needs. Production code mutates through the concrete classes; the test pushes literal `MainUiState` / `ConnectionSummary` values into the fakes.
 


### PR DESCRIPTION
Architecture-hardening pass implementing the launch-gate findings from the data-flow / pattern review, in three commits. No new features: correctness, security, and pattern cleanup, all behind passing CI (ktlint, detekt, lint, ~1130 unit tests, assembleDebug).

## Bugs fixed
- USB path FSM persists `Standard` on a non-stolen Direct claim failure (was re-attempting Direct on every reconnect); `NeedsReplug` marks the `Dropped` reason.
- `ConnectionStore` ghost reconciliation adopts the ghost's shared key before forgetting the row (no forced re-pair).
- `hexToBytes` / `PairingApproval` validate the hex alphabet.

## Security
- TLS: `SatelliteHttpClient` replaces the allow-all hostname verifier with trust-on-first-use cert pinning (`SatellitePinRepository`); trust manager stays permissive for self-signed LAN certs.
- Discovered IPs validated (`isPrivateHostLiteral`); BT HID host rejects inbound connections from an unintended mac; `AndroidHidProxyClient.sendReport` is `@Volatile` + crash-safe.

## Data flow / correctness
- `ConnectionsComposer` derives purely from observable repository flows (no out-of-band store reads).
- `WakeStateController` publishes the streaming count under the `stopped` guard.
- `SatelliteConnectionManager` Path-B approval poll is cancellable; `DiscoveryGateway` mutex scoped to discovery.
- `ConnectionCoordinator.forgetConnection` unbinds slots, clears their types + any orphans (`ControllerTypeStore.clearConnection`), then forgets the host, so a forgotten connection id cannot leak controller-type rows. Done on forget, not on a transient disconnect.

## Patterns formalized and documented (`docs/architecture.md`)
- New `AbstractController<S>` base + `ControllerProbe` harness formalize the lifecycle-actuator pattern; the three controllers extend it (behavior preserved).
- The de-facto Coordinator, Gateway, Reducer, and Mapper patterns are now documented alongside the base classes.
- Extracted pure `reconcileSlots` (+ BT liveness fix), `resolveRumble`, `motionIndicatorFor`, `resolvePathChoice`, and `PhysicalGamepadRegistry.placeholderTransition` from Android/JNI-coupled coordinators.

## Renames / cleanup
- `DiscoveryRepository` to `DiscoveryGateway`; `ConnectionHub` to `ConnectionCoordinator`.
- `ConnectionForegroundObserver` / `StreamingServiceController` use `DefaultLifecycleObserver`; `PhoneMotionAvailability` is a plain holder; removed `LowPowerManager`'s dead `onStop`; split IP-literal validation into `IpLiterals.kt`.
- `distinctUntilChanged` on the three composers; corrupt-JSON WARN breadcrumbs + contract tests for the BT/Touchpad repos; `TouchpadModeRepository.put` validation; deduped `extractJsonErrorField`.

## Testing
New and updated unit tests across every area. No suppressions added (the one `ReturnCount` I introduced was removed by splitting `IpLiterals.kt`). The TLS live-socket handshake and the `StreamingService` foreground start remain integration/Robolectric-only.
