### PR TITLE
ci: group Dependabot updates to cut weekly PR volume

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    groups:
+      gradle-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -15,3 +22,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Adds `groups:` to both Dependabot ecosystems so related bumps arrive batched instead of as separate PRs.

- **gradle**: minor + patch updates group into one weekly PR (`gradle-dependencies`). Major bumps still open individually for isolated review.
- **github-actions**: all updates group into one weekly PR (`github-actions`).

## Why

Five separate Dependabot PRs (#108, #119, #120, #121, #122) piled up against `main`. Grouping collapses each week's routine updates into one PR per ecosystem, which is far easier to triage ahead of release.

## Notes

Config-only change. Takes effect on the next Dependabot run; no impact on the app or build.