### PR TITLE
fix: release workflow startup failure and SLSA runtime blockers

### DIFF
--- a/.github/workflows/_security.yml
+++ b/.github/workflows/_security.yml
@@ -97,10 +97,7 @@ jobs:
                 sub(/^[[:space:]]*-?[[:space:]]*uses:[[:space:]]+/, "", line)
                 if (line ~ /^\.\//) { next }
                 if (line ~ /^docker:\/\/[^@]+@sha256:[0-9a-f]{64}$/) { next }
-                # SLSA builders must be referenced by vX.Y.Z tag (not SHA): the
-                # generator resolves its builder binary from the release that
-                # matches the detected ref, and its OIDC-verified identity is
-                # the integrity control the SHA pin would otherwise provide.
+                # SLSA builders resolve their release binary by tag; OIDC identity covers integrity.
                 if (line ~ /^slsa-framework\/slsa-github-generator\/\.github\/workflows\/[^@]+@v[0-9]+\.[0-9]+\.[0-9]+$/) { next }
                 if (line !~ /@[0-9a-f]{40}([[:space:]]|$)/) {
                   printf "%s: %s\n", FILENAME, line

--- a/.github/workflows/_security.yml
+++ b/.github/workflows/_security.yml
@@ -97,6 +97,11 @@ jobs:
                 sub(/^[[:space:]]*-?[[:space:]]*uses:[[:space:]]+/, "", line)
                 if (line ~ /^\.\//) { next }
                 if (line ~ /^docker:\/\/[^@]+@sha256:[0-9a-f]{64}$/) { next }
+                # SLSA builders must be referenced by vX.Y.Z tag (not SHA): the
+                # generator resolves its builder binary from the release that
+                # matches the detected ref, and its OIDC-verified identity is
+                # the integrity control the SHA pin would otherwise provide.
+                if (line ~ /^slsa-framework\/slsa-github-generator\/\.github\/workflows\/[^@]+@v[0-9]+\.[0-9]+\.[0-9]+$/) { next }
                 if (line !~ /@[0-9a-f]{40}([[:space:]]|$)/) {
                   printf "%s: %s\n", FILENAME, line
                   exit 2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,10 @@ on:
 #   github/codeql-action/upload-sarif @ v4.35.2 → 95e58e9a2cdfd71adc6e0353d5c52f41a045d225
 #   softprops/action-gh-release     @ v3.0.0  → b4309332981a82ec1c5618f44dd2e27cc8bfbfda
 #   slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml
-#                                   @ v2.0.0  → 5a775b367a56d5bd118a224a811bba288150a563
+#                                   @ v2.1.0  → f7dd8c54c2067bafc12ca7a55595d5ee9b75204a
+#                                   (referenced by tag, not SHA: the generator downloads
+#                                   its builder binary from the release matching the
+#                                   detected ref, which must be a vX.Y.Z tag)
 #
 # cosign is installed directly from upstream (see harden job).
 
@@ -57,6 +60,13 @@ concurrency:
 jobs:
   gates:
     name: PR-time gates against tag
+    # Must grant at least what _security.yml declares at workflow level;
+    # a called workflow requesting more than the caller grants fails the
+    # whole run at startup before any job is created.
+    permissions:
+      contents: read
+      pull-requests: read
+      security-events: write
     uses: ./.github/workflows/_security.yml
     with:
       osv_scan_paths: |
@@ -144,9 +154,11 @@ jobs:
 
       - name: Compute version from tag
         id: ver
+        env:
+          TAG_INPUT: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME:-${{ inputs.tag }}}"
+          tag="${TAG_INPUT:-${GITHUB_REF_NAME}}"
           name="${tag#v}"
           # vX.Y.Z → versionCode = X*10000 + Y*100 + Z. Re-derive locally with
           # `git describe --tags` if changing this scheme.
@@ -192,13 +204,15 @@ jobs:
 
       - name: Stage artifacts
         id: stage
+        env:
+          TAG_INPUT: ${{ inputs.tag }}
         run: |
           mkdir -p dist
           suffix=""
           if [ "${{ steps.keystore.outputs.present }}" != "true" ]; then
             suffix="-unsigned"
           fi
-          tag="${GITHUB_REF_NAME:-${{ inputs.tag }}}"
+          tag="${TAG_INPUT:-${GITHUB_REF_NAME}}"
 
           apk=$(find app/build/outputs/apk/release -name '*.apk' | head -1)
           [ -n "$apk" ] && cp "$apk" "dist/dish-${tag}${suffix}.apk"
@@ -230,6 +244,10 @@ jobs:
     name: Harden artifacts (scan, SBOM, sign)
     needs: [release]
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
     outputs:
       hashes: ${{ steps.hashes.outputs.hashes }}
     steps:
@@ -251,7 +269,10 @@ jobs:
           output-format: sarif
 
       - name: Upload Grype SARIF to code scanning
+        # Observability only; the grype step above is the gate. Soft-fail like
+        # the other non-CodeQL SARIF uploads until GHAS is confirmed enabled.
         if: ${{ always() && steps.grype.outputs.sarif != '' }}
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           sarif_file: ${{ steps.grype.outputs.sarif }}
@@ -348,16 +369,21 @@ jobs:
       id-token: write
       contents: write
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0 # f7dd8c54c2067bafc12ca7a55595d5ee9b75204a
     with:
       base64-subjects: ${{ needs.harden.outputs.hashes }}
       provenance-name: dish-android.intoto.jsonl
       upload-assets: false
+      # Keyless signing posts the repo identity to the public Rekor log;
+      # required acknowledgement while the repo is still private.
+      private-repository: true
 
   publish:
     name: Publish to GitHub Releases
     needs: [harden, provenance]
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - name: Download hardened bundle
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,6 @@ on:
 #   softprops/action-gh-release     @ v3.0.0  → b4309332981a82ec1c5618f44dd2e27cc8bfbfda
 #   slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml
 #                                   @ v2.1.0  → f7dd8c54c2067bafc12ca7a55595d5ee9b75204a
-#                                   (referenced by tag, not SHA: the generator downloads
-#                                   its builder binary from the release matching the
-#                                   detected ref, which must be a vX.Y.Z tag)
 #
 # cosign is installed directly from upstream (see harden job).
 
@@ -60,9 +57,7 @@ concurrency:
 jobs:
   gates:
     name: PR-time gates against tag
-    # Must grant at least what _security.yml declares at workflow level;
-    # a called workflow requesting more than the caller grants fails the
-    # whole run at startup before any job is created.
+    # _security.yml declares these; granting less fails the run at startup.
     permissions:
       contents: read
       pull-requests: read
@@ -269,8 +264,7 @@ jobs:
           output-format: sarif
 
       - name: Upload Grype SARIF to code scanning
-        # Observability only; the grype step above is the gate. Soft-fail like
-        # the other non-CodeQL SARIF uploads until GHAS is confirmed enabled.
+        # Soft-fail: the grype step above is the gate, this is observability.
         if: ${{ always() && steps.grype.outputs.sarif != '' }}
         continue-on-error: true
         uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
@@ -374,8 +368,7 @@ jobs:
       base64-subjects: ${{ needs.harden.outputs.hashes }}
       provenance-name: dish-android.intoto.jsonl
       upload-assets: false
-      # Keyless signing posts the repo identity to the public Rekor log;
-      # required acknowledgement while the repo is still private.
+      # Required while private: signing posts the repo name to the public Rekor log.
       private-repository: true
 
   publish:


### PR DESCRIPTION
## Problem

[Run 27430724078](https://github.com/TinkerNorth/dish-android/actions/runs/27430724078) for tag `v0.0.1-alpha` ended in `startup_failure`: GitHub rejected the workflow graph before creating a single job, so there are no logs.

**Root cause:** `release.yml` grants `contents` / `id-token` / `attestations` at the workflow level, so every unlisted permission is `none` for its jobs. The `gates` job calls the reusable `_security.yml`, which declares `pull-requests: read` and `security-events: write` at its workflow level. A called workflow requesting more than its caller grants fails validation at startup. (`security.yml` calls the same file successfully, at this very commit, because it grants exactly those permissions.) Fixed by giving `gates` job-level permissions matching what `_security.yml` declares.

## Runtime blockers the first run never reached

Since this workflow has never executed past startup, I audited the rest of the pipeline and fixed what would have failed on the next attempts:

- **SLSA generator referenced by SHA.** `generator_generic_slsa3.yml` resolves its builder binary from the upstream *release matching its detected ref*, which must be a `vX.Y.Z` tag (the workflow documents this; SHA refs fail at runtime). Now referenced `@v2.1.0` (same commit `f7dd8c5`, noted in the pin map). The action pin lint in `_security.yml` gets a narrow exemption for `slsa-framework/slsa-github-generator` semver tag refs; for SLSA builders the OIDC-verified identity is the integrity control the SHA pin would otherwise provide. Note `_security.yml` is shared across the four TinkerNorth repos, so the other copies will drift until synced.
- **Private repo without acknowledgement.** Keyless provenance signing posts the repo identity to the public Rekor transparency log; on a private repo the generator refuses unless `private-repository: true` is passed. Added. Heads-up: this means the repo name becomes publicly visible in the log, which seems acceptable given the planned OSS publication; the cosign keyless signing in `harden` has the same property.
- **`harden` lacked `id-token: write`** (cosign keyless signing) **and `security-events: write`** (Grype SARIF ingest). Added job-level permissions, and made the SARIF upload `continue-on-error` to match the convention in `security.yml`; the Grype scan itself remains a hard gate via `fail-build: true`.
- **`publish`** scoped to `contents: write` (least privilege; it only uploads release assets).
- **`workflow_dispatch` version bug:** `tag="${GITHUB_REF_NAME:-…}"` never falls through because `GITHUB_REF_NAME` is always set, so dispatch runs would version the build from the *branch name* instead of the requested tag. Now prefers `inputs.tag` (via env var, not inline interpolation) in both the version and staging steps.

## Verification

Local, mirroring the CI release job as closely as possible:

- `actionlint` v1.7.12: clean on all five workflow files.
- The pin-lint awk from `_security.yml`, run locally over `.github/workflows/`: passes with the tag-referenced generator.
- Full release build with CI-equivalent env (`DISH_VERSION_CODE=1`, `DISH_VERSION_NAME=0.0.1-alpha`, throwaway keystore): `assembleRelease bundleRelease` BUILD SUCCESSFUL, producing everything `Stage artifacts` expects: `app-release.apk` (apksigner: V2-signed, CN=DishReleaseTest), `app-release.aab`, `mapping.txt`, merged native libs. `lintVitalRelease` passed and `uploadCrashlyticsMappingFileRelease` succeeded against the local `google-services.json`.
- `:app:generateBaselineProfile --dry-run` resolves the task graph (the emulator run itself is CI-only).
- Upstream checks: SLSA `v2.1.0` tag == `f7dd8c5`; cosign 2.4.1 `cosign-linux-amd64` SHA-256 matches the official `cosign_checksums.txt`; the five not-yet-exercised action pins (download-artifact, gh-release, scan-action, sbom-action, codeql upload-sarif) all resolve upstream, and the anchore action input/output names match the pinned versions.

Not testable locally: the KVM-backed baseline profile generation, Grype results against the built artifacts, and the SLSA/cosign OIDC flows (Actions-only). All four release secrets are already set in the repo, so the `required-secrets` gate will pass.

## After merge

The tag still points at `5b39585`, which carries the broken workflow. Re-point it at the merge commit (or cut a fresh tag):

```
git fetch origin main
git tag -f v0.0.1-alpha origin/main
git push origin v0.0.1-alpha --force
```
