### PR TITLE
feat: pre-select Direct on the configure page for recognized USB models

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsViewModel.kt
@@ -368,7 +368,7 @@ class ConfigureBindingsViewModel
                 if (wantDirect) PathChoice.Direct else PathChoice.Standard,
             )
             if (!wantDirect) return true
-            val key = (device.vendorId shl 16) or device.productId
+            val key = vpKey(device)
             // Direct shows a system permission prompt; wait out the FSM (Routed while still wanting Direct = prompt open).
             val settled =
                 withTimeoutOrNull(DIRECT_TIMEOUT_MS) {
@@ -509,11 +509,16 @@ class ConfigureBindingsViewModel
             return BindingDraft(
                 hostId = hostId,
                 type = type,
-                directOn = device?.isUsbSynthetic ?: false,
+                directOn = seedDirectOn(device, desiredUsbPathFor(device)),
                 motionOn = motionEnabledStore.isEnabled(slotId),
                 touchpadMode = if (TouchpadModeValue.isValid(touchpad)) touchpad else TouchpadModeValue.OFF,
             )
         }
+
+        private fun desiredUsbPathFor(device: PhysicalGamepadRegistry.Device?): PathChoice? =
+            device?.let { usbGamepadManager.controllers.value[vpKey(it)]?.desired }
+
+        private fun vpKey(device: PhysicalGamepadRegistry.Device): Int = (device.vendorId shl 16) or device.productId
 
         private companion object {
             const val DIRECT_TIMEOUT_MS = 20_000L
@@ -524,4 +529,15 @@ class ConfigureBindingsViewModel
             const val SLUG_XBOX360 = "xbox360"
             const val SLUG_DS4 = "ds4"
         }
+    }
+
+internal fun seedDirectOn(
+    device: PhysicalGamepadRegistry.Device?,
+    desired: PathChoice?,
+): Boolean =
+    when {
+        device == null -> false
+        device.isUsbSynthetic -> true
+        device.transport == Transport.Bluetooth -> false
+        else -> desired == PathChoice.Direct
     }

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/SeedDirectOnTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/SeedDirectOnTest.kt
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.main
+
+import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
+import com.tinkernorth.dish.hotpath.input.Transport
+import com.tinkernorth.dish.source.usb.PathChoice
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SeedDirectOnTest {
+    private fun device(
+        isUsbSynthetic: Boolean = false,
+        transport: Transport = Transport.Usb,
+    ) = PhysicalGamepadRegistry.Device(
+        id = 7,
+        name = "Pad",
+        isUsbSynthetic = isUsbSynthetic,
+        vendorId = 0x054C,
+        productId = 0x09CC,
+        transport = transport,
+    )
+
+    @Test
+    fun `no device seeds the toggle off`() {
+        assertFalse(seedDirectOn(null, null))
+    }
+
+    @Test
+    fun `a device already on Direct seeds the toggle on`() {
+        assertTrue(seedDirectOn(device(isUsbSynthetic = true), null))
+    }
+
+    @Test
+    fun `a USB device whose resolved path is Direct seeds the toggle on`() {
+        assertTrue(seedDirectOn(device(), PathChoice.Direct))
+    }
+
+    @Test
+    fun `a USB device whose resolved path is Standard seeds the toggle off`() {
+        assertFalse(seedDirectOn(device(), PathChoice.Standard))
+    }
+
+    @Test
+    fun `an untracked USB device seeds the toggle off`() {
+        assertFalse(seedDirectOn(device(), null))
+    }
+
+    @Test
+    fun `a Bluetooth device never seeds the toggle on`() {
+        assertFalse(seedDirectOn(device(transport = Transport.Bluetooth), PathChoice.Direct))
+    }
+}


### PR DESCRIPTION
## Summary

When a USB controller we recognize as fully supported by Direct mode (a known fast-lane model) enters the Configure bindings page, the Direct toggle is now pre-selected instead of defaulting to Standard.

The seed reads the USB path machine's live resolved intent (`UsbController.desired`), which already encodes the path resolution policy (`resolvePathChoice`), so the page inherits those semantics instead of duplicating them:

- Recognized model, never configured before: Direct pre-selected. Nothing changes until Apply, which performs the claim (including the system USB permission prompt if needed). Since the model is verified, the "guessed" warning callout stays hidden.
- Explicit stored Standard pick: stays Standard. Every Apply persists a choice, so the new default only fires for fresh devices.
- A Direct claim recently failed: stays Standard.
- Already running Direct: pre-selected as before.
- Bluetooth and on-screen controllers: unaffected (toggle hidden, seed forced off even if the same model is also USB-plugged).

Also extracted the vid/pid key packing in the view model into a shared `vpKey` helper used by both call sites.

## Testing

- Added `SeedDirectOnTest` covering the seed matrix (no device, synthetic, desired Direct/Standard, untracked, Bluetooth twin).
- `:app:compileDebugKotlin`, `:app:compileDebugUnitTestKotlin`, `:app:ktlintCheck`, and `:app:detekt` pass locally; unit tests run in CI.
