### PR TITLE
feat: scan for satellites when opening the Connections screen

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
@@ -346,6 +346,11 @@ class ConnectionsActivity : AppCompatActivity() {
         intent.removeExtra(EXTRA_PAIR_PROMPT_FOR_ID)
     }
 
+    override fun onStart() {
+        super.onStart()
+        satellite.startDiscovery()
+    }
+
     override fun onStop() {
         super.onStop()
         gamepadHost.cancelDimOnStop()


### PR DESCRIPTION
## What
Opening (or returning to) the Connections screen now starts a satellite scan automatically, instead of waiting for a manual **Scan** tap.

## Why
- Entering the screen should surface reachable satellites without an extra tap.
- The same discovery pass calls `ConnectionStore.refreshFromDiscovery`, which re-homes remembered satellites whose box moved to a new IP/port. Stale endpoints were a known reconnect-failure source, so refreshing on entry lets a moved satellite reconnect without a manual rescan.

## How
Added an `onStart()` override to `ConnectionsActivity` that calls `satellite.startDiscovery()`.

`startDiscovery()` is non-blocking (launches a coroutine), guarded against overlapping scans (`compareAndSet`, so a re-entry mid-scan is a no-op), and permission-free (UDP discovery, not location-gated Bluetooth scan). Firing it on every entry, including returns from a child screen or a settings deep-link, is therefore safe.

Bluetooth host scanning is intentionally not auto-started: that flow is classic BT discovery for *adding* a new host and needs discoverability plus scan permission, so it stays in the device picker.