### PR TITLE
fix: dedupe identical physical-slot re-binds to stop held-input flicker

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalSlotBindingObserver.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalSlotBindingObserver.kt
@@ -112,6 +112,49 @@ fun reconcileSlots(
     return ops
 }
 
+// The ops reconcileSlots wants applied, paired with the bind-per-device map after applying them, so
+// the next pass can tell what is already live on the native side.
+data class DedupedBindOps(
+    val ops: List<BindOp>,
+    val applied: Map<Int, BindOp>,
+)
+
+// Drops a satellite/bluetooth bind byte-identical to the one already applied for that device, since
+// re-applying it costs a destructive syncSlotBaseline (held inputs flicker to neutral). A changed
+// bind (new handle/controller index/connection) still goes through, and unbinds are always kept --
+// they are idempotent on the native side and carry no neutral publish.
+fun dedupeBindOps(
+    ops: List<BindOp>,
+    lastApplied: Map<Int, BindOp>,
+): DedupedBindOps {
+    val applied = lastApplied.toMutableMap()
+    val out = mutableListOf<BindOp>()
+    for (op in ops) {
+        when (op) {
+            is BindOp.BindSatellite -> {
+                if (applied[op.deviceId] == op) continue
+                applied[op.deviceId] = op
+                out += op
+            }
+            is BindOp.BindBluetooth -> {
+                if (applied[op.deviceId] == op) continue
+                applied[op.deviceId] = op
+                out += op
+            }
+            is BindOp.Unbind -> {
+                applied.remove(op.deviceId)
+                out += op
+            }
+            is BindOp.Forget -> {
+                applied.remove(op.deviceId)
+                out += op
+            }
+            is BindOp.ReleaseHubBinding -> out += op
+        }
+    }
+    return DedupedBindOps(out, applied)
+}
+
 // Process-scoped (not activity-scoped) so bindings survive MainActivity → GamepadOverlayActivity hand-off.
 @Singleton
 class PhysicalSlotBindingObserver
@@ -131,6 +174,7 @@ class PhysicalSlotBindingObserver
 
         private var job: Job? = null
         private var lastBoundDeviceIds: Set<Int> = emptySet()
+        private var lastAppliedBinds: Map<Int, BindOp> = emptyMap()
 
         override fun onStart(owner: LifecycleOwner) {
             if (job != null) return
@@ -142,6 +186,7 @@ class PhysicalSlotBindingObserver
             job = null
             SatelliteNative.clearAllPhysicalSlots()
             lastBoundDeviceIds = emptySet()
+            lastAppliedBinds = emptyMap()
         }
 
         @OptIn(ExperimentalCoroutinesApi::class)
@@ -179,7 +224,14 @@ class PhysicalSlotBindingObserver
                     perConnectionSlotInfo = slotInfo,
                     btConnectedIds = btConnectedIds,
                 )
-            for (op in ops) execute(op)
+            // A satellite re-bind is not idempotent on the native side: bindPhysicalSlotSatellite
+            // re-runs syncSlotBaseline, which resets the device to neutral and publishes it, briefly
+            // releasing every held button/trigger until the next physical report. push() fires on
+            // every upstream re-emit (a few Hz), so replaying an unchanged bind makes held inputs
+            // flicker. Drop binds identical to the one already applied; let changed binds through.
+            val deduped = dedupeBindOps(ops, lastAppliedBinds)
+            for (op in deduped.ops) execute(op)
+            lastAppliedBinds = deduped.applied
             lastBoundDeviceIds = present
         }
 

