### PR TITLE
chore: use bare X.Y.Z release tags instead of vX.Y.Z

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,13 +156,14 @@ jobs:
           set -euo pipefail
           tag="${TAG_INPUT:-${GITHUB_REF_NAME}}"
           name="${tag#v}"
-          # X.Y.Z → versionCode = X*10000 + Y*100 + Z. Re-derive locally with
+          # X.Y.Z → versionCode = max(1, X*10000 + Y*100 + Z). Re-derive locally with
           # `git describe --tags` if changing this scheme.
           if [[ "$name" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
             major="${BASH_REMATCH[1]}"
             minor="${BASH_REMATCH[2]}"
             patch="${BASH_REMATCH[3]}"
             code=$((major * 10000 + minor * 100 + patch))
+            [ "$code" -lt 1 ] && code=1
           else
             echo "::warning::Tag '$tag' does not match MAJOR.MINOR.PATCH, falling back to versionCode=1."
             code=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Release
 
 on:
   push:
-    tags: ["v*"]
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
       tag:
@@ -85,7 +86,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${{ github.ref_type }}" != "tag" ] || [ "${{ startsWith(github.ref, 'refs/tags/v') }}" != "true" ]; then
+          if [ "${{ github.ref_type }}" != "tag" ] || [ "${{ startsWith(github.ref, 'refs/tags/') }}" != "true" ]; then
             echo "::notice::Non-tag release run. Unsigned fallback permitted."
             exit 0
           fi
@@ -155,7 +156,7 @@ jobs:
           set -euo pipefail
           tag="${TAG_INPUT:-${GITHUB_REF_NAME}}"
           name="${tag#v}"
-          # vX.Y.Z → versionCode = X*10000 + Y*100 + Z. Re-derive locally with
+          # X.Y.Z → versionCode = X*10000 + Y*100 + Z. Re-derive locally with
           # `git describe --tags` if changing this scheme.
           if [[ "$name" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
             major="${BASH_REMATCH[1]}"
@@ -163,7 +164,7 @@ jobs:
             patch="${BASH_REMATCH[3]}"
             code=$((major * 10000 + minor * 100 + patch))
           else
-            echo "::warning::Tag '$tag' does not match vMAJOR.MINOR.PATCH, falling back to versionCode=1."
+            echo "::warning::Tag '$tag' does not match MAJOR.MINOR.PATCH, falling back to versionCode=1."
             code=1
           fi
           echo "code=$code" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ replacing the former `docs/wire-format.md`).
   the previous constant 250 Hz re-send of the last state.
 - `versionCode` and `versionName` are now derived from CI environment
   variables (`DISH_VERSION_CODE` / `DISH_VERSION_NAME`), with a
-  `git describe` fallback for local dev. The hardcoded `0` / `"0.0.0"`
+  `git describe` fallback for local dev. The hardcoded `1` / `"0.0.0"`
   defaults remain only when neither signal is present.
 - `release.yml` stages `mapping.txt` into `dist/` alongside the AAB and
   APK so it gets the same SHA256SUMS + cosign signature treatment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Dish Android client are documented in this
 file. The format is loosely based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
 project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
-once it reaches `v1.0.0`.
+once it reaches `1.0.0`.
 
 Cross-repo coordination: changes to the wire protocol or pairing flow
 that require matching updates in `satellite`, `dish-linux`, or `dish-mac`
@@ -105,7 +105,7 @@ replacing the former `docs/wire-format.md`).
   the previous constant 250 Hz re-send of the last state.
 - `versionCode` and `versionName` are now derived from CI environment
   variables (`DISH_VERSION_CODE` / `DISH_VERSION_NAME`), with a
-  `git describe` fallback for local dev. The hardcoded `1` / `"1.0"`
+  `git describe` fallback for local dev. The hardcoded `0` / `"0.0.0"`
   defaults remain only when neither signal is present.
 - `release.yml` stages `mapping.txt` into `dist/` alongside the AAB and
   APK so it gets the same SHA256SUMS + cosign signature treatment.
@@ -124,5 +124,5 @@ binary cares about.
 Initial public release. Tag will be created when the Play Store internal
 testing track is opened.
 
-[Unreleased]: https://github.com/TinkerNorth/dish-android/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/TinkerNorth/dish-android/releases/tag/v1.0.0
+[Unreleased]: https://github.com/TinkerNorth/dish-android/compare/1.0.0...HEAD
+[1.0.0]: https://github.com/TinkerNorth/dish-android/releases/tag/1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ unrelated jars suggests something is off.
 
 ### Verifying a release artifact
 
-Each GitHub Release ships the signed `dish-vX.Y.Z.apk` + `.aab`,
+Each GitHub Release ships the signed `dish-X.Y.Z.apk` + `.aab`,
 `*.sig`/`*.crt` (cosign keyless), `SHA256SUMS` + `SHA256SUMS.sig`/`*.crt`,
 the SPDX + CycloneDX SBOMs, and `dish-android.intoto.jsonl` (SLSA L3).
 
@@ -162,15 +162,15 @@ sha256sum -c SHA256SUMS
 cosign verify-blob \
   --certificate SHA256SUMS.crt \
   --signature   SHA256SUMS.sig \
-  --certificate-identity-regexp '^https://github\.com/TinkerNorth/dish-android/\.github/workflows/release\.yml@refs/tags/v.*$' \
+  --certificate-identity-regexp '^https://github\.com/TinkerNorth/dish-android/\.github/workflows/release\.yml@refs/tags/v?[0-9].*$' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   SHA256SUMS
 
 slsa-verifier verify-artifact \
   --provenance-path dish-android.intoto.jsonl \
   --source-uri      github.com/TinkerNorth/dish-android \
-  --source-tag      vX.Y.Z \
-  dish-vX.Y.Z.apk
+  --source-tag      X.Y.Z \
+  dish-X.Y.Z.apk
 ```
 
 The full cross-repo verification recipe lives in

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -75,7 +75,7 @@ Out of scope:
 | `dish-linux` | latest minor on `main`; previous minor for 90 days | tracks the oldest LTS the release CI builds against |
 | `dish-mac` | latest minor on `main`; previous minor for 90 days | macOS 13+ |
 
-Patch releases (`vX.Y.Z+1`) are issued on demand for the latest minor;
+Patch releases (`X.Y.Z+1`) are issued on demand for the latest minor;
 the previous minor only receives backports for high/critical fixes.
 
 ---
@@ -138,11 +138,11 @@ go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@latest
 
 ### 1) Download every file from the Release
 
-For tag `vX.Y.Z` of `<repo>` (one of `satellite`, `dish-android`,
+For tag `X.Y.Z` of `<repo>` (one of `satellite`, `dish-android`,
 `dish-linux`, `dish-mac`):
 
 ```bash
-gh release download vX.Y.Z -R TinkerNorth/<repo> -D ./release
+gh release download X.Y.Z -R TinkerNorth/<repo> -D ./release
 cd release
 ls
 ```
@@ -177,7 +177,7 @@ modified after release.
 cosign verify-blob \
   --certificate SHA256SUMS.crt \
   --signature   SHA256SUMS.sig \
-  --certificate-identity-regexp '^https://github\.com/TinkerNorth/<repo>/\.github/workflows/release\.yml@refs/tags/v.*$' \
+  --certificate-identity-regexp '^https://github\.com/TinkerNorth/<repo>/\.github/workflows/release\.yml@refs/tags/v?[0-9].*$' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   SHA256SUMS
 ```
@@ -197,7 +197,7 @@ for f in *.exe *.zip *.deb *.AppImage *.apk *.aab; do
   cosign verify-blob \
     --certificate "$f.crt" \
     --signature   "$f.sig" \
-    --certificate-identity-regexp '^https://github\.com/TinkerNorth/<repo>/\.github/workflows/release\.yml@refs/tags/v.*$' \
+    --certificate-identity-regexp '^https://github\.com/TinkerNorth/<repo>/\.github/workflows/release\.yml@refs/tags/v?[0-9].*$' \
     --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
     "$f"
 done
@@ -209,7 +209,7 @@ done
 slsa-verifier verify-artifact \
   --provenance-path <repo>.intoto.jsonl \
   --source-uri      github.com/TinkerNorth/<repo> \
-  --source-tag      vX.Y.Z \
+  --source-tag      X.Y.Z \
   <artifact-filename>
 ```
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,10 +54,10 @@ fun resolveVersion(): ResolvedVersion {
 
     val describe = providers.of(GitDescribeValueSource::class.java) {}.get()
     val match =
-        Regex("^(\\d+)\\.(\\d+)\\.(\\d+)").find(describe) ?: return ResolvedVersion(0, "0.0.0")
+        Regex("^(\\d+)\\.(\\d+)\\.(\\d+)").find(describe) ?: return ResolvedVersion(1, "0.0.0")
     val (major, minor, patch) = match.destructured
     return ResolvedVersion(
-        code = major.toInt() * 10000 + minor.toInt() * 100 + patch.toInt(),
+        code = (major.toInt() * 10000 + minor.toInt() * 100 + patch.toInt()).coerceAtLeast(1),
         name = describe,
     )
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,7 +32,7 @@ abstract class GitDescribeValueSource : ValueSource<String, ValueSourceParameter
         val ran =
             runCatching {
                 execOps.exec {
-                    commandLine("git", "describe", "--tags", "--match", "v*", "--abbrev=0")
+                    commandLine("git", "describe", "--tags", "--match", "[0-9]*.[0-9]*.[0-9]*", "--abbrev=0")
                     standardOutput = stdout
                     errorOutput = ByteArrayOutputStream()
                     isIgnoreExitValue = true
@@ -54,11 +54,11 @@ fun resolveVersion(): ResolvedVersion {
 
     val describe = providers.of(GitDescribeValueSource::class.java) {}.get()
     val match =
-        Regex("^v(\\d+)\\.(\\d+)\\.(\\d+)").find(describe) ?: return ResolvedVersion(1, "1.0")
+        Regex("^(\\d+)\\.(\\d+)\\.(\\d+)").find(describe) ?: return ResolvedVersion(0, "0.0.0")
     val (major, minor, patch) = match.destructured
     return ResolvedVersion(
         code = major.toInt() * 10000 + minor.toInt() * 100 + patch.toInt(),
-        name = describe.removePrefix("v"),
+        name = describe,
     )
 }
 

--- a/play/README.md
+++ b/play/README.md
@@ -32,7 +32,7 @@ play/
 The directory layout follows the [Fastlane Supply](https://docs.fastlane.tools/actions/supply/) convention so it can be uploaded with one command once a Play Console API key is configured:
 
 ```bash
-fastlane supply --aab path/to/dish-v1.0.0.aab --metadata_path play/metadata
+fastlane supply --aab path/to/dish-1.0.0.aab --metadata_path play/metadata
 ```
 
 Without Fastlane, the same files can be copy-pasted into the Play Console store-listing pages by hand.


### PR DESCRIPTION
## What

Release tags drop the `v` prefix and pre-release suffixes. They are now bare semver-core `X.Y.Z`, starting at `0.0.0`.

## Why this touches more than the trigger

The `v` convention was load-bearing in four functional spots. All switch together so a bare tag flows end to end:

- **`release.yml` trigger** now matches `'[0-9]+.[0-9]+.[0-9]+'`.
- **Required-secrets gate** keys off `refs/tags/` instead of `refs/tags/v`. Under the new trigger, the old check would have classified a bare tag as a non-tag run and permitted **unsigned** artifacts. This keeps signing enforced on every tagged release.
- **`build.gradle.kts`**: `git describe --match '[0-9]*.[0-9]*.[0-9]*'`, the parse regex drops the leading `v`, and the no-tag local-dev fallback is now `(0, "0.0.0")` (was `(1, "1.0")`) so untagged dev builds read the real baseline and cannot collide with a future `0.0.1`.
- **cosign verify identity regexp** (`SECURITY.md`, `CONTRIBUTING.md`) is now `@refs/tags/v?[0-9].*$`, tolerant of both the new bare tags and the legacy `v0.0.1-alpha` release.

Release-asset names and changelog links follow (`dish-X.Y.Z.apk`, `compare/1.0.0...HEAD`).

## Notes for reviewers

- **versionCode**: `0.0.0` resolves to versionCode `0`. It builds and publishes to GitHub fine, but it is below Google Play's `versionCode >= 1` floor, so `0.0.0` stays GitHub-only. The `1.0.0` Play launch maps to `10000`.
- **Cross-repo**: `SECURITY.md` is the shared four-repo verification recipe. `satellite`, `dish-linux`, and `dish-mac` still tag with `v` and need the same switch to keep the lockstep version scheme consistent. The verify regexp here is `v?`-tolerant so it still verifies their `v`-tagged artifacts in the meantime.
- The leftover `v0.0.1-alpha` tag is untouched and no longer triggers the (now bare-`X.Y.Z`-only) release workflow.

## Verification

`git describe --match '[0-9]*.[0-9]*.[0-9]*'` correctly ignores the existing `v0.0.1-alpha` tag and falls through to the `0.0.0` default. The full Gradle build is deferred to CI.
