### PR TITLE
fix: stage native debug symbols as a single zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,13 +221,10 @@ jobs:
           [ -n "$mapping" ] && cp "$mapping" "dist/dish-${tag}${suffix}-mapping.txt"
           # Native debug symbols for the JNI .so: lets crash reporters
           # symbolize native stack frames from the encrypted-wire / rumble
-          # hot path.
-          native_symbols=$(find app/build/intermediates/merged_native_libs/release -name '*.so' 2>/dev/null | head -1)
-          if [ -n "$native_symbols" ]; then
-            mkdir -p dist/native-symbols
-            find app/build/intermediates/merged_native_libs/release -name '*.so' \
-              -exec cp --parents {} dist/native-symbols/ \; 2>/dev/null || true
-          fi
+          # hot path. Shipped as AGP's Play Console zip; dist/ must hold only
+          # flat files or the harden job's sign/hash loops break on it.
+          symbols=$(find app/build/outputs/native-debug-symbols/release -name 'native-debug-symbols.zip' 2>/dev/null | head -1)
+          [ -n "$symbols" ] && cp "$symbols" "dist/dish-${tag}${suffix}-native-debug-symbols.zip"
           ls -l dist/
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Problem

Release run for v0.0.2-alpha failed in the harden job at the cosign signing step (https://github.com/TinkerNorth/dish-android/actions/runs/27432938831):

```
Error: signing native-symbols: signing blob: hashing message: read native-symbols: is a directory
```

`Stage artifacts` copied the merged_native_libs intermediates into a `dist/native-symbols/` directory tree. The signing loop (`for f in *`) then handed that directory to `cosign sign-blob`, which can only hash files.

The directory layout had two more latent problems downstream:

- `Generate SHA256SUMS` and the SLSA hashes step both use `-maxdepth 1 -type f`, so the symbol files were silently excluded from checksums and provenance.
- `publish` uploads `release/**/*`, which flattens nested paths; the per-ABI `libsatellite.so` files would have collided on asset name.

## Fix

Stage AGP's `native-debug-symbols.zip` (already produced because the release build type sets `ndk { debugSymbolLevel = "FULL" }`) as a single flat file, `dish-<tag>-native-debug-symbols.zip`, instead of hand-copying the intermediates tree. One flat file flows correctly through Grype, SBOM, SHA256SUMS, cosign, SLSA subjects, and publish, and the zip is the exact format Play Console accepts for native symbol upload.

## Verification

- Ran the updated staging script against the local CI-equivalent release build outputs: dist/ contains only flat files; the zip holds `arm64-v8a/libsatellite.so.dbg` and `x86_64/libsatellite.so.dbg`.
- Confirmed the pinned SLSA generator (v2.1.0) exposes the `provenance-name` output and uploads via `upload-artifact@v4.6.0`, compatible with the `download-artifact@v8` used in `publish`, so the never-yet-run publish job should not hit a follow-on failure.
- YAML parses; no `uses:` pins changed (pin lint unaffected).

After merge, re-point or re-cut the release tag so it picks up the fixed workflow, e.g. cut `v0.0.3-alpha` from main (or `git tag -f v0.0.2-alpha <merge-commit> && git push origin v0.0.2-alpha --force`).