--- a/app/src/test/java/com/tinkernorth/dish/hotpath/input/BindOpDedupeTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/hotpath/input/BindOpDedupeTest.kt
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.hotpath.input
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+// Locks the bind-deduplication that stops an unchanged slot re-bind from being re-applied. The bug it
+// guards: bindPhysicalSlotSatellite re-runs syncSlotBaseline, which resets the device to neutral and
+// publishes it, so replaying an identical bind every reconcile pass (a few Hz) momentarily releases
+// every held button/trigger -- the "tiny gap" seen on a held ZL in USB-direct mode.
+class BindOpDedupeTest {
+    private val satA = BindOp.BindSatellite(deviceId = 5, handle = 9, controllerIndex = 2)
+    private val btA = BindOp.BindBluetooth(deviceId = 5, connectionId = "bt:aa")
+
+    @Test
+    fun `the first bind for a device is emitted and recorded as applied`() {
+        val r = dedupeBindOps(ops = listOf(satA), lastApplied = emptyMap())
+        assertEquals(listOf(satA), r.ops)
+        assertEquals(mapOf(5 to satA), r.applied)
+    }
+
+    @Test
+    fun `a satellite bind identical to the last applied is dropped`() {
+        // The headline failure: a steady, already-bound controller must not be re-bound.
+        val r = dedupeBindOps(ops = listOf(satA), lastApplied = mapOf(5 to satA))
+        assertEquals(emptyList<BindOp>(), r.ops)
+        assertEquals(mapOf(5 to satA), r.applied)
+    }
+
+    @Test
+    fun `a bluetooth bind identical to the last applied is dropped`() {
+        val r = dedupeBindOps(ops = listOf(btA), lastApplied = mapOf(5 to btA))
+        assertEquals(emptyList<BindOp>(), r.ops)
+        assertEquals(mapOf(5 to btA), r.applied)
+    }
+
+    @Test
+    fun `a satellite bind whose controller index changed is re-emitted`() {
+        val moved = satA.copy(controllerIndex = 3)
+        val r = dedupeBindOps(ops = listOf(moved), lastApplied = mapOf(5 to satA))
+        assertEquals(listOf(moved), r.ops)
+        assertEquals(mapOf(5 to moved), r.applied)
+    }
+
+    @Test
+    fun `a satellite bind whose session handle changed is re-emitted`() {
+        // A reconnect hands out a new session handle; the slot must re-bind onto it.
+        val rehandled = satA.copy(handle = 10)
+        val r = dedupeBindOps(ops = listOf(rehandled), lastApplied = mapOf(5 to satA))
+        assertEquals(listOf(rehandled), r.ops)
+        assertEquals(mapOf(5 to rehandled), r.applied)
+    }
+
+    @Test
+    fun `a bluetooth bind whose connection id changed is re-emitted`() {
+        val moved = btA.copy(connectionId = "bt:bb")
+        val r = dedupeBindOps(ops = listOf(moved), lastApplied = mapOf(5 to btA))
+        assertEquals(listOf(moved), r.ops)
+        assertEquals(mapOf(5 to moved), r.applied)
+    }
+
+    @Test
+    fun `switching a device from satellite to bluetooth re-emits`() {
+        val r = dedupeBindOps(ops = listOf(btA), lastApplied = mapOf(5 to satA))
+        assertEquals(listOf(btA), r.ops)
+        assertEquals(mapOf(5 to btA), r.applied)
+    }
+
+    @Test
+    fun `an unbind is always emitted and clears the applied entry`() {
+        val r = dedupeBindOps(ops = listOf(BindOp.Unbind(5)), lastApplied = mapOf(5 to satA))
+        assertEquals(listOf(BindOp.Unbind(5)), r.ops)
+        assertEquals(emptyMap<Int, BindOp>(), r.applied)
+    }
+
+    @Test
+    fun `a departed id's unbind forget and release clear it from applied`() {
+        val ops = listOf(BindOp.Unbind(7), BindOp.Forget(7), BindOp.ReleaseHubBinding(7))
+        val r = dedupeBindOps(ops = ops, lastApplied = mapOf(7 to BindOp.BindSatellite(7, 9, 0)))
+        assertEquals(ops, r.ops)
+        assertEquals(emptyMap<Int, BindOp>(), r.applied)
+    }
+
+    @Test
+    fun `independent devices dedupe independently`() {
+        // Device 5 unchanged (dropped); device 6 newly bound (kept).
+        val sat6 = BindOp.BindSatellite(deviceId = 6, handle = 9, controllerIndex = 3)
+        val r = dedupeBindOps(ops = listOf(satA, sat6), lastApplied = mapOf(5 to satA))
+        assertEquals(listOf(sat6), r.ops)
+        assertEquals(mapOf(5 to satA, 6 to sat6), r.applied)
+    }
+
+    @Test
+    fun `emitted op order is preserved when only some binds are dropped`() {
+        // Departed id 7 ops must still precede the one kept bind; the deduped bind for 5 is gone.
+        val sat6 = BindOp.BindSatellite(deviceId = 6, handle = 9, controllerIndex = 3)
+        val ops =
+            listOf(
+                BindOp.Unbind(7),
+                BindOp.Forget(7),
+                BindOp.ReleaseHubBinding(7),
+                satA,
+                sat6,
+            )
+        val r = dedupeBindOps(ops = ops, lastApplied = mapOf(5 to satA))
+        assertEquals(
+            listOf(BindOp.Unbind(7), BindOp.Forget(7), BindOp.ReleaseHubBinding(7), sat6),
+            r.ops,
+        )
+    }
+
+    @Test
+    fun `repeated identical reconcile passes re-bind a held controller only once`() {
+        // End-to-end reproduction: the same reconcile output replayed many times (every upstream
+        // re-emit during steady play) binds once, then emits nothing -- no neutral-publish flicker.
+        val reconcileOutput = listOf(satA)
+        var applied = emptyMap<Int, BindOp>()
+
+        val first = dedupeBindOps(reconcileOutput, applied)
+        applied = first.applied
+        assertEquals(listOf(satA), first.ops)
+
+        repeat(50) {
+            val pass = dedupeBindOps(reconcileOutput, applied)
+            applied = pass.applied
+            assertEquals(emptyList<BindOp>(), pass.ops)
+        }
+    }
+
+    @Test
+    fun `a device that unbinds then rebinds is emitted again`() {
+        // Drop-out (slot went unregistered) then recovery must re-issue the bind, not stay deduped.
+        var applied = dedupeBindOps(listOf(satA), emptyMap()).applied
+        applied = dedupeBindOps(listOf(BindOp.Unbind(5)), applied).applied
+        assertEquals(emptyMap<Int, BindOp>(), applied)
+
+        val rebind = dedupeBindOps(listOf(satA), applied)
+        assertEquals(listOf(satA), rebind.ops)
+        assertEquals(mapOf(5 to satA), rebind.applied)
+    }
+
+    @Test
+    fun `no ops yields no ops and preserves the applied map`() {
+        val r = dedupeBindOps(ops = emptyList(), lastApplied = mapOf(5 to satA))
+        assertEquals(emptyList<BindOp>(), r.ops)
+        assertEquals(mapOf(5 to satA), r.applied)
+    }
+}


