### PR TITLE
fix: pre-install CMake to stop the parallel SDK install race in CI

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -34,6 +34,10 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
+      - name: Pre-install CMake 3.22.1
+        # Parallel per-ABI configureCMake* tasks otherwise race the SDK auto-install and read a half-written archive.
+        run: ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager "cmake;3.22.1"
+
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -35,7 +35,6 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       - name: Pre-install CMake 3.22.1
-        # Parallel per-ABI configureCMake* tasks otherwise race the SDK auto-install and read a half-written archive.
         run: ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager "cmake;3.22.1"
 
       - name: Set up Python

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,6 +51,10 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
+      - name: Pre-install CMake 3.22.1
+        # Parallel per-ABI configureCMake* tasks otherwise race the SDK auto-install and read a half-written archive.
+        run: ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager "cmake;3.22.1"
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,6 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       - name: Pre-install CMake 3.22.1
-        # Parallel per-ABI configureCMake* tasks otherwise race the SDK auto-install and read a half-written archive.
         run: ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager "cmake;3.22.1"
 
       - name: Initialize CodeQL


### PR DESCRIPTION
## What

Adds a serial `sdkmanager "cmake;3.22.1"` step before the Gradle build in **codeql.yml** and **android-ci.yml**.

## Why

The CodeQL `java-kotlin` Build step failed on the funding-doc push ([run](https://github.com/TinkerNorth/dish-android/actions/runs/27547050555/job/81423071064)):

```
java.util.zip.ZipException: Archive is not a ZIP archive
"Install CMake 3.22.1 v.3.22.1" failed.
> Task :app:configureCMakeDebug[arm64-v8a] FAILED
  com.android.builder.sdk.InstallFailedException: Failed to install ... cmake;3.22.1
```

The funding change (`.github/FUNDING.yml` only) is unrelated. The real cause is a flaky race: `assembleDebug` fans `configureCMakeDebug` out across both ABIs (`arm64-v8a`, `x86_64` per `app/build.gradle.kts`), and with CMake not yet installed, each task auto-installs `cmake;3.22.1` through the SDK manager at the same time. They collide on the shared download and one reads a half-written archive. In the failing log, `[arm64-v8a]` dies while `[x86_64]` installs the same package successfully moments later.

Evidence it is a flake, not the commit: **Android CI passed on the exact same commit** while CodeQL failed, and the `cpp` CodeQL leg (also runs `assembleDebug`) won the race that the `java-kotlin` leg lost.

## Fix

Install `cmake;3.22.1` once, serially, up front via the runner's `sdkmanager`. By the time `configureCMake*` runs, CMake is already present, so no task triggers a concurrent install and the race is gone. The step is a no-op when CMake is already cached, and the SDK license is pre-accepted on GitHub runners.

## Scope

Applied to the two push/PR build workflows. **release.yml** runs the same two-ABI native build (`assembleRelease bundleRelease`, `generateBaselineProfile`) and has identical exposure. I left it out of this PR to avoid touching the recently stabilized release pipeline. Recommend the same one-line step there as a follow-up.