### PR TITLE
fix: pre-install CMake in the release build to avoid the SDK install race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
+      - name: Pre-install CMake 3.22.1
+        run: ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager "cmake;3.22.1"
+
       - name: Decode keystore (if present)
         id: keystore
         env:


### PR DESCRIPTION
Follow-up to #116.

The `release` job builds the same two-ABI native target as CI (`generateBaselineProfile`, then `assembleRelease bundleRelease`), so it has the identical exposure to the CMake SDK-install race that broke the CodeQL build: the per-ABI `configureCMake*` tasks each auto-install `cmake;3.22.1` through the SDK manager, and run in parallel they collide on the shared download so one reads a half-written archive (`Archive is not a ZIP archive`).

A flake here is costlier than in CI because it fails a tagged release mid-run, so this guards the release path the same way #116 guards `codeql.yml` and `android-ci.yml`: install `cmake;3.22.1` once, serially, via the runner's `sdkmanager` before any Gradle build. No-op when CMake is already cached; the SDK license is pre-accepted on GitHub runners; it's a `run:` step so the action-pin lint does not apply.

Kept as a separate PR from #116 so the change to the release pipeline can be reviewed on its own.

Note: the release workflow is tag-triggered, so this change is not exercised by PR CI. It mirrors the exact step already proven green in #116.