### PR DESCRIPTION
## Problem

In USB-direct mode, a continuously **held** input (e.g. ZL on a Switch Pro, mapped to the left trigger) shows tiny periodic gaps in-game — it reads as briefly released and re-pressed a few times a second. Standard mode is unaffected.

## Root cause (confirmed by on-device logcat)

The raw HID stream is clean — a held ZL reports `buf5=0x80` continuously for the full hold, no dropped frames, no report-mode reverts. The gap is ours:

- `PhysicalSlotBindingObserver.push()` runs on **every** upstream flow re-emit (`registry.devices`, `hub.connections`, `slotsTrigger`, …), which churns at a few Hz during play.
- `reconcileSlots` re-issues `BindSatellite` for every present device on every pass — it computes the *desired* state, with no notion of "already applied".
- On the native side, `bindPhysicalSlotSatellite` → `syncSlotBaseline`, which **`resetState()` (zeroes all held inputs) → publishes**. So each redundant, unchanged re-bind sends a *neutral gamepad packet* to the satellite, momentarily releasing everything held; the next physical report (~8 ms later) re-asserts it. That release/re-assert pair is the flicker.

Logcat during a steady 15 s hold showed ~2–4 `0->255` re-presses/second on the synthetic USB device, and exactly one clean press/release on the framework (Standard) device.

## Fix

Add a pure, exhaustively-tested `dedupeBindOps(ops, lastApplied)` that drops a satellite/bluetooth bind byte-identical to the one already applied for that device. Changed binds (new session handle, controller index, or BT connection) still go through; unbinds are always emitted (idempotent on the native side, no neutral publish). The observer carries the applied-bind map across passes and clears it on `onStop()` alongside `clearAllPhysicalSlots()`.

`reconcileSlots` (routing correctness) is left untouched — the dedup is a separate filter on its output.

## Tests

`BindOpDedupeTest` (14 cases) was written first against a passthrough stub to reproduce the failure (5 red), then the real implementation turned them green:

- first bind emitted/recorded; identical satellite/bluetooth re-bind dropped
- changed handle / controller index / connection id re-emitted; satellite↔bluetooth switch re-emitted
- unbind always emitted and clears the applied entry; departed unbind/forget/release clears it
- independent devices dedupe independently; emitted op order preserved
- **headline:** 50 identical reconcile passes re-bind a held controller only once
- unbind-then-rebind re-emits

Existing `PhysicalSlotBindingObserverTest` is unchanged and still green.

## Verification

`ktlintCheck`, `detekt`, `lint`, and the full `testDebugUnitTest` suite all pass locally.