### PR TITLE
fix: invert Y axis for Bluetooth HID gamepad reports

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/core/input/BluetoothGamepad.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/input/BluetoothGamepad.kt
@@ -147,7 +147,7 @@ internal fun buildHidDescriptor(): ByteArray =
 internal const val REPORT_ID = 1
 internal const val REPORT_SIZE = 14
 
-// Axis convention: Xbox/XInput, stick-up = positive Y. Caller does no sign inversion.
+// Caller passes XInput axes (stick-up = +Y); HID Generic Desktop Y is the opposite sign, so Y is negated here.
 @Suppress("MagicNumber")
 internal fun buildHidReport(
     buttons: Int,
@@ -159,6 +159,8 @@ internal fun buildHidReport(
     leftTrigger: Int,
     rightTrigger: Int,
 ): ByteArray {
+    val hidLeftY = (-leftY.toInt()).coerceAtMost(0x7FFF)
+    val hidRightY = (-rightY.toInt()).coerceAtMost(0x7FFF)
     val report = ByteArray(REPORT_SIZE)
     report[0] = REPORT_ID.toByte()
     report[1] = (buttons and 0xFF).toByte()
@@ -166,12 +168,12 @@ internal fun buildHidReport(
     report[3] = (hatSwitch and 0xFF).toByte()
     report[4] = (leftX.toInt() and 0xFF).toByte()
     report[5] = ((leftX.toInt() shr 8) and 0xFF).toByte()
-    report[6] = (leftY.toInt() and 0xFF).toByte()
-    report[7] = ((leftY.toInt() shr 8) and 0xFF).toByte()
+    report[6] = (hidLeftY and 0xFF).toByte()
+    report[7] = ((hidLeftY shr 8) and 0xFF).toByte()
     report[8] = (rightX.toInt() and 0xFF).toByte()
     report[9] = ((rightX.toInt() shr 8) and 0xFF).toByte()
-    report[10] = (rightY.toInt() and 0xFF).toByte()
-    report[11] = ((rightY.toInt() shr 8) and 0xFF).toByte()
+    report[10] = (hidRightY and 0xFF).toByte()
+    report[11] = ((hidRightY shr 8) and 0xFF).toByte()
     report[12] = (leftTrigger and 0xFF).toByte()
     report[13] = (rightTrigger and 0xFF).toByte()
     return report

--- a/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothGamepadReportTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothGamepadReportTest.kt
@@ -44,10 +44,10 @@ class BluetoothGamepadReportTest {
     }
 
     @Test
-    fun `left stick Y occupies bytes 6-7 little-endian`() {
+    fun `left stick Y occupies bytes 6-7 little-endian (negated to HID convention)`() {
         val r = buildHidReport(0, 0, 0, 0x1234.toShort(), 0, 0, 0, 0)
-        assertEquals(0x34.toByte(), r[6])
-        assertEquals(0x12.toByte(), r[7])
+        assertEquals(0xCC.toByte(), r[6])
+        assertEquals(0xED.toByte(), r[7])
     }
 
     @Test
@@ -58,10 +58,10 @@ class BluetoothGamepadReportTest {
     }
 
     @Test
-    fun `right stick Y occupies bytes 10-11 little-endian`() {
+    fun `right stick Y occupies bytes 10-11 little-endian (negated to HID convention)`() {
         val r = buildHidReport(0, 0, 0, 0, 0, 0x1234.toShort(), 0, 0)
-        assertEquals(0x34.toByte(), r[10])
-        assertEquals(0x12.toByte(), r[11])
+        assertEquals(0xCC.toByte(), r[10])
+        assertEquals(0xED.toByte(), r[11])
     }
 
     @Test
@@ -72,17 +72,24 @@ class BluetoothGamepadReportTest {
     }
 
     @Test
-    fun `stick-up on left stick is Y = plus 32767 per Xbox convention`() {
+    fun `XInput stick-up (plus 32767) is negated to HID Y = minus 32767`() {
         val r = buildHidReport(0, 0, 0, Short.MAX_VALUE, 0, 0, 0, 0)
+        assertEquals(0x01.toByte(), r[6])
+        assertEquals(0x80.toByte(), r[7])
+    }
+
+    @Test
+    fun `XInput stick-down (minus 32767) is negated to HID Y = plus 32767`() {
+        val r = buildHidReport(0, 0, 0, (-32767).toShort(), 0, 0, 0, 0)
         assertEquals(0xFF.toByte(), r[6])
         assertEquals(0x7F.toByte(), r[7])
     }
 
     @Test
-    fun `stick-down on left stick is Y = minus 32767`() {
-        val r = buildHidReport(0, 0, 0, (-32767).toShort(), 0, 0, 0, 0)
-        assertEquals(0x01.toByte(), r[6])
-        assertEquals(0x80.toByte(), r[7])
+    fun `XInput Y = min short clamps to HID plus 32767 (no negate overflow)`() {
+        val r = buildHidReport(0, 0, 0, Short.MIN_VALUE, 0, 0, 0, 0)
+        assertEquals(0xFF.toByte(), r[6])
+        assertEquals(0x7F.toByte(), r[7])
     }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothStickYAxisRegressionTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothStickYAxisRegressionTest.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.bluetooth
+
+import com.tinkernorth.dish.core.input.buildHidReport
+import com.tinkernorth.dish.ui.common.computeStickAxes
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BluetoothStickYAxisRegressionTest {
+    private fun le16(
+        lo: Byte,
+        hi: Byte,
+    ): Int = (((hi.toInt() and 0xFF) shl 8) or (lo.toInt() and 0xFF)).toShort().toInt()
+
+    private fun hidLeftY(report: ByteArray): Int = le16(report[6], report[7])
+
+    private fun hidRightY(report: ByteArray): Int = le16(report[10], report[11])
+
+    @Test
+    fun `virtual stick pushed up sends HID stick-up (negative Y) on both sticks`() {
+        val up = computeStickAxes(0f, -1f)
+        val report = buildHidReport(0, 0, up.axisX, up.axisY, up.axisX, up.axisY, 0, 0)
+        assertTrue("left HID Y must be negative for stick-up, was ${hidLeftY(report)}", hidLeftY(report) < 0)
+        assertTrue("right HID Y must be negative for stick-up, was ${hidRightY(report)}", hidRightY(report) < 0)
+    }
+
+    @Test
+    fun `virtual stick pulled down sends HID stick-down (positive Y)`() {
+        val down = computeStickAxes(0f, 1f)
+        val report = buildHidReport(0, 0, down.axisX, down.axisY, 0, 0, 0, 0)
+        assertTrue("left HID Y must be positive for stick-down, was ${hidLeftY(report)}", hidLeftY(report) > 0)
+    }
+
+    @Test
+    fun `virtual stick centered sends HID Y zero`() {
+        val neutral = computeStickAxes(0f, 0f)
+        val report = buildHidReport(0, 0, neutral.axisX, neutral.axisY, 0, 0, 0, 0)
+        assertEquals(0, hidLeftY(report))
+    }
+
+    @Test
+    fun `horizontal axis is unchanged - finger right stays HID X positive`() {
+        val right = computeStickAxes(1f, 0f)
+        val report = buildHidReport(0, 0, right.axisX, right.axisY, 0, 0, 0, 0)
+        assertTrue("left HID X must stay positive for stick-right", le16(report[4], report[5]) > 0)
+        assertEquals("Y must be centered", 0, hidLeftY(report))
+    }
+}


### PR DESCRIPTION
## Problem

When the on-screen virtual controller (or a physical controller bridged over Bluetooth) is bound to a Bluetooth host, the left and right analog sticks read **upside-down** (Y inverted). Horizontal is correct, so the symptom is a pure vertical flip.

## Root cause

A coordinate-convention mismatch isolated to the Bluetooth path:

- The virtual stick (`computeStickAxes`) and the native bridge emit **XInput** convention: stick-up = **+Y**.
- The **satellite (USB/Wi-Fi)** path forwards those values to a remote that re-emits an XInput pad, so up = +Y is correct there. It works.
- The **Bluetooth** path packs the same value straight into a raw **HID Generic Desktop Y axis** (`buildHidReport`). The HID/DirectInput convention for Y is the opposite: stick-up = logical minimum (negative). The host read +Y as "down".

Only Y is affected because X shares the same sign in both conventions (right = positive). That matches the "upside-down, not mirrored" symptom.

## Fix

Negate `leftY`/`rightY` in `buildHidReport`, the single chokepoint both Bluetooth entry points funnel through (virtual via `GamepadOverlayActivity`, physical via `BluetoothGamepadBridge.dispatchReport`). `.coerceAtMost(0x7FFF)` guards the `-(-32768)` overflow so full deflection does not wrap to the wrong rail. The satellite path never calls `buildHidReport`, so it is untouched.

The right stick had the identical latent bug. It is fixed by the same change.

## Tests

- New `BluetoothStickYAxisRegressionTest`: drives `computeStickAxes` into `buildHidReport` end to end. Asserts virtual stick-up produces HID stick-up (negative Y) on both sticks, stick-down produces positive Y, neutral is 0, and horizontal stays positive X with centered Y.
- Updated `BluetoothGamepadReportTest` for the new sign convention (left/right Y inversion, plus a `Short.MIN_VALUE` clamp case).

## Local verification

Full CI mirror run locally, all green: clang-format (JNI), ktlintCheck, detekt, lint, testDebugUnitTest, assembleDebug.
