### PR TITLE
feat: stream on every screen, heal phantom satellite pads, accurate latency readout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,11 @@ jobs:
           DISH_VERSION_CODE: ${{ steps.ver.outputs.code }}
           DISH_VERSION_NAME: ${{ steps.ver.outputs.name }}
         run: |
-          ./gradlew assembleRelease bundleRelease uploadCrashlyticsSymbolFileRelease
+          if [ "${{ steps.firebase.outputs.present }}" = "true" ]; then
+            ./gradlew assembleRelease bundleRelease uploadCrashlyticsSymbolFileRelease
+          else
+            ./gradlew assembleRelease bundleRelease
+          fi
 
       - name: Stage artifacts
         id: stage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,7 @@ jobs:
           DISH_VERSION_CODE: ${{ steps.ver.outputs.code }}
           DISH_VERSION_NAME: ${{ steps.ver.outputs.name }}
         run: |
-          ./gradlew assembleRelease bundleRelease
+          ./gradlew assembleRelease bundleRelease uploadCrashlyticsSymbolFileRelease
 
       - name: Stage artifacts
         id: stage

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,10 +8,6 @@ name: Security
 # Known-vulnerable-dependency coverage: OSV-Scanner and dependency-review
 # here (GitHub/OSV advisory data, exact Maven coordinates), Grype against
 # release artifacts in release.yml (NVD + GHSA), and Dependabot updates.
-# OWASP Dependency-Check was removed 2026-07: its NVD sync burned 30 to
-# 90 runner-minutes per run for CPE-guess matching that never produced a
-# finding here (the suppression file stayed empty for its whole life).
-
 on:
   push:
     branches: [main]

--- a/.security/allowlist.yaml
+++ b/.security/allowlist.yaml
@@ -11,8 +11,5 @@
 #       owner:   "@github-handle" of the engineer accountable for re-evaluation
 #       expires: YYYY-MM-DD (max 90 days out; renew via PR if still applicable)
 #
-# Note: OWASP Dependency-Check has its own XML suppression format; mirror
-# any entry here in `.security/dependency-check-suppressions.xml` when the
-# matching CVE is also surfaced by Dependency-Check.
 
 exceptions: []

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,10 +89,9 @@ Build + style:
 Security gates (also blocking):
 
 - `security.yml`: action-pin lint, vulnerability allowlist expiry,
-  OSV-Scanner, gitleaks secret scan, GitHub `dependency-review-action`
-  (consumes the Gradle dependency graph), and the OWASP Dependency-Check
-  Gradle plugin (`./gradlew dependencyCheckAnalyze`: fails on
-  CVSS >= 7.0).
+  OSV-Scanner, gitleaks secret scan, and GitHub `dependency-review-action`
+  (consumes the Gradle dependency graph). Release artifacts additionally
+  get a Grype scan in `release.yml`.
 - `codeql.yml`: CodeQL `java-kotlin` and `cpp` analysis
   (security-extended + security-and-quality query packs).
 
@@ -107,16 +106,9 @@ Open a PR that adds an entry to [`.security/allowlist.yaml`](.security/allowlist
 `expires`. CI rejects the PR if any field is missing or `expires` is in
 the past.
 
-If the same finding is raised by OWASP Dependency-Check, mirror the
-entry in [`.security/dependency-check-suppressions.xml`](.security/dependency-check-suppressions.xml)
-using the [official suppression schema](https://jeremylong.github.io/DependencyCheck/general/suppression.html).
-
 ### Running security checks locally
 
 ```bash
-# OWASP Dependency-Check (the same task CI runs)
-./gradlew dependencyCheckAnalyze
-
 # Gradle dependency verification: recompute checksums into
 # gradle/verification-metadata.xml after a deliberate dep bump
 ./gradlew --write-verification-metadata sha256 help
@@ -154,7 +146,7 @@ verification metadata so transitive jar tampering fails resolution:
 
 ```bash
 ./gradlew --write-verification-metadata sha256 \
-  assembleDebug bundleRelease testDebugUnitTest dependencyCheckAnalyze
+  assembleDebug bundleRelease testDebugUnitTest
 ```
 
 Commit the regenerated `gradle/verification-metadata.xml` in the same

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,17 @@ license: the project is LGPL-3.0-or-later end-to-end (`LICENSE`,
   `StateFlow`. Don't introduce competing sources of truth: every UI-bound
   field belongs in `MainUiState`.
 - Coroutines for async, `kotlinx.serialization` for JSON, Hilt for DI.
+- Comments state non-obvious constraints only (why a lock order matters,
+  what a magic value encodes). No narration of what the next line does.
+  Older files are denser; new code follows this rule, not their example.
+- All in-app navigation goes through `DishNavigator`; raw Intents are for
+  external targets (system settings, browsers) only.
+- Screens with reactive state or multi-step flows get a ViewModel exposing
+  one immutable UiState `StateFlow`; static content screens may render
+  directly. Derivation lives in composers/ViewModels, never in an Activity.
+- Views are defined in layout XML and inflated; no programmatic View
+  construction. Standard screens go through
+  `BaseGamepadHostActivity.setScaffoldContent`.
 
 ### JNI / C++
 

--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ gradle/libs.versions.toml        Version catalog
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) and the
 [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md). CI runs build + style
 (`android-ci.yml`) and security gates (`security.yml`, `codeql.yml`)
-on every PR: OWASP Dependency-Check (fails on CVSS >= 7.0),
-OSV-Scanner, gitleaks, action-pin lint, and CodeQL for `java-kotlin`
-and `cpp`.
+on every PR: OSV-Scanner, dependency-review, gitleaks, action-pin
+lint, and CodeQL for `java-kotlin` and `cpp`; release artifacts get a
+Grype scan in `release.yml`.
 
 > Branch protection is unavailable on this repo's current org plan,
 > so direct pushes to `main` are blocked by convention only. The CI

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,6 +113,13 @@ android {
             signingConfig = signingConfigs.findByName("release")
             // Emit native-debug-symbols.zip for Play Console and strip the shipped .so.
             ndk { debugSymbolLevel = "FULL" }
+            if (firebaseEnabled) {
+                configure<com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension> {
+                    // Uploaded by release.yml via uploadCrashlyticsSymbolFileRelease so native
+                    // crash reports symbolicate; Play Console gets its copy from debugSymbolLevel.
+                    nativeSymbolUploadEnabled = true
+                }
+            }
         }
         // Optimized measurement build: production native (-O3 + ThinLTO, because it is
         // non-debuggable) but debug-signed so it installs locally, with the hot-path
@@ -191,6 +198,7 @@ dependencies {
     // Firebase SDKs always on classpath; controller no-ops when google-services.json is absent.
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.crashlytics)
+    implementation(libs.firebase.crashlytics.ndk)
     // Firebase Analytics is deliberately omitted: it would auto-inject AD_ID permission and break the zero-analytics privacy posture.
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
@@ -230,6 +238,9 @@ val nativeTestConfigure =
         inputs.file(layout.projectDirectory.file("src/main/cpp/gamepad_input.cpp"))
         inputs.file(layout.projectDirectory.file("src/main/cpp/wire_encoders.h"))
         outputs.dir(nativeTestBuildDir)
+        // Ninja on Windows (no make in a stock environment); Make everywhere else, matching CI.
+        val generator =
+            if (System.getProperty("os.name").startsWith("Windows")) "Ninja" else "Unix Makefiles"
         commandLine(
             "cmake",
             "-S",
@@ -237,7 +248,7 @@ val nativeTestConfigure =
             "-B",
             nativeTestBuildDir.get().asFile.absolutePath,
             "-G",
-            "Unix Makefiles",
+            generator,
         )
     }
 

--- a/app/src/main/cpp/hotpath_latency.cpp
+++ b/app/src/main/cpp/hotpath_latency.cpp
@@ -64,8 +64,6 @@ Ring g_stage1;          // URB reap -> gamepad sent
 Ring g_rtt{kRttWindow}; // heartbeat ping -> ack, sliding
 Ring g_urbGap;          // URB inter-arrival gap (polling jitter)
 
-std::atomic<int64_t> g_lastPingNs{0};
-
 // Gaps above this are stream pauses (idle pad, replug), not polling jitter; recording them
 // would drown the tail the metric exists to expose.
 constexpr double kUrbGapMaxUs = 100000.0;
@@ -108,7 +106,6 @@ void setEnabled(bool on) {
     g_stage1.clear();
     g_rtt.clear();
     g_urbGap.clear();
-    g_lastPingNs.store(0, std::memory_order_relaxed);
 }
 bool enabled() { return g_enabled.load(std::memory_order_relaxed); }
 
@@ -131,21 +128,17 @@ void markGamepadSent() {
     if (us >= 0 && us < 1e6) g_stage1.add(us);
 }
 
-void markPingSent() {
-    if (!g_enabled.load(std::memory_order_relaxed)) return;
-    const int64_t now = nowNs();
-    const int64_t outstanding = g_lastPingNs.load(std::memory_order_relaxed);
-    // Keep an in-flight ping's clock: overwriting would pair its late ack with this
-    // newer ping and read low. Past the validity window the ping is lost; reclaim.
-    if (outstanding != 0 && now - outstanding < kRttMaxNs) return;
-    g_lastPingNs.store(now, std::memory_order_relaxed);
+int64_t nowMonotonicNs() { return nowNs(); }
+
+// Keep an in-flight ping's clock: overwriting would pair its late ack with a newer
+// ping and read low. Past the validity window the ping is lost; reclaim.
+bool shouldArmPing(int64_t outstandingNs, int64_t nowNs) {
+    return outstandingNs == 0 || nowNs - outstandingNs >= kRttMaxNs;
 }
 
-void markAckReceived() {
+void addRttSample(int64_t sentNs, int64_t nowNs) {
     if (!g_enabled.load(std::memory_order_relaxed)) return;
-    int64_t sent = g_lastPingNs.exchange(0, std::memory_order_relaxed);
-    if (sent == 0) return;
-    double us = (double)(nowNs() - sent) / 1000.0;
+    double us = (double)(nowNs - sentNs) / 1000.0;
     if (us >= 0 && us < (double)kRttMaxNs / 1000.0) g_rtt.add(us);
 }
 

--- a/app/src/main/cpp/hotpath_latency.cpp
+++ b/app/src/main/cpp/hotpath_latency.cpp
@@ -30,14 +30,23 @@ thread_local int64_t t_prevReapNs = 0;
 // One bounded ring per metric. A mutex per sample is cheap next to the syscall
 // the send already does, and only taken while benchmarking.
 struct Ring {
+    explicit Ring(size_t window = 0) : window(window) {}
     std::mutex mtx;
     std::vector<double> us; // sample window, microseconds
+    // 0 = accumulate to kCap (bench-dump semantics); >0 = sliding window of the
+    // last N samples so percentiles answer "now", not "since arming".
+    const size_t window;
     // ~262k samples (~2 MB) so an offline "arm, unplug cable, play, replug, dump"
     // session at 1 kHz captures minutes, not seconds, before it stops growing.
     static constexpr size_t kCap = 262144;
     void add(double v) {
         std::lock_guard<std::mutex> lk(mtx);
-        if (us.size() < kCap) us.push_back(v);
+        if (window > 0) {
+            if (us.size() >= window) us.erase(us.begin());
+            us.push_back(v);
+        } else if (us.size() < kCap) {
+            us.push_back(v);
+        }
     }
     void clear() {
         std::lock_guard<std::mutex> lk(mtx);
@@ -45,9 +54,15 @@ struct Ring {
     }
 };
 
-Ring g_stage1; // URB reap -> gamepad sent
-Ring g_rtt;    // heartbeat ping -> ack
-Ring g_urbGap; // URB inter-arrival gap (polling jitter)
+// A ping every 2 s in steady state, 4/s in probe mode: 64 samples spans ~2 min
+// idle and ~16 s while the diagnostics panel probes.
+constexpr size_t kRttWindow = 64;
+// A ping unanswered past this is lost, not in flight (matches the ack-side cap).
+constexpr int64_t kRttMaxNs = 5000000000LL;
+
+Ring g_stage1;          // URB reap -> gamepad sent
+Ring g_rtt{kRttWindow}; // heartbeat ping -> ack, sliding
+Ring g_urbGap;          // URB inter-arrival gap (polling jitter)
 
 std::atomic<int64_t> g_lastPingNs{0};
 
@@ -118,7 +133,12 @@ void markGamepadSent() {
 
 void markPingSent() {
     if (!g_enabled.load(std::memory_order_relaxed)) return;
-    g_lastPingNs.store(nowNs(), std::memory_order_relaxed);
+    const int64_t now = nowNs();
+    const int64_t outstanding = g_lastPingNs.load(std::memory_order_relaxed);
+    // Keep an in-flight ping's clock: overwriting would pair its late ack with this
+    // newer ping and read low. Past the validity window the ping is lost; reclaim.
+    if (outstanding != 0 && now - outstanding < kRttMaxNs) return;
+    g_lastPingNs.store(now, std::memory_order_relaxed);
 }
 
 void markAckReceived() {
@@ -126,8 +146,10 @@ void markAckReceived() {
     int64_t sent = g_lastPingNs.exchange(0, std::memory_order_relaxed);
     if (sent == 0) return;
     double us = (double)(nowNs() - sent) / 1000.0;
-    if (us >= 0 && us < 5e6) g_rtt.add(us);
+    if (us >= 0 && us < (double)kRttMaxNs / 1000.0) g_rtt.add(us);
 }
+
+void resetRttWindow() { g_rtt.clear(); }
 
 std::string statsJson(bool reset) {
     std::string out = "{\"enabled\":";

--- a/app/src/main/cpp/hotpath_latency.h
+++ b/app/src/main/cpp/hotpath_latency.h
@@ -30,6 +30,9 @@ void markGamepadSent(); // the resulting MSG_GAMEPAD_DATA packet has left sendto
 void markPingSent();    // MSG_HEARTBEAT_PING sent
 void markAckReceived(); // MSG_HEARTBEAT_ACK received
 
+// Drops accumulated RTT samples so a probe-mode window starts fresh.
+void resetRttWindow();
+
 // JSON snapshot of the current window (microseconds). reset=true clears samples.
 std::string statsJson(bool reset);
 

--- a/app/src/main/cpp/hotpath_latency.h
+++ b/app/src/main/cpp/hotpath_latency.h
@@ -8,12 +8,14 @@
 // Stages (see satellite tools/bench/README.md for the full chain):
 //   stage 1  USB-direct hot path : markInputRead() at URB reap, markGamepadSent()
 //            right after the gamepad packet leaves sendto() -- delta on one thread.
-//   stage 2  network one-way     : markPingSent()/markAckReceived() time the
-//            heartbeat round trip on the device clock; one-way ~= RTT/2.
+//   stage 2  network one-way     : shouldArmPing()/addRttSample() time the heartbeat
+//            round trip on the device clock (per-session clock); one-way ~= RTT/2.
 //
 // statsJson() returns microsecond percentiles for the JNI/debug readout.
 
 #pragma once
+
+#include <stdint.h>
 
 #include <string>
 
@@ -26,9 +28,12 @@ bool enabled();
 void markInputRead();   // URB reaped with a fresh input report
 void markGamepadSent(); // the resulting MSG_GAMEPAD_DATA packet has left sendto()
 
-// stage 2 (heartbeat thread / receive thread)
-void markPingSent();    // MSG_HEARTBEAT_PING sent
-void markAckReceived(); // MSG_HEARTBEAT_ACK received
+// stage 2 (heartbeat thread / receive thread). The ping clock lives on the Session so
+// concurrent sessions can never pair one session's ping with another's ack; these keep
+// the policy (in-flight guard, loss reclaim, sample validity) in one place.
+int64_t nowMonotonicNs();
+bool shouldArmPing(int64_t outstandingNs, int64_t nowNs);
+void addRttSample(int64_t sentNs, int64_t nowNs);
 
 // Drops accumulated RTT samples so a probe-mode window starts fresh.
 void resetRttWindow();

--- a/app/src/main/cpp/satellite_jni.cpp
+++ b/app/src/main/cpp/satellite_jni.cpp
@@ -41,8 +41,13 @@
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, TAG, __VA_ARGS__)
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, TAG, __VA_ARGS__)
 
-static constexpr int HEARTBEAT_INTERVAL_MS = 2000;
-static constexpr int HEARTBEAT_MISS_MAX = 5;
+// Steady-state cadence is contractual (satellite docs/contract.md: 2000 ms). Probe
+// mode densifies RTT sampling only while the diagnostics latency panel is open; the
+// death window stays ~10 s wall clock because the miss threshold scales with it.
+static constexpr int HEARTBEAT_INTERVAL_DEFAULT_MS = 2000;
+static constexpr int HEARTBEAT_INTERVAL_PROBE_MS = 250;
+static constexpr int HEARTBEAT_DEATH_TIMEOUT_MS = 10000;
+static std::atomic<int> g_heartbeatIntervalMs{HEARTBEAT_INTERVAL_DEFAULT_MS};
 // Topology mutation is REST-only (satellite docs/contract.md): the native
 // layer carries streams + the two authenticated notifications, nothing else.
 static constexpr uint16_t MSG_GAMEPAD_DATA = 0x0001;
@@ -489,16 +494,17 @@ static void heartbeatLoop(std::shared_ptr<Session> s) {
     while (s->heartbeatRunning.load(std::memory_order_relaxed)) {
         sendEncrypted(s.get(), MSG_HEARTBEAT_PING, nullptr, 0);
         hotpath::markPingSent(); // stage-2: round-trip clock starts here
-        s->missedAcks.fetch_add(1, std::memory_order_relaxed);
 
-        if (s->missedAcks.load(std::memory_order_relaxed) >= HEARTBEAT_MISS_MAX) {
-            LOGE("Missed %d heartbeat ACKs, connection dead", HEARTBEAT_MISS_MAX);
+        const int intervalMs = g_heartbeatIntervalMs.load(std::memory_order_relaxed);
+        const int missMax = HEARTBEAT_DEATH_TIMEOUT_MS / intervalMs;
+        if (s->missedAcks.fetch_add(1, std::memory_order_relaxed) + 1 >= missMax) {
+            LOGE("Missed %d heartbeat ACKs, connection dead", missMax);
             s->connectionAlive.store(false, std::memory_order_relaxed);
         }
 
-        for (int i = 0; i < HEARTBEAT_INTERVAL_MS / 100; i++) {
+        for (int i = 0; i < intervalMs / 50; i++) {
             if (!s->heartbeatRunning.load(std::memory_order_relaxed)) break;
-            usleep(100000);
+            usleep(50000);
         }
     }
     LOGI("Heartbeat thread stopped");
@@ -1131,6 +1137,17 @@ Java_com_tinkernorth_dish_core_jni_SatelliteNative_setHotPathBench(JNIEnv*, jobj
 JNIEXPORT jstring JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_hotPathBenchJson(
     JNIEnv* env, jobject, jboolean reset) {
     return env->NewStringUTF(hotpath::statsJson(reset == JNI_TRUE).c_str());
+}
+
+// Densify heartbeat pings for RTT measurement while the diagnostics latency panel is
+// open. The RTT window is dropped on enable so the readout reflects probe-era samples,
+// not the idle-radio tail accumulated before the panel opened.
+JNIEXPORT void JNICALL
+Java_com_tinkernorth_dish_core_jni_SatelliteNative_setLatencyProbe(JNIEnv*, jobject, jboolean on) {
+    g_heartbeatIntervalMs.store(on == JNI_TRUE ? HEARTBEAT_INTERVAL_PROBE_MS
+                                               : HEARTBEAT_INTERVAL_DEFAULT_MS,
+                                std::memory_order_relaxed);
+    if (on == JNI_TRUE) hotpath::resetRttWindow();
 }
 
 JNIEXPORT void JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_setInputInspection(

--- a/app/src/main/cpp/satellite_jni.cpp
+++ b/app/src/main/cpp/satellite_jni.cpp
@@ -90,6 +90,7 @@ struct Session {
     std::atomic<bool> heartbeatRunning{false};
     std::atomic<int> missedAcks{0};
     std::atomic<bool> connectionAlive{true};
+    std::atomic<int64_t> lastPingNs{0};
 
     // Downstream replay guard (server → client direction).
     std::atomic<uint32_t> lastRxCounter{0};
@@ -493,7 +494,13 @@ static void heartbeatLoop(std::shared_ptr<Session> s) {
     LOGI("Heartbeat thread started (sock=%d)", s->udpSock);
     while (s->heartbeatRunning.load(std::memory_order_relaxed)) {
         sendEncrypted(s.get(), MSG_HEARTBEAT_PING, nullptr, 0);
-        hotpath::markPingSent(); // stage-2: round-trip clock starts here
+        if (hotpath::enabled()) {
+            // stage-2: round-trip clock starts here, on this session's own clock.
+            const int64_t now = hotpath::nowMonotonicNs();
+            if (hotpath::shouldArmPing(s->lastPingNs.load(std::memory_order_relaxed), now)) {
+                s->lastPingNs.store(now, std::memory_order_relaxed);
+            }
+        }
 
         const int intervalMs = g_heartbeatIntervalMs.load(std::memory_order_relaxed);
         const int missMax = HEARTBEAT_DEATH_TIMEOUT_MS / intervalMs;
@@ -810,7 +817,10 @@ JNIEXPORT jint JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_receiv
     uint16_t msgLen = ((uint16_t)decrypted[2] << 8) | decrypted[3];
 
     if (msgType == MSG_HEARTBEAT_ACK) {
-        hotpath::markAckReceived(); // stage-2: round-trip clock stops here (RTT)
+        if (hotpath::enabled()) {
+            const int64_t sent = s->lastPingNs.exchange(0, std::memory_order_relaxed);
+            if (sent != 0) hotpath::addRttSample(sent, hotpath::nowMonotonicNs());
+        }
         s->missedAcks.store(0);
         s->connectionAlive.store(true);
         // Enriched ack: backendAvailable(1) + totalActive(1) + epoch(u16 BE) +

--- a/app/src/main/java/com/tinkernorth/dish/DishApplication.kt
+++ b/app/src/main/java/com/tinkernorth/dish/DishApplication.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import com.tinkernorth.dish.bench.HotPathBenchController
 import com.tinkernorth.dish.composer.CrashReportingController
 import com.tinkernorth.dish.composer.DiagnosticsLogRecorder
+import com.tinkernorth.dish.composer.SlotTopologyController
 import com.tinkernorth.dish.composer.StreamingServiceController
 import com.tinkernorth.dish.composer.WakeStateController
 import com.tinkernorth.dish.core.jni.PhysicalInputNative
@@ -62,6 +63,8 @@ class DishApplication : Application() {
     @Inject lateinit var networkStateObserver: NetworkStateObserver
 
     @Inject lateinit var streamingServiceController: StreamingServiceController
+
+    @Inject lateinit var slotTopologyController: SlotTopologyController
 
     @Inject lateinit var crashReportingController: CrashReportingController
 
@@ -137,6 +140,7 @@ class DishApplication : Application() {
     private fun installNativeBackedObservers() {
         val lifecycle = ProcessLifecycleOwner.get().lifecycle
         lifecycle.addObserver(connectionForegroundObserver)
+        lifecycle.addObserver(slotTopologyController)
         // Process-scoped so bindings survive the MainActivity → GamepadOverlayActivity handoff.
         physicalGamepadRegistry.install()
         usbGamepadManager.install()

--- a/app/src/main/java/com/tinkernorth/dish/architecture/abstracts/AbstractController.kt
+++ b/app/src/main/java/com/tinkernorth/dish/architecture/abstracts/AbstractController.kt
@@ -12,6 +12,11 @@ import kotlinx.coroutines.flow.onEach
 
 // Lifecycle-actuator: collects an upstream [Flow] while STARTED and drives a side effect.
 // Subclasses keep their own [apply] and teardown; only the onStart/launchIn/job plumbing is shared.
+//
+// CONTRACT: inputs keep moving while the actuator is stopped, so [apply] must reconcile fully
+// from the current upstream value and never trust memory recorded before the stop. State kept
+// across emissions (dedupe caches, last-seen sets) may only ever suppress redundant work, never
+// substitute for looking at the world again on the post-start emission.
 abstract class AbstractController<S>(
     private val scope: CoroutineScope,
 ) : DefaultLifecycleObserver {

--- a/app/src/main/java/com/tinkernorth/dish/composer/ConnectionCoordinator.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/ConnectionCoordinator.kt
@@ -68,12 +68,11 @@ class ConnectionCoordinator
         }
 
         /**
-         * Bind [slotId] to [connectionId] with its FINAL descriptor: the type travels with the
-         * bind and the touchpad routing is derived from the persisted per-satellite pick at
-         * descriptor-build time, so the satellite plugs the right virtual device on the first
-         * try (no default-then-correct phase anywhere). The binding and type stores are written
-         * BEFORE declareSlot: the descriptor pull reads them synchronously. Returns false
-         * (refusing the bind) for a slot the registry no longer knows.
+         * Record the intent to bind [slotId] to [connectionId] with its FINAL type.
+         * SlotTopologyController converges every satellite connection to the stores, so
+         * this writes intent only. The type is written BEFORE the binding: the topology
+         * composer must never observe a binding without its type (a transient default
+         * would churn the wire). Returns false for a slot the registry no longer knows.
          */
         fun bind(
             slotId: String,
@@ -82,27 +81,21 @@ class ConnectionCoordinator
         ): Boolean {
             if (!slotExists(slotId)) return false
             val priorConnId = bindingStore.connectionFor(slotId)
-            if (priorConnId != null && priorConnId != connectionId) {
-                satellite.get(priorConnId)?.detachSlot(slotId)
-                typeStore.clear(priorConnId, slotId)
-            }
 
             // Android HID Device profile allows only one active host; release prior slot first.
             val isBt = store.rememberedBt().any { it.id == connectionId }
             if (isBt) {
                 val priorSlot =
                     bindingStore.slotsFor(connectionId).firstOrNull { it != slotId }
-                if (priorSlot != null) {
-                    bindingStore.unbind(priorSlot)
-                    satellite.get(connectionId)?.detachSlot(priorSlot)
-                }
+                if (priorSlot != null) bindingStore.unbind(priorSlot)
+            } else {
+                typeStore.setType(connectionId, slotId, controllerType)
             }
 
             bindingStore.bind(slotId, connectionId)
 
-            if (!isBt) {
-                typeStore.setType(connectionId, slotId, controllerType)
-                satellite.get(connectionId)?.declareSlot(slotId, controllerType)
+            if (priorConnId != null && priorConnId != connectionId) {
+                typeStore.clear(priorConnId, slotId)
             }
             return true
         }
@@ -110,7 +103,6 @@ class ConnectionCoordinator
         fun unbind(slotId: String) {
             val connId = bindingStore.connectionFor(slotId) ?: return
             bindingStore.unbind(slotId)
-            satellite.get(connId)?.detachSlot(slotId)
             typeStore.clear(connId, slotId)
         }
 
@@ -130,6 +122,9 @@ class ConnectionCoordinator
             }
         }
 
+        // The binding re-keys in ONE store emission, so the topology diff reads it as a
+        // same-type remove+add pair and renames the connection slot in place (index kept,
+        // no server-side unplug/replug).
         fun migrateSlotBinding(
             fromSlotId: String,
             toSlotId: String,
@@ -137,16 +132,9 @@ class ConnectionCoordinator
             if (fromSlotId == toSlotId) return
             val connId = bindingStore.connectionFor(fromSlotId) ?: return
             val type = typeStore.typeFor(connId, fromSlotId)
-            bindingStore.unbind(fromSlotId)
-            bindingStore.bind(toSlotId, connId)
-            if (type != null) {
-                typeStore.clear(connId, fromSlotId)
-                typeStore.setType(connId, toSlotId, type)
-            }
-            val conn = satellite.get(connId) ?: return
-            if (!conn.renameSlot(fromSlotId, toSlotId)) {
-                conn.attachSlot(toSlotId, controllerType = type ?: CONTROLLER_TYPE_XBOX)
-            }
+            if (type != null) typeStore.setType(connId, toSlotId, type)
+            bindingStore.migrate(fromSlotId, toSlotId)
+            if (type != null) typeStore.clear(connId, fromSlotId)
         }
 
         /**
@@ -181,7 +169,6 @@ class ConnectionCoordinator
         ) {
             if (typeStore.typeFor(connectionId, slotId) == type) return
             typeStore.setType(connectionId, slotId, type)
-            satellite.get(connectionId)?.setControllerType(slotId, type)
         }
 
         fun boundConnection(slotId: String): ConnectionSummary? =

--- a/app/src/main/java/com/tinkernorth/dish/composer/SlotTopologyComposer.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/SlotTopologyComposer.kt
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.composer
+
+import com.tinkernorth.dish.architecture.abstracts.AbstractComposer
+import com.tinkernorth.dish.source.connection.SatelliteConnection
+import com.tinkernorth.dish.source.store.ControllerTypeStore
+import com.tinkernorth.dish.source.store.SlotBindingStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import javax.inject.Inject
+import javax.inject.Singleton
+
+// connectionId -> (slotId -> controller type). The single desired-topology truth every
+// SatelliteConnection is converged to; Bluetooth bindings carry no satellite descriptor.
+typealias SlotTopology = Map<String, Map<String, Int>>
+
+fun composeSlotTopology(
+    bindings: Map<String, String>,
+    types: Map<Pair<String, String>, Int>,
+): SlotTopology {
+    val out = mutableMapOf<String, MutableMap<String, Int>>()
+    for ((slotId, connId) in bindings) {
+        if (!connId.startsWith(SatelliteConnection.ID_PREFIX)) continue
+        out.getOrPut(connId) { mutableMapOf() }[slotId] = types[connId to slotId] ?: CONTROLLER_TYPE_XBOX
+    }
+    return out
+}
+
+@Singleton
+class SlotTopologyComposer
+    @Inject
+    constructor(
+        bindingStore: SlotBindingStore,
+        typeStore: ControllerTypeStore,
+        scope: CoroutineScope,
+    ) : AbstractComposer<SlotTopology>(scope, emptyMap()) {
+        private val bindings: StateFlow<Map<String, String>> = bindingStore.state
+        private val types: StateFlow<Map<Pair<String, String>, Int>> = typeStore.state
+
+        override fun upstream(): Flow<SlotTopology> = combine(bindings, types, ::composeSlotTopology).distinctUntilChanged()
+    }

--- a/app/src/main/java/com/tinkernorth/dish/composer/SlotTopologyController.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/SlotTopologyController.kt
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.composer
+
+import com.tinkernorth.dish.architecture.abstracts.AbstractController
+import com.tinkernorth.dish.source.connection.SatelliteConnection
+import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SlotTopologyController
+    @Inject
+    constructor(
+        private val composer: SlotTopologyComposer,
+        private val satellite: SatelliteConnectionManager,
+        scope: CoroutineScope,
+    ) : AbstractController<SlotTopologyController.Snapshot>(scope) {
+        data class Snapshot(
+            val topology: SlotTopology,
+            val connections: Map<String, SatelliteConnection>,
+        )
+
+        override fun upstream(): Flow<Snapshot> =
+            combine(composer.state, satellite.connections) { topology, conns -> Snapshot(topology, conns) }
+
+        override fun apply(value: Snapshot) {
+            for ((id, conn) in value.connections) {
+                conn.applyDesired(value.topology[id].orEmpty())
+            }
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/core/jni/PhysicalInputNative.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/jni/PhysicalInputNative.kt
@@ -94,6 +94,8 @@ class PhysicalInputNative
 
         fun hotPathBenchJson(reset: Boolean): String = SatelliteNative.hotPathBenchJson(reset)
 
+        fun setLatencyProbe(on: Boolean) = SatelliteNative.setLatencyProbe(on)
+
         fun setInputInspection(on: Boolean) = SatelliteNative.setInputInspection(on)
 
         fun deviceStateJson(deviceId: Int): String = SatelliteNative.deviceStateJson(deviceId)

--- a/app/src/main/java/com/tinkernorth/dish/core/jni/SatelliteNative.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/jni/SatelliteNative.kt
@@ -206,6 +206,10 @@ object SatelliteNative {
     // JSON snapshot of the benchmark window (microsecond percentiles). reset clears it.
     external fun hotPathBenchJson(reset: Boolean): String
 
+    // Heartbeat probe mode: densifies pings for RTT sampling while the diagnostics
+    // latency panel is open; steady-state cadence resumes when off.
+    external fun setLatencyProbe(on: Boolean)
+
     // Inspector mirror gate: while on, USB-direct reports also copy motion/touch into the
     // snapshot state. Off costs one relaxed atomic load per report, like the bench markers.
     external fun setInputInspection(on: Boolean)

--- a/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalSlotBindingObserver.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalSlotBindingObserver.kt
@@ -65,6 +65,10 @@ data class SatelliteSlotSnapshot(
 // controller index a stale entry still owns. A present device only emits BindSatellite when its
 // session is known with a live handle and its slot is registered, and BindBluetooth only when the
 // connection is actually connected now; otherwise it emits Unbind.
+// Departed = ids that vanished since the last pass PLUS any numeric binding whose device the
+// registry no longer knows: a device that left while the observer was stopped is in neither
+// `present` nor `lastBound`, and without the sweep its slot would be re-declared to the satellite
+// on every reconnect forever. Non-numeric slot ids (the on-screen controller) are never swept.
 fun reconcileSlots(
     present: Set<Int>,
     lastBound: Set<Int>,
@@ -74,7 +78,8 @@ fun reconcileSlots(
     btConnectedIds: Set<String>,
 ): List<BindOp> {
     val ops = mutableListOf<BindOp>()
-    for (id in lastBound - present) {
+    val staleBound = bindings.keys.mapNotNull { it.toIntOrNull() }.filter { it !in present }
+    for (id in (lastBound - present) + staleBound) {
         ops += BindOp.Unbind(id)
         // A claimed USB synthetic (negative id) is freed by detachUsbDevice, not forgetPhysicalDevice.
         if (id >= 0) ops += BindOp.Forget(id)

--- a/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
@@ -222,13 +222,39 @@ class SatelliteConnection(
     }
 
     /**
+     * Converge this connection's desired slot set to [desired] (slotId -> type),
+     * derived from the binding/type stores by SlotTopologyComposer. The ONLY
+     * production write path into the slot map; everything below it is plumbing.
+     * A single removed+added pair of the same type is the same physical
+     * controller re-keyed (a USB claim/release swaps the device id): renaming
+     * preserves the controller index so the server-side pad survives without an
+     * unplug/replug.
+     */
+    fun applyDesired(desired: Map<String, Int>) {
+        val current = _slots.value
+        val removed = current.keys - desired.keys
+        val added = desired.keys - current.keys
+        if (removed.size == 1 && added.size == 1) {
+            val from = removed.first()
+            val to = added.first()
+            if (current.getValue(from).controllerType == desired.getValue(to)) {
+                renameSlot(from, to)
+            }
+        }
+        for (slotId in _slots.value.keys.toList()) {
+            if (slotId !in desired) detachSlot(slotId)
+        }
+        for ((slotId, type) in desired) declareSlot(slotId, type)
+    }
+
+    /**
      * Declare a slot with its FINAL descriptor: the type travels with the
      * attach and the touchpad mode is pulled from [touchpadModeFor] when the
      * descriptor is built, so there is never a default-then-correct phase
      * anywhere in the pipeline. While live, the manager converges it via a
      * controller PUT; while idle, it rides the next session PUT.
      */
-    fun attachSlot(
+    internal fun attachSlot(
         slotId: String,
         controllerType: Int,
     ) {
@@ -243,7 +269,7 @@ class SatelliteConnection(
     }
 
     /** Attach-or-update: the WHOLE descriptor in one declaration, one sync. */
-    fun declareSlot(
+    internal fun declareSlot(
         slotId: String,
         controllerType: Int,
     ) {
@@ -254,7 +280,7 @@ class SatelliteConnection(
         mutateSlot(slotId) { it.copy(controllerType = controllerType) }
     }
 
-    fun setControllerType(
+    internal fun setControllerType(
         slotId: String,
         controllerType: Int,
     ) = mutateSlot(slotId) { it.copy(controllerType = controllerType) }
@@ -292,7 +318,7 @@ class SatelliteConnection(
         }
     }
 
-    fun detachSlot(slotId: String) {
+    internal fun detachSlot(slotId: String) {
         var removed: SlotBinding? = null
         _slots.update { map ->
             val cur = map[slotId] ?: return@update map
@@ -306,7 +332,7 @@ class SatelliteConnection(
         }
     }
 
-    fun renameSlot(
+    internal fun renameSlot(
         fromSlotId: String,
         toSlotId: String,
     ): Boolean {
@@ -505,9 +531,11 @@ class SatelliteConnection(
         const val CLOSE_REASON_REPLACED = 2
         const val CLOSE_REASON_UNPAIRED = 3
 
+        const val ID_PREFIX = "satellite:"
+
         // Keyed on the stable machineId so a receiver that changes IP keeps the
         // same identity; ip:udpPort only for a beacon that carries no id at all.
-        fun idFor(server: DiscoveredServer): String = "satellite:${server.stableKey}"
+        fun idFor(server: DiscoveredServer): String = "$ID_PREFIX${server.stableKey}"
 
         private fun lowestFreeIndex(taken: List<Int>): Int {
             val set = taken.toHashSet()

--- a/app/src/main/java/com/tinkernorth/dish/source/notification/DishNotifications.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/notification/DishNotifications.kt
@@ -58,6 +58,26 @@ class DishNotifications
         private val nextId = AtomicLong(1L)
         private val deferred = AtomicReference<DishNotification?>(null)
 
+        // Top of the deque = the attachment whose owner most recently RESUMED: the one
+        // screen the user is actually looking at. Posts route only there, so the old
+        // and new screens of an activity transition can never both render a banner.
+        private val attachments = ArrayDeque<Attachment>()
+        private val attachLock = Any()
+
+        private fun activate(attachment: Attachment) {
+            synchronized(attachLock) {
+                attachments.remove(attachment)
+                attachments.addLast(attachment)
+            }
+            deferred.getAndSet(null)?.let { attachment.handlePost(it) }
+        }
+
+        private fun drop(attachment: Attachment) {
+            synchronized(attachLock) { attachments.remove(attachment) }
+        }
+
+        private fun isActive(attachment: Attachment): Boolean = synchronized(attachLock) { attachments.lastOrNull() === attachment }
+
         fun post(
             severity: DishNotification.Severity = DishNotification.Severity.INFO,
             title: String,
@@ -159,9 +179,8 @@ class DishNotifications
 
             scope.launch {
                 owner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                    deferred.getAndSet(null)?.let { attachment.handlePost(it) }
                     launch {
-                        posts.onEach { n -> attachment.handlePost(n) }.launchIn(this)
+                        posts.onEach { n -> if (isActive(attachment)) attachment.handlePost(n) }.launchIn(this)
                     }
                     launch {
                         dismissals.onEach { id -> attachment.handleDismiss(id) }.launchIn(this)
@@ -171,7 +190,12 @@ class DishNotifications
 
             owner.lifecycle.addObserver(
                 object : DefaultLifecycleObserver {
+                    override fun onResume(o: LifecycleOwner) {
+                        activate(attachment)
+                    }
+
                     override fun onDestroy(o: LifecycleOwner) {
+                        drop(attachment)
                         attachment.dismissAll()
                     }
                 },

--- a/app/src/main/java/com/tinkernorth/dish/source/store/SlotBindingStore.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/store/SlotBindingStore.kt
@@ -31,6 +31,17 @@ class SlotBindingStore
             setState { if (slotId in it) it - slotId else it }
         }
 
+        // One emission: downstream composers must never observe both keys bound at once.
+        fun migrate(
+            fromSlotId: String,
+            toSlotId: String,
+        ) {
+            setState { current ->
+                val connId = current[fromSlotId] ?: return@setState current
+                (current - fromSlotId) + (toSlotId to connId)
+            }
+        }
+
         fun replace(
             slotId: String,
             connectionId: String,

--- a/app/src/main/java/com/tinkernorth/dish/ui/common/BaseGamepadHostActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/BaseGamepadHostActivity.kt
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.common
+
+import android.view.KeyEvent
+import android.view.MotionEvent
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import com.tinkernorth.dish.composer.WakeStateController
+import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
+import com.tinkernorth.dish.hotpath.overlay.GamepadActivityHost
+import com.tinkernorth.dish.source.lowpower.LowPowerSignal
+import com.tinkernorth.dish.source.notification.DishNotifications
+import javax.inject.Inject
+
+// The rootView passed to installGamepadHost must include @layout/overlay_low_power
+// and @layout/overlay_low_power_chip.
+abstract class BaseGamepadHostActivity : AppCompatActivity() {
+    @Inject lateinit var wakeState: WakeStateController
+
+    @Inject lateinit var gamepadRegistry: PhysicalGamepadRegistry
+
+    @Inject lateinit var notifications: DishNotifications
+
+    @Inject lateinit var lowPowerSignal: LowPowerSignal
+
+    private var gamepadHost: GamepadActivityHost? = null
+
+    protected fun installGamepadHost(rootView: View) {
+        gamepadHost = attachGamepadHost(rootView, wakeState, gamepadRegistry, notifications, lowPowerSignal)
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean = gamepadHost?.dispatchKeyEvent(event) == true || super.dispatchKeyEvent(event)
+
+    override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean =
+        gamepadHost?.dispatchGenericMotionEvent(event) == true || super.dispatchGenericMotionEvent(event)
+
+    override fun dispatchTouchEvent(ev: MotionEvent): Boolean = gamepadHost?.dispatchTouchEvent(ev) == true || super.dispatchTouchEvent(ev)
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        gamepadHost?.onWindowFocusChanged(hasFocus)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        gamepadHost?.cancelDimOnStop()
+    }
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/common/BaseGamepadHostActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/BaseGamepadHostActivity.kt
@@ -2,13 +2,16 @@
 
 package com.tinkernorth.dish.ui.common
 
+import android.content.Intent
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.net.toUri
 import androidx.viewbinding.ViewBinding
+import com.tinkernorth.dish.R
 import com.tinkernorth.dish.composer.WakeStateController
 import com.tinkernorth.dish.databinding.ScreenScaffoldBinding
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
@@ -33,6 +36,20 @@ abstract class BaseGamepadHostActivity : AppCompatActivity() {
 
     protected fun installGamepadHost(rootView: View) {
         gamepadHost = attachGamepadHost(rootView, wakeState, gamepadRegistry, notifications, lowPowerSignal)
+    }
+
+    protected fun openExternalUrl(url: String) {
+        val intent =
+            Intent(Intent.ACTION_VIEW, url.toUri())
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        runCatching { startActivity(intent) }
+            .onFailure {
+                notifications.warn(
+                    title = getString(R.string.error_open_url),
+                    body = url,
+                    key = "external-url-failed",
+                )
+            }
     }
 
     protected fun <B : ViewBinding> setScaffoldContent(inflate: (LayoutInflater, ViewGroup, Boolean) -> B): B {

--- a/app/src/main/java/com/tinkernorth/dish/ui/common/BaseGamepadHostActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/BaseGamepadHostActivity.kt
@@ -3,10 +3,14 @@
 package com.tinkernorth.dish.ui.common
 
 import android.view.KeyEvent
+import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
+import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
+import androidx.viewbinding.ViewBinding
 import com.tinkernorth.dish.composer.WakeStateController
+import com.tinkernorth.dish.databinding.ScreenScaffoldBinding
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.hotpath.overlay.GamepadActivityHost
 import com.tinkernorth.dish.source.lowpower.LowPowerSignal
@@ -14,7 +18,8 @@ import com.tinkernorth.dish.source.notification.DishNotifications
 import javax.inject.Inject
 
 // The rootView passed to installGamepadHost must include @layout/overlay_low_power
-// and @layout/overlay_low_power_chip.
+// and @layout/overlay_low_power_chip; setScaffoldContent provides them via
+// @layout/screen_scaffold so standard screens carry no chrome of their own.
 abstract class BaseGamepadHostActivity : AppCompatActivity() {
     @Inject lateinit var wakeState: WakeStateController
 
@@ -28,6 +33,16 @@ abstract class BaseGamepadHostActivity : AppCompatActivity() {
 
     protected fun installGamepadHost(rootView: View) {
         gamepadHost = attachGamepadHost(rootView, wakeState, gamepadRegistry, notifications, lowPowerSignal)
+    }
+
+    protected fun <B : ViewBinding> setScaffoldContent(inflate: (LayoutInflater, ViewGroup, Boolean) -> B): B {
+        val scaffold = ScreenScaffoldBinding.inflate(layoutInflater)
+        setContentView(scaffold.root)
+        val content = inflate(layoutInflater, scaffold.screenContent, true)
+        installGamepadHost(scaffold.root)
+        applyDishSystemBars(scaffold.root)
+        applyDishActivityTransitions()
+        return content
     }
 
     override fun dispatchKeyEvent(event: KeyEvent): Boolean = gamepadHost?.dispatchKeyEvent(event) == true || super.dispatchKeyEvent(event)

--- a/app/src/main/java/com/tinkernorth/dish/ui/common/DishNavigator.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/DishNavigator.kt
@@ -3,6 +3,7 @@
 package com.tinkernorth.dish.ui.common
 
 import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import androidx.navigation.ActivityNavigator
 import androidx.navigation.NavGraph
@@ -10,6 +11,7 @@ import androidx.navigation.NavGraphNavigator
 import androidx.navigation.NavInflater
 import androidx.navigation.NavigatorProvider
 import com.tinkernorth.dish.R
+import com.tinkernorth.dish.ui.main.MainActivity
 import com.tinkernorth.dish.ui.setup.SetupFlow
 
 // Activity destinations can't carry <action> children, so navigate by destination id, not action id.
@@ -116,6 +118,36 @@ class DishNavigator(
 
     fun toDonate() {
         go(R.id.donateActivity)
+    }
+
+    fun toDiagnostics() {
+        go(R.id.diagnosticsActivity)
+    }
+
+    fun toLicenses() {
+        go(R.id.licensesActivity)
+    }
+
+    fun toInputInspector(
+        deviceId: Int,
+        deviceName: String,
+    ) {
+        go(
+            R.id.inputInspectorActivity,
+            Bundle().apply {
+                putInt("extra_device_id", deviceId)
+                putString("extra_device_name", deviceName)
+            },
+        )
+    }
+
+    // Setup flow handoff to the dashboard: the setup task is over, so the back stack resets.
+    fun finishSetupToDashboard() {
+        activity.startActivity(
+            Intent(activity, MainActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK),
+        )
+        activity.finish()
     }
 
     fun toTouchpad(

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
@@ -14,6 +14,7 @@ import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
@@ -30,7 +31,6 @@ import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.composer.ConnectionCoordinator
-import com.tinkernorth.dish.composer.ConnectionKind
 import com.tinkernorth.dish.composer.ConnectionSummary
 import com.tinkernorth.dish.composer.LinkState
 import com.tinkernorth.dish.core.input.BluetoothGamepad
@@ -79,17 +79,18 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
 
     @Inject lateinit var hub: ConnectionCoordinator
 
-    @Inject lateinit var store: com.tinkernorth.dish.repository.ConnectionStore
+    @Inject lateinit var store: ConnectionStore
 
-    @Inject lateinit var btAdapterState: com.tinkernorth.dish.source.system.BluetoothAdapterStateObserver
+    @Inject lateinit var btAdapterState: BluetoothAdapterStateObserver
 
-    @Inject lateinit var btPermissionState: com.tinkernorth.dish.source.system.BluetoothPermissionStateObserver
+    @Inject lateinit var btPermissionState: BluetoothPermissionStateObserver
 
     @Inject lateinit var btPermissionBannerStore: BluetoothPermissionBannerStore
 
-    @Inject lateinit var networkState: com.tinkernorth.dish.source.system.NetworkStateObserver
+    @Inject lateinit var networkState: NetworkStateObserver
 
     private lateinit var binding: ActivityConnectionsBinding
+    private val viewModel: ConnectionsViewModel by viewModels()
 
     private lateinit var satelliteHeader: SectionHeaderAdapter
     private lateinit var bluetoothHeader: SectionHeaderAdapter
@@ -144,7 +145,6 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
                     confirmForgetBt(summary.id, remembered)
                 } else {
                     btRegistry.stop(summary.id)
-                    render()
                 }
             }
         }
@@ -227,35 +227,12 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
     private fun observeSatelliteHub() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                hub.connections.collect { conns ->
-                    render()
+                viewModel.ui.collect { state ->
+                    render(state)
+                    satelliteHeader.setLoading(state.scanning, getString(R.string.action_scanning))
                     // Success path emits no ConnectionEvent, so observe state directly to dismiss PIN dialog.
-                    val pairing = pairingServer
-                    if (pairing != null) {
-                        val pid = SatelliteConnection.idFor(pairing)
-                        val summary = conns.firstOrNull { it.id == pid }
-                        if (summary?.live == LinkState.Connected) {
-                            pinDialog?.dismiss()
-                        }
-                    }
+                    dismissPinDialogIfPaired(state)
                 }
-            }
-        }
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                satellite.discoveredServers.collect { render() }
-            }
-        }
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                satellite.isScanning.collect { scanning ->
-                    satelliteHeader.setLoading(scanning, getString(R.string.action_scanning))
-                }
-            }
-        }
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                satellite.lastScanAtMs.collect { render() }
             }
         }
         lifecycleScope.launch {
@@ -376,44 +353,36 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
         (itemAnimator as? SimpleItemAnimator)?.supportsChangeAnimations = false
     }
 
-    private fun render() {
-        val conns = hub.connections.value
-        renderSatellites(conns)
-        renderBluetooth(conns)
-    }
-
-    private fun renderSatellites(conns: List<ConnectionSummary>) {
-        val satConns = conns.filter { it.kind == ConnectionKind.SATELLITE }
-        val knownIds = satConns.mapTo(mutableSetOf()) { it.id }
-        val rows =
-            buildList {
-                satConns.forEach { add(SatelliteRow.Known(it)) }
-                satellite.discoveredServers.value.forEach { server ->
-                    if (SatelliteConnection.idFor(server) !in knownIds) add(SatelliteRow.Discovered(server))
-                }
+    private fun dismissPinDialogIfPaired(state: ConnectionsUiState) {
+        val pairing = pairingServer ?: return
+        val pid = SatelliteConnection.idFor(pairing)
+        val connected =
+            state.satelliteRows.any {
+                it is SatelliteRow.Known && it.summary.id == pid && it.summary.live == LinkState.Connected
             }
-        satelliteList.submitList(rows.ifEmpty { listOf(SatelliteRow.Empty(satelliteEmptyMessage())) })
+        if (connected) pinDialog?.dismiss()
     }
 
-    private fun satelliteEmptyMessage(): String {
-        val lastScan = satellite.lastScanAtMs.value ?: return getString(R.string.discovery_empty_never_scanned)
-        return getString(R.string.discovery_empty_no_results, formatClock(lastScan))
-    }
-
-    private fun renderBluetooth(conns: List<ConnectionSummary>) {
+    private fun render(state: ConnectionsUiState) {
+        satelliteList.submitList(
+            state.satelliteRows.ifEmpty { listOf(SatelliteRow.Empty(satelliteEmptyMessage(state.lastScanAtMs))) },
+        )
         val rows =
-            conns
-                .filter { it.kind == ConnectionKind.BLUETOOTH }
-                .map { c ->
-                    BluetoothRow.Item(
-                        BtRowUi(
-                            summary = c,
-                            connectingLabel = if (c.live == LinkState.Connecting) btConnectingLabel(c.id) else null,
-                            secondaryIsForget = store.rememberedBt().any { it.id == c.id },
-                        ),
-                    )
-                }
+            state.bluetoothSummaries.map { c ->
+                BluetoothRow.Item(
+                    BtRowUi(
+                        summary = c,
+                        connectingLabel = if (c.live == LinkState.Connecting) btConnectingLabel(c.id) else null,
+                        secondaryIsForget = c.id in state.rememberedBtIds,
+                    ),
+                )
+            }
         bluetoothList.submitList(rows.ifEmpty { listOf(BluetoothRow.Empty(getString(R.string.bt_hosts_empty))) })
+    }
+
+    private fun satelliteEmptyMessage(lastScanAtMs: Long?): String {
+        val lastScan = lastScanAtMs ?: return getString(R.string.discovery_empty_never_scanned)
+        return getString(R.string.discovery_empty_no_results, formatClock(lastScan))
     }
 
     private fun btConnectingLabel(id: String): String {
@@ -455,7 +424,6 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
     private fun commitForgetBt(id: String) {
         btRegistry.stop(id)
         hub.forgetConnection(id)
-        render()
     }
 
     private fun openBluetoothDeviceDetails(mac: String) {

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
@@ -10,14 +10,11 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
-import android.view.KeyEvent
-import android.view.MotionEvent
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -36,14 +33,11 @@ import com.tinkernorth.dish.composer.ConnectionCoordinator
 import com.tinkernorth.dish.composer.ConnectionKind
 import com.tinkernorth.dish.composer.ConnectionSummary
 import com.tinkernorth.dish.composer.LinkState
-import com.tinkernorth.dish.composer.WakeStateController
 import com.tinkernorth.dish.core.input.BluetoothGamepad
 import com.tinkernorth.dish.core.model.DiscoveredServer
 import com.tinkernorth.dish.core.model.DiscoverySource
 import com.tinkernorth.dish.core.model.DishNotification
 import com.tinkernorth.dish.databinding.ActivityConnectionsBinding
-import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
-import com.tinkernorth.dish.hotpath.overlay.GamepadActivityHost
 import com.tinkernorth.dish.repository.ConnectionStore
 import com.tinkernorth.dish.repository.RememberedBt
 import com.tinkernorth.dish.source.bluetooth.BluetoothDeviceScanner
@@ -53,7 +47,6 @@ import com.tinkernorth.dish.source.connection.ConnectionEvent
 import com.tinkernorth.dish.source.connection.PairingApproval
 import com.tinkernorth.dish.source.connection.SatelliteConnection
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
-import com.tinkernorth.dish.source.notification.DishNotifications
 import com.tinkernorth.dish.source.notification.dishSnackbar
 import com.tinkernorth.dish.source.store.BluetoothPermissionBannerStore
 import com.tinkernorth.dish.source.system.BluetoothAdapterState
@@ -63,11 +56,11 @@ import com.tinkernorth.dish.source.system.BluetoothPermissionBannerVariant
 import com.tinkernorth.dish.source.system.BluetoothPermissionStateObserver
 import com.tinkernorth.dish.source.system.NetworkState
 import com.tinkernorth.dish.source.system.NetworkStateObserver
+import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.StaticViewAdapter
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.attachDonatePill
-import com.tinkernorth.dish.ui.common.attachGamepadHost
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
@@ -77,7 +70,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class ConnectionsActivity : AppCompatActivity() {
+class ConnectionsActivity : BaseGamepadHostActivity() {
     @Inject lateinit var satellite: SatelliteConnectionManager
 
     @Inject lateinit var btRegistry: BluetoothGamepadRegistry
@@ -88,14 +81,6 @@ class ConnectionsActivity : AppCompatActivity() {
 
     @Inject lateinit var store: com.tinkernorth.dish.repository.ConnectionStore
 
-    @Inject lateinit var wakeState: WakeStateController
-
-    @Inject lateinit var gamepadRegistry: PhysicalGamepadRegistry
-
-    @Inject lateinit var notifications: DishNotifications
-
-    @Inject lateinit var lowPowerSignal: com.tinkernorth.dish.source.lowpower.LowPowerSignal
-
     @Inject lateinit var btAdapterState: com.tinkernorth.dish.source.system.BluetoothAdapterStateObserver
 
     @Inject lateinit var btPermissionState: com.tinkernorth.dish.source.system.BluetoothPermissionStateObserver
@@ -105,7 +90,6 @@ class ConnectionsActivity : AppCompatActivity() {
     @Inject lateinit var networkState: com.tinkernorth.dish.source.system.NetworkStateObserver
 
     private lateinit var binding: ActivityConnectionsBinding
-    private lateinit var gamepadHost: GamepadActivityHost
 
     private lateinit var satelliteHeader: SectionHeaderAdapter
     private lateinit var bluetoothHeader: SectionHeaderAdapter
@@ -226,7 +210,7 @@ class ConnectionsActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityConnectionsBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        gamepadHost = attachGamepadHost(binding.root, wakeState, gamepadRegistry, notifications, lowPowerSignal)
+        installGamepadHost(binding.root)
         setupDishToolbar(binding.toolbar)
         applyDishSystemBars(binding.root)
         applyDishActivityTransitions()
@@ -349,11 +333,6 @@ class ConnectionsActivity : AppCompatActivity() {
     override fun onStart() {
         super.onStart()
         satellite.startDiscovery()
-    }
-
-    override fun onStop() {
-        super.onStop()
-        gamepadHost.cancelDimOnStop()
     }
 
     private fun setupList() {
@@ -1067,18 +1046,6 @@ class ConnectionsActivity : AppCompatActivity() {
 
     private fun openWifiSettings() {
         runCatching { startActivity(Intent(Settings.ACTION_WIFI_SETTINGS)) }
-    }
-
-    override fun dispatchKeyEvent(event: KeyEvent): Boolean = gamepadHost.dispatchKeyEvent(event) || super.dispatchKeyEvent(event)
-
-    override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean =
-        gamepadHost.dispatchGenericMotionEvent(event) || super.dispatchGenericMotionEvent(event)
-
-    override fun dispatchTouchEvent(ev: MotionEvent): Boolean = gamepadHost.dispatchTouchEvent(ev) || super.dispatchTouchEvent(ev)
-
-    override fun onWindowFocusChanged(hasFocus: Boolean) {
-        super.onWindowFocusChanged(hasFocus)
-        gamepadHost.onWindowFocusChanged(hasFocus)
     }
 
     companion object {

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsUiState.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsUiState.kt
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.connections
+
+import com.tinkernorth.dish.composer.ConnectionKind
+import com.tinkernorth.dish.composer.ConnectionSummary
+import com.tinkernorth.dish.core.model.DiscoveredServer
+import com.tinkernorth.dish.source.connection.SatelliteConnection
+
+data class ConnectionsUiState(
+    val satelliteRows: List<SatelliteRow>,
+    val bluetoothSummaries: List<ConnectionSummary>,
+    val rememberedBtIds: Set<String>,
+    val scanning: Boolean,
+    val lastScanAtMs: Long?,
+) {
+    companion object {
+        val Empty =
+            ConnectionsUiState(
+                satelliteRows = emptyList(),
+                bluetoothSummaries = emptyList(),
+                rememberedBtIds = emptySet(),
+                scanning = false,
+                lastScanAtMs = null,
+            )
+    }
+}
+
+// Known connections first, then discovered servers not already known under their stable id.
+fun satelliteRows(
+    conns: List<ConnectionSummary>,
+    discovered: List<DiscoveredServer>,
+): List<SatelliteRow> {
+    val satConns = conns.filter { it.kind == ConnectionKind.SATELLITE }
+    val knownIds = satConns.mapTo(mutableSetOf()) { it.id }
+    return buildList {
+        satConns.forEach { add(SatelliteRow.Known(it)) }
+        discovered.forEach { server ->
+            if (SatelliteConnection.idFor(server) !in knownIds) add(SatelliteRow.Discovered(server))
+        }
+    }
+}
+
+fun bluetoothSummaries(conns: List<ConnectionSummary>): List<ConnectionSummary> = conns.filter { it.kind == ConnectionKind.BLUETOOTH }

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsViewModel.kt
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.connections
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.tinkernorth.dish.composer.ConnectionCoordinator
+import com.tinkernorth.dish.repository.ConnectionStore
+import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class ConnectionsViewModel
+    @Inject
+    constructor(
+        hub: ConnectionCoordinator,
+        satellite: SatelliteConnectionManager,
+        store: ConnectionStore,
+    ) : ViewModel() {
+        val ui: StateFlow<ConnectionsUiState> =
+            combine(
+                hub.connections,
+                satellite.discoveredServers,
+                satellite.isScanning,
+                satellite.lastScanAtMs,
+                store.rememberedBtFlow,
+            ) { conns, discovered, scanning, lastScan, rememberedBt ->
+                ConnectionsUiState(
+                    satelliteRows = satelliteRows(conns, discovered),
+                    bluetoothSummaries = bluetoothSummaries(conns),
+                    rememberedBtIds = rememberedBt.mapTo(mutableSetOf()) { it.id },
+                    scanning = scanning,
+                    lastScanAtMs = lastScan,
+                )
+            }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), ConnectionsUiState.Empty)
+    }

--- a/app/src/main/java/com/tinkernorth/dish/ui/diagnostics/DiagnosticsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/diagnostics/DiagnosticsActivity.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.float
+import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -343,9 +344,14 @@ class DiagnosticsActivity : BaseGamepadHostActivity() {
     }
 
     private suspend fun pollLatencyStats() {
-        while (true) {
-            renderLatencyStats(physicalInputNative.hotPathBenchJson(false))
-            delay(LATENCY_POLL_MS)
+        physicalInputNative.setLatencyProbe(true)
+        try {
+            while (true) {
+                renderLatencyStats(physicalInputNative.hotPathBenchJson(false))
+                delay(LATENCY_POLL_MS)
+            }
+        } finally {
+            physicalInputNative.setLatencyProbe(false)
         }
     }
 
@@ -360,8 +366,11 @@ class DiagnosticsActivity : BaseGamepadHostActivity() {
         val phoneP50 = microToMs(root, STAGE1, P50)
         val phoneP99 = microToMs(root, STAGE1, P99)
         // The bench measures the full heartbeat round trip; one-way network latency is half
-        // of it (symmetric-path estimate, hence the ~ rendering).
+        // of it (symmetric-path estimate, hence the ~ rendering). The RTT window slides, so
+        // the figure answers "now"; the sample count is shown so a barely-seeded window reads
+        // as tentative instead of authoritative.
         val networkP50 = microToMs(root, RTT, P50)?.let { it / 2 }
+        val rttSamples = intField(root, RTT, "n")
         container.addView(statRow(getString(R.string.diagnostics_phone_path), phoneP50, phoneP99))
         container.addView(
             statRow(
@@ -370,7 +379,15 @@ class DiagnosticsActivity : BaseGamepadHostActivity() {
                 microToMs(root, URB_GAP, P99),
             ),
         )
-        container.addView(statRow(getString(R.string.diagnostics_network_latency), networkP50, null, approx = true))
+        container.addView(
+            statRow(
+                getString(R.string.diagnostics_network_latency),
+                networkP50,
+                null,
+                approx = true,
+                windowSamples = rttSamples,
+            ),
+        )
         rttHistoryMs(root)?.let { history ->
             val spark = layoutInflater.inflate(R.layout.diagnostics_rtt_sparkline, container, false) as SparklineView
             spark.update(history)
@@ -403,15 +420,31 @@ class DiagnosticsActivity : BaseGamepadHostActivity() {
         return value / MICROS_PER_MS
     }
 
+    private fun intField(
+        root: JsonObject,
+        group: String,
+        field: String,
+    ): Int? =
+        runCatching {
+            root[group]
+                ?.jsonObject
+                ?.get(field)
+                ?.jsonPrimitive
+                ?.int
+        }.getOrNull()
+
     private fun statRow(
         label: String,
         p50: Double?,
         p99: Double?,
         approx: Boolean = false,
+        windowSamples: Int? = null,
     ): android.view.View {
         val value =
             when {
                 p50 == null -> getString(R.string.diagnostics_unknown)
+                approx && windowSamples != null ->
+                    getString(R.string.diagnostics_ms_approx_window, p50, windowSamples)
                 approx -> getString(R.string.diagnostics_ms_approx, p50)
                 p99 == null -> getString(R.string.diagnostics_ms, p50)
                 else -> getString(R.string.diagnostics_ms_p50_p99, p50, p99)
@@ -555,7 +588,7 @@ class DiagnosticsActivity : BaseGamepadHostActivity() {
 
     private companion object {
         const val HANDLE_NONE = -1
-        const val LATENCY_POLL_MS = 2000L
+        const val LATENCY_POLL_MS = 1000L
         const val WIFI_POLL_MS = 2000L
         const val MICROS_PER_MS = 1000.0
         const val STAGE1 = "stage1_hotpath_us"

--- a/app/src/main/java/com/tinkernorth/dish/ui/diagnostics/DiagnosticsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/diagnostics/DiagnosticsActivity.kt
@@ -5,10 +5,7 @@ package com.tinkernorth.dish.ui.diagnostics
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.os.Bundle
-import android.view.Gravity
 import android.view.ViewGroup
-import android.widget.LinearLayout
-import android.widget.TextView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -23,6 +20,9 @@ import com.tinkernorth.dish.composer.ConnectionSummary
 import com.tinkernorth.dish.core.jni.ControllerRepository
 import com.tinkernorth.dish.core.jni.PhysicalInputNative
 import com.tinkernorth.dish.databinding.ActivityDiagnosticsBinding
+import com.tinkernorth.dish.databinding.DiagnosticsBodyRowBinding
+import com.tinkernorth.dish.databinding.DiagnosticsCardBinding
+import com.tinkernorth.dish.databinding.DiagnosticsEmptyRowBinding
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.hotpath.input.Transport
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
@@ -34,6 +34,7 @@ import com.tinkernorth.dish.source.system.WifiBand
 import com.tinkernorth.dish.source.system.WifiLink
 import com.tinkernorth.dish.source.system.WifiLinkSource
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
+import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
@@ -75,6 +76,7 @@ class DiagnosticsActivity : BaseGamepadHostActivity() {
     @Inject lateinit var json: Json
 
     private lateinit var binding: ActivityDiagnosticsBinding
+    private val nav by lazy { DishNavigator(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -117,13 +119,16 @@ class DiagnosticsActivity : BaseGamepadHostActivity() {
         val container = binding.containerControllers
         container.removeAllViews()
         if (devices.isEmpty()) {
-            container.addView(emptyRow(getString(R.string.diagnostics_no_controllers)))
+            container.addView(emptyRow(container, getString(R.string.diagnostics_no_controllers)))
             return
         }
-        devices.forEach { container.addView(controllerCard(it)) }
+        devices.forEach { container.addView(controllerCard(container, it)) }
     }
 
-    private fun controllerCard(device: PhysicalGamepadRegistry.Device): android.view.View {
+    private fun controllerCard(
+        parent: ViewGroup,
+        device: PhysicalGamepadRegistry.Device,
+    ): android.view.View {
         val lines = mutableListOf<String>()
         lines += getString(R.string.diagnostics_kv, getString(R.string.diagnostics_transport), transportLabel(device))
         lines += getString(R.string.diagnostics_kv, getString(R.string.diagnostics_poll_rate), pollRateLabel(device))
@@ -131,7 +136,7 @@ class DiagnosticsActivity : BaseGamepadHostActivity() {
             lines += getString(R.string.diagnostics_kv, getString(R.string.diagnostics_gyro), gyroLabel(device))
         }
         lines += getString(R.string.diagnostics_kv, getString(R.string.diagnostics_state), controllerStateLabel(device))
-        return cardWithTitle(device.name, lines) { parent -> inspectButton(parent, device) }
+        return cardWithTitle(parent, device.name, lines) { footerParent -> inspectButton(footerParent, device) }
     }
 
     private fun inspectButton(
@@ -139,14 +144,7 @@ class DiagnosticsActivity : BaseGamepadHostActivity() {
         device: PhysicalGamepadRegistry.Device,
     ): android.view.View {
         val button = layoutInflater.inflate(R.layout.diagnostics_inspect_button, parent, false)
-        button.setOnClickListener {
-            startActivity(
-                android.content.Intent(this, InputInspectorActivity::class.java).apply {
-                    putExtra(InputInspectorActivity.EXTRA_DEVICE_ID, device.id)
-                    putExtra(InputInspectorActivity.EXTRA_DEVICE_NAME, device.name)
-                },
-            )
-        }
+        button.setOnClickListener { nav.toInputInspector(device.id, device.name) }
         return button
     }
 
@@ -201,19 +199,22 @@ class DiagnosticsActivity : BaseGamepadHostActivity() {
         val container = binding.containerConnections
         container.removeAllViews()
         if (connections.isEmpty()) {
-            container.addView(emptyRow(getString(R.string.diagnostics_no_connections)))
+            container.addView(emptyRow(container, getString(R.string.diagnostics_no_connections)))
             return
         }
-        connections.forEach { container.addView(connectionCard(it)) }
+        connections.forEach { container.addView(connectionCard(container, it)) }
     }
 
-    private fun connectionCard(summary: ConnectionSummary): android.view.View {
+    private fun connectionCard(
+        parent: ViewGroup,
+        summary: ConnectionSummary,
+    ): android.view.View {
         val lines = mutableListOf<String>()
         lines += getString(R.string.diagnostics_kv, getString(R.string.diagnostics_link), summary.live.name)
         if (summary.kind == ConnectionKind.SATELLITE) {
             lines += satelliteTelemetry(summary.id)
         }
-        return cardWithTitle(summary.label, lines)
+        return cardWithTitle(parent, summary.label, lines)
     }
 
     private fun satelliteTelemetry(id: String): List<String> {
@@ -334,7 +335,7 @@ class DiagnosticsActivity : BaseGamepadHostActivity() {
     private fun renderLatencyOff() {
         val container = binding.containerLatencyStats
         container.removeAllViews()
-        container.addView(emptyRow(getString(R.string.diagnostics_latency_off_hint)))
+        container.addView(emptyRow(container, getString(R.string.diagnostics_latency_off_hint)))
     }
 
     private suspend fun pollLatencyStats() {
@@ -354,7 +355,7 @@ class DiagnosticsActivity : BaseGamepadHostActivity() {
         container.removeAllViews()
         val root = runCatching { json.parseToJsonElement(rawJson).jsonObject }.getOrNull()
         if (root == null) {
-            container.addView(emptyRow(getString(R.string.diagnostics_latency_waiting)))
+            container.addView(emptyRow(container, getString(R.string.diagnostics_latency_waiting)))
             return
         }
         val phoneP50 = microToMs(root, STAGE1, P50)
@@ -365,9 +366,10 @@ class DiagnosticsActivity : BaseGamepadHostActivity() {
         // as tentative instead of authoritative.
         val networkP50 = microToMs(root, RTT, P50)?.let { it / 2 }
         val rttSamples = intField(root, RTT, "n")
-        container.addView(statRow(getString(R.string.diagnostics_phone_path), phoneP50, phoneP99))
+        container.addView(statRow(container, getString(R.string.diagnostics_phone_path), phoneP50, phoneP99))
         container.addView(
             statRow(
+                container,
                 getString(R.string.diagnostics_polling_jitter),
                 microToMs(root, URB_GAP, P50),
                 microToMs(root, URB_GAP, P99),
@@ -375,6 +377,7 @@ class DiagnosticsActivity : BaseGamepadHostActivity() {
         )
         container.addView(
             statRow(
+                container,
                 getString(R.string.diagnostics_network_latency),
                 networkP50,
                 null,
@@ -428,6 +431,7 @@ class DiagnosticsActivity : BaseGamepadHostActivity() {
         }.getOrNull()
 
     private fun statRow(
+        parent: ViewGroup,
         label: String,
         p50: Double?,
         p99: Double?,
@@ -443,7 +447,7 @@ class DiagnosticsActivity : BaseGamepadHostActivity() {
                 p99 == null -> getString(R.string.diagnostics_ms, p50)
                 else -> getString(R.string.diagnostics_ms_p50_p99, p50, p99)
             }
-        return bodyRow(getString(R.string.diagnostics_kv, label, value))
+        return bodyRow(parent, getString(R.string.diagnostics_kv, label, value))
     }
 
     // ── Events (flight recorder) ────────────────────────────────────────────
@@ -460,13 +464,13 @@ class DiagnosticsActivity : BaseGamepadHostActivity() {
         val container = binding.containerEvents
         container.removeAllViews()
         if (entries.isEmpty()) {
-            container.addView(emptyRow(getString(R.string.diagnostics_events_empty)))
+            container.addView(emptyRow(container, getString(R.string.diagnostics_events_empty)))
             return
         }
         entries
             .takeLast(SHOWN_EVENTS)
             .asReversed()
-            .forEach { container.addView(bodyRow(formatEvent(it))) }
+            .forEach { container.addView(bodyRow(container, formatEvent(it))) }
     }
 
     // Log lines are export material (English, fixed clock format), so bug reports paste uniformly.
@@ -521,64 +525,27 @@ class DiagnosticsActivity : BaseGamepadHostActivity() {
     // ── Row builders ────────────────────────────────────────────────────────
 
     private fun cardWithTitle(
+        parent: ViewGroup,
         title: String,
         lines: List<String>,
         footer: ((ViewGroup) -> android.view.View)? = null,
     ): android.view.View {
-        val card =
-            com.google.android.material.card.MaterialCardView(this).apply {
-                layoutParams =
-                    LinearLayout
-                        .LayoutParams(
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                            ViewGroup.LayoutParams.WRAP_CONTENT,
-                        ).apply { topMargin = resources.getDimensionPixelSize(R.dimen.card_margin_bottom) }
-            }
-        val column =
-            LinearLayout(this).apply {
-                orientation = LinearLayout.VERTICAL
-                val pad = resources.getDimensionPixelSize(R.dimen.card_padding)
-                setPadding(pad, pad, pad, pad)
-            }
-        column.addView(titleView(title))
-        lines.forEach { column.addView(bodyView(it)) }
-        footer?.let { column.addView(it(column)) }
-        card.addView(column)
-        return card
+        val card = DiagnosticsCardBinding.inflate(layoutInflater, parent, false)
+        card.diagCardTitle.text = title
+        lines.forEach { card.diagCardColumn.addView(bodyRow(card.diagCardColumn, it)) }
+        footer?.let { card.diagCardColumn.addView(it(card.diagCardColumn)) }
+        return card.root
     }
 
-    private fun titleView(text: String): TextView =
-        TextView(this, null, 0, R.style.TextAppearance_Dish_Title).apply {
-            this.text = text
-        }
+    private fun bodyRow(
+        parent: ViewGroup,
+        text: String,
+    ): android.view.View = DiagnosticsBodyRowBinding.inflate(layoutInflater, parent, false).root.apply { this.text = text }
 
-    private fun bodyView(text: String): TextView =
-        TextView(this, null, 0, R.style.TextAppearance_Dish_Body).apply {
-            this.text = text
-            layoutParams =
-                LinearLayout
-                    .LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.WRAP_CONTENT,
-                    ).apply { topMargin = resources.getDimensionPixelSize(R.dimen.spacing_xs) }
-        }
-
-    private fun bodyRow(text: String): TextView =
-        TextView(this, null, 0, R.style.TextAppearance_Dish_Body).apply {
-            this.text = text
-            layoutParams =
-                LinearLayout
-                    .LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.WRAP_CONTENT,
-                    ).apply { topMargin = resources.getDimensionPixelSize(R.dimen.spacing_xs) }
-        }
-
-    private fun emptyRow(text: String): TextView =
-        TextView(this, null, 0, R.style.TextAppearance_Dish_Body).apply {
-            this.text = text
-            gravity = Gravity.START
-        }
+    private fun emptyRow(
+        parent: ViewGroup,
+        text: String,
+    ): android.view.View = DiagnosticsEmptyRowBinding.inflate(layoutInflater, parent, false).root.apply { this.text = text }
 
     private companion object {
         const val HANDLE_NONE = -1

--- a/app/src/main/java/com/tinkernorth/dish/ui/diagnostics/DiagnosticsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/diagnostics/DiagnosticsActivity.kt
@@ -9,7 +9,6 @@ import android.view.Gravity
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.TextView
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -34,6 +33,7 @@ import com.tinkernorth.dish.source.store.LatencyProfilingStore
 import com.tinkernorth.dish.source.system.WifiBand
 import com.tinkernorth.dish.source.system.WifiLink
 import com.tinkernorth.dish.source.system.WifiLinkSource
+import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.setupDishToolbar
@@ -54,9 +54,7 @@ import javax.inject.Inject
 
 @Suppress("TooManyFunctions")
 @AndroidEntryPoint
-class DiagnosticsActivity : AppCompatActivity() {
-    @Inject lateinit var gamepadRegistry: PhysicalGamepadRegistry
-
+class DiagnosticsActivity : BaseGamepadHostActivity() {
     @Inject lateinit var inputRateStore: InputRateStore
 
     @Inject lateinit var connectionCoordinator: ConnectionCoordinator
@@ -83,6 +81,7 @@ class DiagnosticsActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityDiagnosticsBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        installGamepadHost(binding.root)
         setupDishToolbar(binding.toolbar)
         applyDishSystemBars(binding.root)
         applyDishActivityTransitions()

--- a/app/src/main/java/com/tinkernorth/dish/ui/diagnostics/DiagnosticsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/diagnostics/DiagnosticsActivity.kt
@@ -34,8 +34,6 @@ import com.tinkernorth.dish.source.system.WifiBand
 import com.tinkernorth.dish.source.system.WifiLink
 import com.tinkernorth.dish.source.system.WifiLinkSource
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
-import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
-import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
@@ -80,12 +78,8 @@ class DiagnosticsActivity : BaseGamepadHostActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityDiagnosticsBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-        installGamepadHost(binding.root)
+        binding = setScaffoldContent(ActivityDiagnosticsBinding::inflate)
         setupDishToolbar(binding.toolbar)
-        applyDishSystemBars(binding.root)
-        applyDishActivityTransitions()
 
         binding.sectionControllers.labelSection.setText(R.string.section_controllers)
         binding.sectionConnections.labelSection.setText(R.string.section_connections)

--- a/app/src/main/java/com/tinkernorth/dish/ui/diagnostics/DiagnosticsViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/diagnostics/DiagnosticsViewModel.kt
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.diagnostics
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.tinkernorth.dish.core.jni.PhysicalInputNative
+import com.tinkernorth.dish.source.store.LatencyProfilingStore
+import com.tinkernorth.dish.source.system.WifiLink
+import com.tinkernorth.dish.source.system.WifiLinkSource
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+
+@HiltViewModel
+class DiagnosticsViewModel
+    @Inject
+    constructor(
+        latencyProfilingStore: LatencyProfilingStore,
+        private val physicalInputNative: PhysicalInputNative,
+        private val wifiLinkSource: WifiLinkSource,
+        private val json: Json,
+    ) : ViewModel() {
+        sealed interface LatencyUi {
+            data object Off : LatencyUi
+
+            data object Waiting : LatencyUi
+
+            data class Stats(
+                val panel: LatencyPanel,
+            ) : LatencyUi
+        }
+
+        // WhileSubscribed ties the probe to the screen: the collector lives inside
+        // repeatOnLifecycle(STARTED), so leaving the screen stops the fast pings.
+        @OptIn(ExperimentalCoroutinesApi::class)
+        val latency: StateFlow<LatencyUi> =
+            latencyProfilingStore.state
+                .flatMapLatest { enabled -> if (enabled) probeTicks() else flowOf(LatencyUi.Off) }
+                .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), LatencyUi.Off)
+
+        val wifi: StateFlow<WifiLink?> =
+            flow<WifiLink?> {
+                while (true) {
+                    emit(wifiLinkSource.read())
+                    delay(WIFI_POLL_MS)
+                }
+            }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
+
+        private fun probeTicks(): Flow<LatencyUi> =
+            flow {
+                physicalInputNative.setLatencyProbe(true)
+                try {
+                    while (true) {
+                        val panel = parseLatencyPanel(physicalInputNative.hotPathBenchJson(false), json)
+                        emit(panel?.let { LatencyUi.Stats(it) } ?: LatencyUi.Waiting)
+                        delay(LATENCY_POLL_MS)
+                    }
+                } finally {
+                    physicalInputNative.setLatencyProbe(false)
+                }
+            }
+
+        private companion object {
+            const val LATENCY_POLL_MS = 1000L
+            const val WIFI_POLL_MS = 2000L
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/ui/diagnostics/InputInspectorActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/diagnostics/InputInspectorActivity.kt
@@ -12,8 +12,6 @@ import com.tinkernorth.dish.core.jni.PhysicalInputNative
 import com.tinkernorth.dish.databinding.ActivityInputInspectorBinding
 import com.tinkernorth.dish.hotpath.input.RumbleRouter
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
-import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
-import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
@@ -43,12 +41,8 @@ class InputInspectorActivity : BaseGamepadHostActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityInputInspectorBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-        installGamepadHost(binding.root)
+        binding = setScaffoldContent(ActivityInputInspectorBinding::inflate)
         setupDishToolbar(binding.toolbar)
-        applyDishSystemBars(binding.root)
-        applyDishActivityTransitions()
         deviceId = intent.getIntExtra(EXTRA_DEVICE_ID, 0)
         intent.getStringExtra(EXTRA_DEVICE_NAME)?.let { binding.toolbar.subtitle = it }
 

--- a/app/src/main/java/com/tinkernorth/dish/ui/diagnostics/InputInspectorActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/diagnostics/InputInspectorActivity.kt
@@ -4,7 +4,6 @@ package com.tinkernorth.dish.ui.diagnostics
 
 import android.os.Bundle
 import android.os.SystemClock
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -12,6 +11,7 @@ import com.tinkernorth.dish.R
 import com.tinkernorth.dish.core.jni.PhysicalInputNative
 import com.tinkernorth.dish.databinding.ActivityInputInspectorBinding
 import com.tinkernorth.dish.hotpath.input.RumbleRouter
+import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.setupDishToolbar
@@ -23,7 +23,7 @@ import javax.inject.Inject
 import kotlin.math.roundToInt
 
 @AndroidEntryPoint
-class InputInspectorActivity : AppCompatActivity() {
+class InputInspectorActivity : BaseGamepadHostActivity() {
     @Inject lateinit var physicalInputNative: PhysicalInputNative
 
     @Inject lateinit var rumbleRouter: RumbleRouter
@@ -45,6 +45,7 @@ class InputInspectorActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityInputInspectorBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        installGamepadHost(binding.root)
         setupDishToolbar(binding.toolbar)
         applyDishSystemBars(binding.root)
         applyDishActivityTransitions()

--- a/app/src/main/java/com/tinkernorth/dish/ui/diagnostics/LatencyPanel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/diagnostics/LatencyPanel.kt
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.diagnostics
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.float
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+// The bench measures the full heartbeat round trip; one-way network latency is half of it
+// (symmetric-path estimate). The RTT window slides, so the figure answers "now"; the sample
+// count travels with it so a barely-seeded window reads as tentative instead of authoritative.
+data class LatencyPanel(
+    val phonePathP50Ms: Double?,
+    val phonePathP99Ms: Double?,
+    val pollingJitterP50Ms: Double?,
+    val pollingJitterP99Ms: Double?,
+    val networkOneWayP50Ms: Double?,
+    val rttSamples: Int?,
+    val rttHistoryMs: List<Float>,
+)
+
+fun parseLatencyPanel(
+    rawJson: String,
+    json: Json,
+): LatencyPanel? {
+    val root = runCatching { json.parseToJsonElement(rawJson).jsonObject }.getOrNull() ?: return null
+    return LatencyPanel(
+        phonePathP50Ms = microToMs(root, STAGE1, P50),
+        phonePathP99Ms = microToMs(root, STAGE1, P99),
+        pollingJitterP50Ms = microToMs(root, URB_GAP, P50),
+        pollingJitterP99Ms = microToMs(root, URB_GAP, P99),
+        networkOneWayP50Ms = microToMs(root, RTT, P50)?.let { it / 2 },
+        rttSamples = intField(root, RTT, "n"),
+        rttHistoryMs = rttHistoryMs(root),
+    )
+}
+
+// Recent full-RTT samples in ms for the sparkline; empty hides it until two samples exist.
+private fun rttHistoryMs(root: JsonObject): List<Float> {
+    val recent =
+        runCatching {
+            root[RTT_RECENT]?.jsonArray?.map { it.jsonPrimitive.float / MICROS_PER_MS.toFloat() }
+        }.getOrNull() ?: return emptyList()
+    return if (recent.size < 2) emptyList() else recent
+}
+
+private fun microToMs(
+    root: JsonObject,
+    group: String,
+    field: String,
+): Double? {
+    val value =
+        runCatching {
+            root[group]
+                ?.jsonObject
+                ?.get(field)
+                ?.jsonPrimitive
+                ?.float
+        }.getOrNull() ?: return null
+    return value / MICROS_PER_MS
+}
+
+private fun intField(
+    root: JsonObject,
+    group: String,
+    field: String,
+): Int? =
+    runCatching {
+        root[group]
+            ?.jsonObject
+            ?.get(field)
+            ?.jsonPrimitive
+            ?.int
+    }.getOrNull()
+
+private const val MICROS_PER_MS = 1000.0
+private const val STAGE1 = "stage1_hotpath_us"
+private const val URB_GAP = "urb_gap_us"
+private const val RTT = "rtt_us"
+private const val RTT_RECENT = "rtt_recent_us"
+private const val P50 = "p50"
+private const val P99 = "p99"

--- a/app/src/main/java/com/tinkernorth/dish/ui/donate/DonateActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/donate/DonateActivity.kt
@@ -5,29 +5,26 @@ package com.tinkernorth.dish.ui.donate
 import android.content.Intent
 import android.os.Bundle
 import androidx.annotation.StringRes
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.net.toUri
 import androidx.core.view.isVisible
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.databinding.ActivityDonateBinding
 import com.tinkernorth.dish.databinding.DonateRailCardBinding
-import com.tinkernorth.dish.source.notification.DishNotifications
+import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 
 @AndroidEntryPoint
-class DonateActivity : AppCompatActivity() {
-    @Inject lateinit var notifications: DishNotifications
-
+class DonateActivity : BaseGamepadHostActivity() {
     private lateinit var binding: ActivityDonateBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityDonateBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        installGamepadHost(binding.root)
         setupDishToolbar(binding.toolbar)
         applyDishSystemBars(binding.root)
         applyDishActivityTransitions()

--- a/app/src/main/java/com/tinkernorth/dish/ui/donate/DonateActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/donate/DonateActivity.kt
@@ -2,10 +2,8 @@
 
 package com.tinkernorth.dish.ui.donate
 
-import android.content.Intent
 import android.os.Bundle
 import androidx.annotation.StringRes
-import androidx.core.net.toUri
 import androidx.core.view.isVisible
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.databinding.ActivityDonateBinding
@@ -88,19 +86,5 @@ class DonateActivity : BaseGamepadHostActivity() {
         binding.whySigning.donateWhyText.setText(R.string.donate_why_signing)
         binding.whyPlay.donateWhyText.setText(R.string.donate_why_play)
         binding.whyTime.donateWhyText.setText(R.string.donate_why_time)
-    }
-
-    private fun openExternalUrl(url: String) {
-        val intent =
-            Intent(Intent.ACTION_VIEW, url.toUri())
-                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        runCatching { startActivity(intent) }
-            .onFailure {
-                notifications.warn(
-                    title = getString(R.string.error_open_url),
-                    body = url,
-                    key = "external-url-failed",
-                )
-            }
     }
 }

--- a/app/src/main/java/com/tinkernorth/dish/ui/donate/DonateActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/donate/DonateActivity.kt
@@ -11,8 +11,6 @@ import com.tinkernorth.dish.R
 import com.tinkernorth.dish.databinding.ActivityDonateBinding
 import com.tinkernorth.dish.databinding.DonateRailCardBinding
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
-import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
-import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -22,12 +20,8 @@ class DonateActivity : BaseGamepadHostActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityDonateBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-        installGamepadHost(binding.root)
+        binding = setScaffoldContent(ActivityDonateBinding::inflate)
         setupDishToolbar(binding.toolbar)
-        applyDishSystemBars(binding.root)
-        applyDishActivityTransitions()
 
         bindCta()
         bindRails()

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/BaseInputOverlayActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/BaseInputOverlayActivity.kt
@@ -6,14 +6,11 @@ import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.Process
-import android.view.KeyEvent
-import android.view.MotionEvent
 import android.view.Surface
 import android.view.View
 import android.view.WindowInsets
 import android.view.WindowInsetsController
 import android.view.WindowManager
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -24,15 +21,11 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.composer.ConnectionCoordinator
 import com.tinkernorth.dish.composer.ConnectionSummary
-import com.tinkernorth.dish.composer.WakeStateController
 import com.tinkernorth.dish.core.model.DishNotification
-import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
-import com.tinkernorth.dish.hotpath.overlay.GamepadActivityHost
 import com.tinkernorth.dish.source.connection.ConnectionEvent
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.inputrate.InputRateStore
-import com.tinkernorth.dish.source.lowpower.LowPowerSignal
-import com.tinkernorth.dish.source.notification.DishNotifications
+import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.FoldAwareSession
 import com.tinkernorth.dish.ui.common.Posture
 import com.tinkernorth.dish.ui.common.ResendPacer
@@ -49,22 +42,12 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.math.max
 
-abstract class BaseInputOverlayActivity : AppCompatActivity() {
+abstract class BaseInputOverlayActivity : BaseGamepadHostActivity() {
     @Inject lateinit var hub: ConnectionCoordinator
 
     @Inject lateinit var satellite: SatelliteConnectionManager
 
-    @Inject lateinit var wakeState: WakeStateController
-
-    @Inject lateinit var gamepadRegistry: PhysicalGamepadRegistry
-
-    @Inject lateinit var notifications: DishNotifications
-
-    @Inject lateinit var lowPowerSignal: LowPowerSignal
-
     @Inject lateinit var inputRateStore: InputRateStore
-
-    protected lateinit var gamepadHost: GamepadActivityHost
 
     protected var connectionId: String = ""
 
@@ -99,9 +82,7 @@ abstract class BaseInputOverlayActivity : AppCompatActivity() {
                 }
         }
 
-        gamepadHost =
-            GamepadActivityHost(this, rootView(), wakeState, gamepadRegistry, lowPowerSignal)
-                .also { it.install(notifications) }
+        installGamepadHost(rootView())
         hideSystemBars()
 
         ViewCompat.setOnApplyWindowInsetsListener(rootView()) { v, wi ->
@@ -287,23 +268,6 @@ abstract class BaseInputOverlayActivity : AppCompatActivity() {
                     or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
             )
         }
-    }
-
-    override fun dispatchKeyEvent(event: KeyEvent): Boolean = gamepadHost.dispatchKeyEvent(event) || super.dispatchKeyEvent(event)
-
-    override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean =
-        gamepadHost.dispatchGenericMotionEvent(event) || super.dispatchGenericMotionEvent(event)
-
-    override fun dispatchTouchEvent(ev: MotionEvent): Boolean = gamepadHost.dispatchTouchEvent(ev) || super.dispatchTouchEvent(ev)
-
-    override fun onWindowFocusChanged(hasFocus: Boolean) {
-        super.onWindowFocusChanged(hasFocus)
-        gamepadHost.onWindowFocusChanged(hasFocus)
-    }
-
-    override fun onStop() {
-        super.onStop()
-        gamepadHost.cancelDimOnStop()
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsActivity.kt
@@ -4,8 +4,6 @@ package com.tinkernorth.dish.ui.main
 
 import android.content.res.ColorStateList
 import android.os.Bundle
-import android.view.KeyEvent
-import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
@@ -14,7 +12,6 @@ import androidx.activity.viewModels
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -22,7 +19,6 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.composer.CONTROLLER_TYPE_XBOX
 import com.tinkernorth.dish.composer.ConnectionKind
-import com.tinkernorth.dish.composer.WakeStateController
 import com.tinkernorth.dish.core.model.DishNotification
 import com.tinkernorth.dish.core.model.Feature
 import com.tinkernorth.dish.core.model.SlotCapabilities
@@ -31,15 +27,11 @@ import com.tinkernorth.dish.databinding.BindingApplyStepBinding
 import com.tinkernorth.dish.databinding.BindingValueNoneBinding
 import com.tinkernorth.dish.databinding.SetupReviewCardBinding
 import com.tinkernorth.dish.databinding.SetupTypeCardBinding
-import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
-import com.tinkernorth.dish.hotpath.overlay.GamepadActivityHost
 import com.tinkernorth.dish.repository.TouchpadModeValue
-import com.tinkernorth.dish.source.lowpower.LowPowerSignal
-import com.tinkernorth.dish.source.notification.DishNotifications
+import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
-import com.tinkernorth.dish.ui.common.attachGamepadHost
 import com.tinkernorth.dish.ui.common.wireDonateButton
 import com.tinkernorth.dish.ui.setup.ReviewFlow
 import com.tinkernorth.dish.ui.setup.bindCapabilityRows
@@ -47,20 +39,10 @@ import com.tinkernorth.dish.ui.setup.bindReviewFlows
 import com.tinkernorth.dish.ui.setup.capabilityRows
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @AndroidEntryPoint
-class ConfigureBindingsActivity : AppCompatActivity() {
-    @Inject lateinit var wakeState: WakeStateController
-
-    @Inject lateinit var gamepadRegistry: PhysicalGamepadRegistry
-
-    @Inject lateinit var notifications: DishNotifications
-
-    @Inject lateinit var lowPowerSignal: LowPowerSignal
-
+class ConfigureBindingsActivity : BaseGamepadHostActivity() {
     private lateinit var binding: ActivityConfigureBindingsBinding
-    private lateinit var gamepadHost: GamepadActivityHost
     private val viewModel: ConfigureBindingsViewModel by viewModels()
     private val nav by lazy { DishNavigator(this) }
 
@@ -68,7 +50,7 @@ class ConfigureBindingsActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityConfigureBindingsBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        gamepadHost = attachGamepadHost(binding.root, wakeState, gamepadRegistry, notifications, lowPowerSignal)
+        installGamepadHost(binding.root)
         applyDishSystemBars(binding.root)
         applyDishActivityTransitions()
         wireDonateButton()
@@ -89,11 +71,6 @@ class ConfigureBindingsActivity : AppCompatActivity() {
 
         viewModel.load(slotId)
         observe()
-    }
-
-    override fun onStop() {
-        super.onStop()
-        gamepadHost.cancelDimOnStop()
     }
 
     private fun observe() {
@@ -470,18 +447,6 @@ class ConfigureBindingsActivity : AppCompatActivity() {
             container.addView(card.root)
         }
         dialog.show()
-    }
-
-    override fun dispatchKeyEvent(event: KeyEvent): Boolean = gamepadHost.dispatchKeyEvent(event) || super.dispatchKeyEvent(event)
-
-    override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean =
-        gamepadHost.dispatchGenericMotionEvent(event) || super.dispatchGenericMotionEvent(event)
-
-    override fun dispatchTouchEvent(ev: MotionEvent): Boolean = gamepadHost.dispatchTouchEvent(ev) || super.dispatchTouchEvent(ev)
-
-    override fun onWindowFocusChanged(hasFocus: Boolean) {
-        super.onWindowFocusChanged(hasFocus)
-        gamepadHost.onWindowFocusChanged(hasFocus)
     }
 
     companion object {

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsActivity.kt
@@ -6,8 +6,6 @@ import android.content.res.ColorStateList
 import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
-import android.widget.LinearLayout
-import android.widget.ScrollView
 import androidx.activity.viewModels
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
@@ -25,6 +23,7 @@ import com.tinkernorth.dish.core.model.SlotCapabilities
 import com.tinkernorth.dish.databinding.ActivityConfigureBindingsBinding
 import com.tinkernorth.dish.databinding.BindingApplyStepBinding
 import com.tinkernorth.dish.databinding.BindingValueNoneBinding
+import com.tinkernorth.dish.databinding.DialogCardListBinding
 import com.tinkernorth.dish.databinding.SetupReviewCardBinding
 import com.tinkernorth.dish.databinding.SetupTypeCardBinding
 import com.tinkernorth.dish.repository.TouchpadModeValue
@@ -362,16 +361,12 @@ class ConfigureBindingsActivity : BaseGamepadHostActivity() {
         val state = viewModel.ui.value
         val snapshot = state.snapshot ?: return
         val type = state.draft?.type ?: CONTROLLER_TYPE_XBOX
-        val container =
-            LinearLayout(this).apply {
-                orientation = LinearLayout.VERTICAL
-                val side = resources.getDimensionPixelSize(R.dimen.spacing_5xl)
-                setPadding(side, 0, side, 0)
-            }
+        val list = DialogCardListBinding.inflate(layoutInflater)
+        val container = list.dialogCardList
         val dialog =
             MaterialAlertDialogBuilder(this)
                 .setTitle(R.string.binding_label_destination)
-                .setView(ScrollView(this).apply { addView(container) })
+                .setView(list.root)
                 .setNegativeButton(android.R.string.cancel, null)
                 .create()
         state.hosts.forEach { host ->
@@ -421,16 +416,12 @@ class ConfigureBindingsActivity : BaseGamepadHostActivity() {
         val state = viewModel.ui.value
         val snapshot = state.snapshot ?: return
         val host = state.selectedHost ?: return
-        val container =
-            LinearLayout(this).apply {
-                orientation = LinearLayout.VERTICAL
-                val side = resources.getDimensionPixelSize(R.dimen.spacing_5xl)
-                setPadding(side, 0, side, 0)
-            }
+        val list = DialogCardListBinding.inflate(layoutInflater)
+        val container = list.dialogCardList
         val dialog =
             MaterialAlertDialogBuilder(this)
                 .setTitle(R.string.binding_label_emulate)
-                .setView(ScrollView(this).apply { addView(container) })
+                .setView(list.root)
                 .setNegativeButton(android.R.string.cancel, null)
                 .create()
         state.typeOptions.forEach { option ->

--- a/app/src/main/java/com/tinkernorth/dish/ui/onboarding/HelpActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/onboarding/HelpActivity.kt
@@ -12,8 +12,6 @@ import com.tinkernorth.dish.databinding.ActivityHelpBinding
 import com.tinkernorth.dish.databinding.HelpFaqRowBinding
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.DishNavigator
-import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
-import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.attachDonatePill
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -25,12 +23,8 @@ class HelpActivity : BaseGamepadHostActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityHelpBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-        installGamepadHost(binding.root)
+        binding = setScaffoldContent(ActivityHelpBinding::inflate)
         setupDishToolbar(binding.toolbar)
-        applyDishSystemBars(binding.root)
-        applyDishActivityTransitions()
         attachDonatePill()
 
         bindRunSetupCard()

--- a/app/src/main/java/com/tinkernorth/dish/ui/onboarding/HelpActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/onboarding/HelpActivity.kt
@@ -2,10 +2,8 @@
 
 package com.tinkernorth.dish.ui.onboarding
 
-import android.content.Intent
 import android.os.Bundle
 import androidx.annotation.StringRes
-import androidx.core.net.toUri
 import androidx.core.view.isVisible
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.databinding.ActivityHelpBinding
@@ -112,19 +110,5 @@ class HelpActivity : BaseGamepadHostActivity() {
         binding.cardHelpGithub.setOnClickListener {
             openExternalUrl(getString(R.string.url_github))
         }
-    }
-
-    private fun openExternalUrl(url: String) {
-        val intent =
-            Intent(Intent.ACTION_VIEW, url.toUri())
-                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        runCatching { startActivity(intent) }
-            .onFailure {
-                notifications.warn(
-                    title = getString(R.string.error_open_url),
-                    body = url,
-                    key = "external-url-failed",
-                )
-            }
     }
 }

--- a/app/src/main/java/com/tinkernorth/dish/ui/onboarding/HelpActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/onboarding/HelpActivity.kt
@@ -5,25 +5,21 @@ package com.tinkernorth.dish.ui.onboarding
 import android.content.Intent
 import android.os.Bundle
 import androidx.annotation.StringRes
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.net.toUri
 import androidx.core.view.isVisible
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.databinding.ActivityHelpBinding
 import com.tinkernorth.dish.databinding.HelpFaqRowBinding
-import com.tinkernorth.dish.source.notification.DishNotifications
+import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.attachDonatePill
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 
 @AndroidEntryPoint
-class HelpActivity : AppCompatActivity() {
-    @Inject lateinit var notifications: DishNotifications
-
+class HelpActivity : BaseGamepadHostActivity() {
     private lateinit var binding: ActivityHelpBinding
     private val nav by lazy { DishNavigator(this) }
 
@@ -31,6 +27,7 @@ class HelpActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityHelpBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        installGamepadHost(binding.root)
         setupDishToolbar(binding.toolbar)
         applyDishSystemBars(binding.root)
         applyDishActivityTransitions()

--- a/app/src/main/java/com/tinkernorth/dish/ui/settings/LicensesActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/settings/LicensesActivity.kt
@@ -4,24 +4,27 @@ package com.tinkernorth.dish.ui.settings
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.net.toUri
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.databinding.ActivityLicensesBinding
+import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.attachDonatePill
 import com.tinkernorth.dish.ui.common.setupDishToolbar
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.serialization.json.Json
 
-class LicensesActivity : AppCompatActivity() {
+@AndroidEntryPoint
+class LicensesActivity : BaseGamepadHostActivity() {
     private lateinit var binding: ActivityLicensesBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityLicensesBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        installGamepadHost(binding.root)
         setupDishToolbar(binding.toolbar)
         applyDishSystemBars(binding.root)
         applyDishActivityTransitions()

--- a/app/src/main/java/com/tinkernorth/dish/ui/settings/LicensesActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/settings/LicensesActivity.kt
@@ -2,9 +2,7 @@
 
 package com.tinkernorth.dish.ui.settings
 
-import android.content.Intent
 import android.os.Bundle
-import androidx.core.net.toUri
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.databinding.ActivityLicensesBinding
@@ -39,10 +37,7 @@ class LicensesActivity : BaseGamepadHostActivity() {
 
     private fun openLicenseUrl(entry: LicenseEntry) {
         val url = entry.licenses.firstOrNull()?.url ?: entry.url ?: return
-        val intent =
-            Intent(Intent.ACTION_VIEW, url.toUri())
-                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        runCatching { startActivity(intent) }
+        openExternalUrl(url)
     }
 
     companion object {

--- a/app/src/main/java/com/tinkernorth/dish/ui/settings/LicensesActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/settings/LicensesActivity.kt
@@ -9,8 +9,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.databinding.ActivityLicensesBinding
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
-import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
-import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.attachDonatePill
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -22,12 +20,8 @@ class LicensesActivity : BaseGamepadHostActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityLicensesBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-        installGamepadHost(binding.root)
+        binding = setScaffoldContent(ActivityLicensesBinding::inflate)
         setupDishToolbar(binding.toolbar)
-        applyDishSystemBars(binding.root)
-        applyDishActivityTransitions()
         attachDonatePill()
 
         binding.toolbar.title = getString(R.string.settings_open_source_licenses_title)

--- a/app/src/main/java/com/tinkernorth/dish/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/settings/SettingsActivity.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.content.res.ColorStateList
 import android.os.Bundle
 import android.text.TextUtils
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -15,10 +14,10 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.tinkernorth.dish.BuildConfig
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.databinding.ActivitySettingsBinding
-import com.tinkernorth.dish.source.notification.DishNotifications
 import com.tinkernorth.dish.source.store.CrashReportingStore
 import com.tinkernorth.dish.source.store.ThemeMode
 import com.tinkernorth.dish.source.store.ThemePreferenceStore
+import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
@@ -30,12 +29,10 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class SettingsActivity : AppCompatActivity() {
+class SettingsActivity : BaseGamepadHostActivity() {
     @Inject lateinit var crashReportingStore: CrashReportingStore
 
     @Inject lateinit var themePreferenceStore: ThemePreferenceStore
-
-    @Inject lateinit var notifications: DishNotifications
 
     private lateinit var binding: ActivitySettingsBinding
     private val nav by lazy { DishNavigator(this) }
@@ -44,6 +41,7 @@ class SettingsActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivitySettingsBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        installGamepadHost(binding.root)
         setupDishToolbar(binding.toolbar)
         applyDishSystemBars(binding.root)
         applyDishActivityTransitions()

--- a/app/src/main/java/com/tinkernorth/dish/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/settings/SettingsActivity.kt
@@ -2,12 +2,10 @@
 
 package com.tinkernorth.dish.ui.settings
 
-import android.content.Intent
 import android.content.res.ColorStateList
 import android.os.Bundle
 import android.text.TextUtils
 import androidx.core.content.ContextCompat
-import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -21,7 +19,6 @@ import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.attachDonatePill
 import com.tinkernorth.dish.ui.common.setupDishToolbar
-import com.tinkernorth.dish.ui.diagnostics.DiagnosticsActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -78,9 +75,7 @@ class SettingsActivity : BaseGamepadHostActivity() {
         binding.cardRowDiagnostics.cardRowIcon.setImageResource(R.drawable.ic_bug)
         binding.cardRowDiagnostics.cardRowTitle.setText(R.string.settings_diagnostics_title)
         binding.cardRowDiagnostics.cardRowSubtitle.setText(R.string.settings_diagnostics_body)
-        binding.cardDiagnostics.setOnClickListener {
-            startActivity(Intent(this, DiagnosticsActivity::class.java))
-        }
+        binding.cardDiagnostics.setOnClickListener { nav.toDiagnostics() }
 
         binding.cardRowCrash.cardRowIcon.setImageResource(R.drawable.ic_bug)
         binding.cardRowCrash.cardRowTitle.setText(R.string.settings_crash_reporting_title)
@@ -97,9 +92,7 @@ class SettingsActivity : BaseGamepadHostActivity() {
         binding.cardRowOpenSourceLicenses.cardRowIcon.setImageResource(R.drawable.ic_license)
         binding.cardRowOpenSourceLicenses.cardRowTitle.setText(R.string.settings_open_source_licenses_title)
         binding.cardRowOpenSourceLicenses.cardRowSubtitle.setText(R.string.settings_open_source_licenses_body)
-        binding.cardOpenSourceLicenses.setOnClickListener {
-            startActivity(Intent(this, LicensesActivity::class.java))
-        }
+        binding.cardOpenSourceLicenses.setOnClickListener { nav.toLicenses() }
 
         binding.cardRowSupport.cardRowIcon.setImageResource(R.drawable.ic_heart)
         binding.cardRowSupport.cardRowIcon.imageTintList =
@@ -145,18 +138,4 @@ class SettingsActivity : BaseGamepadHostActivity() {
     }
 
     private fun formatVersion(): String = "${BuildConfig.VERSION_NAME} · build ${BuildConfig.VERSION_CODE}"
-
-    private fun openExternalUrl(url: String) {
-        val intent =
-            Intent(Intent.ACTION_VIEW, url.toUri())
-                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        runCatching { startActivity(intent) }
-            .onFailure {
-                notifications.warn(
-                    title = getString(R.string.error_open_url),
-                    body = url,
-                    key = "external-url-failed",
-                )
-            }
-    }
 }

--- a/app/src/main/java/com/tinkernorth/dish/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/settings/SettingsActivity.kt
@@ -19,8 +19,6 @@ import com.tinkernorth.dish.source.store.ThemeMode
 import com.tinkernorth.dish.source.store.ThemePreferenceStore
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.DishNavigator
-import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
-import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.attachDonatePill
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import com.tinkernorth.dish.ui.diagnostics.DiagnosticsActivity
@@ -39,12 +37,8 @@ class SettingsActivity : BaseGamepadHostActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivitySettingsBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-        installGamepadHost(binding.root)
+        binding = setScaffoldContent(ActivitySettingsBinding::inflate)
         setupDishToolbar(binding.toolbar)
-        applyDishSystemBars(binding.root)
-        applyDishActivityTransitions()
         attachDonatePill()
 
         binding.sectionSetup.labelSection.setText(R.string.settings_section_setup)

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupBluetoothControllerActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupBluetoothControllerActivity.kt
@@ -20,8 +20,6 @@ import com.tinkernorth.dish.databinding.SetupBtcPairedRowBinding
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.DishNavigator
-import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
-import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -48,14 +46,10 @@ class SetupBluetoothControllerActivity : BaseGamepadHostActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivitySetupBluetoothControllerBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-        installGamepadHost(binding.root)
+        binding = setScaffoldContent(ActivitySetupBluetoothControllerBinding::inflate)
         setupDishToolbar(binding.toolbar)
         wireSetupSkip(binding.toolbar, onboarding)
         binding.toolbar.setNavigationOnClickListener { handleBack() }
-        applyDishSystemBars(binding.root)
-        applyDishActivityTransitions()
         binding.breadcrumb.applyStep(SETUP_STEP_INPUT)
 
         binding.btnBack.setOnClickListener { handleBack() }

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupBluetoothControllerActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupBluetoothControllerActivity.kt
@@ -11,7 +11,6 @@ import android.view.View
 import androidx.activity.addCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -19,6 +18,7 @@ import com.tinkernorth.dish.R
 import com.tinkernorth.dish.databinding.ActivitySetupBluetoothControllerBinding
 import com.tinkernorth.dish.databinding.SetupBtcPairedRowBinding
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
+import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
@@ -32,7 +32,7 @@ import javax.inject.Inject
 // currently connected, and advances the moment one is tapped. The Activity owns
 // the permission prompt and the jump to settings, mirroring ConnectionsActivity.
 @AndroidEntryPoint
-class SetupBluetoothControllerActivity : AppCompatActivity() {
+class SetupBluetoothControllerActivity : BaseGamepadHostActivity() {
     @Inject lateinit var onboarding: OnboardingPreferenceStore
 
     private lateinit var binding: ActivitySetupBluetoothControllerBinding
@@ -50,6 +50,7 @@ class SetupBluetoothControllerActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivitySetupBluetoothControllerBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        installGamepadHost(binding.root)
         setupDishToolbar(binding.toolbar)
         wireSetupSkip(binding.toolbar, onboarding)
         binding.toolbar.setNavigationOnClickListener { handleBack() }

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupBluetoothHostActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupBluetoothHostActivity.kt
@@ -26,8 +26,8 @@ import com.tinkernorth.dish.databinding.SetupChoiceRowBinding
 import com.tinkernorth.dish.databinding.SetupTypeCardBinding
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
+import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.setupDishToolbar
-import com.tinkernorth.dish.ui.main.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -42,6 +42,7 @@ class SetupBluetoothHostActivity : BaseGamepadHostActivity() {
     @Inject lateinit var onboarding: OnboardingPreferenceStore
 
     private lateinit var binding: ActivitySetupBluetoothHostBinding
+    private val nav by lazy { DishNavigator(this) }
     private val viewModel: SetupBluetoothHostViewModel by viewModels()
 
     private val permissionLauncher =
@@ -233,11 +234,7 @@ class SetupBluetoothHostActivity : BaseGamepadHostActivity() {
             )
         }
         onboarding.markWelcomeCompleted()
-        startActivity(
-            Intent(this, MainActivity::class.java)
-                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK),
-        )
-        finish()
+        nav.finishSetupToDashboard()
     }
 
     private fun typeTitleRes(profile: BluetoothGamepad.GamepadProfile): Int =

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupBluetoothHostActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupBluetoothHostActivity.kt
@@ -13,7 +13,6 @@ import android.view.View
 import androidx.activity.addCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -25,8 +24,8 @@ import com.tinkernorth.dish.core.model.DishNotification
 import com.tinkernorth.dish.databinding.ActivitySetupBluetoothHostBinding
 import com.tinkernorth.dish.databinding.SetupChoiceRowBinding
 import com.tinkernorth.dish.databinding.SetupTypeCardBinding
-import com.tinkernorth.dish.source.notification.DishNotifications
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
+import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.setupDishToolbar
@@ -41,10 +40,8 @@ import javax.inject.Inject
 // Everything else (host list, type lock, advertising session, the proceed gate)
 // lives in the ViewModel.
 @AndroidEntryPoint
-class SetupBluetoothHostActivity : AppCompatActivity() {
+class SetupBluetoothHostActivity : BaseGamepadHostActivity() {
     @Inject lateinit var onboarding: OnboardingPreferenceStore
-
-    @Inject lateinit var notifications: DishNotifications
 
     private lateinit var binding: ActivitySetupBluetoothHostBinding
     private val viewModel: SetupBluetoothHostViewModel by viewModels()
@@ -63,6 +60,7 @@ class SetupBluetoothHostActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivitySetupBluetoothHostBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        installGamepadHost(binding.root)
         setupDishToolbar(binding.toolbar)
         wireSetupSkip(binding.toolbar, onboarding)
         binding.toolbar.setNavigationOnClickListener { handleBack() }

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupBluetoothHostActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupBluetoothHostActivity.kt
@@ -26,8 +26,6 @@ import com.tinkernorth.dish.databinding.SetupChoiceRowBinding
 import com.tinkernorth.dish.databinding.SetupTypeCardBinding
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
-import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
-import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import com.tinkernorth.dish.ui.main.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
@@ -58,14 +56,10 @@ class SetupBluetoothHostActivity : BaseGamepadHostActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivitySetupBluetoothHostBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-        installGamepadHost(binding.root)
+        binding = setScaffoldContent(ActivitySetupBluetoothHostBinding::inflate)
         setupDishToolbar(binding.toolbar)
         wireSetupSkip(binding.toolbar, onboarding)
         binding.toolbar.setNavigationOnClickListener { handleBack() }
-        applyDishSystemBars(binding.root)
-        applyDishActivityTransitions()
         binding.breadcrumb.applyStep(SETUP_STEP_DESTINATION)
 
         viewModel.bindArgs(intent.getStringExtra(SetupFlow.EXTRA_SLOT_ID).orEmpty())

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConfigureActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConfigureActivity.kt
@@ -9,7 +9,6 @@ import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -22,10 +21,9 @@ import com.tinkernorth.dish.core.model.Feature
 import com.tinkernorth.dish.databinding.ActivitySetupConfigureBinding
 import com.tinkernorth.dish.databinding.SetupReviewCardBinding
 import com.tinkernorth.dish.databinding.SetupTypeCardBinding
-import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.repository.TouchpadModeValue
-import com.tinkernorth.dish.source.notification.DishNotifications
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
+import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.setupDishToolbar
@@ -46,12 +44,8 @@ import javax.inject.Inject
 // and the bind round-trip; this screen only renders sub-steps and feeds the
 // wizard's chosen destination in via setHost.
 @AndroidEntryPoint
-class SetupConfigureActivity : AppCompatActivity() {
+class SetupConfigureActivity : BaseGamepadHostActivity() {
     @Inject lateinit var onboarding: OnboardingPreferenceStore
-
-    @Inject lateinit var notifications: DishNotifications
-
-    @Inject lateinit var gamepadRegistry: PhysicalGamepadRegistry
 
     private lateinit var binding: ActivitySetupConfigureBinding
     private val viewModel: ConfigureBindingsViewModel by viewModels()
@@ -73,6 +67,7 @@ class SetupConfigureActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivitySetupConfigureBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        installGamepadHost(binding.root)
         setupDishToolbar(binding.toolbar)
         wireSetupSkip(binding.toolbar, onboarding)
         applyDishSystemBars(binding.root)

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConfigureActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConfigureActivity.kt
@@ -2,7 +2,6 @@
 
 package com.tinkernorth.dish.ui.setup
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.activity.addCallback
@@ -24,13 +23,13 @@ import com.tinkernorth.dish.databinding.SetupTypeCardBinding
 import com.tinkernorth.dish.repository.TouchpadModeValue
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
+import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import com.tinkernorth.dish.ui.main.ApplyState
 import com.tinkernorth.dish.ui.main.BindingLink
 import com.tinkernorth.dish.ui.main.BindingSnapshot
 import com.tinkernorth.dish.ui.main.ConfigUiState
 import com.tinkernorth.dish.ui.main.ConfigureBindingsViewModel
-import com.tinkernorth.dish.ui.main.MainActivity
 import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
 import com.tinkernorth.dish.ui.main.iconRes
 import dagger.hilt.android.AndroidEntryPoint
@@ -46,6 +45,7 @@ class SetupConfigureActivity : BaseGamepadHostActivity() {
     @Inject lateinit var onboarding: OnboardingPreferenceStore
 
     private lateinit var binding: ActivitySetupConfigureBinding
+    private val nav by lazy { DishNavigator(this) }
     private val viewModel: ConfigureBindingsViewModel by viewModels()
 
     private var step = Step.TYPE
@@ -426,11 +426,7 @@ class SetupConfigureActivity : BaseGamepadHostActivity() {
             )
         }
         onboarding.markWelcomeCompleted()
-        startActivity(
-            Intent(this, MainActivity::class.java)
-                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK),
-        )
-        finish()
+        nav.finishSetupToDashboard()
     }
 
     // Tapping a type commits it and advances; the Bluetooth host's type is fixed

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConfigureActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConfigureActivity.kt
@@ -24,8 +24,6 @@ import com.tinkernorth.dish.databinding.SetupTypeCardBinding
 import com.tinkernorth.dish.repository.TouchpadModeValue
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
-import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
-import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import com.tinkernorth.dish.ui.main.ApplyState
 import com.tinkernorth.dish.ui.main.BindingLink
@@ -65,13 +63,9 @@ class SetupConfigureActivity : BaseGamepadHostActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivitySetupConfigureBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-        installGamepadHost(binding.root)
+        binding = setScaffoldContent(ActivitySetupConfigureBinding::inflate)
         setupDishToolbar(binding.toolbar)
         wireSetupSkip(binding.toolbar, onboarding)
-        applyDishSystemBars(binding.root)
-        applyDishActivityTransitions()
         binding.breadcrumb.applyStep(SETUP_STEP_BINDING)
 
         val slotId = intent.getStringExtra(SetupFlow.EXTRA_SLOT_ID)

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConnectionActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConnectionActivity.kt
@@ -9,7 +9,6 @@ import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -22,6 +21,7 @@ import com.tinkernorth.dish.databinding.SetupChoiceRowBinding
 import com.tinkernorth.dish.databinding.SetupHostRowBinding
 import com.tinkernorth.dish.source.connection.PairingApproval
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
+import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
@@ -36,7 +36,7 @@ import javax.inject.Inject
 // for PIN entry + reverse approval. On a satellite reaching Connected/Unstable
 // the flow hands off to the configure step with the host id as the connection id.
 @AndroidEntryPoint
-class SetupConnectionActivity : AppCompatActivity() {
+class SetupConnectionActivity : BaseGamepadHostActivity() {
     @Inject lateinit var onboarding: OnboardingPreferenceStore
 
     private lateinit var binding: ActivitySetupConnectionBinding
@@ -58,6 +58,7 @@ class SetupConnectionActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivitySetupConnectionBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        installGamepadHost(binding.root)
         setupDishToolbar(binding.toolbar)
         wireSetupSkip(binding.toolbar, onboarding)
         binding.toolbar.setNavigationOnClickListener { handleBack() }

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConnectionActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConnectionActivity.kt
@@ -23,8 +23,6 @@ import com.tinkernorth.dish.source.connection.PairingApproval
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.DishNavigator
-import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
-import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import com.tinkernorth.dish.ui.connections.PairPinDialog
 import dagger.hilt.android.AndroidEntryPoint
@@ -56,14 +54,10 @@ class SetupConnectionActivity : BaseGamepadHostActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivitySetupConnectionBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-        installGamepadHost(binding.root)
+        binding = setScaffoldContent(ActivitySetupConnectionBinding::inflate)
         setupDishToolbar(binding.toolbar)
         wireSetupSkip(binding.toolbar, onboarding)
         binding.toolbar.setNavigationOnClickListener { handleBack() }
-        applyDishSystemBars(binding.root)
-        applyDishActivityTransitions()
         binding.breadcrumb.applyStep(SETUP_STEP_DESTINATION)
 
         bindChoice(

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupInputActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupInputActivity.kt
@@ -12,8 +12,6 @@ import com.tinkernorth.dish.databinding.SetupChoiceRowBinding
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.DishNavigator
-import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
-import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
 import dagger.hilt.android.AndroidEntryPoint
@@ -30,13 +28,9 @@ class SetupInputActivity : BaseGamepadHostActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivitySetupInputBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-        installGamepadHost(binding.root)
+        binding = setScaffoldContent(ActivitySetupInputBinding::inflate)
         setupDishToolbar(binding.toolbar)
         wireSetupSkip(binding.toolbar, onboarding)
-        applyDishSystemBars(binding.root)
-        applyDishActivityTransitions()
         binding.breadcrumb.applyStep(SETUP_STEP_INPUT)
 
         bindChoice(

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupInputActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupInputActivity.kt
@@ -6,11 +6,11 @@ import android.os.Bundle
 import android.view.View
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.appcompat.app.AppCompatActivity
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.databinding.ActivitySetupInputBinding
 import com.tinkernorth.dish.databinding.SetupChoiceRowBinding
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
+import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
@@ -22,7 +22,7 @@ import javax.inject.Inject
 // Entry point of the guided flow and the app's first-run destination. Each
 // input opens its own branch; all branches rejoin at the connection step.
 @AndroidEntryPoint
-class SetupInputActivity : AppCompatActivity() {
+class SetupInputActivity : BaseGamepadHostActivity() {
     @Inject lateinit var onboarding: OnboardingPreferenceStore
 
     private lateinit var binding: ActivitySetupInputBinding
@@ -32,6 +32,7 @@ class SetupInputActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivitySetupInputBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        installGamepadHost(binding.root)
         setupDishToolbar(binding.toolbar)
         wireSetupSkip(binding.toolbar, onboarding)
         applyDishSystemBars(binding.root)

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupUsbActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupUsbActivity.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.activity.addCallback
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -14,6 +13,7 @@ import com.tinkernorth.dish.R
 import com.tinkernorth.dish.databinding.ActivitySetupUsbBinding
 import com.tinkernorth.dish.databinding.SetupChoiceRowBinding
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
+import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
@@ -23,7 +23,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class SetupUsbActivity : AppCompatActivity() {
+class SetupUsbActivity : BaseGamepadHostActivity() {
     @Inject lateinit var onboarding: OnboardingPreferenceStore
 
     private lateinit var binding: ActivitySetupUsbBinding
@@ -34,6 +34,7 @@ class SetupUsbActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivitySetupUsbBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        installGamepadHost(binding.root)
         setupDishToolbar(binding.toolbar)
         wireSetupSkip(binding.toolbar, onboarding)
         binding.toolbar.setNavigationOnClickListener { handleBack() }

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupUsbActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupUsbActivity.kt
@@ -15,8 +15,6 @@ import com.tinkernorth.dish.databinding.SetupChoiceRowBinding
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.DishNavigator
-import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
-import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -32,14 +30,10 @@ class SetupUsbActivity : BaseGamepadHostActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivitySetupUsbBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-        installGamepadHost(binding.root)
+        binding = setScaffoldContent(ActivitySetupUsbBinding::inflate)
         setupDishToolbar(binding.toolbar)
         wireSetupSkip(binding.toolbar, onboarding)
         binding.toolbar.setNavigationOnClickListener { handleBack() }
-        applyDishSystemBars(binding.root)
-        applyDishActivityTransitions()
         binding.breadcrumb.applyStep(SETUP_STEP_INPUT)
 
         binding.btnBack.setOnClickListener { handleBack() }

--- a/app/src/main/res/layout-sw600dp/activity_donate.xml
+++ b/app/src/main/res/layout-sw600dp/activity_donate.xml
@@ -173,4 +173,8 @@
             </LinearLayout>
         </androidx.core.widget.NestedScrollView>
     </LinearLayout>
+
+    <include layout="@layout/overlay_low_power_chip" />
+
+    <include layout="@layout/overlay_low_power" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout-sw600dp/activity_donate.xml
+++ b/app/src/main/res/layout-sw600dp/activity_donate.xml
@@ -1,180 +1,171 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Dish.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        app:title="@string/donate_title" />
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/Widget.Dish.Toolbar"
-            android:layout_width="match_parent"
-            app:title="@string/donate_title" />
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:paddingTop="@dimen/spacing_md"
+        android:paddingBottom="@dimen/spacing_6xl">
 
-        <androidx.core.widget.NestedScrollView
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:paddingTop="@dimen/spacing_md"
-            android:paddingBottom="@dimen/spacing_6xl">
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center_horizontal">
 
             <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="@dimen/donate_content_max_width"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:gravity="center_horizontal">
+                android:orientation="vertical">
 
                 <LinearLayout
-                    android:layout_width="@dimen/donate_content_max_width"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical">
+                    android:orientation="vertical"
+                    android:gravity="center_horizontal"
+                    android:paddingBottom="@dimen/spacing_6xl">
+
+                    <FrameLayout
+                        android:layout_width="@dimen/donate_hero_heart_badge_size"
+                        android:layout_height="@dimen/donate_hero_heart_badge_size"
+                        android:background="@drawable/bg_pulse_badge">
+
+                        <ImageView
+                            android:id="@+id/donateHeroHeart"
+                            android:layout_width="@dimen/donate_hero_heart_size"
+                            android:layout_height="@dimen/donate_hero_heart_size"
+                            android:layout_gravity="center"
+                            android:src="@drawable/ic_heart"
+                            android:importantForAccessibility="no" />
+                    </FrameLayout>
+
+                    <TextView
+                        style="@style/TextAppearance.Dish.Label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_xl"
+                        android:textColor="@color/colorPulse"
+                        android:textAllCaps="true"
+                        android:text="@string/donate_eyebrow" />
+
+                    <TextView
+                        style="@style/TextAppearance.Dish.Title.Large"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_md"
+                        android:gravity="center"
+                        android:text="@string/donate_h1" />
+
+                    <TextView
+                        style="@style/TextAppearance.Dish.Body"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_lg"
+                        android:gravity="center"
+                        android:text="@string/donate_lead" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/btnDonateCta"
+                        style="@style/Widget.Dish.Button"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_6xl"
+                        app:backgroundTint="@color/colorPulse"
+                        android:textColor="@color/colorOnPulse"
+                        app:icon="@drawable/ic_heart"
+                        app:iconTint="@color/colorOnPulse"
+                        app:iconGravity="textStart"
+                        tools:text="Sponsor on GitHub Sponsors (recommended)" />
+                </LinearLayout>
+
+                <include
+                    android:id="@+id/railSponsors"
+                    layout="@layout/donate_rail_card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+
+                <include
+                    android:id="@+id/railKofi"
+                    layout="@layout/donate_rail_card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/card_margin_bottom" />
+
+                <include
+                    android:id="@+id/railBmac"
+                    layout="@layout/donate_rail_card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/card_margin_bottom" />
+
+                <com.google.android.material.card.MaterialCardView
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/section_header_gap_above">
 
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="vertical"
-                        android:gravity="center_horizontal"
-                        android:paddingBottom="@dimen/spacing_6xl">
-
-                        <FrameLayout
-                            android:layout_width="@dimen/donate_hero_heart_badge_size"
-                            android:layout_height="@dimen/donate_hero_heart_badge_size"
-                            android:background="@drawable/bg_pulse_badge">
-
-                            <ImageView
-                                android:id="@+id/donateHeroHeart"
-                                android:layout_width="@dimen/donate_hero_heart_size"
-                                android:layout_height="@dimen/donate_hero_heart_size"
-                                android:layout_gravity="center"
-                                android:src="@drawable/ic_heart"
-                                android:importantForAccessibility="no" />
-                        </FrameLayout>
+                        android:padding="@dimen/card_padding">
 
                         <TextView
-                            style="@style/TextAppearance.Dish.Label"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/spacing_xl"
-                            android:textColor="@color/colorPulse"
-                            android:textAllCaps="true"
-                            android:text="@string/donate_eyebrow" />
-
-                        <TextView
-                            style="@style/TextAppearance.Dish.Title.Large"
+                            style="@style/TextAppearance.Dish.Title"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/spacing_md"
-                            android:gravity="center"
-                            android:text="@string/donate_h1" />
+                            android:text="@string/donate_why_title" />
 
-                        <TextView
-                            style="@style/TextAppearance.Dish.Body"
+                        <include
+                            android:id="@+id/whyHosting"
+                            layout="@layout/donate_why_row"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/spacing_lg"
-                            android:gravity="center"
-                            android:text="@string/donate_lead" />
+                            android:layout_marginTop="@dimen/spacing_lg" />
 
-                        <com.google.android.material.button.MaterialButton
-                            android:id="@+id/btnDonateCta"
-                            style="@style/Widget.Dish.Button"
-                            android:layout_width="wrap_content"
+                        <include
+                            android:id="@+id/whySigning"
+                            layout="@layout/donate_why_row"
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/spacing_6xl"
-                            app:backgroundTint="@color/colorPulse"
-                            android:textColor="@color/colorOnPulse"
-                            app:icon="@drawable/ic_heart"
-                            app:iconTint="@color/colorOnPulse"
-                            app:iconGravity="textStart"
-                            tools:text="Sponsor on GitHub Sponsors (recommended)" />
+                            android:layout_marginTop="@dimen/spacing_lg" />
+
+                        <include
+                            android:id="@+id/whyPlay"
+                            layout="@layout/donate_why_row"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_lg" />
+
+                        <include
+                            android:id="@+id/whyTime"
+                            layout="@layout/donate_why_row"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_lg" />
                     </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
 
-                    <include
-                        android:id="@+id/railSponsors"
-                        layout="@layout/donate_rail_card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
-
-                    <include
-                        android:id="@+id/railKofi"
-                        layout="@layout/donate_rail_card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/card_margin_bottom" />
-
-                    <include
-                        android:id="@+id/railBmac"
-                        layout="@layout/donate_rail_card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/card_margin_bottom" />
-
-                    <com.google.android.material.card.MaterialCardView
-                        style="@style/Widget.Dish.Card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/section_header_gap_above">
-
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:orientation="vertical"
-                            android:padding="@dimen/card_padding">
-
-                            <TextView
-                                style="@style/TextAppearance.Dish.Title"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:text="@string/donate_why_title" />
-
-                            <include
-                                android:id="@+id/whyHosting"
-                                layout="@layout/donate_why_row"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_marginTop="@dimen/spacing_lg" />
-
-                            <include
-                                android:id="@+id/whySigning"
-                                layout="@layout/donate_why_row"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_marginTop="@dimen/spacing_lg" />
-
-                            <include
-                                android:id="@+id/whyPlay"
-                                layout="@layout/donate_why_row"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_marginTop="@dimen/spacing_lg" />
-
-                            <include
-                                android:id="@+id/whyTime"
-                                layout="@layout/donate_why_row"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_marginTop="@dimen/spacing_lg" />
-                        </LinearLayout>
-                    </com.google.android.material.card.MaterialCardView>
-
-                    <TextView
-                        style="@style/TextAppearance.Dish.BodySmall"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/section_header_gap_above"
-                        android:gravity="center"
-                        android:text="@string/donate_thanks" />
-                </LinearLayout>
+                <TextView
+                    style="@style/TextAppearance.Dish.BodySmall"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/section_header_gap_above"
+                    android:gravity="center"
+                    android:text="@string/donate_thanks" />
             </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
-    </LinearLayout>
-
-    <include layout="@layout/overlay_low_power_chip" />
-
-    <include layout="@layout/overlay_low_power" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+</LinearLayout>

--- a/app/src/main/res/layout-sw600dp/activity_help.xml
+++ b/app/src/main/res/layout-sw600dp/activity_help.xml
@@ -1,215 +1,205 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Dish.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        app:title="@string/help_title" />
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/Widget.Dish.Toolbar"
-            android:layout_width="match_parent"
-            app:title="@string/help_title" />
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:paddingTop="@dimen/spacing_md"
+        android:paddingBottom="@dimen/spacing_6xl">
 
-        <androidx.core.widget.NestedScrollView
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:paddingTop="@dimen/spacing_md"
-            android:paddingBottom="@dimen/spacing_6xl">
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center_horizontal">
 
             <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="@dimen/welcome_content_max_width"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:gravity="center_horizontal">
+                android:orientation="vertical">
 
-                <LinearLayout
-                    android:layout_width="@dimen/welcome_content_max_width"
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardRunSetup"
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical">
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
 
-                    <com.google.android.material.card.MaterialCardView
-                        android:id="@+id/cardRunSetup"
-                        style="@style/Widget.Dish.Card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:clickable="true"
-                        android:focusable="true"
-                        android:foreground="?attr/selectableItemBackground">
+                    <LinearLayout
+                        style="@style/Widget.Dish.Card.RowContainer"
+                        android:gravity="center_vertical">
 
-                        <LinearLayout
-                            style="@style/Widget.Dish.Card.RowContainer"
-                            android:gravity="center_vertical">
+                        <include
+                            android:id="@+id/cardRowRunSetup"
+                            layout="@layout/card_row_icon_label_value"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1" />
 
-                            <include
-                                android:id="@+id/cardRowRunSetup"
-                                layout="@layout/card_row_icon_label_value"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1" />
+                        <ImageView
+                            android:layout_width="@dimen/icon_card_glyph"
+                            android:layout_height="@dimen/icon_card_glyph"
+                            android:layout_marginStart="@dimen/spacing_xl"
+                            android:src="@drawable/ic_chevron_right"
+                            android:importantForAccessibility="no" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
 
-                            <ImageView
-                                android:layout_width="@dimen/icon_card_glyph"
-                                android:layout_height="@dimen/icon_card_glyph"
-                                android:layout_marginStart="@dimen/spacing_xl"
-                                android:src="@drawable/ic_chevron_right"
-                                android:importantForAccessibility="no" />
-                        </LinearLayout>
-                    </com.google.android.material.card.MaterialCardView>
+                <include
+                    android:id="@+id/sectionConcepts"
+                    layout="@layout/section_header"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/section_header_gap_above"
+                    android:layout_marginBottom="@dimen/section_header_gap_below" />
 
-                    <include
-                        android:id="@+id/sectionConcepts"
-                        layout="@layout/section_header"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/section_header_gap_above"
-                        android:layout_marginBottom="@dimen/section_header_gap_below" />
+                <include
+                    android:id="@+id/faqWhatIsDish"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqWhatIsSatellite"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqLanVsBluetooth"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqControllerModes"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqMotionTouchpad"
+                    layout="@layout/help_faq_row" />
 
-                    <include
-                        android:id="@+id/faqWhatIsDish"
-                        layout="@layout/help_faq_row" />
-                    <include
-                        android:id="@+id/faqWhatIsSatellite"
-                        layout="@layout/help_faq_row" />
-                    <include
-                        android:id="@+id/faqLanVsBluetooth"
-                        layout="@layout/help_faq_row" />
-                    <include
-                        android:id="@+id/faqControllerModes"
-                        layout="@layout/help_faq_row" />
-                    <include
-                        android:id="@+id/faqMotionTouchpad"
-                        layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/sectionPerformance"
+                    layout="@layout/section_header"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/section_header_gap_above"
+                    android:layout_marginBottom="@dimen/section_header_gap_below" />
 
-                    <include
-                        android:id="@+id/sectionPerformance"
-                        layout="@layout/section_header"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/section_header_gap_above"
-                        android:layout_marginBottom="@dimen/section_header_gap_below" />
+                <include
+                    android:id="@+id/faqBestSetup"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqWhyLanLower"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqWiredBetter"
+                    layout="@layout/help_faq_row" />
 
-                    <include
-                        android:id="@+id/faqBestSetup"
-                        layout="@layout/help_faq_row" />
-                    <include
-                        android:id="@+id/faqWhyLanLower"
-                        layout="@layout/help_faq_row" />
-                    <include
-                        android:id="@+id/faqWiredBetter"
-                        layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/sectionTrouble"
+                    layout="@layout/section_header"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/section_header_gap_above"
+                    android:layout_marginBottom="@dimen/section_header_gap_below" />
 
-                    <include
-                        android:id="@+id/sectionTrouble"
-                        layout="@layout/section_header"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/section_header_gap_above"
-                        android:layout_marginBottom="@dimen/section_header_gap_below" />
+                <include
+                    android:id="@+id/faqNoSatellites"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqPinRejected"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqDisconnects"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqNoMotion"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqBatteryDrain"
+                    layout="@layout/help_faq_row" />
 
-                    <include
-                        android:id="@+id/faqNoSatellites"
-                        layout="@layout/help_faq_row" />
-                    <include
-                        android:id="@+id/faqPinRejected"
-                        layout="@layout/help_faq_row" />
-                    <include
-                        android:id="@+id/faqDisconnects"
-                        layout="@layout/help_faq_row" />
-                    <include
-                        android:id="@+id/faqNoMotion"
-                        layout="@layout/help_faq_row" />
-                    <include
-                        android:id="@+id/faqBatteryDrain"
-                        layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/sectionAbout"
+                    layout="@layout/section_header"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/section_header_gap_above"
+                    android:layout_marginBottom="@dimen/section_header_gap_below" />
 
-                    <include
-                        android:id="@+id/sectionAbout"
-                        layout="@layout/section_header"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/section_header_gap_above"
-                        android:layout_marginBottom="@dimen/section_header_gap_below" />
+                <include
+                    android:id="@+id/faqOpenSource"
+                    layout="@layout/help_faq_row" />
+                <include
+                    android:id="@+id/faqPrivacy"
+                    layout="@layout/help_faq_row" />
 
-                    <include
-                        android:id="@+id/faqOpenSource"
-                        layout="@layout/help_faq_row" />
-                    <include
-                        android:id="@+id/faqPrivacy"
-                        layout="@layout/help_faq_row" />
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardHelpPrivacy"
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/card_margin_bottom"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
 
-                    <com.google.android.material.card.MaterialCardView
-                        android:id="@+id/cardHelpPrivacy"
-                        style="@style/Widget.Dish.Card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/card_margin_bottom"
-                        android:clickable="true"
-                        android:focusable="true"
-                        android:foreground="?attr/selectableItemBackground">
+                    <LinearLayout
+                        style="@style/Widget.Dish.Card.RowContainer"
+                        android:gravity="center_vertical">
 
-                        <LinearLayout
-                            style="@style/Widget.Dish.Card.RowContainer"
-                            android:gravity="center_vertical">
+                        <include
+                            android:id="@+id/cardRowHelpPrivacy"
+                            layout="@layout/card_row_icon_label_value"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1" />
 
-                            <include
-                                android:id="@+id/cardRowHelpPrivacy"
-                                layout="@layout/card_row_icon_label_value"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1" />
+                        <ImageView
+                            android:layout_width="@dimen/icon_card_glyph"
+                            android:layout_height="@dimen/icon_card_glyph"
+                            android:layout_marginStart="@dimen/spacing_xl"
+                            android:src="@drawable/ic_open_in_new"
+                            android:importantForAccessibility="no" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
 
-                            <ImageView
-                                android:layout_width="@dimen/icon_card_glyph"
-                                android:layout_height="@dimen/icon_card_glyph"
-                                android:layout_marginStart="@dimen/spacing_xl"
-                                android:src="@drawable/ic_open_in_new"
-                                android:importantForAccessibility="no" />
-                        </LinearLayout>
-                    </com.google.android.material.card.MaterialCardView>
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardHelpGithub"
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/card_margin_bottom"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
 
-                    <com.google.android.material.card.MaterialCardView
-                        android:id="@+id/cardHelpGithub"
-                        style="@style/Widget.Dish.Card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/card_margin_bottom"
-                        android:clickable="true"
-                        android:focusable="true"
-                        android:foreground="?attr/selectableItemBackground">
+                    <LinearLayout
+                        style="@style/Widget.Dish.Card.RowContainer"
+                        android:gravity="center_vertical">
 
-                        <LinearLayout
-                            style="@style/Widget.Dish.Card.RowContainer"
-                            android:gravity="center_vertical">
+                        <include
+                            android:id="@+id/cardRowHelpGithub"
+                            layout="@layout/card_row_icon_label_value"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1" />
 
-                            <include
-                                android:id="@+id/cardRowHelpGithub"
-                                layout="@layout/card_row_icon_label_value"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1" />
-
-                            <ImageView
-                                android:layout_width="@dimen/icon_card_glyph"
-                                android:layout_height="@dimen/icon_card_glyph"
-                                android:layout_marginStart="@dimen/spacing_xl"
-                                android:src="@drawable/ic_open_in_new"
-                                android:importantForAccessibility="no" />
-                        </LinearLayout>
-                    </com.google.android.material.card.MaterialCardView>
-                </LinearLayout>
+                        <ImageView
+                            android:layout_width="@dimen/icon_card_glyph"
+                            android:layout_height="@dimen/icon_card_glyph"
+                            android:layout_marginStart="@dimen/spacing_xl"
+                            android:src="@drawable/ic_open_in_new"
+                            android:importantForAccessibility="no" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
             </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
-    </LinearLayout>
-
-    <include layout="@layout/overlay_low_power_chip" />
-
-    <include layout="@layout/overlay_low_power" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+</LinearLayout>

--- a/app/src/main/res/layout-sw600dp/activity_help.xml
+++ b/app/src/main/res/layout-sw600dp/activity_help.xml
@@ -208,4 +208,8 @@
             </LinearLayout>
         </androidx.core.widget.NestedScrollView>
     </LinearLayout>
+
+    <include layout="@layout/overlay_low_power_chip" />
+
+    <include layout="@layout/overlay_low_power" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout-sw600dp/activity_settings.xml
+++ b/app/src/main/res/layout-sw600dp/activity_settings.xml
@@ -367,4 +367,7 @@
         </androidx.core.widget.NestedScrollView>
     </LinearLayout>
 
+    <include layout="@layout/overlay_low_power_chip" />
+
+    <include layout="@layout/overlay_low_power" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout-sw600dp/activity_settings.xml
+++ b/app/src/main/res/layout-sw600dp/activity_settings.xml
@@ -1,373 +1,364 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Dish.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        app:title="@string/settings_title" />
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/Widget.Dish.Toolbar"
-            android:layout_width="match_parent"
-            app:title="@string/settings_title" />
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:paddingTop="@dimen/spacing_md"
+        android:paddingBottom="@dimen/spacing_6xl">
 
-        <androidx.core.widget.NestedScrollView
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:paddingTop="@dimen/spacing_md"
-            android:paddingBottom="@dimen/spacing_6xl">
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center_horizontal">
 
             <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="@dimen/settings_content_max_width"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:gravity="center_horizontal">
+                android:orientation="vertical">
 
-                <LinearLayout
-                    android:layout_width="@dimen/settings_content_max_width"
+                <include
+                    android:id="@+id/sectionSetup"
+                    layout="@layout/section_header"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical">
+                    android:layout_marginBottom="@dimen/section_header_gap_below" />
 
-                    <include
-                        android:id="@+id/sectionSetup"
-                        layout="@layout/section_header"
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardSetupWizard"
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
+
+                    <LinearLayout
+                        style="@style/Widget.Dish.Card.RowContainer"
+                        android:gravity="center_vertical">
+
+                        <include
+                            android:id="@+id/cardRowSetupWizard"
+                            layout="@layout/card_row_icon_label_value"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1" />
+
+                        <ImageView
+                            android:layout_width="@dimen/icon_card_glyph"
+                            android:layout_height="@dimen/icon_card_glyph"
+                            android:layout_marginStart="@dimen/spacing_xl"
+                            android:src="@drawable/ic_chevron_right"
+                            android:importantForAccessibility="no" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardHelp"
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/card_margin_bottom"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
+
+                    <LinearLayout
+                        style="@style/Widget.Dish.Card.RowContainer"
+                        android:gravity="center_vertical">
+
+                        <include
+                            android:id="@+id/cardRowHelp"
+                            layout="@layout/card_row_icon_label_value"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1" />
+
+                        <ImageView
+                            android:layout_width="@dimen/icon_card_glyph"
+                            android:layout_height="@dimen/icon_card_glyph"
+                            android:layout_marginStart="@dimen/spacing_xl"
+                            android:src="@drawable/ic_chevron_right"
+                            android:importantForAccessibility="no" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <include
+                    android:id="@+id/sectionAppearance"
+                    layout="@layout/section_header"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/section_header_gap_above"
+                    android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+                <com.google.android.material.card.MaterialCardView
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/section_header_gap_below" />
+                        android:orientation="vertical"
+                        android:padding="@dimen/card_padding">
 
-                    <com.google.android.material.card.MaterialCardView
-                        android:id="@+id/cardSetupWizard"
-                        style="@style/Widget.Dish.Card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:clickable="true"
-                        android:focusable="true"
-                        android:foreground="?attr/selectableItemBackground">
+                        <include
+                            android:id="@+id/cardRowAppearance"
+                            layout="@layout/card_row_icon_label_value"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content" />
 
-                        <LinearLayout
-                            style="@style/Widget.Dish.Card.RowContainer"
-                            android:gravity="center_vertical">
-
-                            <include
-                                android:id="@+id/cardRowSetupWizard"
-                                layout="@layout/card_row_icon_label_value"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1" />
-
-                            <ImageView
-                                android:layout_width="@dimen/icon_card_glyph"
-                                android:layout_height="@dimen/icon_card_glyph"
-                                android:layout_marginStart="@dimen/spacing_xl"
-                                android:src="@drawable/ic_chevron_right"
-                                android:importantForAccessibility="no" />
-                        </LinearLayout>
-                    </com.google.android.material.card.MaterialCardView>
-
-                    <com.google.android.material.card.MaterialCardView
-                        android:id="@+id/cardHelp"
-                        style="@style/Widget.Dish.Card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/card_margin_bottom"
-                        android:clickable="true"
-                        android:focusable="true"
-                        android:foreground="?attr/selectableItemBackground">
-
-                        <LinearLayout
-                            style="@style/Widget.Dish.Card.RowContainer"
-                            android:gravity="center_vertical">
-
-                            <include
-                                android:id="@+id/cardRowHelp"
-                                layout="@layout/card_row_icon_label_value"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1" />
-
-                            <ImageView
-                                android:layout_width="@dimen/icon_card_glyph"
-                                android:layout_height="@dimen/icon_card_glyph"
-                                android:layout_marginStart="@dimen/spacing_xl"
-                                android:src="@drawable/ic_chevron_right"
-                                android:importantForAccessibility="no" />
-                        </LinearLayout>
-                    </com.google.android.material.card.MaterialCardView>
-
-                    <include
-                        android:id="@+id/sectionAppearance"
-                        layout="@layout/section_header"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/section_header_gap_above"
-                        android:layout_marginBottom="@dimen/section_header_gap_below" />
-
-                    <com.google.android.material.card.MaterialCardView
-                        style="@style/Widget.Dish.Card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content">
-
-                        <LinearLayout
+                        <com.google.android.material.chip.ChipGroup
+                            android:id="@+id/chipGroupTheme"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:orientation="vertical"
-                            android:padding="@dimen/card_padding">
+                            android:layout_marginTop="@dimen/spacing_lg"
+                            app:chipSpacingHorizontal="@dimen/chip_margin_end"
+                            app:selectionRequired="true"
+                            app:singleSelection="true">
 
-                            <include
-                                android:id="@+id/cardRowAppearance"
-                                layout="@layout/card_row_icon_label_value"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content" />
-
-                            <com.google.android.material.chip.ChipGroup
-                                android:id="@+id/chipGroupTheme"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_marginTop="@dimen/spacing_lg"
-                                app:chipSpacingHorizontal="@dimen/chip_margin_end"
-                                app:selectionRequired="true"
-                                app:singleSelection="true">
-
-                                <com.google.android.material.chip.Chip
-                                    android:id="@+id/chipThemeSystem"
-                                    style="@style/Widget.Dish.Chip"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/settings_appearance_system" />
-
-                                <com.google.android.material.chip.Chip
-                                    android:id="@+id/chipThemeLight"
-                                    style="@style/Widget.Dish.Chip"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/settings_appearance_light" />
-
-                                <com.google.android.material.chip.Chip
-                                    android:id="@+id/chipThemeDark"
-                                    style="@style/Widget.Dish.Chip"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/settings_appearance_dark" />
-                            </com.google.android.material.chip.ChipGroup>
-                        </LinearLayout>
-                    </com.google.android.material.card.MaterialCardView>
-
-                    <include
-                        android:id="@+id/sectionDiagnostics"
-                        layout="@layout/section_header"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/section_header_gap_above"
-                        android:layout_marginBottom="@dimen/section_header_gap_below" />
-
-                    <com.google.android.material.card.MaterialCardView
-                        android:id="@+id/cardDiagnostics"
-                        style="@style/Widget.Dish.Card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/card_margin_bottom"
-                        android:clickable="true"
-                        android:focusable="true"
-                        android:foreground="?attr/selectableItemBackground">
-
-                        <LinearLayout
-                            style="@style/Widget.Dish.Card.RowContainer"
-                            android:gravity="center_vertical">
-
-                            <include
-                                android:id="@+id/cardRowDiagnostics"
-                                layout="@layout/card_row_icon_label_value"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1" />
-
-                            <ImageView
-                                android:layout_width="@dimen/icon_card_glyph"
-                                android:layout_height="@dimen/icon_card_glyph"
-                                android:layout_marginStart="@dimen/spacing_xl"
-                                android:src="@drawable/ic_chevron_right"
-                                android:importantForAccessibility="no" />
-                        </LinearLayout>
-                    </com.google.android.material.card.MaterialCardView>
-
-                    <com.google.android.material.card.MaterialCardView
-                        style="@style/Widget.Dish.Card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content">
-
-                        <LinearLayout
-                            style="@style/Widget.Dish.Card.RowContainer"
-                            android:gravity="top">
-
-                            <include
-                                android:id="@+id/cardRowCrash"
-                                layout="@layout/card_row_icon_label_value"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1" />
-
-                            <com.google.android.material.materialswitch.MaterialSwitch
-                                android:id="@+id/switchCrashReporting"
-                                style="@style/Widget.Dish.Switch"
+                            <com.google.android.material.chip.Chip
+                                android:id="@+id/chipThemeSystem"
+                                style="@style/Widget.Dish.Chip"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:layout_marginStart="@dimen/spacing_xl"
-                                android:layout_marginTop="@dimen/size_2"
-                                android:contentDescription="@string/settings_crash_reporting_title" />
-                        </LinearLayout>
-                    </com.google.android.material.card.MaterialCardView>
+                                android:text="@string/settings_appearance_system" />
 
-                    <include
-                        android:id="@+id/sectionAbout"
-                        layout="@layout/section_header"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/section_header_gap_above"
-                        android:layout_marginBottom="@dimen/section_header_gap_below" />
-
-                    <com.google.android.material.card.MaterialCardView
-                        android:id="@+id/cardSupport"
-                        style="@style/Widget.Dish.Card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:clickable="true"
-                        android:focusable="true"
-                        android:foreground="?attr/selectableItemBackground">
-
-                        <LinearLayout
-                            style="@style/Widget.Dish.Card.RowContainer"
-                            android:gravity="center_vertical">
-
-                            <include
-                                android:id="@+id/cardRowSupport"
-                                layout="@layout/card_row_icon_label_value"
-                                android:layout_width="0dp"
+                            <com.google.android.material.chip.Chip
+                                android:id="@+id/chipThemeLight"
+                                style="@style/Widget.Dish.Chip"
+                                android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:layout_weight="1" />
+                                android:text="@string/settings_appearance_light" />
 
-                            <ImageView
-                                android:layout_width="@dimen/icon_card_glyph"
-                                android:layout_height="@dimen/icon_card_glyph"
-                                android:layout_marginStart="@dimen/spacing_xl"
-                                android:src="@drawable/ic_chevron_right"
-                                android:importantForAccessibility="no" />
-                        </LinearLayout>
-                    </com.google.android.material.card.MaterialCardView>
-
-                    <com.google.android.material.card.MaterialCardView
-                        android:id="@+id/cardPrivacyPolicy"
-                        style="@style/Widget.Dish.Card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/card_margin_bottom"
-                        android:clickable="true"
-                        android:focusable="true"
-                        android:foreground="?attr/selectableItemBackground">
-
-                        <LinearLayout
-                            style="@style/Widget.Dish.Card.RowContainer"
-                            android:gravity="center_vertical">
-
-                            <include
-                                android:id="@+id/cardRowPrivacy"
-                                layout="@layout/card_row_icon_label_value"
-                                android:layout_width="0dp"
+                            <com.google.android.material.chip.Chip
+                                android:id="@+id/chipThemeDark"
+                                style="@style/Widget.Dish.Chip"
+                                android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:layout_weight="1" />
+                                android:text="@string/settings_appearance_dark" />
+                        </com.google.android.material.chip.ChipGroup>
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
 
-                            <ImageView
-                                android:layout_width="@dimen/icon_card_glyph"
-                                android:layout_height="@dimen/icon_card_glyph"
-                                android:layout_marginStart="@dimen/spacing_xl"
-                                android:src="@drawable/ic_open_in_new"
-                                android:importantForAccessibility="no" />
-                        </LinearLayout>
-                    </com.google.android.material.card.MaterialCardView>
+                <include
+                    android:id="@+id/sectionDiagnostics"
+                    layout="@layout/section_header"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/section_header_gap_above"
+                    android:layout_marginBottom="@dimen/section_header_gap_below" />
 
-                    <com.google.android.material.card.MaterialCardView
-                        android:id="@+id/cardOpenSourceLicenses"
-                        style="@style/Widget.Dish.Card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/card_margin_bottom"
-                        android:clickable="true"
-                        android:focusable="true"
-                        android:foreground="?attr/selectableItemBackground">
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardDiagnostics"
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/card_margin_bottom"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
 
-                        <LinearLayout
-                            style="@style/Widget.Dish.Card.RowContainer"
-                            android:gravity="center_vertical">
+                    <LinearLayout
+                        style="@style/Widget.Dish.Card.RowContainer"
+                        android:gravity="center_vertical">
 
-                            <include
-                                android:id="@+id/cardRowOpenSourceLicenses"
-                                layout="@layout/card_row_icon_label_value"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1" />
-
-                            <ImageView
-                                android:layout_width="@dimen/icon_card_glyph"
-                                android:layout_height="@dimen/icon_card_glyph"
-                                android:layout_marginStart="@dimen/spacing_xl"
-                                android:src="@drawable/ic_chevron_right"
-                                android:importantForAccessibility="no" />
-                        </LinearLayout>
-                    </com.google.android.material.card.MaterialCardView>
-
-                    <com.google.android.material.card.MaterialCardView
-                        style="@style/Widget.Dish.Card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/card_margin_bottom">
-
-                        <LinearLayout
-                            android:layout_width="match_parent"
+                        <include
+                            android:id="@+id/cardRowDiagnostics"
+                            layout="@layout/card_row_icon_label_value"
+                            android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:orientation="horizontal"
-                            android:gravity="center_vertical"
-                            android:paddingHorizontal="@dimen/card_padding_horizontal"
-                            android:paddingVertical="@dimen/size_11">
+                            android:layout_weight="1" />
 
-                            <TextView
-                                style="@style/TextAppearance.Dish.Label"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/settings_version_label"
-                                android:textAllCaps="true" />
+                        <ImageView
+                            android:layout_width="@dimen/icon_card_glyph"
+                            android:layout_height="@dimen/icon_card_glyph"
+                            android:layout_marginStart="@dimen/spacing_xl"
+                            android:src="@drawable/ic_chevron_right"
+                            android:importantForAccessibility="no" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
 
-                            <TextView
-                                android:id="@+id/tvVersion"
-                                style="@style/TextAppearance.Dish.Body.Mono"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1"
-                                android:layout_marginStart="@dimen/spacing_xl"
-                                android:gravity="end"
-                                android:singleLine="true"
-                                android:ellipsize="end" />
-                        </LinearLayout>
-                    </com.google.android.material.card.MaterialCardView>
+                <com.google.android.material.card.MaterialCardView
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
 
-                    <TextView
-                        style="@style/TextAppearance.Dish.Caption"
+                    <LinearLayout
+                        style="@style/Widget.Dish.Card.RowContainer"
+                        android:gravity="top">
+
+                        <include
+                            android:id="@+id/cardRowCrash"
+                            layout="@layout/card_row_icon_label_value"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1" />
+
+                        <com.google.android.material.materialswitch.MaterialSwitch
+                            android:id="@+id/switchCrashReporting"
+                            style="@style/Widget.Dish.Switch"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="@dimen/spacing_xl"
+                            android:layout_marginTop="@dimen/size_2"
+                            android:contentDescription="@string/settings_crash_reporting_title" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <include
+                    android:id="@+id/sectionAbout"
+                    layout="@layout/section_header"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/section_header_gap_above"
+                    android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardSupport"
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
+
+                    <LinearLayout
+                        style="@style/Widget.Dish.Card.RowContainer"
+                        android:gravity="center_vertical">
+
+                        <include
+                            android:id="@+id/cardRowSupport"
+                            layout="@layout/card_row_icon_label_value"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1" />
+
+                        <ImageView
+                            android:layout_width="@dimen/icon_card_glyph"
+                            android:layout_height="@dimen/icon_card_glyph"
+                            android:layout_marginStart="@dimen/spacing_xl"
+                            android:src="@drawable/ic_chevron_right"
+                            android:importantForAccessibility="no" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardPrivacyPolicy"
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/card_margin_bottom"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
+
+                    <LinearLayout
+                        style="@style/Widget.Dish.Card.RowContainer"
+                        android:gravity="center_vertical">
+
+                        <include
+                            android:id="@+id/cardRowPrivacy"
+                            layout="@layout/card_row_icon_label_value"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1" />
+
+                        <ImageView
+                            android:layout_width="@dimen/icon_card_glyph"
+                            android:layout_height="@dimen/icon_card_glyph"
+                            android:layout_marginStart="@dimen/spacing_xl"
+                            android:src="@drawable/ic_open_in_new"
+                            android:importantForAccessibility="no" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardOpenSourceLicenses"
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/card_margin_bottom"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
+
+                    <LinearLayout
+                        style="@style/Widget.Dish.Card.RowContainer"
+                        android:gravity="center_vertical">
+
+                        <include
+                            android:id="@+id/cardRowOpenSourceLicenses"
+                            layout="@layout/card_row_icon_label_value"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1" />
+
+                        <ImageView
+                            android:layout_width="@dimen/icon_card_glyph"
+                            android:layout_height="@dimen/icon_card_glyph"
+                            android:layout_marginStart="@dimen/spacing_xl"
+                            android:src="@drawable/ic_chevron_right"
+                            android:importantForAccessibility="no" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/card_margin_bottom">
+
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/size_32"
-                        android:text="@string/settings_brand_footer"
-                        android:textAllCaps="true"
-                        android:gravity="center"
-                        android:alpha="0.7" />
-                </LinearLayout>
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:paddingHorizontal="@dimen/card_padding_horizontal"
+                        android:paddingVertical="@dimen/size_11">
+
+                        <TextView
+                            style="@style/TextAppearance.Dish.Label"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/settings_version_label"
+                            android:textAllCaps="true" />
+
+                        <TextView
+                            android:id="@+id/tvVersion"
+                            style="@style/TextAppearance.Dish.Body.Mono"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:layout_marginStart="@dimen/spacing_xl"
+                            android:gravity="end"
+                            android:singleLine="true"
+                            android:ellipsize="end" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <TextView
+                    style="@style/TextAppearance.Dish.Caption"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/size_32"
+                    android:text="@string/settings_brand_footer"
+                    android:textAllCaps="true"
+                    android:gravity="center"
+                    android:alpha="0.7" />
             </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
-    </LinearLayout>
-
-    <include layout="@layout/overlay_low_power_chip" />
-
-    <include layout="@layout/overlay_low_power" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_diagnostics.xml
+++ b/app/src/main/res/layout/activity_diagnostics.xml
@@ -13,164 +13,155 @@
     TextView/MaterialCardView rows; the switch defaults unchecked and is only
     armed after the user accepts the warning dialog.
 -->
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Dish.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        app:title="@string/diagnostics_title" />
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/Widget.Dish.Toolbar"
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:paddingHorizontal="@dimen/spacing_5xl"
+        android:paddingTop="@dimen/spacing_md"
+        android:paddingBottom="@dimen/spacing_6xl">
+
+        <LinearLayout
             android:layout_width="match_parent"
-            app:title="@string/diagnostics_title" />
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
-        <androidx.core.widget.NestedScrollView
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingTop="@dimen/spacing_md"
-            android:paddingBottom="@dimen/spacing_6xl">
-
-            <LinearLayout
+            <!-- ═══ CONTROLLERS ════════════════════════════════════════ -->
+            <include
+                android:id="@+id/sectionControllers"
+                layout="@layout/section_header"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:layout_marginBottom="@dimen/section_header_gap_below" />
 
-                <!-- ═══ CONTROLLERS ════════════════════════════════════════ -->
-                <include
-                    android:id="@+id/sectionControllers"
-                    layout="@layout/section_header"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/section_header_gap_below" />
+            <LinearLayout
+                android:id="@+id/containerControllers"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
+
+            <!-- ═══ CONNECTIONS ════════════════════════════════════════ -->
+            <include
+                android:id="@+id/sectionConnections"
+                layout="@layout/section_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/section_header_gap_above"
+                android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+            <TextView
+                android:id="@+id/tvWifiLink"
+                style="@style/TextAppearance.Dish.Body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_md" />
+
+            <LinearLayout
+                android:id="@+id/containerConnections"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
+
+            <!-- ═══ LATENCY ════════════════════════════════════════════ -->
+            <include
+                android:id="@+id/sectionLatency"
+                layout="@layout/section_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/section_header_gap_above"
+                android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+            <com.google.android.material.card.MaterialCardView
+                style="@style/Widget.Dish.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
 
                 <LinearLayout
-                    android:id="@+id/containerControllers"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical" />
-
-                <!-- ═══ CONNECTIONS ════════════════════════════════════════ -->
-                <include
-                    android:id="@+id/sectionConnections"
-                    layout="@layout/section_header"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/section_header_gap_above"
-                    android:layout_marginBottom="@dimen/section_header_gap_below" />
-
-                <TextView
-                    android:id="@+id/tvWifiLink"
-                    style="@style/TextAppearance.Dish.Body"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/spacing_md" />
-
-                <LinearLayout
-                    android:id="@+id/containerConnections"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical" />
-
-                <!-- ═══ LATENCY ════════════════════════════════════════════ -->
-                <include
-                    android:id="@+id/sectionLatency"
-                    layout="@layout/section_header"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/section_header_gap_above"
-                    android:layout_marginBottom="@dimen/section_header_gap_below" />
-
-                <com.google.android.material.card.MaterialCardView
-                    style="@style/Widget.Dish.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
+                    android:orientation="vertical"
+                    android:padding="@dimen/card_padding">
 
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="vertical"
-                        android:padding="@dimen/card_padding">
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical">
 
                         <LinearLayout
-                            android:layout_width="match_parent"
+                            android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:orientation="horizontal"
-                            android:gravity="center_vertical">
+                            android:layout_weight="1"
+                            android:orientation="vertical">
 
-                            <LinearLayout
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1"
-                                android:orientation="vertical">
-
-                                <TextView
-                                    style="@style/TextAppearance.Dish.Title"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/diagnostics_latency_title" />
-
-                                <TextView
-                                    style="@style/TextAppearance.Dish.Body"
-                                    android:layout_width="match_parent"
-                                    android:layout_height="wrap_content"
-                                    android:layout_marginTop="@dimen/spacing_xs"
-                                    android:text="@string/diagnostics_latency_body" />
-                            </LinearLayout>
-
-                            <com.google.android.material.materialswitch.MaterialSwitch
-                                android:id="@+id/switchLatencyProfiling"
-                                style="@style/Widget.Dish.Switch"
+                            <TextView
+                                style="@style/TextAppearance.Dish.Title"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:layout_marginStart="@dimen/spacing_xl"
-                                android:layout_marginTop="@dimen/size_2"
-                                android:contentDescription="@string/diagnostics_latency_title" />
+                                android:text="@string/diagnostics_latency_title" />
+
+                            <TextView
+                                style="@style/TextAppearance.Dish.Body"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="@dimen/spacing_xs"
+                                android:text="@string/diagnostics_latency_body" />
                         </LinearLayout>
 
-                        <LinearLayout
-                            android:id="@+id/containerLatencyStats"
-                            android:layout_width="match_parent"
+                        <com.google.android.material.materialswitch.MaterialSwitch
+                            android:id="@+id/switchLatencyProfiling"
+                            style="@style/Widget.Dish.Switch"
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/spacing_lg"
-                            android:orientation="vertical" />
+                            android:layout_marginStart="@dimen/spacing_xl"
+                            android:layout_marginTop="@dimen/size_2"
+                            android:contentDescription="@string/diagnostics_latency_title" />
                     </LinearLayout>
-                </com.google.android.material.card.MaterialCardView>
 
-                <!-- ═══ EVENTS ═════════════════════════════════════════════ -->
-                <include
-                    android:id="@+id/sectionEvents"
-                    layout="@layout/section_header"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/section_header_gap_above"
-                    android:layout_marginBottom="@dimen/section_header_gap_below" />
+                    <LinearLayout
+                        android:id="@+id/containerLatencyStats"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_lg"
+                        android:orientation="vertical" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
 
-                <LinearLayout
-                    android:id="@+id/containerEvents"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical" />
+            <!-- ═══ EVENTS ═════════════════════════════════════════════ -->
+            <include
+                android:id="@+id/sectionEvents"
+                layout="@layout/section_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/section_header_gap_above"
+                android:layout_marginBottom="@dimen/section_header_gap_below" />
 
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/btnCopyEvents"
-                    style="@style/Widget.Dish.Button.Outlined"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_md"
-                    android:text="@string/diagnostics_copy_events" />
+            <LinearLayout
+                android:id="@+id/containerEvents"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
 
-            </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
-    </LinearLayout>
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnCopyEvents"
+                style="@style/Widget.Dish.Button.Outlined"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_md"
+                android:text="@string/diagnostics_copy_events" />
 
-    <include layout="@layout/overlay_low_power_chip" />
-
-    <include layout="@layout/overlay_low_power" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_diagnostics.xml
+++ b/app/src/main/res/layout/activity_diagnostics.xml
@@ -170,4 +170,7 @@
         </androidx.core.widget.NestedScrollView>
     </LinearLayout>
 
+    <include layout="@layout/overlay_low_power_chip" />
+
+    <include layout="@layout/overlay_low_power" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_donate.xml
+++ b/app/src/main/res/layout/activity_donate.xml
@@ -167,4 +167,8 @@
             </LinearLayout>
         </androidx.core.widget.NestedScrollView>
     </LinearLayout>
+
+    <include layout="@layout/overlay_low_power_chip" />
+
+    <include layout="@layout/overlay_low_power" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_donate.xml
+++ b/app/src/main/res/layout/activity_donate.xml
@@ -1,174 +1,165 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Dish.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        app:title="@string/donate_title" />
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/Widget.Dish.Toolbar"
-            android:layout_width="match_parent"
-            app:title="@string/donate_title" />
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:paddingHorizontal="@dimen/spacing_5xl"
+        android:paddingTop="@dimen/spacing_md"
+        android:paddingBottom="@dimen/spacing_6xl">
 
-        <androidx.core.widget.NestedScrollView
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingTop="@dimen/spacing_md"
-            android:paddingBottom="@dimen/spacing_6xl">
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:gravity="center_horizontal"
+                android:paddingBottom="@dimen/spacing_6xl">
+
+                <FrameLayout
+                    android:layout_width="@dimen/donate_hero_heart_badge_size"
+                    android:layout_height="@dimen/donate_hero_heart_badge_size"
+                    android:background="@drawable/bg_pulse_badge">
+
+                    <ImageView
+                        android:id="@+id/donateHeroHeart"
+                        android:layout_width="@dimen/donate_hero_heart_size"
+                        android:layout_height="@dimen/donate_hero_heart_size"
+                        android:layout_gravity="center"
+                        android:src="@drawable/ic_heart"
+                        android:importantForAccessibility="no" />
+                </FrameLayout>
+
+                <TextView
+                    style="@style/TextAppearance.Dish.Label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_xl"
+                    android:textColor="@color/colorPulse"
+                    android:textAllCaps="true"
+                    android:text="@string/donate_eyebrow" />
+
+                <TextView
+                    style="@style/TextAppearance.Dish.Title.Large"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_md"
+                    android:gravity="center"
+                    android:text="@string/donate_h1" />
+
+                <TextView
+                    style="@style/TextAppearance.Dish.Body"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_lg"
+                    android:gravity="center"
+                    android:text="@string/donate_lead" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnDonateCta"
+                    style="@style/Widget.Dish.Button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_6xl"
+                    app:backgroundTint="@color/colorPulse"
+                    android:textColor="@color/colorOnPulse"
+                    app:icon="@drawable/ic_heart"
+                    app:iconTint="@color/colorOnPulse"
+                    app:iconGravity="textStart"
+                    tools:text="Sponsor on GitHub Sponsors (recommended)" />
+            </LinearLayout>
+
+            <include
+                android:id="@+id/railSponsors"
+                layout="@layout/donate_rail_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <include
+                android:id="@+id/railKofi"
+                layout="@layout/donate_rail_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/card_margin_bottom" />
+
+            <include
+                android:id="@+id/railBmac"
+                layout="@layout/donate_rail_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/card_margin_bottom" />
+
+            <com.google.android.material.card.MaterialCardView
+                style="@style/Widget.Dish.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/section_header_gap_above">
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
-                    android:gravity="center_horizontal"
-                    android:paddingBottom="@dimen/spacing_6xl">
-
-                    <FrameLayout
-                        android:layout_width="@dimen/donate_hero_heart_badge_size"
-                        android:layout_height="@dimen/donate_hero_heart_badge_size"
-                        android:background="@drawable/bg_pulse_badge">
-
-                        <ImageView
-                            android:id="@+id/donateHeroHeart"
-                            android:layout_width="@dimen/donate_hero_heart_size"
-                            android:layout_height="@dimen/donate_hero_heart_size"
-                            android:layout_gravity="center"
-                            android:src="@drawable/ic_heart"
-                            android:importantForAccessibility="no" />
-                    </FrameLayout>
+                    android:padding="@dimen/card_padding">
 
                     <TextView
-                        style="@style/TextAppearance.Dish.Label"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/spacing_xl"
-                        android:textColor="@color/colorPulse"
-                        android:textAllCaps="true"
-                        android:text="@string/donate_eyebrow" />
-
-                    <TextView
-                        style="@style/TextAppearance.Dish.Title.Large"
+                        style="@style/TextAppearance.Dish.Title"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/spacing_md"
-                        android:gravity="center"
-                        android:text="@string/donate_h1" />
+                        android:text="@string/donate_why_title" />
 
-                    <TextView
-                        style="@style/TextAppearance.Dish.Body"
+                    <include
+                        android:id="@+id/whyHosting"
+                        layout="@layout/donate_why_row"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/spacing_lg"
-                        android:gravity="center"
-                        android:text="@string/donate_lead" />
+                        android:layout_marginTop="@dimen/spacing_lg" />
 
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/btnDonateCta"
-                        style="@style/Widget.Dish.Button"
-                        android:layout_width="wrap_content"
+                    <include
+                        android:id="@+id/whySigning"
+                        layout="@layout/donate_why_row"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/spacing_6xl"
-                        app:backgroundTint="@color/colorPulse"
-                        android:textColor="@color/colorOnPulse"
-                        app:icon="@drawable/ic_heart"
-                        app:iconTint="@color/colorOnPulse"
-                        app:iconGravity="textStart"
-                        tools:text="Sponsor on GitHub Sponsors (recommended)" />
+                        android:layout_marginTop="@dimen/spacing_lg" />
+
+                    <include
+                        android:id="@+id/whyPlay"
+                        layout="@layout/donate_why_row"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_lg" />
+
+                    <include
+                        android:id="@+id/whyTime"
+                        layout="@layout/donate_why_row"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_lg" />
                 </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
 
-                <include
-                    android:id="@+id/railSponsors"
-                    layout="@layout/donate_rail_card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-                <include
-                    android:id="@+id/railKofi"
-                    layout="@layout/donate_rail_card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/card_margin_bottom" />
-
-                <include
-                    android:id="@+id/railBmac"
-                    layout="@layout/donate_rail_card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/card_margin_bottom" />
-
-                <com.google.android.material.card.MaterialCardView
-                    style="@style/Widget.Dish.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/section_header_gap_above">
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical"
-                        android:padding="@dimen/card_padding">
-
-                        <TextView
-                            style="@style/TextAppearance.Dish.Title"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="@string/donate_why_title" />
-
-                        <include
-                            android:id="@+id/whyHosting"
-                            layout="@layout/donate_why_row"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/spacing_lg" />
-
-                        <include
-                            android:id="@+id/whySigning"
-                            layout="@layout/donate_why_row"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/spacing_lg" />
-
-                        <include
-                            android:id="@+id/whyPlay"
-                            layout="@layout/donate_why_row"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/spacing_lg" />
-
-                        <include
-                            android:id="@+id/whyTime"
-                            layout="@layout/donate_why_row"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/spacing_lg" />
-                    </LinearLayout>
-                </com.google.android.material.card.MaterialCardView>
-
-                <TextView
-                    style="@style/TextAppearance.Dish.BodySmall"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/section_header_gap_above"
-                    android:gravity="center"
-                    android:text="@string/donate_thanks" />
-            </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
-    </LinearLayout>
-
-    <include layout="@layout/overlay_low_power_chip" />
-
-    <include layout="@layout/overlay_low_power" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+            <TextView
+                style="@style/TextAppearance.Dish.BodySmall"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/section_header_gap_above"
+                android:gravity="center"
+                android:text="@string/donate_thanks" />
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_help.xml
+++ b/app/src/main/res/layout/activity_help.xml
@@ -1,216 +1,206 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Dish.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        app:title="@string/help_title">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/Widget.Dish.Toolbar"
+        <include
+            layout="@layout/view_donate_heart_button"
+            android:layout_width="@dimen/icon_settings_button"
+            android:layout_height="@dimen/icon_settings_button"
+            android:layout_gravity="end" />
+    </com.google.android.material.appbar.MaterialToolbar>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:paddingHorizontal="@dimen/spacing_5xl"
+        android:paddingTop="@dimen/spacing_md"
+        android:paddingBottom="@dimen/spacing_6xl">
+
+        <LinearLayout
             android:layout_width="match_parent"
-            app:title="@string/help_title">
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
-            <include
-                layout="@layout/view_donate_heart_button"
-                android:layout_width="@dimen/icon_settings_button"
-                android:layout_height="@dimen/icon_settings_button"
-                android:layout_gravity="end" />
-        </com.google.android.material.appbar.MaterialToolbar>
-
-        <androidx.core.widget.NestedScrollView
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingTop="@dimen/spacing_md"
-            android:paddingBottom="@dimen/spacing_6xl">
-
-            <LinearLayout
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardRunSetup"
+                style="@style/Widget.Dish.Card"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?attr/selectableItemBackground">
 
-                <com.google.android.material.card.MaterialCardView
-                    android:id="@+id/cardRunSetup"
-                    style="@style/Widget.Dish.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:foreground="?attr/selectableItemBackground">
+                <LinearLayout
+                    style="@style/Widget.Dish.Card.RowContainer"
+                    android:gravity="center_vertical">
 
-                    <LinearLayout
-                        style="@style/Widget.Dish.Card.RowContainer"
-                        android:gravity="center_vertical">
+                    <include
+                        android:id="@+id/cardRowRunSetup"
+                        layout="@layout/card_row_icon_label_value"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1" />
 
-                        <include
-                            android:id="@+id/cardRowRunSetup"
-                            layout="@layout/card_row_icon_label_value"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1" />
+                    <ImageView
+                        android:layout_width="@dimen/icon_card_glyph"
+                        android:layout_height="@dimen/icon_card_glyph"
+                        android:layout_marginStart="@dimen/spacing_xl"
+                        android:src="@drawable/ic_chevron_right"
+                        android:importantForAccessibility="no" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
 
-                        <ImageView
-                            android:layout_width="@dimen/icon_card_glyph"
-                            android:layout_height="@dimen/icon_card_glyph"
-                            android:layout_marginStart="@dimen/spacing_xl"
-                            android:src="@drawable/ic_chevron_right"
-                            android:importantForAccessibility="no" />
-                    </LinearLayout>
-                </com.google.android.material.card.MaterialCardView>
+            <include
+                android:id="@+id/sectionConcepts"
+                layout="@layout/section_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/section_header_gap_above"
+                android:layout_marginBottom="@dimen/section_header_gap_below" />
 
-                <include
-                    android:id="@+id/sectionConcepts"
-                    layout="@layout/section_header"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/section_header_gap_above"
-                    android:layout_marginBottom="@dimen/section_header_gap_below" />
+            <include
+                android:id="@+id/faqWhatIsDish"
+                layout="@layout/help_faq_row" />
+            <include
+                android:id="@+id/faqWhatIsSatellite"
+                layout="@layout/help_faq_row" />
+            <include
+                android:id="@+id/faqLanVsBluetooth"
+                layout="@layout/help_faq_row" />
+            <include
+                android:id="@+id/faqControllerModes"
+                layout="@layout/help_faq_row" />
+            <include
+                android:id="@+id/faqMotionTouchpad"
+                layout="@layout/help_faq_row" />
 
-                <include
-                    android:id="@+id/faqWhatIsDish"
-                    layout="@layout/help_faq_row" />
-                <include
-                    android:id="@+id/faqWhatIsSatellite"
-                    layout="@layout/help_faq_row" />
-                <include
-                    android:id="@+id/faqLanVsBluetooth"
-                    layout="@layout/help_faq_row" />
-                <include
-                    android:id="@+id/faqControllerModes"
-                    layout="@layout/help_faq_row" />
-                <include
-                    android:id="@+id/faqMotionTouchpad"
-                    layout="@layout/help_faq_row" />
+            <include
+                android:id="@+id/sectionPerformance"
+                layout="@layout/section_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/section_header_gap_above"
+                android:layout_marginBottom="@dimen/section_header_gap_below" />
 
-                <include
-                    android:id="@+id/sectionPerformance"
-                    layout="@layout/section_header"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/section_header_gap_above"
-                    android:layout_marginBottom="@dimen/section_header_gap_below" />
+            <include
+                android:id="@+id/faqBestSetup"
+                layout="@layout/help_faq_row" />
+            <include
+                android:id="@+id/faqWhyLanLower"
+                layout="@layout/help_faq_row" />
+            <include
+                android:id="@+id/faqWiredBetter"
+                layout="@layout/help_faq_row" />
 
-                <include
-                    android:id="@+id/faqBestSetup"
-                    layout="@layout/help_faq_row" />
-                <include
-                    android:id="@+id/faqWhyLanLower"
-                    layout="@layout/help_faq_row" />
-                <include
-                    android:id="@+id/faqWiredBetter"
-                    layout="@layout/help_faq_row" />
+            <include
+                android:id="@+id/sectionTrouble"
+                layout="@layout/section_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/section_header_gap_above"
+                android:layout_marginBottom="@dimen/section_header_gap_below" />
 
-                <include
-                    android:id="@+id/sectionTrouble"
-                    layout="@layout/section_header"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/section_header_gap_above"
-                    android:layout_marginBottom="@dimen/section_header_gap_below" />
+            <include
+                android:id="@+id/faqNoSatellites"
+                layout="@layout/help_faq_row" />
+            <include
+                android:id="@+id/faqPinRejected"
+                layout="@layout/help_faq_row" />
+            <include
+                android:id="@+id/faqDisconnects"
+                layout="@layout/help_faq_row" />
+            <include
+                android:id="@+id/faqNoMotion"
+                layout="@layout/help_faq_row" />
+            <include
+                android:id="@+id/faqBatteryDrain"
+                layout="@layout/help_faq_row" />
 
-                <include
-                    android:id="@+id/faqNoSatellites"
-                    layout="@layout/help_faq_row" />
-                <include
-                    android:id="@+id/faqPinRejected"
-                    layout="@layout/help_faq_row" />
-                <include
-                    android:id="@+id/faqDisconnects"
-                    layout="@layout/help_faq_row" />
-                <include
-                    android:id="@+id/faqNoMotion"
-                    layout="@layout/help_faq_row" />
-                <include
-                    android:id="@+id/faqBatteryDrain"
-                    layout="@layout/help_faq_row" />
+            <include
+                android:id="@+id/sectionAbout"
+                layout="@layout/section_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/section_header_gap_above"
+                android:layout_marginBottom="@dimen/section_header_gap_below" />
 
-                <include
-                    android:id="@+id/sectionAbout"
-                    layout="@layout/section_header"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/section_header_gap_above"
-                    android:layout_marginBottom="@dimen/section_header_gap_below" />
+            <include
+                android:id="@+id/faqOpenSource"
+                layout="@layout/help_faq_row" />
+            <include
+                android:id="@+id/faqPrivacy"
+                layout="@layout/help_faq_row" />
 
-                <include
-                    android:id="@+id/faqOpenSource"
-                    layout="@layout/help_faq_row" />
-                <include
-                    android:id="@+id/faqPrivacy"
-                    layout="@layout/help_faq_row" />
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardHelpPrivacy"
+                style="@style/Widget.Dish.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/card_margin_bottom"
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?attr/selectableItemBackground">
 
-                <com.google.android.material.card.MaterialCardView
-                    android:id="@+id/cardHelpPrivacy"
-                    style="@style/Widget.Dish.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/card_margin_bottom"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:foreground="?attr/selectableItemBackground">
+                <LinearLayout
+                    style="@style/Widget.Dish.Card.RowContainer"
+                    android:gravity="center_vertical">
 
-                    <LinearLayout
-                        style="@style/Widget.Dish.Card.RowContainer"
-                        android:gravity="center_vertical">
+                    <include
+                        android:id="@+id/cardRowHelpPrivacy"
+                        layout="@layout/card_row_icon_label_value"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1" />
 
-                        <include
-                            android:id="@+id/cardRowHelpPrivacy"
-                            layout="@layout/card_row_icon_label_value"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1" />
+                    <ImageView
+                        android:layout_width="@dimen/icon_card_glyph"
+                        android:layout_height="@dimen/icon_card_glyph"
+                        android:layout_marginStart="@dimen/spacing_xl"
+                        android:src="@drawable/ic_open_in_new"
+                        android:importantForAccessibility="no" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
 
-                        <ImageView
-                            android:layout_width="@dimen/icon_card_glyph"
-                            android:layout_height="@dimen/icon_card_glyph"
-                            android:layout_marginStart="@dimen/spacing_xl"
-                            android:src="@drawable/ic_open_in_new"
-                            android:importantForAccessibility="no" />
-                    </LinearLayout>
-                </com.google.android.material.card.MaterialCardView>
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardHelpGithub"
+                style="@style/Widget.Dish.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/card_margin_bottom"
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?attr/selectableItemBackground">
 
-                <com.google.android.material.card.MaterialCardView
-                    android:id="@+id/cardHelpGithub"
-                    style="@style/Widget.Dish.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/card_margin_bottom"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:foreground="?attr/selectableItemBackground">
+                <LinearLayout
+                    style="@style/Widget.Dish.Card.RowContainer"
+                    android:gravity="center_vertical">
 
-                    <LinearLayout
-                        style="@style/Widget.Dish.Card.RowContainer"
-                        android:gravity="center_vertical">
+                    <include
+                        android:id="@+id/cardRowHelpGithub"
+                        layout="@layout/card_row_icon_label_value"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1" />
 
-                        <include
-                            android:id="@+id/cardRowHelpGithub"
-                            layout="@layout/card_row_icon_label_value"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1" />
-
-                        <ImageView
-                            android:layout_width="@dimen/icon_card_glyph"
-                            android:layout_height="@dimen/icon_card_glyph"
-                            android:layout_marginStart="@dimen/spacing_xl"
-                            android:src="@drawable/ic_open_in_new"
-                            android:importantForAccessibility="no" />
-                    </LinearLayout>
-                </com.google.android.material.card.MaterialCardView>
-            </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
-    </LinearLayout>
-
-    <include layout="@layout/overlay_low_power_chip" />
-
-    <include layout="@layout/overlay_low_power" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+                    <ImageView
+                        android:layout_width="@dimen/icon_card_glyph"
+                        android:layout_height="@dimen/icon_card_glyph"
+                        android:layout_marginStart="@dimen/spacing_xl"
+                        android:src="@drawable/ic_open_in_new"
+                        android:importantForAccessibility="no" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_help.xml
+++ b/app/src/main/res/layout/activity_help.xml
@@ -209,4 +209,8 @@
             </LinearLayout>
         </androidx.core.widget.NestedScrollView>
     </LinearLayout>
+
+    <include layout="@layout/overlay_low_power_chip" />
+
+    <include layout="@layout/overlay_low_power" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_input_inspector.xml
+++ b/app/src/main/res/layout/activity_input_inspector.xml
@@ -204,4 +204,7 @@
         </androidx.core.widget.NestedScrollView>
     </LinearLayout>
 
+    <include layout="@layout/overlay_low_power_chip" />
+
+    <include layout="@layout/overlay_low_power" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_input_inspector.xml
+++ b/app/src/main/res/layout/activity_input_inspector.xml
@@ -14,197 +14,188 @@
     Polling and the native inspection mirror are armed in onStart and disarmed
     in onStop, so the input path pays nothing while this screen is closed.
 -->
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Dish.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        app:title="@string/inspector_title" />
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/Widget.Dish.Toolbar"
-            android:layout_width="match_parent"
-            app:title="@string/inspector_title" />
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:paddingHorizontal="@dimen/spacing_5xl"
+        android:paddingTop="@dimen/spacing_md"
+        android:paddingBottom="@dimen/spacing_6xl">
 
-        <androidx.core.widget.NestedScrollView
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingTop="@dimen/spacing_md"
-            android:paddingBottom="@dimen/spacing_6xl">
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:orientation="horizontal">
 
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                <com.tinkernorth.dish.ui.diagnostics.StickPlotView
+                    android:id="@+id/plotLeftStick"
+                    android:layout_width="0dp"
+                    android:layout_height="160dp"
+                    android:layout_weight="1"
+                    android:layout_marginEnd="@dimen/spacing_md" />
 
-                    <com.tinkernorth.dish.ui.diagnostics.StickPlotView
-                        android:id="@+id/plotLeftStick"
-                        android:layout_width="0dp"
-                        android:layout_height="160dp"
-                        android:layout_weight="1"
-                        android:layout_marginEnd="@dimen/spacing_md" />
-
-                    <com.tinkernorth.dish.ui.diagnostics.StickPlotView
-                        android:id="@+id/plotRightStick"
-                        android:layout_width="0dp"
-                        android:layout_height="160dp"
-                        android:layout_weight="1" />
-                </LinearLayout>
-
-                <TextView
-                    android:id="@+id/tvRawValues"
-                    style="@style/TextAppearance.Dish.Body"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_xs" />
-
-                <ProgressBar
-                    android:id="@+id/barLeftTrigger"
-                    style="?android:attr/progressBarStyleHorizontal"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_md"
-                    android:max="255" />
-
-                <ProgressBar
-                    android:id="@+id/barRightTrigger"
-                    style="?android:attr/progressBarStyleHorizontal"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:max="255" />
-
-                <TextView
-                    android:id="@+id/tvButtons"
-                    style="@style/TextAppearance.Dish.Body"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_md" />
-
-                <include
-                    android:id="@+id/sectionMotion"
-                    layout="@layout/section_header"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/section_header_gap_above"
-                    android:layout_marginBottom="@dimen/section_header_gap_below" />
-
-                <TextView
-                    android:id="@+id/tvGyro"
-                    style="@style/TextAppearance.Dish.Body"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-                <TextView
-                    android:id="@+id/tvAccel"
-                    style="@style/TextAppearance.Dish.Body"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-                <include
-                    android:id="@+id/sectionTouch"
-                    layout="@layout/section_header"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/section_header_gap_above"
-                    android:layout_marginBottom="@dimen/section_header_gap_below" />
-
-                <com.tinkernorth.dish.ui.diagnostics.TouchPlotView
-                    android:id="@+id/plotTouch"
-                    android:layout_width="match_parent"
-                    android:layout_height="140dp" />
-
-                <TextView
-                    android:id="@+id/tvTouchHint"
-                    style="@style/TextAppearance.Dish.Body"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-                <include
-                    android:id="@+id/sectionTests"
-                    layout="@layout/section_header"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/section_header_gap_above"
-                    android:layout_marginBottom="@dimen/section_header_gap_below" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/btnDriftTest"
-                    style="@style/Widget.Dish.Button.Outlined"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/inspector_drift_button" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/btnRangeTest"
-                    style="@style/Widget.Dish.Button.Outlined"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_md"
-                    android:text="@string/inspector_range_button" />
-
-                <TextView
-                    android:id="@+id/tvTestResult"
-                    style="@style/TextAppearance.Dish.Body"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_md" />
-
-                <include
-                    android:id="@+id/sectionRumble"
-                    layout="@layout/section_header"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/section_header_gap_above"
-                    android:layout_marginBottom="@dimen/section_header_gap_below" />
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
-
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/btnRumbleWeak"
-                        style="@style/Widget.Dish.Button.Outlined"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="@string/inspector_rumble_weak" />
-
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/btnRumbleStrong"
-                        style="@style/Widget.Dish.Button.Outlined"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:layout_marginStart="@dimen/spacing_md"
-                        android:text="@string/inspector_rumble_strong" />
-
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/btnRumbleBoth"
-                        style="@style/Widget.Dish.Button"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:layout_marginStart="@dimen/spacing_md"
-                        android:text="@string/inspector_rumble_both" />
-                </LinearLayout>
-
+                <com.tinkernorth.dish.ui.diagnostics.StickPlotView
+                    android:id="@+id/plotRightStick"
+                    android:layout_width="0dp"
+                    android:layout_height="160dp"
+                    android:layout_weight="1" />
             </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
-    </LinearLayout>
 
-    <include layout="@layout/overlay_low_power_chip" />
+            <TextView
+                android:id="@+id/tvRawValues"
+                style="@style/TextAppearance.Dish.Body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_xs" />
 
-    <include layout="@layout/overlay_low_power" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+            <ProgressBar
+                android:id="@+id/barLeftTrigger"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_md"
+                android:max="255" />
+
+            <ProgressBar
+                android:id="@+id/barRightTrigger"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:max="255" />
+
+            <TextView
+                android:id="@+id/tvButtons"
+                style="@style/TextAppearance.Dish.Body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_md" />
+
+            <include
+                android:id="@+id/sectionMotion"
+                layout="@layout/section_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/section_header_gap_above"
+                android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+            <TextView
+                android:id="@+id/tvGyro"
+                style="@style/TextAppearance.Dish.Body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:id="@+id/tvAccel"
+                style="@style/TextAppearance.Dish.Body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <include
+                android:id="@+id/sectionTouch"
+                layout="@layout/section_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/section_header_gap_above"
+                android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+            <com.tinkernorth.dish.ui.diagnostics.TouchPlotView
+                android:id="@+id/plotTouch"
+                android:layout_width="match_parent"
+                android:layout_height="140dp" />
+
+            <TextView
+                android:id="@+id/tvTouchHint"
+                style="@style/TextAppearance.Dish.Body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <include
+                android:id="@+id/sectionTests"
+                layout="@layout/section_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/section_header_gap_above"
+                android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnDriftTest"
+                style="@style/Widget.Dish.Button.Outlined"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/inspector_drift_button" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnRangeTest"
+                style="@style/Widget.Dish.Button.Outlined"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_md"
+                android:text="@string/inspector_range_button" />
+
+            <TextView
+                android:id="@+id/tvTestResult"
+                style="@style/TextAppearance.Dish.Body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_md" />
+
+            <include
+                android:id="@+id/sectionRumble"
+                layout="@layout/section_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/section_header_gap_above"
+                android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnRumbleWeak"
+                    style="@style/Widget.Dish.Button.Outlined"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/inspector_rumble_weak" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnRumbleStrong"
+                    style="@style/Widget.Dish.Button.Outlined"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="@dimen/spacing_md"
+                    android:text="@string/inspector_rumble_strong" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnRumbleBoth"
+                    style="@style/Widget.Dish.Button"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="@dimen/spacing_md"
+                    android:text="@string/inspector_rumble_both" />
+            </LinearLayout>
+
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_licenses.xml
+++ b/app/src/main/res/layout/activity_licenses.xml
@@ -34,4 +34,7 @@
             android:scrollbars="vertical" />
     </LinearLayout>
 
+    <include layout="@layout/overlay_low_power_chip" />
+
+    <include layout="@layout/overlay_low_power" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_licenses.xml
+++ b/app/src/main/res/layout/activity_licenses.xml
@@ -1,40 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Dish.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        app:title="@string/settings_open_source_licenses_title">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/Widget.Dish.Toolbar"
-            android:layout_width="match_parent"
-            app:title="@string/settings_open_source_licenses_title">
+        <include
+            layout="@layout/view_donate_heart_button"
+            android:layout_width="@dimen/icon_settings_button"
+            android:layout_height="@dimen/icon_settings_button"
+            android:layout_gravity="end" />
+    </com.google.android.material.appbar.MaterialToolbar>
 
-            <include
-                layout="@layout/view_donate_heart_button"
-                android:layout_width="@dimen/icon_settings_button"
-                android:layout_height="@dimen/icon_settings_button"
-                android:layout_gravity="end" />
-        </com.google.android.material.appbar.MaterialToolbar>
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recyclerLicenses"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:clipToPadding="false"
-            android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingTop="@dimen/spacing_md"
-            android:paddingBottom="@dimen/spacing_6xl"
-            android:scrollbars="vertical" />
-    </LinearLayout>
-
-    <include layout="@layout/overlay_low_power_chip" />
-
-    <include layout="@layout/overlay_low_power" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerLicenses"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:clipToPadding="false"
+        android:paddingHorizontal="@dimen/spacing_5xl"
+        android:paddingTop="@dimen/spacing_md"
+        android:paddingBottom="@dimen/spacing_6xl"
+        android:scrollbars="vertical" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -23,427 +23,418 @@
       C.night      → @color/navy_800        → @color/colorSurface
       C.cardStroke → @color/signal_cyan_200 → @color/colorCardStroke  (~12% alpha)
 -->
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Dish.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        app:title="@string/settings_title">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/Widget.Dish.Toolbar"
+        <include
+            layout="@layout/view_donate_heart_button"
+            android:layout_width="@dimen/icon_settings_button"
+            android:layout_height="@dimen/icon_settings_button"
+            android:layout_gravity="end" />
+    </com.google.android.material.appbar.MaterialToolbar>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:paddingHorizontal="@dimen/spacing_5xl"
+        android:paddingTop="@dimen/spacing_md"
+        android:paddingBottom="@dimen/spacing_6xl">
+
+        <LinearLayout
             android:layout_width="match_parent"
-            app:title="@string/settings_title">
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
             <include
-                layout="@layout/view_donate_heart_button"
-                android:layout_width="@dimen/icon_settings_button"
-                android:layout_height="@dimen/icon_settings_button"
-                android:layout_gravity="end" />
-        </com.google.android.material.appbar.MaterialToolbar>
-
-        <androidx.core.widget.NestedScrollView
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingTop="@dimen/spacing_md"
-            android:paddingBottom="@dimen/spacing_6xl">
-
-            <LinearLayout
+                android:id="@+id/sectionSetup"
+                layout="@layout/section_header"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:layout_marginBottom="@dimen/section_header_gap_below" />
 
-                <include
-                    android:id="@+id/sectionSetup"
-                    layout="@layout/section_header"
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardSetupWizard"
+                style="@style/Widget.Dish.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?attr/selectableItemBackground">
+
+                <LinearLayout
+                    style="@style/Widget.Dish.Card.RowContainer"
+                    android:gravity="center_vertical">
+
+                    <include
+                        android:id="@+id/cardRowSetupWizard"
+                        layout="@layout/card_row_icon_label_value"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1" />
+
+                    <ImageView
+                        android:layout_width="@dimen/icon_card_glyph"
+                        android:layout_height="@dimen/icon_card_glyph"
+                        android:layout_marginStart="@dimen/spacing_xl"
+                        android:src="@drawable/ic_chevron_right"
+                        android:importantForAccessibility="no" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardHelp"
+                style="@style/Widget.Dish.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/card_margin_bottom"
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?attr/selectableItemBackground">
+
+                <LinearLayout
+                    style="@style/Widget.Dish.Card.RowContainer"
+                    android:gravity="center_vertical">
+
+                    <include
+                        android:id="@+id/cardRowHelp"
+                        layout="@layout/card_row_icon_label_value"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1" />
+
+                    <ImageView
+                        android:layout_width="@dimen/icon_card_glyph"
+                        android:layout_height="@dimen/icon_card_glyph"
+                        android:layout_marginStart="@dimen/spacing_xl"
+                        android:src="@drawable/ic_chevron_right"
+                        android:importantForAccessibility="no" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <!-- ═══ APPEARANCE ═════════════════════════════════════════
+                 Eyebrow uses the canonical `section_header.xml` include
+                 (label only); SettingsActivity.onCreate sets the text. -->
+            <include
+                android:id="@+id/sectionAppearance"
+                layout="@layout/section_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/section_header_gap_above"
+                android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+            <!-- Theme card. Vertical orientation deviates from the other
+                 Settings cards (which are horizontal `Widget.Dish.Card.RowContainer`
+                 rows): the icon+title+body composite sits on top, then the
+                 three-way chip picker stacks underneath. The horizontal
+                 row container can't host this because the chip group is
+                 wider than any trailing affordance and would push the
+                 icon column off-screen on narrow devices. -->
+            <com.google.android.material.card.MaterialCardView
+                style="@style/Widget.Dish.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/section_header_gap_below" />
+                    android:orientation="vertical"
+                    android:padding="@dimen/card_padding">
 
-                <com.google.android.material.card.MaterialCardView
-                    android:id="@+id/cardSetupWizard"
-                    style="@style/Widget.Dish.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:foreground="?attr/selectableItemBackground">
+                    <!-- Same composite as the Crash + Privacy cards;
+                         SettingsActivity.onCreate sets icon (ic_contrast),
+                         title, and body. -->
+                    <include
+                        android:id="@+id/cardRowAppearance"
+                        layout="@layout/card_row_icon_label_value"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content" />
 
-                    <LinearLayout
-                        style="@style/Widget.Dish.Card.RowContainer"
-                        android:gravity="center_vertical">
-
-                        <include
-                            android:id="@+id/cardRowSetupWizard"
-                            layout="@layout/card_row_icon_label_value"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1" />
-
-                        <ImageView
-                            android:layout_width="@dimen/icon_card_glyph"
-                            android:layout_height="@dimen/icon_card_glyph"
-                            android:layout_marginStart="@dimen/spacing_xl"
-                            android:src="@drawable/ic_chevron_right"
-                            android:importantForAccessibility="no" />
-                    </LinearLayout>
-                </com.google.android.material.card.MaterialCardView>
-
-                <com.google.android.material.card.MaterialCardView
-                    android:id="@+id/cardHelp"
-                    style="@style/Widget.Dish.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/card_margin_bottom"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:foreground="?attr/selectableItemBackground">
-
-                    <LinearLayout
-                        style="@style/Widget.Dish.Card.RowContainer"
-                        android:gravity="center_vertical">
-
-                        <include
-                            android:id="@+id/cardRowHelp"
-                            layout="@layout/card_row_icon_label_value"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1" />
-
-                        <ImageView
-                            android:layout_width="@dimen/icon_card_glyph"
-                            android:layout_height="@dimen/icon_card_glyph"
-                            android:layout_marginStart="@dimen/spacing_xl"
-                            android:src="@drawable/ic_chevron_right"
-                            android:importantForAccessibility="no" />
-                    </LinearLayout>
-                </com.google.android.material.card.MaterialCardView>
-
-                <!-- ═══ APPEARANCE ═════════════════════════════════════════
-                     Eyebrow uses the canonical `section_header.xml` include
-                     (label only); SettingsActivity.onCreate sets the text. -->
-                <include
-                    android:id="@+id/sectionAppearance"
-                    layout="@layout/section_header"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/section_header_gap_above"
-                    android:layout_marginBottom="@dimen/section_header_gap_below" />
-
-                <!-- Theme card. Vertical orientation deviates from the other
-                     Settings cards (which are horizontal `Widget.Dish.Card.RowContainer`
-                     rows): the icon+title+body composite sits on top, then the
-                     three-way chip picker stacks underneath. The horizontal
-                     row container can't host this because the chip group is
-                     wider than any trailing affordance and would push the
-                     icon column off-screen on narrow devices. -->
-                <com.google.android.material.card.MaterialCardView
-                    style="@style/Widget.Dish.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-
-                    <LinearLayout
+                    <!-- Three-way chip picker for ThemeMode: System /
+                         Light / Dark. ChipGroup's `singleSelection` +
+                         `selectionRequired` enforce the invariant that
+                         exactly one chip is checked at any time, so
+                         SettingsActivity only has to map a chip id to a
+                         ThemeMode and persist the choice. The chip style
+                         (`Widget.Dish.Chip`) is the same one the slot
+                         card's inline pickers use, so the cyan-filled
+                         checked / pale-cyan-stroked unchecked treatment
+                         matches the rest of the app. -->
+                    <com.google.android.material.chip.ChipGroup
+                        android:id="@+id/chipGroupTheme"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="vertical"
-                        android:padding="@dimen/card_padding">
+                        android:layout_marginTop="@dimen/spacing_lg"
+                        app:chipSpacingHorizontal="@dimen/chip_margin_end"
+                        app:selectionRequired="true"
+                        app:singleSelection="true">
 
-                        <!-- Same composite as the Crash + Privacy cards;
-                             SettingsActivity.onCreate sets icon (ic_contrast),
-                             title, and body. -->
-                        <include
-                            android:id="@+id/cardRowAppearance"
-                            layout="@layout/card_row_icon_label_value"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content" />
-
-                        <!-- Three-way chip picker for ThemeMode: System /
-                             Light / Dark. ChipGroup's `singleSelection` +
-                             `selectionRequired` enforce the invariant that
-                             exactly one chip is checked at any time, so
-                             SettingsActivity only has to map a chip id to a
-                             ThemeMode and persist the choice. The chip style
-                             (`Widget.Dish.Chip`) is the same one the slot
-                             card's inline pickers use, so the cyan-filled
-                             checked / pale-cyan-stroked unchecked treatment
-                             matches the rest of the app. -->
-                        <com.google.android.material.chip.ChipGroup
-                            android:id="@+id/chipGroupTheme"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/spacing_lg"
-                            app:chipSpacingHorizontal="@dimen/chip_margin_end"
-                            app:selectionRequired="true"
-                            app:singleSelection="true">
-
-                            <com.google.android.material.chip.Chip
-                                android:id="@+id/chipThemeSystem"
-                                style="@style/Widget.Dish.Chip"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/settings_appearance_system" />
-
-                            <com.google.android.material.chip.Chip
-                                android:id="@+id/chipThemeLight"
-                                style="@style/Widget.Dish.Chip"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/settings_appearance_light" />
-
-                            <com.google.android.material.chip.Chip
-                                android:id="@+id/chipThemeDark"
-                                style="@style/Widget.Dish.Chip"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/settings_appearance_dark" />
-                        </com.google.android.material.chip.ChipGroup>
-                    </LinearLayout>
-                </com.google.android.material.card.MaterialCardView>
-
-                <!-- ═══ DIAGNOSTICS ════════════════════════════════════════
-                     Eyebrow uses the canonical `section_header.xml` include
-                     with icon + button hidden by default (`Label.Accent`
-                     label only). SettingsActivity.onCreate sets the label
-                     text. -->
-                <include
-                    android:id="@+id/sectionDiagnostics"
-                    layout="@layout/section_header"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/section_header_gap_above"
-                    android:layout_marginBottom="@dimen/section_header_gap_below" />
-
-                <com.google.android.material.card.MaterialCardView
-                    android:id="@+id/cardDiagnostics"
-                    style="@style/Widget.Dish.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/card_margin_bottom"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:foreground="?attr/selectableItemBackground">
-
-                    <LinearLayout
-                        style="@style/Widget.Dish.Card.RowContainer"
-                        android:gravity="center_vertical">
-
-                        <include
-                            android:id="@+id/cardRowDiagnostics"
-                            layout="@layout/card_row_icon_label_value"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1" />
-
-                        <ImageView
-                            android:layout_width="@dimen/icon_card_glyph"
-                            android:layout_height="@dimen/icon_card_glyph"
-                            android:layout_marginStart="@dimen/spacing_xl"
-                            android:src="@drawable/ic_chevron_right"
-                            android:importantForAccessibility="no" />
-                    </LinearLayout>
-                </com.google.android.material.card.MaterialCardView>
-
-                <com.google.android.material.card.MaterialCardView
-                    style="@style/Widget.Dish.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-
-                    <LinearLayout
-                        style="@style/Widget.Dish.Card.RowContainer"
-                        android:gravity="top">
-
-                        <!-- Leading icon + title/subtitle column. Icon
-                             (`ic_bug`) + title + subtitle text are set in
-                             SettingsActivity.onCreate. The Switch sits as a
-                             sibling so this card keeps the multi-line
-                             gravity=top alignment without the composite
-                             knowing about the trailing affordance. -->
-                        <include
-                            android:id="@+id/cardRowCrash"
-                            layout="@layout/card_row_icon_label_value"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1" />
-
-                        <com.google.android.material.materialswitch.MaterialSwitch
-                            android:id="@+id/switchCrashReporting"
-                            style="@style/Widget.Dish.Switch"
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chipThemeSystem"
+                            style="@style/Widget.Dish.Chip"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_marginStart="@dimen/spacing_xl"
-                            android:layout_marginTop="@dimen/size_2"
-                            android:contentDescription="@string/settings_crash_reporting_title" />
-                    </LinearLayout>
-                </com.google.android.material.card.MaterialCardView>
+                            android:text="@string/settings_appearance_system" />
 
-                <!-- ═══ ABOUT ══════════════════════════════════════════════
-                     Eyebrow uses the canonical `section_header.xml` include.
-                     SettingsActivity.onCreate sets the label text. -->
-                <include
-                    android:id="@+id/sectionAbout"
-                    layout="@layout/section_header"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/section_header_gap_above"
-                    android:layout_marginBottom="@dimen/section_header_gap_below" />
-
-                <com.google.android.material.card.MaterialCardView
-                    android:id="@+id/cardSupport"
-                    style="@style/Widget.Dish.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:foreground="?attr/selectableItemBackground">
-
-                    <LinearLayout
-                        style="@style/Widget.Dish.Card.RowContainer"
-                        android:gravity="center_vertical">
-
-                        <include
-                            android:id="@+id/cardRowSupport"
-                            layout="@layout/card_row_icon_label_value"
-                            android:layout_width="0dp"
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chipThemeLight"
+                            style="@style/Widget.Dish.Chip"
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_weight="1" />
+                            android:text="@string/settings_appearance_light" />
 
-                        <ImageView
-                            android:layout_width="@dimen/icon_card_glyph"
-                            android:layout_height="@dimen/icon_card_glyph"
-                            android:layout_marginStart="@dimen/spacing_xl"
-                            android:src="@drawable/ic_chevron_right"
-                            android:importantForAccessibility="no" />
-                    </LinearLayout>
-                </com.google.android.material.card.MaterialCardView>
-
-                <com.google.android.material.card.MaterialCardView
-                    android:id="@+id/cardPrivacyPolicy"
-                    style="@style/Widget.Dish.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/card_margin_bottom"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:foreground="?attr/selectableItemBackground">
-
-                    <LinearLayout
-                        style="@style/Widget.Dish.Card.RowContainer"
-                        android:gravity="center_vertical">
-
-                        <!-- Leading icon + title/subtitle column. Icon
-                             (`ic_shield`), title, and subtitle URL text +
-                             single-line ellipsizing are wired in
-                             SettingsActivity.onCreate. The subtitle's
-                             TextAppearance is swapped from the composite
-                             default `Body` to `Body.Mono` so the URL renders
-                             in the on-surface mono tone the version row uses. -->
-                        <include
-                            android:id="@+id/cardRowPrivacy"
-                            layout="@layout/card_row_icon_label_value"
-                            android:layout_width="0dp"
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chipThemeDark"
+                            style="@style/Widget.Dish.Chip"
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_weight="1" />
+                            android:text="@string/settings_appearance_dark" />
+                    </com.google.android.material.chip.ChipGroup>
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
 
-                        <ImageView
-                            android:layout_width="@dimen/icon_card_glyph"
-                            android:layout_height="@dimen/icon_card_glyph"
-                            android:layout_marginStart="@dimen/spacing_xl"
-                            android:src="@drawable/ic_open_in_new"
-                            android:importantForAccessibility="no" />
-                    </LinearLayout>
-                </com.google.android.material.card.MaterialCardView>
+            <!-- ═══ DIAGNOSTICS ════════════════════════════════════════
+                 Eyebrow uses the canonical `section_header.xml` include
+                 with icon + button hidden by default (`Label.Accent`
+                 label only). SettingsActivity.onCreate sets the label
+                 text. -->
+            <include
+                android:id="@+id/sectionDiagnostics"
+                layout="@layout/section_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/section_header_gap_above"
+                android:layout_marginBottom="@dimen/section_header_gap_below" />
 
-                <com.google.android.material.card.MaterialCardView
-                    android:id="@+id/cardOpenSourceLicenses"
-                    style="@style/Widget.Dish.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/card_margin_bottom"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:foreground="?attr/selectableItemBackground">
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardDiagnostics"
+                style="@style/Widget.Dish.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/card_margin_bottom"
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?attr/selectableItemBackground">
 
-                    <LinearLayout
-                        style="@style/Widget.Dish.Card.RowContainer"
-                        android:gravity="center_vertical">
+                <LinearLayout
+                    style="@style/Widget.Dish.Card.RowContainer"
+                    android:gravity="center_vertical">
 
-                        <include
-                            android:id="@+id/cardRowOpenSourceLicenses"
-                            layout="@layout/card_row_icon_label_value"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1" />
-
-                        <ImageView
-                            android:layout_width="@dimen/icon_card_glyph"
-                            android:layout_height="@dimen/icon_card_glyph"
-                            android:layout_marginStart="@dimen/spacing_xl"
-                            android:src="@drawable/ic_chevron_right"
-                            android:importantForAccessibility="no" />
-                    </LinearLayout>
-                </com.google.android.material.card.MaterialCardView>
-
-                <com.google.android.material.card.MaterialCardView
-                    style="@style/Widget.Dish.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/card_margin_bottom">
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
+                    <include
+                        android:id="@+id/cardRowDiagnostics"
+                        layout="@layout/card_row_icon_label_value"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:gravity="center_vertical"
-                        android:paddingHorizontal="@dimen/card_padding_horizontal"
-                        android:paddingVertical="@dimen/size_11">
+                        android:layout_weight="1" />
 
-                        <!-- Version label adopts Label and keeps textAllCaps
-                             inline: capitalisation is callsite intent, not a
-                             style-wide concern. -->
-                        <TextView
-                            style="@style/TextAppearance.Dish.Label"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/settings_version_label"
-                            android:textAllCaps="true" />
+                    <ImageView
+                        android:layout_width="@dimen/icon_card_glyph"
+                        android:layout_height="@dimen/icon_card_glyph"
+                        android:layout_marginStart="@dimen/spacing_xl"
+                        android:src="@drawable/ic_chevron_right"
+                        android:importantForAccessibility="no" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
 
-                        <TextView
-                            android:id="@+id/tvVersion"
-                            style="@style/TextAppearance.Dish.Body.Mono"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:layout_marginStart="@dimen/spacing_xl"
-                            android:gravity="end"
-                            android:singleLine="true"
-                            android:ellipsize="end" />
-                    </LinearLayout>
-                </com.google.android.material.card.MaterialCardView>
+            <com.google.android.material.card.MaterialCardView
+                style="@style/Widget.Dish.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
 
-                <!-- Brand footer: stylistic constant, not localised. Adopts
-                     Caption and keeps textAllCaps + alpha + gravity inline
-                     (those are callsite intent, not style-wide concerns). -->
-                <TextView
-                    style="@style/TextAppearance.Dish.Caption"
+                <LinearLayout
+                    style="@style/Widget.Dish.Card.RowContainer"
+                    android:gravity="top">
+
+                    <!-- Leading icon + title/subtitle column. Icon
+                         (`ic_bug`) + title + subtitle text are set in
+                         SettingsActivity.onCreate. The Switch sits as a
+                         sibling so this card keeps the multi-line
+                         gravity=top alignment without the composite
+                         knowing about the trailing affordance. -->
+                    <include
+                        android:id="@+id/cardRowCrash"
+                        layout="@layout/card_row_icon_label_value"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1" />
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/switchCrashReporting"
+                        style="@style/Widget.Dish.Switch"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/spacing_xl"
+                        android:layout_marginTop="@dimen/size_2"
+                        android:contentDescription="@string/settings_crash_reporting_title" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <!-- ═══ ABOUT ══════════════════════════════════════════════
+                 Eyebrow uses the canonical `section_header.xml` include.
+                 SettingsActivity.onCreate sets the label text. -->
+            <include
+                android:id="@+id/sectionAbout"
+                layout="@layout/section_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/section_header_gap_above"
+                android:layout_marginBottom="@dimen/section_header_gap_below" />
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardSupport"
+                style="@style/Widget.Dish.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?attr/selectableItemBackground">
+
+                <LinearLayout
+                    style="@style/Widget.Dish.Card.RowContainer"
+                    android:gravity="center_vertical">
+
+                    <include
+                        android:id="@+id/cardRowSupport"
+                        layout="@layout/card_row_icon_label_value"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1" />
+
+                    <ImageView
+                        android:layout_width="@dimen/icon_card_glyph"
+                        android:layout_height="@dimen/icon_card_glyph"
+                        android:layout_marginStart="@dimen/spacing_xl"
+                        android:src="@drawable/ic_chevron_right"
+                        android:importantForAccessibility="no" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardPrivacyPolicy"
+                style="@style/Widget.Dish.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/card_margin_bottom"
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?attr/selectableItemBackground">
+
+                <LinearLayout
+                    style="@style/Widget.Dish.Card.RowContainer"
+                    android:gravity="center_vertical">
+
+                    <!-- Leading icon + title/subtitle column. Icon
+                         (`ic_shield`), title, and subtitle URL text +
+                         single-line ellipsizing are wired in
+                         SettingsActivity.onCreate. The subtitle's
+                         TextAppearance is swapped from the composite
+                         default `Body` to `Body.Mono` so the URL renders
+                         in the on-surface mono tone the version row uses. -->
+                    <include
+                        android:id="@+id/cardRowPrivacy"
+                        layout="@layout/card_row_icon_label_value"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1" />
+
+                    <ImageView
+                        android:layout_width="@dimen/icon_card_glyph"
+                        android:layout_height="@dimen/icon_card_glyph"
+                        android:layout_marginStart="@dimen/spacing_xl"
+                        android:src="@drawable/ic_open_in_new"
+                        android:importantForAccessibility="no" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardOpenSourceLicenses"
+                style="@style/Widget.Dish.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/card_margin_bottom"
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?attr/selectableItemBackground">
+
+                <LinearLayout
+                    style="@style/Widget.Dish.Card.RowContainer"
+                    android:gravity="center_vertical">
+
+                    <include
+                        android:id="@+id/cardRowOpenSourceLicenses"
+                        layout="@layout/card_row_icon_label_value"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1" />
+
+                    <ImageView
+                        android:layout_width="@dimen/icon_card_glyph"
+                        android:layout_height="@dimen/icon_card_glyph"
+                        android:layout_marginStart="@dimen/spacing_xl"
+                        android:src="@drawable/ic_chevron_right"
+                        android:importantForAccessibility="no" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                style="@style/Widget.Dish.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/card_margin_bottom">
+
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/size_32"
-                    android:text="@string/settings_brand_footer"
-                    android:textAllCaps="true"
-                    android:gravity="center"
-                    android:alpha="0.7" />
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:paddingHorizontal="@dimen/card_padding_horizontal"
+                    android:paddingVertical="@dimen/size_11">
 
-            </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
-    </LinearLayout>
+                    <!-- Version label adopts Label and keeps textAllCaps
+                         inline: capitalisation is callsite intent, not a
+                         style-wide concern. -->
+                    <TextView
+                        style="@style/TextAppearance.Dish.Label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/settings_version_label"
+                        android:textAllCaps="true" />
 
-    <include layout="@layout/overlay_low_power_chip" />
+                    <TextView
+                        android:id="@+id/tvVersion"
+                        style="@style/TextAppearance.Dish.Body.Mono"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:layout_marginStart="@dimen/spacing_xl"
+                        android:gravity="end"
+                        android:singleLine="true"
+                        android:ellipsize="end" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
 
-    <include layout="@layout/overlay_low_power" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+            <!-- Brand footer: stylistic constant, not localised. Adopts
+                 Caption and keeps textAllCaps + alpha + gravity inline
+                 (those are callsite intent, not style-wide concerns). -->
+            <TextView
+                style="@style/TextAppearance.Dish.Caption"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/size_32"
+                android:text="@string/settings_brand_footer"
+                android:textAllCaps="true"
+                android:gravity="center"
+                android:alpha="0.7" />
+
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -443,4 +443,7 @@
         </androidx.core.widget.NestedScrollView>
     </LinearLayout>
 
+    <include layout="@layout/overlay_low_power_chip" />
+
+    <include layout="@layout/overlay_low_power" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_setup_bluetooth_controller.xml
+++ b/app/src/main/res/layout/activity_setup_bluetooth_controller.xml
@@ -1,261 +1,251 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Dish.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        app:title="@string/setup_btc_toolbar" />
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/Widget.Dish.Toolbar"
-            android:layout_width="match_parent"
-            app:title="@string/setup_btc_toolbar" />
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/loader"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:visibility="invisible"
+        app:indicatorColor="@color/colorPrimary"
+        app:trackColor="@color/colorSurfaceVariant" />
 
-        <com.google.android.material.progressindicator.LinearProgressIndicator
-            android:id="@+id/loader"
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:paddingHorizontal="@dimen/spacing_5xl"
+        android:paddingTop="@dimen/spacing_md"
+        android:paddingBottom="@dimen/spacing_5xl">
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:indeterminate="true"
-            android:visibility="invisible"
-            app:indicatorColor="@color/colorPrimary"
-            app:trackColor="@color/colorSurfaceVariant" />
+            android:orientation="vertical">
 
-        <androidx.core.widget.NestedScrollView
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingTop="@dimen/spacing_md"
-            android:paddingBottom="@dimen/spacing_5xl">
+            <include
+                android:id="@+id/breadcrumb"
+                layout="@layout/view_setup_breadcrumb"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
 
-            <LinearLayout
+            <TextView
+                style="@style/TextAppearance.Dish.Title.Large"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:layout_marginTop="@dimen/spacing_5xl"
+                android:text="@string/setup_btc_title" />
 
-                <include
-                    android:id="@+id/breadcrumb"
-                    layout="@layout/view_setup_breadcrumb"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
+            <TextView
+                style="@style/TextAppearance.Dish.Body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_md"
+                android:text="@string/setup_btc_subtitle" />
 
-                <TextView
-                    style="@style/TextAppearance.Dish.Title.Large"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_5xl"
-                    android:text="@string/setup_btc_title" />
+            <!-- Permission gate: amber prompt + locked placeholder -->
+            <LinearLayout
+                android:id="@+id/groupPermission"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginTop="@dimen/spacing_xl"
+                android:visibility="gone"
+                tools:visibility="visible">
 
-                <TextView
-                    style="@style/TextAppearance.Dish.Body"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_md"
-                    android:text="@string/setup_btc_subtitle" />
-
-                <!-- Permission gate: amber prompt + locked placeholder -->
                 <LinearLayout
-                    android:id="@+id/groupPermission"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_marginTop="@dimen/spacing_xl"
-                    android:visibility="gone"
-                    tools:visibility="visible">
+                    android:orientation="horizontal"
+                    android:gravity="top"
+                    android:background="@drawable/bg_setup_callout_warning"
+                    android:padding="@dimen/config_callout_padding">
+
+                    <ImageView
+                        android:layout_width="@dimen/config_callout_icon_size"
+                        android:layout_height="@dimen/config_callout_icon_size"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_bluetooth"
+                        app:tint="@color/colorWarning" />
 
                     <LinearLayout
-                        android:layout_width="match_parent"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:gravity="top"
-                        android:background="@drawable/bg_setup_callout_warning"
-                        android:padding="@dimen/config_callout_padding">
+                        android:layout_weight="1"
+                        android:layout_marginStart="@dimen/config_callout_icon_gap"
+                        android:orientation="vertical">
+
+                        <TextView
+                            style="@style/TextAppearance.Dish.BodySmall"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:textColor="@color/colorOnTertiaryContainer"
+                            android:text="@string/setup_btc_permission_title" />
+
+                        <TextView
+                            style="@style/TextAppearance.Dish.BodySmall"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_xs"
+                            android:textColor="@color/colorOnTertiaryContainer"
+                            android:text="@string/setup_btc_permission_body" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnGrant"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_md"
+                            app:icon="@drawable/ic_chevron_right"
+                            app:iconGravity="end"
+                            android:text="@string/setup_btc_permission_action" />
+                    </LinearLayout>
+                </LinearLayout>
+
+                <com.google.android.material.card.MaterialCardView
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/card_margin_bottom">
+
+                    <LinearLayout
+                        style="@style/Widget.Dish.Card.RowContainer"
+                        android:gravity="center_vertical">
 
                         <ImageView
-                            android:layout_width="@dimen/config_callout_icon_size"
-                            android:layout_height="@dimen/config_callout_icon_size"
+                            android:layout_width="@dimen/icon_picker_glyph"
+                            android:layout_height="@dimen/icon_picker_glyph"
                             android:importantForAccessibility="no"
-                            android:src="@drawable/ic_bluetooth"
-                            app:tint="@color/colorWarning" />
+                            android:src="@drawable/ic_lock"
+                            app:tint="@color/colorMuted" />
+
+                        <TextView
+                            style="@style/TextAppearance.Dish.Body"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:layout_marginStart="@dimen/spacing_2xl"
+                            android:textColor="@color/colorMuted"
+                            android:text="@string/setup_btc_locked_placeholder" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+            </LinearLayout>
+
+            <!-- Granted: pair-new row, "on this phone" eyebrow, bonded list -->
+            <LinearLayout
+                android:id="@+id/groupPaired"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginTop="@dimen/spacing_xl"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardPairNew"
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
+
+                    <LinearLayout
+                        style="@style/Widget.Dish.Card.RowContainer"
+                        android:gravity="center_vertical">
+
+                        <ImageView
+                            android:layout_width="@dimen/icon_picker_glyph"
+                            android:layout_height="@dimen/icon_picker_glyph"
+                            android:importantForAccessibility="no"
+                            android:src="@drawable/ic_add"
+                            app:tint="@color/colorPrimary" />
 
                         <LinearLayout
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
                             android:layout_weight="1"
-                            android:layout_marginStart="@dimen/config_callout_icon_gap"
+                            android:layout_marginStart="@dimen/spacing_2xl"
                             android:orientation="vertical">
 
                             <TextView
-                                style="@style/TextAppearance.Dish.BodySmall"
+                                style="@style/TextAppearance.Dish.Title"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:textColor="@color/colorOnTertiaryContainer"
-                                android:text="@string/setup_btc_permission_title" />
-
-                            <TextView
-                                style="@style/TextAppearance.Dish.BodySmall"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_marginTop="@dimen/spacing_xs"
-                                android:textColor="@color/colorOnTertiaryContainer"
-                                android:text="@string/setup_btc_permission_body" />
-
-                            <com.google.android.material.button.MaterialButton
-                                android:id="@+id/btnGrant"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_marginTop="@dimen/spacing_md"
-                                app:icon="@drawable/ic_chevron_right"
-                                app:iconGravity="end"
-                                android:text="@string/setup_btc_permission_action" />
-                        </LinearLayout>
-                    </LinearLayout>
-
-                    <com.google.android.material.card.MaterialCardView
-                        style="@style/Widget.Dish.Card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/card_margin_bottom">
-
-                        <LinearLayout
-                            style="@style/Widget.Dish.Card.RowContainer"
-                            android:gravity="center_vertical">
-
-                            <ImageView
-                                android:layout_width="@dimen/icon_picker_glyph"
-                                android:layout_height="@dimen/icon_picker_glyph"
-                                android:importantForAccessibility="no"
-                                android:src="@drawable/ic_lock"
-                                app:tint="@color/colorMuted" />
+                                android:text="@string/setup_btc_pair_new_title" />
 
                             <TextView
                                 style="@style/TextAppearance.Dish.Body"
-                                android:layout_width="0dp"
+                                android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:layout_weight="1"
-                                android:layout_marginStart="@dimen/spacing_2xl"
-                                android:textColor="@color/colorMuted"
-                                android:text="@string/setup_btc_locked_placeholder" />
+                                android:layout_marginTop="@dimen/spacing_xs"
+                                android:text="@string/setup_btc_pair_new_body" />
                         </LinearLayout>
-                    </com.google.android.material.card.MaterialCardView>
-                </LinearLayout>
 
-                <!-- Granted: pair-new row, "on this phone" eyebrow, bonded list -->
-                <LinearLayout
-                    android:id="@+id/groupPaired"
+                        <ImageView
+                            android:layout_width="@dimen/icon_chevron_lg"
+                            android:layout_height="@dimen/icon_chevron_lg"
+                            android:layout_marginStart="@dimen/spacing_md"
+                            android:importantForAccessibility="no"
+                            android:src="@drawable/ic_chevron_right"
+                            app:tint="@color/colorMuted" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <TextView
+                    android:id="@+id/eyebrowPaired"
+                    style="@style/TextAppearance.Dish.Label.Micro"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_marginTop="@dimen/spacing_xl"
+                    android:layout_marginTop="@dimen/spacing_3xl"
+                    android:textAllCaps="true"
+                    android:textColor="@color/colorMuted"
+                    android:text="@string/setup_btc_paired_eyebrow" />
+
+                <LinearLayout
+                    android:id="@+id/pairedList"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical" />
+
+                <TextView
+                    android:id="@+id/tvPairedEmpty"
+                    style="@style/TextAppearance.Dish.Body"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_md"
+                    android:textColor="@color/colorMuted"
+                    android:text="@string/setup_btc_paired_empty"
                     android:visibility="gone"
-                    tools:visibility="visible">
-
-                    <com.google.android.material.card.MaterialCardView
-                        android:id="@+id/cardPairNew"
-                        style="@style/Widget.Dish.Card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:clickable="true"
-                        android:focusable="true"
-                        android:foreground="?attr/selectableItemBackground">
-
-                        <LinearLayout
-                            style="@style/Widget.Dish.Card.RowContainer"
-                            android:gravity="center_vertical">
-
-                            <ImageView
-                                android:layout_width="@dimen/icon_picker_glyph"
-                                android:layout_height="@dimen/icon_picker_glyph"
-                                android:importantForAccessibility="no"
-                                android:src="@drawable/ic_add"
-                                app:tint="@color/colorPrimary" />
-
-                            <LinearLayout
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1"
-                                android:layout_marginStart="@dimen/spacing_2xl"
-                                android:orientation="vertical">
-
-                                <TextView
-                                    style="@style/TextAppearance.Dish.Title"
-                                    android:layout_width="match_parent"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/setup_btc_pair_new_title" />
-
-                                <TextView
-                                    style="@style/TextAppearance.Dish.Body"
-                                    android:layout_width="match_parent"
-                                    android:layout_height="wrap_content"
-                                    android:layout_marginTop="@dimen/spacing_xs"
-                                    android:text="@string/setup_btc_pair_new_body" />
-                            </LinearLayout>
-
-                            <ImageView
-                                android:layout_width="@dimen/icon_chevron_lg"
-                                android:layout_height="@dimen/icon_chevron_lg"
-                                android:layout_marginStart="@dimen/spacing_md"
-                                android:importantForAccessibility="no"
-                                android:src="@drawable/ic_chevron_right"
-                                app:tint="@color/colorMuted" />
-                        </LinearLayout>
-                    </com.google.android.material.card.MaterialCardView>
-
-                    <TextView
-                        android:id="@+id/eyebrowPaired"
-                        style="@style/TextAppearance.Dish.Label.Micro"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/spacing_3xl"
-                        android:textAllCaps="true"
-                        android:textColor="@color/colorMuted"
-                        android:text="@string/setup_btc_paired_eyebrow" />
-
-                    <LinearLayout
-                        android:id="@+id/pairedList"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical" />
-
-                    <TextView
-                        android:id="@+id/tvPairedEmpty"
-                        style="@style/TextAppearance.Dish.Body"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/spacing_md"
-                        android:textColor="@color/colorMuted"
-                        android:text="@string/setup_btc_paired_empty"
-                        android:visibility="gone"
-                        tools:visibility="visible" />
-                </LinearLayout>
+                    tools:visibility="visible" />
             </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingVertical="@dimen/spacing_xl"
-            android:gravity="center_vertical">
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/btnBack"
-                style="@style/Widget.Dish.Button.Outlined"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:icon="@drawable/ic_chevron_left"
-                android:text="@string/setup_action_back" />
         </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingHorizontal="@dimen/spacing_5xl"
+        android:paddingVertical="@dimen/spacing_xl"
+        android:gravity="center_vertical">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnBack"
+            style="@style/Widget.Dish.Button.Outlined"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_chevron_left"
+            android:text="@string/setup_action_back" />
     </LinearLayout>
-
-    <include layout="@layout/overlay_low_power_chip" />
-
-    <include layout="@layout/overlay_low_power" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_setup_bluetooth_controller.xml
+++ b/app/src/main/res/layout/activity_setup_bluetooth_controller.xml
@@ -254,4 +254,8 @@
                 android:text="@string/setup_action_back" />
         </LinearLayout>
     </LinearLayout>
+
+    <include layout="@layout/overlay_low_power_chip" />
+
+    <include layout="@layout/overlay_low_power" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_setup_bluetooth_host.xml
+++ b/app/src/main/res/layout/activity_setup_bluetooth_host.xml
@@ -317,4 +317,8 @@
                 android:layout_weight="1" />
         </LinearLayout>
     </LinearLayout>
+
+    <include layout="@layout/overlay_low_power_chip" />
+
+    <include layout="@layout/overlay_low_power" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_setup_bluetooth_host.xml
+++ b/app/src/main/res/layout/activity_setup_bluetooth_host.xml
@@ -1,324 +1,314 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Dish.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        app:title="@string/setup_bth_toolbar" />
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/Widget.Dish.Toolbar"
-            android:layout_width="match_parent"
-            app:title="@string/setup_bth_toolbar" />
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/loader"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:visibility="invisible"
+        app:indicatorColor="@color/colorPrimary"
+        app:trackColor="@color/colorSurfaceVariant" />
 
-        <com.google.android.material.progressindicator.LinearProgressIndicator
-            android:id="@+id/loader"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:indeterminate="true"
-            android:visibility="invisible"
-            app:indicatorColor="@color/colorPrimary"
-            app:trackColor="@color/colorSurfaceVariant" />
-
-        <androidx.core.widget.NestedScrollView
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingTop="@dimen/spacing_md"
-            android:paddingBottom="@dimen/spacing_5xl">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
-
-                <include
-                    android:id="@+id/breadcrumb"
-                    layout="@layout/view_setup_breadcrumb"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-                <TextView
-                    android:id="@+id/tvTitle"
-                    style="@style/TextAppearance.Dish.Title.Large"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_5xl"
-                    tools:text="Which PC?" />
-
-                <LinearLayout
-                    android:id="@+id/groupPickPc"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_marginTop="@dimen/spacing_xl">
-
-                    <TextView
-                        style="@style/TextAppearance.Dish.Body"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:text="@string/setup_bth_pick_pc_subtitle" />
-
-                    <LinearLayout
-                        android:id="@+id/hostContainer"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical"
-                        android:layout_marginTop="@dimen/spacing_sm" />
-
-                    <include
-                        android:id="@+id/rowPairNew"
-                        layout="@layout/setup_choice_row" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:id="@+id/groupPermission"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_marginTop="@dimen/spacing_xl"
-                    android:visibility="gone"
-                    tools:visibility="gone">
-
-                    <TextView
-                        style="@style/TextAppearance.Dish.Body"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:text="@string/setup_bth_permission_body" />
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:gravity="top"
-                        android:layout_marginTop="@dimen/spacing_2xl"
-                        android:background="@drawable/bg_setup_callout_warning"
-                        android:padding="@dimen/config_callout_padding">
-
-                        <ImageView
-                            android:layout_width="@dimen/config_callout_icon_size"
-                            android:layout_height="@dimen/config_callout_icon_size"
-                            android:importantForAccessibility="no"
-                            android:src="@drawable/ic_bluetooth"
-                            app:tint="@color/colorWarning" />
-
-                        <LinearLayout
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="@dimen/config_callout_icon_gap"
-                            android:orientation="vertical">
-
-                            <TextView
-                                style="@style/TextAppearance.Dish.BodySmall"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:textColor="@color/colorOnTertiaryContainer"
-                                android:text="@string/setup_bth_permission_callout_title" />
-
-                            <TextView
-                                style="@style/TextAppearance.Dish.BodySmall"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_marginTop="@dimen/spacing_xs"
-                                android:textColor="@color/colorOnTertiaryContainer"
-                                android:text="@string/setup_bth_permission_callout_body" />
-                        </LinearLayout>
-                    </LinearLayout>
-
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/btnGrant"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/spacing_xl"
-                        app:icon="@drawable/ic_chevron_right"
-                        app:iconGravity="end"
-                        android:text="@string/setup_bth_permission_action" />
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:gravity="center_vertical"
-                        android:layout_marginTop="@dimen/spacing_2xl">
-
-                        <ImageView
-                            android:layout_width="@dimen/config_callout_icon_size"
-                            android:layout_height="@dimen/config_callout_icon_size"
-                            android:importantForAccessibility="no"
-                            android:src="@drawable/ic_lock"
-                            app:tint="@color/colorMuted" />
-
-                        <TextView
-                            style="@style/TextAppearance.Dish.BodySmall"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="@dimen/spacing_sm"
-                            android:textColor="@color/colorMuted"
-                            android:text="@string/setup_bth_type_locked_until_permission" />
-                    </LinearLayout>
-                </LinearLayout>
-
-                <LinearLayout
-                    android:id="@+id/groupPickType"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_marginTop="@dimen/spacing_xl"
-                    android:visibility="gone"
-                    tools:visibility="gone">
-
-                    <TextView
-                        style="@style/TextAppearance.Dish.Body"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:text="@string/setup_bth_pick_type_subtitle" />
-
-                    <include
-                        android:id="@+id/cardXbox"
-                        layout="@layout/setup_type_card" />
-
-                    <include
-                        android:id="@+id/cardPlaystation"
-                        layout="@layout/setup_type_card" />
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:gravity="top"
-                        android:layout_marginTop="@dimen/spacing_2xl">
-
-                        <ImageView
-                            android:layout_width="@dimen/config_callout_icon_size"
-                            android:layout_height="@dimen/config_callout_icon_size"
-                            android:importantForAccessibility="no"
-                            android:src="@drawable/ic_lock"
-                            app:tint="@color/colorMuted" />
-
-                        <TextView
-                            style="@style/TextAppearance.Dish.BodySmall"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:layout_marginStart="@dimen/spacing_sm"
-                            android:textColor="@color/colorMuted"
-                            android:text="@string/setup_bth_type_lock_note" />
-                    </LinearLayout>
-                </LinearLayout>
-
-                <LinearLayout
-                    android:id="@+id/groupAdvertising"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_marginTop="@dimen/spacing_xl"
-                    android:visibility="gone"
-                    tools:visibility="gone">
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:gravity="center_vertical"
-                        android:background="@drawable/bg_setup_callout_warning"
-                        android:padding="@dimen/config_callout_padding">
-
-                        <ImageView
-                            android:layout_width="@dimen/config_callout_icon_size"
-                            android:layout_height="@dimen/config_callout_icon_size"
-                            android:importantForAccessibility="no"
-                            android:src="@drawable/ic_gamepad"
-                            app:tint="@color/colorPrimary" />
-
-                        <TextView
-                            android:id="@+id/tvAdvertisingType"
-                            style="@style/TextAppearance.Dish.BodySmall"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="@dimen/config_callout_icon_gap"
-                            android:textColor="@color/colorOnTertiaryContainer"
-                            tools:text="Set to Xbox controller" />
-                    </LinearLayout>
-
-                    <TextView
-                        android:id="@+id/tvAdvertisingBody"
-                        style="@style/TextAppearance.Dish.Body"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/spacing_2xl"
-                        tools:text="On the PC open Bluetooth, choose Add a device, and pick &quot;Dish Xbox Controller&quot;." />
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:gravity="center_vertical"
-                        android:layout_marginTop="@dimen/spacing_2xl">
-
-                        <ImageView
-                            android:id="@+id/icDiscoverable"
-                            android:layout_width="@dimen/icon_card_glyph"
-                            android:layout_height="@dimen/icon_card_glyph"
-                            android:importantForAccessibility="no"
-                            android:src="@drawable/ic_bluetooth_searching"
-                            app:tint="@color/colorMuted" />
-
-                        <TextView
-                            android:id="@+id/tvDiscoverable"
-                            style="@style/TextAppearance.Dish.Label"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:layout_marginStart="@dimen/spacing_md"
-                            android:textAllCaps="true"
-                            tools:text="Waiting for your PC" />
-                    </LinearLayout>
-
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/btnTryAgain"
-                        style="@style/Widget.Dish.Button.Outlined"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/spacing_xl"
-                        app:icon="@drawable/ic_refresh"
-                        android:text="@string/setup_bth_discoverable_retry"
-                        android:visibility="gone"
-                        tools:visibility="visible" />
-                </LinearLayout>
-            </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:paddingHorizontal="@dimen/spacing_5xl"
+        android:paddingTop="@dimen/spacing_md"
+        android:paddingBottom="@dimen/spacing_5xl">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingVertical="@dimen/spacing_xl"
-            android:gravity="center_vertical">
+            android:orientation="vertical">
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/btnBack"
-                style="@style/Widget.Dish.Button.Outlined"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:icon="@drawable/ic_chevron_left"
-                android:text="@string/setup_action_back" />
+            <include
+                android:id="@+id/breadcrumb"
+                layout="@layout/view_setup_breadcrumb"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
 
-            <Space
-                android:layout_width="0dp"
+            <TextView
+                android:id="@+id/tvTitle"
+                style="@style/TextAppearance.Dish.Title.Large"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1" />
+                android:layout_marginTop="@dimen/spacing_5xl"
+                tools:text="Which PC?" />
+
+            <LinearLayout
+                android:id="@+id/groupPickPc"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginTop="@dimen/spacing_xl">
+
+                <TextView
+                    style="@style/TextAppearance.Dish.Body"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/setup_bth_pick_pc_subtitle" />
+
+                <LinearLayout
+                    android:id="@+id/hostContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_marginTop="@dimen/spacing_sm" />
+
+                <include
+                    android:id="@+id/rowPairNew"
+                    layout="@layout/setup_choice_row" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/groupPermission"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginTop="@dimen/spacing_xl"
+                android:visibility="gone"
+                tools:visibility="gone">
+
+                <TextView
+                    style="@style/TextAppearance.Dish.Body"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/setup_bth_permission_body" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="top"
+                    android:layout_marginTop="@dimen/spacing_2xl"
+                    android:background="@drawable/bg_setup_callout_warning"
+                    android:padding="@dimen/config_callout_padding">
+
+                    <ImageView
+                        android:layout_width="@dimen/config_callout_icon_size"
+                        android:layout_height="@dimen/config_callout_icon_size"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_bluetooth"
+                        app:tint="@color/colorWarning" />
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/config_callout_icon_gap"
+                        android:orientation="vertical">
+
+                        <TextView
+                            style="@style/TextAppearance.Dish.BodySmall"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textColor="@color/colorOnTertiaryContainer"
+                            android:text="@string/setup_bth_permission_callout_title" />
+
+                        <TextView
+                            style="@style/TextAppearance.Dish.BodySmall"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_xs"
+                            android:textColor="@color/colorOnTertiaryContainer"
+                            android:text="@string/setup_bth_permission_callout_body" />
+                    </LinearLayout>
+                </LinearLayout>
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnGrant"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_xl"
+                    app:icon="@drawable/ic_chevron_right"
+                    app:iconGravity="end"
+                    android:text="@string/setup_bth_permission_action" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:layout_marginTop="@dimen/spacing_2xl">
+
+                    <ImageView
+                        android:layout_width="@dimen/config_callout_icon_size"
+                        android:layout_height="@dimen/config_callout_icon_size"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_lock"
+                        app:tint="@color/colorMuted" />
+
+                    <TextView
+                        style="@style/TextAppearance.Dish.BodySmall"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/spacing_sm"
+                        android:textColor="@color/colorMuted"
+                        android:text="@string/setup_bth_type_locked_until_permission" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/groupPickType"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginTop="@dimen/spacing_xl"
+                android:visibility="gone"
+                tools:visibility="gone">
+
+                <TextView
+                    style="@style/TextAppearance.Dish.Body"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/setup_bth_pick_type_subtitle" />
+
+                <include
+                    android:id="@+id/cardXbox"
+                    layout="@layout/setup_type_card" />
+
+                <include
+                    android:id="@+id/cardPlaystation"
+                    layout="@layout/setup_type_card" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="top"
+                    android:layout_marginTop="@dimen/spacing_2xl">
+
+                    <ImageView
+                        android:layout_width="@dimen/config_callout_icon_size"
+                        android:layout_height="@dimen/config_callout_icon_size"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_lock"
+                        app:tint="@color/colorMuted" />
+
+                    <TextView
+                        style="@style/TextAppearance.Dish.BodySmall"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:layout_marginStart="@dimen/spacing_sm"
+                        android:textColor="@color/colorMuted"
+                        android:text="@string/setup_bth_type_lock_note" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/groupAdvertising"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginTop="@dimen/spacing_xl"
+                android:visibility="gone"
+                tools:visibility="gone">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:background="@drawable/bg_setup_callout_warning"
+                    android:padding="@dimen/config_callout_padding">
+
+                    <ImageView
+                        android:layout_width="@dimen/config_callout_icon_size"
+                        android:layout_height="@dimen/config_callout_icon_size"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_gamepad"
+                        app:tint="@color/colorPrimary" />
+
+                    <TextView
+                        android:id="@+id/tvAdvertisingType"
+                        style="@style/TextAppearance.Dish.BodySmall"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/config_callout_icon_gap"
+                        android:textColor="@color/colorOnTertiaryContainer"
+                        tools:text="Set to Xbox controller" />
+                </LinearLayout>
+
+                <TextView
+                    android:id="@+id/tvAdvertisingBody"
+                    style="@style/TextAppearance.Dish.Body"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_2xl"
+                    tools:text="On the PC open Bluetooth, choose Add a device, and pick &quot;Dish Xbox Controller&quot;." />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:layout_marginTop="@dimen/spacing_2xl">
+
+                    <ImageView
+                        android:id="@+id/icDiscoverable"
+                        android:layout_width="@dimen/icon_card_glyph"
+                        android:layout_height="@dimen/icon_card_glyph"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_bluetooth_searching"
+                        app:tint="@color/colorMuted" />
+
+                    <TextView
+                        android:id="@+id/tvDiscoverable"
+                        style="@style/TextAppearance.Dish.Label"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:layout_marginStart="@dimen/spacing_md"
+                        android:textAllCaps="true"
+                        tools:text="Waiting for your PC" />
+                </LinearLayout>
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnTryAgain"
+                    style="@style/Widget.Dish.Button.Outlined"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_xl"
+                    app:icon="@drawable/ic_refresh"
+                    android:text="@string/setup_bth_discoverable_retry"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+            </LinearLayout>
         </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingHorizontal="@dimen/spacing_5xl"
+        android:paddingVertical="@dimen/spacing_xl"
+        android:gravity="center_vertical">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnBack"
+            style="@style/Widget.Dish.Button.Outlined"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_chevron_left"
+            android:text="@string/setup_action_back" />
+
+        <Space
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1" />
     </LinearLayout>
-
-    <include layout="@layout/overlay_low_power_chip" />
-
-    <include layout="@layout/overlay_low_power" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_setup_configure.xml
+++ b/app/src/main/res/layout/activity_setup_configure.xml
@@ -312,4 +312,8 @@
                 android:text="@string/setup_cfg_continue" />
         </LinearLayout>
     </LinearLayout>
+
+    <include layout="@layout/overlay_low_power_chip" />
+
+    <include layout="@layout/overlay_low_power" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_setup_configure.xml
+++ b/app/src/main/res/layout/activity_setup_configure.xml
@@ -1,319 +1,309 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Dish.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        app:title="@string/setup_cfg_toolbar" />
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/Widget.Dish.Toolbar"
-            android:layout_width="match_parent"
-            app:title="@string/setup_cfg_toolbar" />
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/loader"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:visibility="invisible"
+        app:indicatorColor="@color/colorPrimary"
+        app:trackColor="@color/colorSurfaceVariant" />
 
-        <com.google.android.material.progressindicator.LinearProgressIndicator
-            android:id="@+id/loader"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:indeterminate="true"
-            android:visibility="invisible"
-            app:indicatorColor="@color/colorPrimary"
-            app:trackColor="@color/colorSurfaceVariant" />
-
-        <androidx.core.widget.NestedScrollView
-            android:id="@+id/scroll"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingTop="@dimen/spacing_md"
-            android:paddingBottom="@dimen/spacing_5xl">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
-
-                <include
-                    android:id="@+id/breadcrumb"
-                    layout="@layout/view_setup_breadcrumb"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-                <TextView
-                    android:id="@+id/tvTitle"
-                    style="@style/TextAppearance.Dish.Title.Large"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_5xl"
-                    tools:text="How should the PC see it?" />
-
-                <TextView
-                    android:id="@+id/tvSubtitle"
-                    style="@style/TextAppearance.Dish.Body"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_xs"
-                    tools:text="Pick the controller the PC should report." />
-
-                <LinearLayout
-                    android:id="@+id/groupType"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_marginTop="@dimen/spacing_xl">
-
-                    <include
-                        android:id="@+id/cardTypeXbox"
-                        layout="@layout/setup_type_card" />
-
-                    <include
-                        android:id="@+id/cardTypePlaystation"
-                        layout="@layout/setup_type_card" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:id="@+id/groupFeel"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_marginTop="@dimen/spacing_xl"
-                    android:visibility="gone"
-                    tools:visibility="gone">
-
-                    <LinearLayout
-                        android:id="@+id/touchpadRow"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
-                        android:visibility="gone"
-                        tools:visibility="visible">
-
-                        <ImageView
-                            android:layout_width="@dimen/config_row_icon_size"
-                            android:layout_height="@dimen/config_row_icon_size"
-                            android:layout_marginEnd="@dimen/config_row_icon_gap"
-                            android:importantForAccessibility="no"
-                            android:src="@drawable/ic_touchpad"
-                            app:tint="@color/colorPrimary" />
-
-                        <TextView
-                            style="@style/TextAppearance.Dish.Body"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:text="@string/binding_func_touchpad"
-                            android:textColor="@color/colorOnSurface" />
-
-                        <LinearLayout
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:background="@drawable/bg_binding_segmented"
-                            android:divider="@drawable/binding_segment_divider"
-                            android:orientation="horizontal"
-                            android:showDividers="middle">
-
-                            <TextView
-                                android:id="@+id/segOff"
-                                style="@style/Widget.Dish.Segment"
-                                android:text="@string/touchpad_mode_off" />
-
-                            <TextView
-                                android:id="@+id/segPad"
-                                style="@style/Widget.Dish.Segment"
-                                android:text="@string/touchpad_mode_pad" />
-
-                            <TextView
-                                android:id="@+id/segMouse"
-                                style="@style/Widget.Dish.Segment"
-                                android:text="@string/touchpad_mode_mouse" />
-                        </LinearLayout>
-                    </LinearLayout>
-
-                    <View
-                        android:id="@+id/motionDivider"
-                        style="@style/Widget.Dish.Divider"
-                        android:layout_marginTop="@dimen/config_row_gap"
-                        android:layout_marginBottom="@dimen/config_row_gap"
-                        android:visibility="gone"
-                        tools:visibility="visible" />
-
-                    <LinearLayout
-                        android:id="@+id/motionRow"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
-                        android:visibility="gone"
-                        tools:visibility="visible">
-
-                        <ImageView
-                            android:layout_width="@dimen/config_row_icon_size"
-                            android:layout_height="@dimen/config_row_icon_size"
-                            android:layout_marginEnd="@dimen/config_row_icon_gap"
-                            android:importantForAccessibility="no"
-                            android:src="@drawable/ic_motion"
-                            app:tint="@color/colorPrimary" />
-
-                        <LinearLayout
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:orientation="vertical">
-
-                            <TextView
-                                style="@style/TextAppearance.Dish.Body"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/binding_func_motion"
-                                android:textColor="@color/colorOnSurface" />
-
-                            <TextView
-                                style="@style/TextAppearance.Dish.BodySmall"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/setup_cfg_feel_motion_body"
-                                android:textColor="@color/colorOnSurfaceVariant" />
-                        </LinearLayout>
-
-                        <com.google.android.material.materialswitch.MaterialSwitch
-                            android:id="@+id/swMotion"
-                            style="@style/Widget.Dish.Switch"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content" />
-                    </LinearLayout>
-
-                    <View
-                        android:id="@+id/rumbleDivider"
-                        style="@style/Widget.Dish.Divider"
-                        android:layout_marginTop="@dimen/config_row_gap"
-                        android:layout_marginBottom="@dimen/config_row_gap"
-                        android:visibility="gone"
-                        tools:visibility="visible" />
-
-                    <LinearLayout
-                        android:id="@+id/rumbleRow"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
-                        android:visibility="gone"
-                        tools:visibility="visible">
-
-                        <ImageView
-                            android:layout_width="@dimen/config_row_icon_size"
-                            android:layout_height="@dimen/config_row_icon_size"
-                            android:layout_marginEnd="@dimen/config_row_icon_gap"
-                            android:importantForAccessibility="no"
-                            android:src="@drawable/ic_rumble"
-                            app:tint="@color/colorPrimary" />
-
-                        <LinearLayout
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:orientation="vertical">
-
-                            <TextView
-                                style="@style/TextAppearance.Dish.Body"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/binding_func_rumble"
-                                android:textColor="@color/colorOnSurface" />
-
-                            <TextView
-                                style="@style/TextAppearance.Dish.BodySmall"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/setup_cfg_feel_rumble_body"
-                                android:textColor="@color/colorOnSurfaceVariant" />
-                        </LinearLayout>
-
-                        <com.google.android.material.materialswitch.MaterialSwitch
-                            android:id="@+id/swRumble"
-                            style="@style/Widget.Dish.Switch"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content" />
-                    </LinearLayout>
-
-                    <TextView
-                        android:id="@+id/tvFeelEmpty"
-                        style="@style/TextAppearance.Dish.Body"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:text="@string/setup_cfg_feel_empty"
-                        android:textColor="@color/colorOnSurfaceVariant"
-                        android:visibility="gone"
-                        tools:visibility="visible" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:id="@+id/groupReview"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_marginTop="@dimen/spacing_xl"
-                    android:visibility="gone"
-                    tools:visibility="gone">
-
-                    <LinearLayout
-                        android:id="@+id/reviewContainer"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical" />
-                </LinearLayout>
-            </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/scroll"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:paddingHorizontal="@dimen/spacing_5xl"
+        android:paddingTop="@dimen/spacing_md"
+        android:paddingBottom="@dimen/spacing_5xl">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingVertical="@dimen/spacing_xl"
-            android:gravity="center_vertical">
+            android:orientation="vertical">
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/btnBack"
-                style="@style/Widget.Dish.Button.Outlined"
-                android:layout_width="wrap_content"
+            <include
+                android:id="@+id/breadcrumb"
+                layout="@layout/view_setup_breadcrumb"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:id="@+id/tvTitle"
+                style="@style/TextAppearance.Dish.Title.Large"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:icon="@drawable/ic_chevron_left"
-                android:text="@string/setup_action_back" />
+                android:layout_marginTop="@dimen/spacing_5xl"
+                tools:text="How should the PC see it?" />
 
-            <Space
-                android:layout_width="0dp"
+            <TextView
+                android:id="@+id/tvSubtitle"
+                style="@style/TextAppearance.Dish.Body"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1" />
+                android:layout_marginTop="@dimen/spacing_xs"
+                tools:text="Pick the controller the PC should report." />
 
-            <ProgressBar
-                android:id="@+id/btnBindProgress"
-                android:layout_width="@dimen/binding_edge_spinner_size"
-                android:layout_height="@dimen/binding_edge_spinner_size"
-                android:layout_marginEnd="@dimen/spacing_md"
-                android:indeterminate="true"
-                android:indeterminateTint="@color/colorPrimary"
+            <LinearLayout
+                android:id="@+id/groupType"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginTop="@dimen/spacing_xl">
+
+                <include
+                    android:id="@+id/cardTypeXbox"
+                    layout="@layout/setup_type_card" />
+
+                <include
+                    android:id="@+id/cardTypePlaystation"
+                    layout="@layout/setup_type_card" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/groupFeel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginTop="@dimen/spacing_xl"
                 android:visibility="gone"
-                tools:visibility="visible" />
+                tools:visibility="gone">
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/btnContinue"
-                android:layout_width="wrap_content"
+                <LinearLayout
+                    android:id="@+id/touchpadRow"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:visibility="gone"
+                    tools:visibility="visible">
+
+                    <ImageView
+                        android:layout_width="@dimen/config_row_icon_size"
+                        android:layout_height="@dimen/config_row_icon_size"
+                        android:layout_marginEnd="@dimen/config_row_icon_gap"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_touchpad"
+                        app:tint="@color/colorPrimary" />
+
+                    <TextView
+                        style="@style/TextAppearance.Dish.Body"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/binding_func_touchpad"
+                        android:textColor="@color/colorOnSurface" />
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/bg_binding_segmented"
+                        android:divider="@drawable/binding_segment_divider"
+                        android:orientation="horizontal"
+                        android:showDividers="middle">
+
+                        <TextView
+                            android:id="@+id/segOff"
+                            style="@style/Widget.Dish.Segment"
+                            android:text="@string/touchpad_mode_off" />
+
+                        <TextView
+                            android:id="@+id/segPad"
+                            style="@style/Widget.Dish.Segment"
+                            android:text="@string/touchpad_mode_pad" />
+
+                        <TextView
+                            android:id="@+id/segMouse"
+                            style="@style/Widget.Dish.Segment"
+                            android:text="@string/touchpad_mode_mouse" />
+                    </LinearLayout>
+                </LinearLayout>
+
+                <View
+                    android:id="@+id/motionDivider"
+                    style="@style/Widget.Dish.Divider"
+                    android:layout_marginTop="@dimen/config_row_gap"
+                    android:layout_marginBottom="@dimen/config_row_gap"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
+                <LinearLayout
+                    android:id="@+id/motionRow"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:visibility="gone"
+                    tools:visibility="visible">
+
+                    <ImageView
+                        android:layout_width="@dimen/config_row_icon_size"
+                        android:layout_height="@dimen/config_row_icon_size"
+                        android:layout_marginEnd="@dimen/config_row_icon_gap"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_motion"
+                        app:tint="@color/colorPrimary" />
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            style="@style/TextAppearance.Dish.Body"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/binding_func_motion"
+                            android:textColor="@color/colorOnSurface" />
+
+                        <TextView
+                            style="@style/TextAppearance.Dish.BodySmall"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/setup_cfg_feel_motion_body"
+                            android:textColor="@color/colorOnSurfaceVariant" />
+                    </LinearLayout>
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/swMotion"
+                        style="@style/Widget.Dish.Switch"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content" />
+                </LinearLayout>
+
+                <View
+                    android:id="@+id/rumbleDivider"
+                    style="@style/Widget.Dish.Divider"
+                    android:layout_marginTop="@dimen/config_row_gap"
+                    android:layout_marginBottom="@dimen/config_row_gap"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
+                <LinearLayout
+                    android:id="@+id/rumbleRow"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:visibility="gone"
+                    tools:visibility="visible">
+
+                    <ImageView
+                        android:layout_width="@dimen/config_row_icon_size"
+                        android:layout_height="@dimen/config_row_icon_size"
+                        android:layout_marginEnd="@dimen/config_row_icon_gap"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_rumble"
+                        app:tint="@color/colorPrimary" />
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            style="@style/TextAppearance.Dish.Body"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/binding_func_rumble"
+                            android:textColor="@color/colorOnSurface" />
+
+                        <TextView
+                            style="@style/TextAppearance.Dish.BodySmall"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/setup_cfg_feel_rumble_body"
+                            android:textColor="@color/colorOnSurfaceVariant" />
+                    </LinearLayout>
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/swRumble"
+                        style="@style/Widget.Dish.Switch"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content" />
+                </LinearLayout>
+
+                <TextView
+                    android:id="@+id/tvFeelEmpty"
+                    style="@style/TextAppearance.Dish.Body"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/setup_cfg_feel_empty"
+                    android:textColor="@color/colorOnSurfaceVariant"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/groupReview"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:icon="@drawable/ic_chevron_right"
-                app:iconGravity="end"
-                android:text="@string/setup_cfg_continue" />
+                android:orientation="vertical"
+                android:layout_marginTop="@dimen/spacing_xl"
+                android:visibility="gone"
+                tools:visibility="gone">
+
+                <LinearLayout
+                    android:id="@+id/reviewContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical" />
+            </LinearLayout>
         </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingHorizontal="@dimen/spacing_5xl"
+        android:paddingVertical="@dimen/spacing_xl"
+        android:gravity="center_vertical">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnBack"
+            style="@style/Widget.Dish.Button.Outlined"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_chevron_left"
+            android:text="@string/setup_action_back" />
+
+        <Space
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1" />
+
+        <ProgressBar
+            android:id="@+id/btnBindProgress"
+            android:layout_width="@dimen/binding_edge_spinner_size"
+            android:layout_height="@dimen/binding_edge_spinner_size"
+            android:layout_marginEnd="@dimen/spacing_md"
+            android:indeterminate="true"
+            android:indeterminateTint="@color/colorPrimary"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnContinue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_chevron_right"
+            app:iconGravity="end"
+            android:text="@string/setup_cfg_continue" />
     </LinearLayout>
-
-    <include layout="@layout/overlay_low_power_chip" />
-
-    <include layout="@layout/overlay_low_power" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_setup_connection.xml
+++ b/app/src/main/res/layout/activity_setup_connection.xml
@@ -171,4 +171,8 @@
                 tools:visibility="visible" />
         </LinearLayout>
     </LinearLayout>
+
+    <include layout="@layout/overlay_low_power_chip" />
+
+    <include layout="@layout/overlay_low_power" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_setup_connection.xml
+++ b/app/src/main/res/layout/activity_setup_connection.xml
@@ -1,178 +1,168 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Dish.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        app:title="@string/setup_conn_toolbar" />
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/Widget.Dish.Toolbar"
-            android:layout_width="match_parent"
-            app:title="@string/setup_conn_toolbar" />
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/loader"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:visibility="invisible"
+        app:indicatorColor="@color/colorPrimary"
+        app:trackColor="@color/colorSurfaceVariant" />
 
-        <com.google.android.material.progressindicator.LinearProgressIndicator
-            android:id="@+id/loader"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:indeterminate="true"
-            android:visibility="invisible"
-            app:indicatorColor="@color/colorPrimary"
-            app:trackColor="@color/colorSurfaceVariant" />
-
-        <androidx.core.widget.NestedScrollView
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingTop="@dimen/spacing_md"
-            android:paddingBottom="@dimen/spacing_5xl">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
-
-                <include
-                    android:id="@+id/breadcrumb"
-                    layout="@layout/view_setup_breadcrumb"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-                <TextView
-                    android:id="@+id/tvTitle"
-                    style="@style/TextAppearance.Dish.Title.Large"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_5xl"
-                    tools:text="How does input reach your PC?" />
-
-                <LinearLayout
-                    android:id="@+id/groupPath"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_marginTop="@dimen/spacing_xl">
-
-                    <TextView
-                        style="@style/TextAppearance.Dish.Body"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:text="@string/setup_conn_path_subtitle" />
-
-                    <include
-                        android:id="@+id/cardSatellite"
-                        layout="@layout/setup_choice_row" />
-
-                    <include
-                        android:id="@+id/cardBluetoothHost"
-                        layout="@layout/setup_choice_row" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:id="@+id/groupSatellite"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_marginTop="@dimen/spacing_xl"
-                    android:visibility="gone"
-                    tools:visibility="visible">
-
-                    <TextView
-                        android:id="@+id/tvScanEyebrow"
-                        style="@style/TextAppearance.Dish.Label.Accent"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/setup_conn_scanning_eyebrow"
-                        android:visibility="gone"
-                        tools:visibility="visible" />
-
-                    <LinearLayout
-                        android:id="@+id/hostList"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical"
-                        android:layout_marginTop="@dimen/spacing_md" />
-
-                    <!-- "Don't see your PC?" help. Shown while the list is empty
-                         or still scanning; the button opens the project's GitHub. -->
-                    <LinearLayout
-                        android:id="@+id/groupGetSatellite"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical"
-                        android:layout_marginTop="@dimen/spacing_2xl"
-                        android:background="@drawable/bg_setup_callout_warning"
-                        android:padding="@dimen/card_padding">
-
-                        <TextView
-                            style="@style/TextAppearance.Dish.Title"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="@string/setup_conn_missing_title" />
-
-                        <TextView
-                            style="@style/TextAppearance.Dish.BodySmall"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/spacing_xs"
-                            android:textColor="@color/colorOnTertiaryContainer"
-                            android:text="@string/setup_conn_missing_body" />
-
-                        <com.google.android.material.button.MaterialButton
-                            android:id="@+id/btnGetSatellite"
-                            style="@style/Widget.Dish.Button.Text"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/spacing_md"
-                            app:icon="@drawable/ic_open_in_new"
-                            app:iconGravity="end"
-                            android:text="@string/setup_conn_get_satellite" />
-                    </LinearLayout>
-                </LinearLayout>
-            </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:paddingHorizontal="@dimen/spacing_5xl"
+        android:paddingTop="@dimen/spacing_md"
+        android:paddingBottom="@dimen/spacing_5xl">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingVertical="@dimen/spacing_xl"
-            android:gravity="center_vertical">
+            android:orientation="vertical">
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/btnBack"
-                style="@style/Widget.Dish.Button.Outlined"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:icon="@drawable/ic_chevron_left"
-                android:text="@string/setup_action_back" />
+            <include
+                android:id="@+id/breadcrumb"
+                layout="@layout/view_setup_breadcrumb"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
 
-            <Space
-                android:layout_width="0dp"
+            <TextView
+                android:id="@+id/tvTitle"
+                style="@style/TextAppearance.Dish.Title.Large"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1" />
+                android:layout_marginTop="@dimen/spacing_5xl"
+                tools:text="How does input reach your PC?" />
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/btnRescan"
-                style="@style/Widget.Dish.Button.Outlined"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:id="@+id/groupPath"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:icon="@drawable/ic_refresh"
-                android:text="@string/setup_conn_rescan"
+                android:orientation="vertical"
+                android:layout_marginTop="@dimen/spacing_xl">
+
+                <TextView
+                    style="@style/TextAppearance.Dish.Body"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/setup_conn_path_subtitle" />
+
+                <include
+                    android:id="@+id/cardSatellite"
+                    layout="@layout/setup_choice_row" />
+
+                <include
+                    android:id="@+id/cardBluetoothHost"
+                    layout="@layout/setup_choice_row" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/groupSatellite"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginTop="@dimen/spacing_xl"
                 android:visibility="gone"
-                tools:visibility="visible" />
+                tools:visibility="visible">
+
+                <TextView
+                    android:id="@+id/tvScanEyebrow"
+                    style="@style/TextAppearance.Dish.Label.Accent"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/setup_conn_scanning_eyebrow"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
+                <LinearLayout
+                    android:id="@+id/hostList"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_marginTop="@dimen/spacing_md" />
+
+                <!-- "Don't see your PC?" help. Shown while the list is empty
+                     or still scanning; the button opens the project's GitHub. -->
+                <LinearLayout
+                    android:id="@+id/groupGetSatellite"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_marginTop="@dimen/spacing_2xl"
+                    android:background="@drawable/bg_setup_callout_warning"
+                    android:padding="@dimen/card_padding">
+
+                    <TextView
+                        style="@style/TextAppearance.Dish.Title"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/setup_conn_missing_title" />
+
+                    <TextView
+                        style="@style/TextAppearance.Dish.BodySmall"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_xs"
+                        android:textColor="@color/colorOnTertiaryContainer"
+                        android:text="@string/setup_conn_missing_body" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/btnGetSatellite"
+                        style="@style/Widget.Dish.Button.Text"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_md"
+                        app:icon="@drawable/ic_open_in_new"
+                        app:iconGravity="end"
+                        android:text="@string/setup_conn_get_satellite" />
+                </LinearLayout>
+            </LinearLayout>
         </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingHorizontal="@dimen/spacing_5xl"
+        android:paddingVertical="@dimen/spacing_xl"
+        android:gravity="center_vertical">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnBack"
+            style="@style/Widget.Dish.Button.Outlined"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_chevron_left"
+            android:text="@string/setup_action_back" />
+
+        <Space
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnRescan"
+            style="@style/Widget.Dish.Button.Outlined"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_refresh"
+            android:text="@string/setup_conn_rescan"
+            android:visibility="gone"
+            tools:visibility="visible" />
     </LinearLayout>
-
-    <include layout="@layout/overlay_low_power_chip" />
-
-    <include layout="@layout/overlay_low_power" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_setup_input.xml
+++ b/app/src/main/res/layout/activity_setup_input.xml
@@ -64,4 +64,8 @@
             </LinearLayout>
         </androidx.core.widget.NestedScrollView>
     </LinearLayout>
+
+    <include layout="@layout/overlay_low_power_chip" />
+
+    <include layout="@layout/overlay_low_power" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_setup_input.xml
+++ b/app/src/main/res/layout/activity_setup_input.xml
@@ -1,71 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Dish.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        app:navigationIcon="@null"
+        app:title="@string/setup_input_toolbar" />
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/Widget.Dish.Toolbar"
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:paddingHorizontal="@dimen/spacing_5xl"
+        android:paddingTop="@dimen/spacing_md"
+        android:paddingBottom="@dimen/spacing_5xl">
+
+        <LinearLayout
             android:layout_width="match_parent"
-            app:navigationIcon="@null"
-            app:title="@string/setup_input_toolbar" />
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
-        <androidx.core.widget.NestedScrollView
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingTop="@dimen/spacing_md"
-            android:paddingBottom="@dimen/spacing_5xl">
+            <include
+                android:id="@+id/breadcrumb"
+                layout="@layout/view_setup_breadcrumb"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
 
-            <LinearLayout
+            <TextView
+                style="@style/TextAppearance.Dish.Title.Large"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:layout_marginTop="@dimen/spacing_5xl"
+                android:text="@string/setup_input_title" />
 
-                <include
-                    android:id="@+id/breadcrumb"
-                    layout="@layout/view_setup_breadcrumb"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
+            <TextView
+                style="@style/TextAppearance.Dish.Body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_md"
+                android:text="@string/setup_input_subtitle" />
 
-                <TextView
-                    style="@style/TextAppearance.Dish.Title.Large"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_5xl"
-                    android:text="@string/setup_input_title" />
+            <include
+                android:id="@+id/cardWired"
+                layout="@layout/setup_choice_row" />
 
-                <TextView
-                    style="@style/TextAppearance.Dish.Body"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_md"
-                    android:text="@string/setup_input_subtitle" />
+            <include
+                android:id="@+id/cardBluetooth"
+                layout="@layout/setup_choice_row" />
 
-                <include
-                    android:id="@+id/cardWired"
-                    layout="@layout/setup_choice_row" />
-
-                <include
-                    android:id="@+id/cardBluetooth"
-                    layout="@layout/setup_choice_row" />
-
-                <include
-                    android:id="@+id/cardOnscreen"
-                    layout="@layout/setup_choice_row" />
-            </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
-    </LinearLayout>
-
-    <include layout="@layout/overlay_low_power_chip" />
-
-    <include layout="@layout/overlay_low_power" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+            <include
+                android:id="@+id/cardOnscreen"
+                layout="@layout/setup_choice_row" />
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_setup_usb.xml
+++ b/app/src/main/res/layout/activity_setup_usb.xml
@@ -1,411 +1,401 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Dish.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        app:title="@string/setup_usb_toolbar" />
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/Widget.Dish.Toolbar"
-            android:layout_width="match_parent"
-            app:title="@string/setup_usb_toolbar" />
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/loader"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:visibility="invisible"
+        app:indicatorColor="@color/colorPrimary"
+        app:trackColor="@color/colorSurfaceVariant" />
 
-        <com.google.android.material.progressindicator.LinearProgressIndicator
-            android:id="@+id/loader"
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:paddingHorizontal="@dimen/spacing_5xl"
+        android:paddingTop="@dimen/spacing_md"
+        android:paddingBottom="@dimen/spacing_5xl">
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:indeterminate="true"
-            android:visibility="invisible"
-            app:indicatorColor="@color/colorPrimary"
-            app:trackColor="@color/colorSurfaceVariant" />
+            android:orientation="vertical">
 
-        <androidx.core.widget.NestedScrollView
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingTop="@dimen/spacing_md"
-            android:paddingBottom="@dimen/spacing_5xl">
+            <include
+                android:id="@+id/breadcrumb"
+                layout="@layout/view_setup_breadcrumb"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
 
-            <LinearLayout
+            <TextView
+                android:id="@+id/tvTitle"
+                style="@style/TextAppearance.Dish.Title.Large"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:layout_marginTop="@dimen/spacing_5xl"
+                tools:text="Plug your controller in" />
 
-                <include
-                    android:id="@+id/breadcrumb"
-                    layout="@layout/view_setup_breadcrumb"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
+            <LinearLayout
+                android:id="@+id/groupDetect"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginTop="@dimen/spacing_xl">
 
                 <TextView
-                    android:id="@+id/tvTitle"
-                    style="@style/TextAppearance.Dish.Title.Large"
+                    style="@style/TextAppearance.Dish.Body"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_5xl"
-                    tools:text="Plug your controller in" />
+                    android:text="@string/setup_usb_detect_subtitle" />
 
                 <LinearLayout
-                    android:id="@+id/groupDetect"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_marginTop="@dimen/spacing_xl">
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:layout_marginTop="@dimen/spacing_2xl">
+
+                    <ImageView
+                        android:layout_width="@dimen/icon_card_glyph"
+                        android:layout_height="@dimen/icon_card_glyph"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_usb"
+                        app:tint="@color/colorMuted" />
 
                     <TextView
-                        style="@style/TextAppearance.Dish.Body"
-                        android:layout_width="match_parent"
+                        android:id="@+id/tvStatus"
+                        style="@style/TextAppearance.Dish.Label"
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/setup_usb_detect_subtitle" />
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:gravity="center_vertical"
-                        android:layout_marginTop="@dimen/spacing_2xl">
-
-                        <ImageView
-                            android:layout_width="@dimen/icon_card_glyph"
-                            android:layout_height="@dimen/icon_card_glyph"
-                            android:importantForAccessibility="no"
-                            android:src="@drawable/ic_usb"
-                            app:tint="@color/colorMuted" />
-
-                        <TextView
-                            android:id="@+id/tvStatus"
-                            style="@style/TextAppearance.Dish.Label"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="@dimen/spacing_md"
-                            android:textAllCaps="true"
-                            tools:text="Scanning" />
-                    </LinearLayout>
-
-                    <LinearLayout
-                        android:id="@+id/usbList"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/spacing_md"
-                        android:orientation="vertical" />
+                        android:layout_marginStart="@dimen/spacing_md"
+                        android:textAllCaps="true"
+                        tools:text="Scanning" />
                 </LinearLayout>
 
                 <LinearLayout
-                    android:id="@+id/groupMode"
+                    android:id="@+id/usbList"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_marginTop="@dimen/spacing_xl"
+                    android:layout_marginTop="@dimen/spacing_md"
+                    android:orientation="vertical" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/groupMode"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginTop="@dimen/spacing_xl"
+                android:visibility="gone"
+                tools:visibility="gone">
+
+                <LinearLayout
+                    android:id="@+id/calloutVerified"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:background="@drawable/bg_setup_callout_success"
+                    android:padding="@dimen/config_callout_padding"
                     android:visibility="gone"
-                    tools:visibility="gone">
+                    tools:visibility="visible">
+
+                    <ImageView
+                        android:layout_width="@dimen/config_callout_icon_size"
+                        android:layout_height="@dimen/config_callout_icon_size"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_check_circle"
+                        app:tint="@color/colorSuccess" />
+
+                    <TextView
+                        style="@style/TextAppearance.Dish.BodySmall"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/config_callout_icon_gap"
+                        android:textColor="@color/colorSuccess"
+                        android:text="@string/setup_usb_supported" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/calloutUnverified"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:background="@drawable/bg_setup_callout_warning"
+                    android:padding="@dimen/config_callout_padding"
+                    android:visibility="gone"
+                    tools:visibility="visible">
+
+                    <ImageView
+                        android:layout_width="@dimen/config_callout_icon_size"
+                        android:layout_height="@dimen/config_callout_icon_size"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_warning"
+                        app:tint="@color/colorWarning" />
 
                     <LinearLayout
-                        android:id="@+id/calloutVerified"
-                        android:layout_width="match_parent"
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:gravity="center_vertical"
-                        android:background="@drawable/bg_setup_callout_success"
-                        android:padding="@dimen/config_callout_padding"
-                        android:visibility="gone"
-                        tools:visibility="visible">
-
-                        <ImageView
-                            android:layout_width="@dimen/config_callout_icon_size"
-                            android:layout_height="@dimen/config_callout_icon_size"
-                            android:importantForAccessibility="no"
-                            android:src="@drawable/ic_check_circle"
-                            app:tint="@color/colorSuccess" />
+                        android:layout_marginStart="@dimen/config_callout_icon_gap"
+                        android:orientation="vertical">
 
                         <TextView
                             style="@style/TextAppearance.Dish.BodySmall"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_marginStart="@dimen/config_callout_icon_gap"
-                            android:textColor="@color/colorSuccess"
-                            android:text="@string/setup_usb_supported" />
-                    </LinearLayout>
+                            android:textColor="@color/colorOnTertiaryContainer"
+                            android:text="@string/setup_usb_unverified_title" />
 
-                    <LinearLayout
-                        android:id="@+id/calloutUnverified"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:gravity="center_vertical"
-                        android:background="@drawable/bg_setup_callout_warning"
-                        android:padding="@dimen/config_callout_padding"
-                        android:visibility="gone"
-                        tools:visibility="visible">
-
-                        <ImageView
-                            android:layout_width="@dimen/config_callout_icon_size"
-                            android:layout_height="@dimen/config_callout_icon_size"
-                            android:importantForAccessibility="no"
-                            android:src="@drawable/ic_warning"
-                            app:tint="@color/colorWarning" />
-
-                        <LinearLayout
+                        <TextView
+                            style="@style/TextAppearance.Dish.BodySmall"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_marginStart="@dimen/config_callout_icon_gap"
-                            android:orientation="vertical">
-
-                            <TextView
-                                style="@style/TextAppearance.Dish.BodySmall"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:textColor="@color/colorOnTertiaryContainer"
-                                android:text="@string/setup_usb_unverified_title" />
-
-                            <TextView
-                                style="@style/TextAppearance.Dish.BodySmall"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:textColor="@color/colorOnTertiaryContainer"
-                                android:text="@string/setup_usb_unverified_body" />
-                        </LinearLayout>
+                            android:textColor="@color/colorOnTertiaryContainer"
+                            android:text="@string/setup_usb_unverified_body" />
                     </LinearLayout>
-
-                    <com.google.android.material.card.MaterialCardView
-                        android:id="@+id/cardDirect"
-                        style="@style/Widget.Dish.Card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/spacing_2xl"
-                        android:clickable="true"
-                        android:focusable="true"
-                        android:foreground="?attr/selectableItemBackground">
-
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:orientation="vertical"
-                            android:padding="@dimen/card_padding">
-
-                            <LinearLayout
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:orientation="horizontal"
-                                android:gravity="center_vertical">
-
-                                <ImageView
-                                    android:layout_width="@dimen/icon_picker_glyph"
-                                    android:layout_height="@dimen/icon_picker_glyph"
-                                    android:importantForAccessibility="no"
-                                    android:src="@drawable/ic_bolt"
-                                    app:tint="@color/colorPrimary" />
-
-                                <TextView
-                                    style="@style/TextAppearance.Dish.Title"
-                                    android:layout_width="0dp"
-                                    android:layout_height="wrap_content"
-                                    android:layout_weight="1"
-                                    android:layout_marginStart="@dimen/config_row_icon_gap"
-                                    android:text="@string/setup_usb_direct_title" />
-
-                                <TextView
-                                    android:id="@+id/pillDirect"
-                                    style="@style/TextAppearance.Dish.Caption"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:background="@drawable/bg_recommended_pill"
-                                    android:paddingHorizontal="@dimen/spacing_md"
-                                    android:paddingVertical="@dimen/recommended_pill_vertical_padding"
-                                    android:textColor="@color/colorOnPrimary"
-                                    android:textAllCaps="true"
-                                    android:text="@string/setup_usb_badge_recommended"
-                                    android:visibility="gone"
-                                    tools:visibility="visible" />
-                            </LinearLayout>
-
-                            <TextView
-                                android:id="@+id/tvDirectBody"
-                                style="@style/TextAppearance.Dish.Body"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_marginTop="@dimen/spacing_sm"
-                                tools:text="Reads the controller directly. Lowest latency. One-time permission." />
-
-                            <LinearLayout
-                                android:id="@+id/directWarningRow"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:orientation="horizontal"
-                                android:layout_marginTop="@dimen/spacing_md"
-                                android:gravity="top"
-                                android:visibility="gone"
-                                tools:visibility="visible">
-
-                                <ImageView
-                                    android:layout_width="@dimen/config_section_icon_size"
-                                    android:layout_height="@dimen/config_section_icon_size"
-                                    android:importantForAccessibility="no"
-                                    android:src="@drawable/ic_warning"
-                                    app:tint="@color/colorWarning" />
-
-                                <TextView
-                                    style="@style/TextAppearance.Dish.BodySmall"
-                                    android:layout_width="0dp"
-                                    android:layout_height="wrap_content"
-                                    android:layout_weight="1"
-                                    android:layout_marginStart="@dimen/spacing_sm"
-                                    android:textColor="@color/colorWarning"
-                                    android:text="@string/setup_usb_direct_warning" />
-                            </LinearLayout>
-                        </LinearLayout>
-                    </com.google.android.material.card.MaterialCardView>
-
-                    <com.google.android.material.card.MaterialCardView
-                        android:id="@+id/cardStandard"
-                        style="@style/Widget.Dish.Card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/card_margin_bottom"
-                        android:clickable="true"
-                        android:focusable="true"
-                        android:foreground="?attr/selectableItemBackground">
-
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:orientation="vertical"
-                            android:padding="@dimen/card_padding">
-
-                            <LinearLayout
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:orientation="horizontal"
-                                android:gravity="center_vertical">
-
-                                <ImageView
-                                    android:layout_width="@dimen/icon_picker_glyph"
-                                    android:layout_height="@dimen/icon_picker_glyph"
-                                    android:importantForAccessibility="no"
-                                    android:src="@drawable/ic_tune"
-                                    app:tint="@color/colorPrimary" />
-
-                                <TextView
-                                    style="@style/TextAppearance.Dish.Title"
-                                    android:layout_width="0dp"
-                                    android:layout_height="wrap_content"
-                                    android:layout_weight="1"
-                                    android:layout_marginStart="@dimen/config_row_icon_gap"
-                                    android:text="@string/setup_usb_standard_title" />
-
-                                <TextView
-                                    android:id="@+id/pillStandard"
-                                    style="@style/TextAppearance.Dish.Caption"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:background="@drawable/bg_recommended_pill"
-                                    android:paddingHorizontal="@dimen/spacing_md"
-                                    android:paddingVertical="@dimen/recommended_pill_vertical_padding"
-                                    android:textColor="@color/colorOnPrimary"
-                                    android:textAllCaps="true"
-                                    android:text="@string/setup_usb_badge_recommended"
-                                    android:visibility="gone"
-                                    tools:visibility="visible" />
-                            </LinearLayout>
-
-                            <TextView
-                                android:id="@+id/tvStandardBody"
-                                style="@style/TextAppearance.Dish.Body"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_marginTop="@dimen/spacing_sm"
-                                tools:text="Android's gamepad layer. Works everywhere, no prompt." />
-                        </LinearLayout>
-                    </com.google.android.material.card.MaterialCardView>
                 </LinearLayout>
 
-                <LinearLayout
-                    android:id="@+id/groupGrant"
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardDirect"
+                    style="@style/Widget.Dish.Card"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_marginTop="@dimen/spacing_xl"
-                    android:visibility="gone"
-                    tools:visibility="gone">
-
-                    <TextView
-                        style="@style/TextAppearance.Dish.Body"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:text="@string/setup_usb_grant_body" />
+                    android:layout_marginTop="@dimen/spacing_2xl"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
 
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="vertical"
-                        android:gravity="center_horizontal"
-                        android:layout_marginTop="@dimen/spacing_3xl"
-                        android:background="@drawable/bg_setup_callout_warning"
                         android:padding="@dimen/card_padding">
 
-                        <ImageView
-                            android:layout_width="@dimen/config_empty_glyph_size"
-                            android:layout_height="@dimen/config_empty_glyph_size"
-                            android:importantForAccessibility="no"
-                            android:src="@drawable/ic_usb"
-                            app:tint="@color/colorPrimary" />
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:gravity="center_vertical">
+
+                            <ImageView
+                                android:layout_width="@dimen/icon_picker_glyph"
+                                android:layout_height="@dimen/icon_picker_glyph"
+                                android:importantForAccessibility="no"
+                                android:src="@drawable/ic_bolt"
+                                app:tint="@color/colorPrimary" />
+
+                            <TextView
+                                style="@style/TextAppearance.Dish.Title"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:layout_marginStart="@dimen/config_row_icon_gap"
+                                android:text="@string/setup_usb_direct_title" />
+
+                            <TextView
+                                android:id="@+id/pillDirect"
+                                style="@style/TextAppearance.Dish.Caption"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:background="@drawable/bg_recommended_pill"
+                                android:paddingHorizontal="@dimen/spacing_md"
+                                android:paddingVertical="@dimen/recommended_pill_vertical_padding"
+                                android:textColor="@color/colorOnPrimary"
+                                android:textAllCaps="true"
+                                android:text="@string/setup_usb_badge_recommended"
+                                android:visibility="gone"
+                                tools:visibility="visible" />
+                        </LinearLayout>
 
                         <TextView
-                            style="@style/TextAppearance.Dish.Title"
-                            android:layout_width="wrap_content"
+                            android:id="@+id/tvDirectBody"
+                            style="@style/TextAppearance.Dish.Body"
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_sm"
+                            tools:text="Reads the controller directly. Lowest latency. One-time permission." />
+
+                        <LinearLayout
+                            android:id="@+id/directWarningRow"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
                             android:layout_marginTop="@dimen/spacing_md"
-                            android:gravity="center"
-                            android:text="@string/setup_usb_grant_card_title" />
+                            android:gravity="top"
+                            android:visibility="gone"
+                            tools:visibility="visible">
+
+                            <ImageView
+                                android:layout_width="@dimen/config_section_icon_size"
+                                android:layout_height="@dimen/config_section_icon_size"
+                                android:importantForAccessibility="no"
+                                android:src="@drawable/ic_warning"
+                                app:tint="@color/colorWarning" />
+
+                            <TextView
+                                style="@style/TextAppearance.Dish.BodySmall"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:layout_marginStart="@dimen/spacing_sm"
+                                android:textColor="@color/colorWarning"
+                                android:text="@string/setup_usb_direct_warning" />
+                        </LinearLayout>
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardStandard"
+                    style="@style/Widget.Dish.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/card_margin_bottom"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:padding="@dimen/card_padding">
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:gravity="center_vertical">
+
+                            <ImageView
+                                android:layout_width="@dimen/icon_picker_glyph"
+                                android:layout_height="@dimen/icon_picker_glyph"
+                                android:importantForAccessibility="no"
+                                android:src="@drawable/ic_tune"
+                                app:tint="@color/colorPrimary" />
+
+                            <TextView
+                                style="@style/TextAppearance.Dish.Title"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:layout_marginStart="@dimen/config_row_icon_gap"
+                                android:text="@string/setup_usb_standard_title" />
+
+                            <TextView
+                                android:id="@+id/pillStandard"
+                                style="@style/TextAppearance.Dish.Caption"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:background="@drawable/bg_recommended_pill"
+                                android:paddingHorizontal="@dimen/spacing_md"
+                                android:paddingVertical="@dimen/recommended_pill_vertical_padding"
+                                android:textColor="@color/colorOnPrimary"
+                                android:textAllCaps="true"
+                                android:text="@string/setup_usb_badge_recommended"
+                                android:visibility="gone"
+                                tools:visibility="visible" />
+                        </LinearLayout>
 
                         <TextView
-                            style="@style/TextAppearance.Dish.BodySmall"
+                            android:id="@+id/tvStandardBody"
+                            style="@style/TextAppearance.Dish.Body"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/spacing_xs"
-                            android:gravity="center"
-                            android:textColor="@color/colorOnTertiaryContainer"
-                            android:text="@string/setup_usb_grant_card_body" />
-
-                        <com.google.android.material.button.MaterialButton
-                            android:id="@+id/btnGrant"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/spacing_xl"
-                            app:icon="@drawable/ic_chevron_right"
-                            app:iconGravity="end"
-                            android:text="@string/setup_usb_grant_action" />
+                            android:layout_marginTop="@dimen/spacing_sm"
+                            tools:text="Android's gamepad layer. Works everywhere, no prompt." />
                     </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/groupGrant"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginTop="@dimen/spacing_xl"
+                android:visibility="gone"
+                tools:visibility="gone">
+
+                <TextView
+                    style="@style/TextAppearance.Dish.Body"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/setup_usb_grant_body" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:gravity="center_horizontal"
+                    android:layout_marginTop="@dimen/spacing_3xl"
+                    android:background="@drawable/bg_setup_callout_warning"
+                    android:padding="@dimen/card_padding">
+
+                    <ImageView
+                        android:layout_width="@dimen/config_empty_glyph_size"
+                        android:layout_height="@dimen/config_empty_glyph_size"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_usb"
+                        app:tint="@color/colorPrimary" />
+
+                    <TextView
+                        style="@style/TextAppearance.Dish.Title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_md"
+                        android:gravity="center"
+                        android:text="@string/setup_usb_grant_card_title" />
+
+                    <TextView
+                        style="@style/TextAppearance.Dish.BodySmall"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_xs"
+                        android:gravity="center"
+                        android:textColor="@color/colorOnTertiaryContainer"
+                        android:text="@string/setup_usb_grant_card_body" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/btnGrant"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_xl"
+                        app:icon="@drawable/ic_chevron_right"
+                        app:iconGravity="end"
+                        android:text="@string/setup_usb_grant_action" />
                 </LinearLayout>
             </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingVertical="@dimen/spacing_xl"
-            android:gravity="center_vertical">
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/btnBack"
-                style="@style/Widget.Dish.Button.Outlined"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:icon="@drawable/ic_chevron_left"
-                android:text="@string/setup_action_back" />
         </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingHorizontal="@dimen/spacing_5xl"
+        android:paddingVertical="@dimen/spacing_xl"
+        android:gravity="center_vertical">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnBack"
+            style="@style/Widget.Dish.Button.Outlined"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_chevron_left"
+            android:text="@string/setup_action_back" />
     </LinearLayout>
-
-    <include layout="@layout/overlay_low_power_chip" />
-
-    <include layout="@layout/overlay_low_power" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_setup_usb.xml
+++ b/app/src/main/res/layout/activity_setup_usb.xml
@@ -404,4 +404,8 @@
                 android:text="@string/setup_action_back" />
         </LinearLayout>
     </LinearLayout>
+
+    <include layout="@layout/overlay_low_power_chip" />
+
+    <include layout="@layout/overlay_low_power" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/diagnostics_body_row.xml
+++ b/app/src/main/res/layout/diagnostics_body_row.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/TextAppearance.Dish.Body"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/spacing_xs" />

--- a/app/src/main/res/layout/diagnostics_card.xml
+++ b/app/src/main/res/layout/diagnostics_card.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/card_margin_bottom">
+
+    <LinearLayout
+        android:id="@+id/diagCardColumn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="@dimen/card_padding">
+
+        <TextView
+            android:id="@+id/diagCardTitle"
+            style="@style/TextAppearance.Dish.Title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/diagnostics_empty_row.xml
+++ b/app/src/main/res/layout/diagnostics_empty_row.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/TextAppearance.Dish.Body"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:gravity="start" />

--- a/app/src/main/res/layout/dialog_card_list.xml
+++ b/app/src/main/res/layout/dialog_card_list.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:id="@+id/dialogCardList"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="@dimen/spacing_5xl" />
+</ScrollView>

--- a/app/src/main/res/layout/screen_scaffold.xml
+++ b/app/src/main/res/layout/screen_scaffold.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Shared chrome for standard screens: content inflates into screenContent via
+     BaseGamepadHostActivity.setScaffoldContent, so the streaming overlays exist
+     exactly once. Bespoke screens (main, connections, bindings, input overlays)
+     keep their own coordinator roots and must carry these includes themselves. -->
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <FrameLayout
+        android:id="@+id/screenContent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <include layout="@layout/overlay_low_power_chip" />
+
+    <include layout="@layout/overlay_low_power" />
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -161,6 +161,30 @@
             android:defaultValue="false" />
     </activity>
 
+    <activity
+        android:id="@+id/diagnosticsActivity"
+        android:name="com.tinkernorth.dish.ui.diagnostics.DiagnosticsActivity"
+        android:label="@string/settings_diagnostics_title" />
+
+    <activity
+        android:id="@+id/inputInspectorActivity"
+        android:name="com.tinkernorth.dish.ui.diagnostics.InputInspectorActivity"
+        android:label="@string/settings_diagnostics_title">
+        <argument
+            android:name="extra_device_id"
+            app:argType="integer"
+            android:defaultValue="0" />
+        <argument
+            android:name="extra_device_name"
+            app:argType="string"
+            android:defaultValue="" />
+    </activity>
+
+    <activity
+        android:id="@+id/licensesActivity"
+        android:name="com.tinkernorth.dish.ui.settings.LicensesActivity"
+        android:label="@string/settings_open_source_licenses_title" />
+
     <!-- ═══ FATAL FALLBACK ════════════════════════════════════════════ -->
     <activity
         android:id="@+id/nativeUnavailableActivity"

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -416,6 +416,7 @@
     <string name="diagnostics_hz">%1$d Hz</string>
     <string name="diagnostics_ms">%1$.2f ms</string>
     <string name="diagnostics_ms_approx">~%1$.2f ms</string>
+    <string name="diagnostics_ms_approx_window">~%1$.2f ms · zadnjih %2$d pingova</string>
     <string name="diagnostics_ms_p50_p99">%1$.2f ms (p50) · %2$.2f ms (p99)</string>
     <string name="diagnostics_unknown">Nepoznato</string>
     <string name="diagnostics_present">Prisutno</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -413,6 +413,7 @@
     <string name="diagnostics_hz">%1$d Hz</string>
     <string name="diagnostics_ms">%1$.2f ms</string>
     <string name="diagnostics_ms_approx">~%1$.2f ms</string>
+    <string name="diagnostics_ms_approx_window">~%1$.2f ms · letzte %2$d Pings</string>
     <string name="diagnostics_ms_p50_p99">%1$.2f ms (p50) · %2$.2f ms (p99)</string>
     <string name="diagnostics_unknown">Unbekannt</string>
     <string name="diagnostics_present">Vorhanden</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -417,6 +417,7 @@
     <string name="diagnostics_hz">%1$d Hz</string>
     <string name="diagnostics_ms">%1$.2f ms</string>
     <string name="diagnostics_ms_approx">~%1$.2f ms</string>
+    <string name="diagnostics_ms_approx_window">~%1$.2f ms · últimos %2$d pings</string>
     <string name="diagnostics_ms_p50_p99">%1$.2f ms (p50) · %2$.2f ms (p99)</string>
     <string name="diagnostics_unknown">Desconocido</string>
     <string name="diagnostics_present">Presente</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -416,6 +416,7 @@
     <string name="diagnostics_hz">%1$d Hz</string>
     <string name="diagnostics_ms">%1$.2f ms</string>
     <string name="diagnostics_ms_approx">~%1$.2f ms</string>
+    <string name="diagnostics_ms_approx_window">~%1$.2f ms · %2$d derniers pings</string>
     <string name="diagnostics_ms_p50_p99">%1$.2f ms (p50) · %2$.2f ms (p99)</string>
     <string name="diagnostics_unknown">Inconnu</string>
     <string name="diagnostics_present">Présent</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -417,6 +417,7 @@
     <string name="diagnostics_hz">%1$d Hz</string>
     <string name="diagnostics_ms">%1$.2f ms</string>
     <string name="diagnostics_ms_approx">~%1$.2f ms</string>
+    <string name="diagnostics_ms_approx_window">~%1$.2f ms · últimos %2$d pings</string>
     <string name="diagnostics_ms_p50_p99">%1$.2f ms (p50) · %2$.2f ms (p99)</string>
     <string name="diagnostics_unknown">Desconhecido</string>
     <string name="diagnostics_present">Presente</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -351,6 +351,7 @@
     <string name="diagnostics_hz">%1$d Hz</string>
     <string name="diagnostics_ms">%1$.2f ms</string>
     <string name="diagnostics_ms_approx">~%1$.2f ms</string>
+    <string name="diagnostics_ms_approx_window">~%1$.2f ms · last %2$d pings</string>
     <string name="diagnostics_ms_p50_p99">%1$.2f ms (p50) · %2$.2f ms (p99)</string>
     <string name="diagnostics_unknown">Unknown</string>
     <string name="diagnostics_present">Present</string>

--- a/app/src/test/java/com/tinkernorth/dish/architecture/testing/TestLifecycleOwner.kt
+++ b/app/src/test/java/com/tinkernorth/dish/architecture/testing/TestLifecycleOwner.kt
@@ -18,6 +18,14 @@ class TestLifecycleOwner : LifecycleOwner {
         registry.currentState = Lifecycle.State.STARTED
     }
 
+    fun resume() {
+        registry.currentState = Lifecycle.State.RESUMED
+    }
+
+    fun pause() {
+        registry.currentState = Lifecycle.State.STARTED
+    }
+
     fun stop() {
         registry.currentState = Lifecycle.State.CREATED
     }

--- a/app/src/test/java/com/tinkernorth/dish/composer/ConnectionCoordinatorTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/ConnectionCoordinatorTest.kt
@@ -13,14 +13,15 @@ import com.tinkernorth.dish.source.connection.ConnectIntent
 import com.tinkernorth.dish.source.connection.SatelliteConnection
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.connection.SatelliteSessionState
-import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -376,7 +377,6 @@ class ConnectionCoordinatorTest {
         )
         val summary = hub.connections.value.first { it.id == "s:1" }
         assertEquals(setOf("slot-A", "slot-B"), summary.boundSlotIds.toSet())
-        verify(exactly = 0) { satConn.detachSlot(any()) }
     }
 
     @Test
@@ -395,11 +395,7 @@ class ConnectionCoordinatorTest {
     }
 
     @Test
-    fun `binding a slot to a new satellite detaches it from the prior one`() {
-        val sat1 = mockk<SatelliteConnection>(relaxed = true)
-        val sat2 = mockk<SatelliteConnection>(relaxed = true)
-        every { satellite.get("s:1") } returns sat1
-        every { satellite.get("s:2") } returns sat2
+    fun `binding a slot to a new satellite moves the binding and drops the prior type`() {
         satEntriesFlow.value =
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
@@ -407,17 +403,16 @@ class ConnectionCoordinatorTest {
             )
         val hub = buildHub()
 
-        hub.bind("slot-A", "s:1", CONTROLLER_TYPE_XBOX)
+        hub.bind("slot-A", "s:1", CONTROLLER_TYPE_PLAYSTATION)
         hub.bind("slot-A", "s:2", CONTROLLER_TYPE_XBOX)
 
         assertEquals(mapOf("slot-A" to "s:2"), hub.bindings.value)
-        verify { sat1.detachSlot("slot-A") }
+        assertNull(hub.satTypes.value["s:1" to "slot-A"])
+        assertEquals(CONTROLLER_TYPE_XBOX, hub.satTypes.value["s:2" to "slot-A"])
     }
 
     @Test
-    fun `unbind removes the binding and detaches the satellite slot by id`() {
-        val satConn = mockk<SatelliteConnection>(relaxed = true)
-        every { satellite.get("s:1") } returns satConn
+    fun `unbind removes the binding and its type`() {
         satEntriesFlow.value =
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
@@ -428,13 +423,11 @@ class ConnectionCoordinatorTest {
         hub.unbind("slot-A")
 
         assertNull(hub.bindings.value["slot-A"])
-        verify { satConn.detachSlot("slot-A") }
+        assertNull(hub.satTypes.value["s:1" to "slot-A"])
     }
 
     @Test
     fun `bind records the caller's type - the descriptor travels with the bind`() {
-        val satConn = mockk<SatelliteConnection>(relaxed = true)
-        every { satellite.get("s:1") } returns satConn
         satEntriesFlow.value =
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
@@ -446,13 +439,10 @@ class ConnectionCoordinatorTest {
 
         val summary = hub.connections.value.first { it.id == "s:1" }
         assertEquals(CONTROLLER_TYPE_PLAYSTATION, summary.satelliteControllerTypes["slot-A"])
-        verify { satConn.declareSlot("slot-A", CONTROLLER_TYPE_PLAYSTATION) }
     }
 
     @Test
     fun `bind refuses a numeric slot id the registry no longer knows (zombie guard)`() {
-        val satConn = mockk<SatelliteConnection>(relaxed = true)
-        every { satellite.get("s:1") } returns satConn
         satEntriesFlow.value =
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
@@ -464,7 +454,7 @@ class ConnectionCoordinatorTest {
 
         assertEquals(false, bound)
         assertNull(hub.bindings.value["42"])
-        verify(exactly = 0) { satConn.declareSlot(any(), any()) }
+        assertNull(hub.satTypes.value["s:1" to "42"])
     }
 
     @Test
@@ -537,9 +527,7 @@ class ConnectionCoordinatorTest {
     }
 
     @Test
-    fun `setSatelliteControllerType updates the summary and pushes to the connection`() {
-        val satConn = mockk<SatelliteConnection>(relaxed = true)
-        every { satellite.get("s:1") } returns satConn
+    fun `setSatelliteControllerType updates the summary through the type store`() {
         satEntriesFlow.value =
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
@@ -784,10 +772,7 @@ class ConnectionCoordinatorTest {
     }
 
     @Test
-    fun `migrateSlotBinding carries binding and type to the new slot id and re-keys the satellite slot`() {
-        val satConn = mockk<SatelliteConnection>(relaxed = true)
-        every { satellite.get("s:1") } returns satConn
-        every { satConn.renameSlot("slot-fw", "slot-usb") } returns true
+    fun `migrateSlotBinding carries binding and type to the new slot id`() {
         satEntriesFlow.value =
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
@@ -805,42 +790,40 @@ class ConnectionCoordinatorTest {
         val summary = hub.connections.value.first { it.id == "s:1" }
         assertEquals(CONTROLLER_TYPE_PLAYSTATION, summary.satelliteControllerTypes["slot-usb"])
         assertNull(summary.satelliteControllerTypes["slot-fw"])
-        verify { satConn.renameSlot("slot-fw", "slot-usb") }
-        verify(exactly = 0) { satConn.detachSlot(any()) }
+    }
+
+    @Test
+    fun `migrateSlotBinding re-keys the binding in one emission so the topology diff reads a rename`() {
+        satEntriesFlow.value =
+            listOf(
+                RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
+            )
+        val hub = buildHub()
+        hub.bind("slot-fw", "s:1", CONTROLLER_TYPE_XBOX)
+
+        // Unconfined collector: sees every distinct value synchronously, so a two-step
+        // unbind+bind implementation could not hide behind StateFlow conflation.
+        val observed = mutableListOf<Map<String, String>>()
+        val job =
+            scope.backgroundScope.launch(UnconfinedTestDispatcher(scope.testScheduler)) {
+                hub.bindings.collect { observed += it }
+            }
+
+        hub.migrateSlotBinding("slot-fw", "slot-usb")
+        job.cancel()
+
+        assertTrue(observed.none { "slot-fw" in it && "slot-usb" in it })
+        assertTrue(observed.none { "slot-fw" !in it && "slot-usb" !in it })
     }
 
     @Test
     fun `migrateSlotBinding does nothing when the source slot is unbound`() {
-        val satConn = mockk<SatelliteConnection>(relaxed = true)
-        every { satellite.get(any()) } returns satConn
         val hub = buildHub()
 
         hub.migrateSlotBinding("ghost", "slot-usb")
         scope.testScheduler.runCurrent()
 
         assertEquals(emptyMap<String, String>(), hub.bindings.value)
-        verify(exactly = 0) { satConn.renameSlot(any(), any()) }
-    }
-
-    @Test
-    fun `migrateSlotBinding attaches the new slot when the source slot was never registered`() {
-        val satConn = mockk<SatelliteConnection>(relaxed = true)
-        every { satellite.get("s:1") } returns satConn
-        every { satConn.renameSlot("slot-fw", "slot-usb") } returns false
-        satEntriesFlow.value =
-            listOf(
-                RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
-            )
-        val hub = buildHub()
-
-        hub.bind("slot-fw", "s:1", CONTROLLER_TYPE_XBOX)
-        scope.testScheduler.runCurrent()
-
-        hub.migrateSlotBinding("slot-fw", "slot-usb")
-        scope.testScheduler.runCurrent()
-
-        assertEquals(mapOf("slot-usb" to "s:1"), hub.bindings.value)
-        coVerify { satConn.attachSlot("slot-usb", any()) }
     }
 
     @Test
@@ -886,24 +869,21 @@ class ConnectionCoordinatorTest {
         }
 
     @Test
-    fun `bindClaimedSynthetic carries a bound twin's binding to the synthetic slot`() {
-        val satConn = mockk<SatelliteConnection>(relaxed = true)
-        every { satellite.get("s:1") } returns satConn
-        every { satConn.renameSlot("slot-fw", "-1000") } returns true
+    fun `bindClaimedSynthetic carries a bound twin's binding and type to the synthetic slot`() {
         satEntriesFlow.value =
             listOf(
                 RememberedSatellite(id = "s:1", name = "A", ip = "1", udpPort = 1, pairPort = 2, httpPort = 3),
             )
         val hub = buildHub()
 
-        hub.bind("slot-fw", "s:1", CONTROLLER_TYPE_XBOX)
+        hub.bind("slot-fw", "s:1", CONTROLLER_TYPE_PLAYSTATION)
         scope.testScheduler.runCurrent()
 
         hub.bindClaimedSynthetic(twinSlotId = "slot-fw", syntheticSlotId = "-1000")
         scope.testScheduler.runCurrent()
 
         assertEquals(mapOf("-1000" to "s:1"), hub.bindings.value)
-        verify { satConn.renameSlot("slot-fw", "-1000") }
+        assertEquals(CONTROLLER_TYPE_PLAYSTATION, hub.satTypes.value["s:1" to "-1000"])
     }
 
     // The claim registers the synthetic in the gamepad registry BEFORE the

--- a/app/src/test/java/com/tinkernorth/dish/composer/SlotTopologyComposerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/SlotTopologyComposerTest.kt
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.composer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SlotTopologyComposerTest {
+    @Test
+    fun `a satellite binding projects with its stored type`() {
+        val topology =
+            composeSlotTopology(
+                bindings = mapOf("5" to "satellite:m1"),
+                types = mapOf(("satellite:m1" to "5") to CONTROLLER_TYPE_PLAYSTATION),
+            )
+        assertEquals(mapOf("satellite:m1" to mapOf("5" to CONTROLLER_TYPE_PLAYSTATION)), topology)
+    }
+
+    @Test
+    fun `a binding without a stored type defaults to xbox`() {
+        val topology = composeSlotTopology(bindings = mapOf("5" to "satellite:m1"), types = emptyMap())
+        assertEquals(mapOf("satellite:m1" to mapOf("5" to CONTROLLER_TYPE_XBOX)), topology)
+    }
+
+    @Test
+    fun `bluetooth bindings carry no satellite descriptor`() {
+        val topology = composeSlotTopology(bindings = mapOf("5" to "bt:aa:bb"), types = emptyMap())
+        assertEquals(emptyMap<String, Map<String, Int>>(), topology)
+    }
+
+    @Test
+    fun `slots group under their own connection`() {
+        val topology =
+            composeSlotTopology(
+                bindings = mapOf("5" to "satellite:m1", "7" to "satellite:m2", "virtual" to "satellite:m1"),
+                types = mapOf(("satellite:m1" to "virtual") to CONTROLLER_TYPE_PLAYSTATION),
+            )
+        assertEquals(
+            mapOf(
+                "satellite:m1" to
+                    mapOf("5" to CONTROLLER_TYPE_XBOX, "virtual" to CONTROLLER_TYPE_PLAYSTATION),
+                "satellite:m2" to mapOf("7" to CONTROLLER_TYPE_XBOX),
+            ),
+            topology,
+        )
+    }
+
+    @Test
+    fun `a type stored for another connection does not leak into the projection`() {
+        val topology =
+            composeSlotTopology(
+                bindings = mapOf("5" to "satellite:m1"),
+                types = mapOf(("satellite:m2" to "5") to CONTROLLER_TYPE_PLAYSTATION),
+            )
+        assertEquals(mapOf("satellite:m1" to mapOf("5" to CONTROLLER_TYPE_XBOX)), topology)
+    }
+
+    @Test
+    fun `no bindings compose an empty topology`() {
+        assertEquals(emptyMap<String, Map<String, Int>>(), composeSlotTopology(emptyMap(), emptyMap()))
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/composer/SlotTopologyControllerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/SlotTopologyControllerTest.kt
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.composer
+
+import com.tinkernorth.dish.architecture.testing.TestLifecycleOwner
+import com.tinkernorth.dish.source.connection.SatelliteConnection
+import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
+import com.tinkernorth.dish.source.store.ControllerTypeStore
+import com.tinkernorth.dish.source.store.SlotBindingStore
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SlotTopologyControllerTest {
+    private val scope = TestScope(StandardTestDispatcher())
+    private val bindingStore = SlotBindingStore()
+    private val typeStore = ControllerTypeStore()
+    private val connsFlow = MutableStateFlow<Map<String, SatelliteConnection>>(emptyMap())
+    private lateinit var satellite: SatelliteConnectionManager
+    private lateinit var owner: TestLifecycleOwner
+
+    @Before
+    fun setUp() {
+        satellite = mockk { every { connections } returns connsFlow }
+        owner = TestLifecycleOwner()
+    }
+
+    private fun startController() {
+        val controller =
+            SlotTopologyController(
+                composer = SlotTopologyComposer(bindingStore, typeStore, scope),
+                satellite = satellite,
+                scope = scope,
+            )
+        owner.lifecycle.addObserver(controller)
+        owner.start()
+        scope.testScheduler.runCurrent()
+    }
+
+    private fun mockConn(): SatelliteConnection = mockk { justRun { applyDesired(any()) } }
+
+    @Test
+    fun `a bind converges the target connection to the desired slot set`() =
+        runTest(scope.testScheduler) {
+            val conn = mockConn()
+            connsFlow.value = mapOf("satellite:m1" to conn)
+            startController()
+
+            typeStore.setType("satellite:m1", "5", CONTROLLER_TYPE_PLAYSTATION)
+            bindingStore.bind("5", "satellite:m1")
+            scope.testScheduler.runCurrent()
+
+            verify { conn.applyDesired(mapOf("5" to CONTROLLER_TYPE_PLAYSTATION)) }
+        }
+
+    @Test
+    fun `an unbind converges the connection to an empty slot set`() =
+        runTest(scope.testScheduler) {
+            val conn = mockConn()
+            connsFlow.value = mapOf("satellite:m1" to conn)
+            startController()
+
+            bindingStore.bind("5", "satellite:m1")
+            scope.testScheduler.runCurrent()
+            bindingStore.unbind("5")
+            scope.testScheduler.runCurrent()
+
+            verify { conn.applyDesired(emptyMap()) }
+        }
+
+    @Test
+    fun `a binding recorded before the session object exists converges once it appears`() =
+        runTest(scope.testScheduler) {
+            startController()
+            bindingStore.bind("5", "satellite:m1")
+            scope.testScheduler.runCurrent()
+
+            val conn = mockConn()
+            connsFlow.value = mapOf("satellite:m1" to conn)
+            scope.testScheduler.runCurrent()
+
+            verify { conn.applyDesired(mapOf("5" to CONTROLLER_TYPE_XBOX)) }
+        }
+
+    @Test
+    fun `every live connection is converged, including to empty`() =
+        runTest(scope.testScheduler) {
+            val bound = mockConn()
+            val other = mockConn()
+            connsFlow.value = mapOf("satellite:m1" to bound, "satellite:m2" to other)
+            startController()
+
+            bindingStore.bind("5", "satellite:m1")
+            scope.testScheduler.runCurrent()
+
+            verify { bound.applyDesired(mapOf("5" to CONTROLLER_TYPE_XBOX)) }
+            verify { other.applyDesired(emptyMap()) }
+        }
+
+    @Test
+    fun `a restart reconciles from current stores, not remembered state`() =
+        runTest(scope.testScheduler) {
+            val conn = mockConn()
+            connsFlow.value = mapOf("satellite:m1" to conn)
+            startController()
+            owner.stop()
+            scope.testScheduler.runCurrent()
+
+            // Stores moved while the actuator was stopped.
+            bindingStore.bind("5", "satellite:m1")
+
+            owner.start()
+            scope.testScheduler.runCurrent()
+
+            verify { conn.applyDesired(mapOf("5" to CONTROLLER_TYPE_XBOX)) }
+        }
+}

--- a/app/src/test/java/com/tinkernorth/dish/hotpath/input/PhysicalSlotBindingObserverTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/hotpath/input/PhysicalSlotBindingObserverTest.kt
@@ -262,4 +262,82 @@ class PhysicalSlotBindingObserverTest {
     fun `an empty snapshot yields no ops`() {
         assertEquals(emptyList<BindOp>(), reconcile())
     }
+
+    @Test
+    fun `a stale binding whose device is in neither present nor lastBound is swept`() {
+        // Device 7 departed while the observer was stopped: it is in neither set, yet its binding
+        // survived. Without the sweep its slot re-registers on the satellite on every reconnect.
+        val ops =
+            reconcile(
+                bindings = mapOf("7" to "sat:a"),
+                summaries = listOf(satSummary("sat:a")),
+            )
+        assertEquals(
+            listOf(
+                BindOp.Unbind(7),
+                BindOp.Forget(7),
+                BindOp.ReleaseHubBinding(7),
+            ),
+            ops,
+        )
+    }
+
+    @Test
+    fun `a stale synthetic binding is swept without a forget`() {
+        val ops = reconcile(bindings = mapOf("-1000" to "sat:a"))
+        assertEquals(listOf(BindOp.Unbind(-1000), BindOp.ReleaseHubBinding(-1000)), ops)
+    }
+
+    @Test
+    fun `a non-numeric slot binding is never swept`() {
+        val ops = reconcile(bindings = mapOf("virtual" to "sat:a"))
+        assertEquals(emptyList<BindOp>(), ops)
+    }
+
+    @Test
+    fun `a stale binding also departed this pass is swept once`() {
+        val ops = reconcile(lastBound = setOf(7), bindings = mapOf("7" to "sat:a"))
+        assertEquals(
+            listOf(
+                BindOp.Unbind(7),
+                BindOp.Forget(7),
+                BindOp.ReleaseHubBinding(7),
+            ),
+            ops,
+        )
+    }
+
+    @Test
+    fun `a swept stale binding precedes the present device's bind`() {
+        val ops =
+            reconcile(
+                present = setOf(5),
+                lastBound = setOf(5),
+                bindings = mapOf("5" to "sat:a", "7" to "sat:a"),
+                summaries = listOf(satSummary("sat:a")),
+                slotInfo = mapOf("sat:a" to SatelliteSlotSnapshot(handle = 9, slots = mapOf("5" to slot(0)))),
+            )
+        assertEquals(
+            listOf(
+                BindOp.Unbind(7),
+                BindOp.Forget(7),
+                BindOp.ReleaseHubBinding(7),
+                BindOp.BindSatellite(deviceId = 5, handle = 9, controllerIndex = 0),
+            ),
+            ops,
+        )
+    }
+
+    @Test
+    fun `a bound present device is not swept`() {
+        val ops =
+            reconcile(
+                present = setOf(5),
+                lastBound = setOf(5),
+                bindings = mapOf("5" to "sat:a"),
+                summaries = listOf(satSummary("sat:a")),
+                slotInfo = mapOf("sat:a" to SatelliteSlotSnapshot(handle = 9, slots = mapOf("5" to slot(0)))),
+            )
+        assertEquals(listOf(BindOp.BindSatellite(deviceId = 5, handle = 9, controllerIndex = 0)), ops)
+    }
 }

--- a/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionTest.kt
@@ -701,4 +701,98 @@ class SatelliteConnectionTest {
         conn.adoptEpoch(8)
         assertEquals(8, conn.lastAppliedEpoch)
     }
+
+    @Test
+    fun `applyDesired attaches every desired slot with its type`() {
+        conn.applyDesired(mapOf("slot-A" to 1, "slot-B" to 0))
+
+        assertEquals(1, conn.slots.value["slot-A"]?.controllerType)
+        assertEquals(0, conn.slots.value["slot-B"]?.controllerType)
+        assertEquals(
+            setOf(0, 1),
+            conn.slots.value.values
+                .map { it.controllerIndex }
+                .toSet(),
+        )
+    }
+
+    @Test
+    fun `applyDesired detaches slots absent from the desired set`() {
+        every { repo.isConnectionAlive(any()) } returns true
+        conn.applyDesired(mapOf("slot-A" to 0, "slot-B" to 0))
+        connectLive(applied = listOf(okApply(0), okApply(1)))
+
+        conn.applyDesired(mapOf("slot-A" to 0))
+
+        assertNull(conn.slots.value["slot-B"])
+        assertEquals(listOf(1), slotRemovals)
+    }
+
+    @Test
+    fun `applyDesired updates a changed type in place`() {
+        every { repo.isConnectionAlive(any()) } returns true
+        conn.applyDesired(mapOf("slot-A" to 0))
+        connectLive(applied = listOf(okApply(0)))
+        slotSyncs.clear()
+
+        conn.applyDesired(mapOf("slot-A" to 1))
+
+        assertEquals(1, conn.slots.value["slot-A"]?.controllerType)
+        assertEquals(listOf("slot-A"), slotSyncs)
+    }
+
+    @Test
+    fun `applyDesired with an unchanged set is silent`() {
+        every { repo.isConnectionAlive(any()) } returns true
+        conn.applyDesired(mapOf("slot-A" to 1))
+        connectLive(applied = listOf(okApply(0, appliedType = 1)))
+        slotSyncs.clear()
+
+        conn.applyDesired(mapOf("slot-A" to 1))
+
+        assertTrue(slotSyncs.isEmpty())
+        assertTrue(slotRemovals.isEmpty())
+    }
+
+    @Test
+    fun `applyDesired treats a same-type remove+add pair as a rename that keeps the pad alive`() {
+        every { repo.isConnectionAlive(any()) } returns true
+        conn.applyDesired(mapOf("slot-fw" to 1))
+        connectLive(applied = listOf(okApply(0, appliedType = 1)))
+        slotSyncs.clear()
+
+        conn.applyDesired(mapOf("slot-usb" to 1))
+
+        val renamed = conn.slots.value["slot-usb"]
+        assertEquals(0, renamed?.controllerIndex)
+        assertTrue(renamed?.registered == true)
+        assertNull(conn.slots.value["slot-fw"])
+        assertTrue(slotSyncs.isEmpty())
+        assertTrue(slotRemovals.isEmpty())
+    }
+
+    @Test
+    fun `applyDesired re-key with a different type is a real detach and attach`() {
+        every { repo.isConnectionAlive(any()) } returns true
+        conn.applyDesired(mapOf("slot-fw" to 1))
+        connectLive(applied = listOf(okApply(0, appliedType = 1)))
+        slotSyncs.clear()
+
+        conn.applyDesired(mapOf("slot-usb" to 0))
+
+        assertEquals(listOf(0), slotRemovals)
+        assertEquals(listOf("slot-usb"), slotSyncs)
+        assertTrue(conn.slots.value["slot-usb"]?.registered == false)
+    }
+
+    @Test
+    fun `applyDesired rename among unchanged siblings still renames`() {
+        conn.applyDesired(mapOf("slot-fw" to 1, "virtual" to 0))
+        val fwIndex = conn.slots.value["slot-fw"]!!.controllerIndex
+
+        conn.applyDesired(mapOf("slot-usb" to 1, "virtual" to 0))
+
+        assertEquals(fwIndex, conn.slots.value["slot-usb"]?.controllerIndex)
+        assertEquals(2, conn.slots.value.size)
+    }
 }

--- a/app/src/test/java/com/tinkernorth/dish/source/notification/DishNotificationsAttachmentTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/notification/DishNotificationsAttachmentTest.kt
@@ -50,7 +50,7 @@ class DishNotificationsAttachmentTest {
         )
 
     @Test
-    fun `posts before STARTED are not rendered`() =
+    fun `posts before the owner is resumed are not rendered`() =
         runTest {
             val notifications = DishNotifications()
             val owner = TestLifecycleOwner()
@@ -64,13 +64,13 @@ class DishNotificationsAttachmentTest {
         }
 
     @Test
-    fun `posts during STARTED are rendered`() =
+    fun `posts while the owner is resumed are rendered`() =
         runTest {
             val notifications = DishNotifications()
             val owner = TestLifecycleOwner()
             val renderer = RecordingRenderer()
             attach(notifications, owner, renderer, this)
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
 
             notifications.error(title = "boom")
@@ -88,7 +88,7 @@ class DishNotificationsAttachmentTest {
             val renderer = RecordingRenderer()
             attach(notifications, owner, renderer, this)
 
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
             notifications.info(title = "while-started")
             testScheduler.runCurrent()
@@ -112,14 +112,14 @@ class DishNotificationsAttachmentTest {
             val renderer = RecordingRenderer()
             attach(notifications, owner, renderer, this)
 
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
             owner.stop()
             testScheduler.runCurrent()
             notifications.info(title = "between")
             testScheduler.runCurrent()
 
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
             notifications.info(title = "after-restart")
             testScheduler.runCurrent()
@@ -137,7 +137,7 @@ class DishNotificationsAttachmentTest {
             val owner = TestLifecycleOwner()
             val renderer = RecordingRenderer()
             val attachment = attach(notifications, owner, renderer, this)
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
 
             notifications.info(title = "x")
@@ -154,7 +154,7 @@ class DishNotificationsAttachmentTest {
             val owner = TestLifecycleOwner()
             val renderer = RecordingRenderer()
             val attachment = attach(notifications, owner, renderer, this)
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
 
             notifications.info(title = "first")
@@ -176,7 +176,7 @@ class DishNotificationsAttachmentTest {
             val owner = TestLifecycleOwner()
             val renderer = RecordingRenderer()
             val attachment = attach(notifications, owner, renderer, this)
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
 
             val anchor = mockk<View>()
@@ -199,7 +199,7 @@ class DishNotificationsAttachmentTest {
             val owner = TestLifecycleOwner()
             val renderer = RecordingRenderer()
             val attachment = attach(notifications, owner, renderer, this)
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
 
             val id = notifications.info(title = "x")
@@ -221,7 +221,7 @@ class DishNotificationsAttachmentTest {
             val owner = TestLifecycleOwner()
             val renderer = RecordingRenderer()
             val attachment = attach(notifications, owner, renderer, this)
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
 
             notifications.info(title = "live")
@@ -244,7 +244,7 @@ class DishNotificationsAttachmentTest {
             val owner = TestLifecycleOwner()
             val renderer = RecordingRenderer()
             attach(notifications, owner, renderer, this)
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
 
             val firstId = notifications.info(title = "v1", key = "k")
@@ -268,7 +268,7 @@ class DishNotificationsAttachmentTest {
             val owner = TestLifecycleOwner()
             val renderer = RecordingRenderer()
             val attachment = attach(notifications, owner, renderer, this)
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
 
             notifications.warn(title = "v1", key = "bt-off")
@@ -294,7 +294,7 @@ class DishNotificationsAttachmentTest {
             val owner = TestLifecycleOwner()
             val renderer = RecordingRenderer()
             val attachment = attach(notifications, owner, renderer, this)
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
 
             notifications.warn(title = "x", key = "a")
@@ -313,7 +313,7 @@ class DishNotificationsAttachmentTest {
             val owner = TestLifecycleOwner()
             val renderer = RecordingRenderer()
             val attachment = attach(notifications, owner, renderer, this)
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
 
             notifications.info(title = "a")
@@ -335,7 +335,7 @@ class DishNotificationsAttachmentTest {
             val owner = TestLifecycleOwner()
             val renderer = RecordingRenderer()
             val attachment = attach(notifications, owner, renderer, this)
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
 
             val id = notifications.info(title = "x", key = "the-key")
@@ -356,7 +356,7 @@ class DishNotificationsAttachmentTest {
             val owner = TestLifecycleOwner()
             val renderer = RecordingRenderer()
             attach(notifications, owner, renderer, this)
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
 
             notifications.info(title = "a")
@@ -376,7 +376,7 @@ class DishNotificationsAttachmentTest {
             val owner = TestLifecycleOwner()
             val renderer = RecordingRenderer()
             val attachment = attach(notifications, owner, renderer, this)
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
 
             notifications.info(title = "a")
@@ -402,7 +402,7 @@ class DishNotificationsAttachmentTest {
             val owner = TestLifecycleOwner()
             val renderer = RecordingRenderer()
             attach(notifications, owner, renderer, this)
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
 
             owner.destroy()
@@ -425,7 +425,7 @@ class DishNotificationsAttachmentTest {
             val owner = TestLifecycleOwner()
             val renderer = RecordingRenderer()
             attach(notifications, owner, renderer, this)
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
 
             val ids =
@@ -444,7 +444,7 @@ class DishNotificationsAttachmentTest {
             val owner = TestLifecycleOwner()
             val renderer = RecordingRenderer()
             attach(notifications, owner, renderer, this)
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
 
             val a = notifications.info(title = "a")
@@ -470,7 +470,7 @@ class DishNotificationsAttachmentTest {
             val owner = TestLifecycleOwner()
             val renderer = RecordingRenderer()
             attach(notifications, owner, renderer, this)
-            owner.start()
+            owner.resume()
             testScheduler.runCurrent()
 
             val first = notifications.warn(title = "x", key = "k")

--- a/app/src/test/java/com/tinkernorth/dish/source/notification/DishNotificationsTransitionTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/notification/DishNotificationsTransitionTest.kt
@@ -44,7 +44,7 @@ class DishNotificationsTransitionTest {
         )
 
     @Test
-    fun `two STARTED attachments both render the same post`() =
+    fun `a post renders only on the most recently resumed attachment`() =
         runTest {
             val notifications = DishNotifications()
             val ownerA = TestLifecycleOwner()
@@ -54,15 +54,64 @@ class DishNotificationsTransitionTest {
             val rendererB = RecordingRenderer()
             attach(notifications, ownerB, rendererB, this)
 
-            ownerA.start()
-            ownerB.start()
+            // Transition overlap: A is still STARTED while B comes to the front.
+            ownerA.resume()
+            ownerA.pause()
+            ownerB.resume()
             testScheduler.runCurrent()
 
-            notifications.info(title = "fanout")
+            notifications.info(title = "front-only")
+            testScheduler.runCurrent()
+
+            assertTrue(rendererA.shown.isEmpty())
+            assertEquals(1, rendererB.shown.size)
+        }
+
+    @Test
+    fun `destroying the front attachment routes posts back to the previous one`() =
+        runTest {
+            val notifications = DishNotifications()
+            val ownerA = TestLifecycleOwner()
+            val rendererA = RecordingRenderer()
+            attach(notifications, ownerA, rendererA, this)
+            val ownerB = TestLifecycleOwner()
+            val rendererB = RecordingRenderer()
+            attach(notifications, ownerB, rendererB, this)
+
+            ownerA.resume()
+            ownerA.pause()
+            ownerB.resume()
+            testScheduler.runCurrent()
+
+            ownerB.destroy()
+            ownerA.resume()
+            testScheduler.runCurrent()
+
+            notifications.info(title = "back-on-a")
             testScheduler.runCurrent()
 
             assertEquals(1, rendererA.shown.size)
-            assertEquals(1, rendererB.shown.size)
+            assertTrue(rendererB.shown.isEmpty())
+        }
+
+    @Test
+    fun `a deferred post renders on the attachment that resumes next`() =
+        runTest {
+            val notifications = DishNotifications()
+            notifications.postDeferred(title = "held")
+
+            val owner = TestLifecycleOwner()
+            val renderer = RecordingRenderer()
+            attach(notifications, owner, renderer, this)
+            owner.start()
+            testScheduler.runCurrent()
+            assertTrue(renderer.shown.isEmpty())
+
+            owner.resume()
+            testScheduler.runCurrent()
+
+            assertEquals(1, renderer.shown.size)
+            assertEquals("held", renderer.shown[0].notification.title)
         }
 
     @Test
@@ -73,7 +122,7 @@ class DishNotificationsTransitionTest {
             val rendererA = RecordingRenderer()
             attach(notifications, ownerA, rendererA, this)
 
-            ownerA.start()
+            ownerA.resume()
             testScheduler.runCurrent()
             notifications.info(title = "on-a")
             testScheduler.runCurrent()
@@ -85,7 +134,7 @@ class DishNotificationsTransitionTest {
             val ownerB = TestLifecycleOwner()
             val rendererB = RecordingRenderer()
             attach(notifications, ownerB, rendererB, this)
-            ownerB.start()
+            ownerB.resume()
             testScheduler.runCurrent()
 
             notifications.error(title = "on-b")
@@ -138,10 +187,14 @@ class DishNotificationsTransitionTest {
             val rendererB = RecordingRenderer()
             val attachmentB = attach(notifications, ownerB, rendererB, this)
 
-            ownerA.start()
-            ownerB.start()
+            ownerA.resume()
             testScheduler.runCurrent()
-            notifications.info(title = "shared")
+            notifications.info(title = "on-a")
+            testScheduler.runCurrent()
+            ownerA.pause()
+            ownerB.resume()
+            testScheduler.runCurrent()
+            notifications.info(title = "on-b")
             testScheduler.runCurrent()
 
             assertEquals(1, attachmentA.liveById())
@@ -159,7 +212,7 @@ class DishNotificationsTransitionTest {
         }
 
     @Test
-    fun `same-key dedup is per-attachment - A's key does not affect B`() =
+    fun `a same-key repost on the new screen leaves the old screen handle alone`() =
         runTest {
             val notifications = DishNotifications()
             val ownerA = TestLifecycleOwner()
@@ -169,26 +222,29 @@ class DishNotificationsTransitionTest {
             val rendererB = RecordingRenderer()
             val attachmentB = attach(notifications, ownerB, rendererB, this)
 
-            ownerA.start()
-            ownerB.start()
+            ownerA.resume()
             testScheduler.runCurrent()
-
             notifications.warn(title = "v1", key = "shared-key")
             testScheduler.runCurrent()
             val a1 = rendererA.handles.last()
-            val b1 = rendererB.handles.last()
 
+            ownerA.pause()
+            ownerB.resume()
+            testScheduler.runCurrent()
             notifications.warn(title = "v2", key = "shared-key")
             testScheduler.runCurrent()
 
-            assertTrue(a1.dismissed)
-            assertTrue(b1.dismissed)
+            assertFalse(a1.dismissed)
             assertEquals(1, attachmentA.liveById())
             assertEquals(1, attachmentB.liveByKey())
+
+            ownerA.destroy()
+            testScheduler.runCurrent()
+            assertTrue(a1.dismissed)
         }
 
     @Test
-    fun `dismiss(id) propagates to every attachment that has the live handle`() =
+    fun `dismiss(id) reaches the attachment holding the live handle`() =
         runTest {
             val notifications = DishNotifications()
             val ownerA = TestLifecycleOwner()
@@ -198,21 +254,20 @@ class DishNotificationsTransitionTest {
             val rendererB = RecordingRenderer()
             val attachmentB = attach(notifications, ownerB, rendererB, this)
 
-            ownerA.start()
-            ownerB.start()
+            ownerA.resume()
+            ownerA.pause()
+            ownerB.resume()
             testScheduler.runCurrent()
 
             val id = notifications.info(title = "x")
             testScheduler.runCurrent()
-            assertEquals(1, attachmentA.liveById())
+            assertEquals(0, attachmentA.liveById())
             assertEquals(1, attachmentB.liveById())
 
             notifications.dismiss(id)
             testScheduler.runCurrent()
 
-            assertEquals(0, attachmentA.liveById())
             assertEquals(0, attachmentB.liveById())
-            assertTrue(rendererA.handles.last().dismissed)
             assertTrue(rendererB.handles.last().dismissed)
         }
 
@@ -224,7 +279,7 @@ class DishNotificationsTransitionTest {
             val rendererA1 = RecordingRenderer()
             val attachmentA1 = attach(notifications, ownerA1, rendererA1, this)
 
-            ownerA1.start()
+            ownerA1.resume()
             testScheduler.runCurrent()
             notifications.info(title = "a")
             testScheduler.runCurrent()
@@ -235,7 +290,7 @@ class DishNotificationsTransitionTest {
             val ownerA2 = TestLifecycleOwner()
             val rendererA2 = RecordingRenderer()
             val attachmentA2 = attach(notifications, ownerA2, rendererA2, this)
-            ownerA2.start()
+            ownerA2.resume()
             testScheduler.runCurrent()
 
             assertEquals(0, attachmentA2.liveById())

--- a/app/src/test/java/com/tinkernorth/dish/ui/common/StickAxesTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/common/StickAxesTest.kt
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.common
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+
+// Locks the virtual pad's touch-to-axis mapping: magnitude clamp, the y-down to
+// stick-up sign flip, and full-deflection wire values.
+class StickAxesTest {
+    @Test
+    fun `center maps to zero on both axes`() {
+        val axes = computeStickAxes(0f, 0f)
+        assertEquals(0, axes.axisX.toInt())
+        assertEquals(0, axes.axisY.toInt())
+    }
+
+    @Test
+    fun `full right deflection saturates axisX positive`() {
+        val axes = computeStickAxes(1f, 0f)
+        assertEquals(Short.MAX_VALUE.toInt(), axes.axisX.toInt())
+        assertEquals(0, axes.axisY.toInt())
+    }
+
+    @Test
+    fun `touch up (negative view y) is wire stick-up (positive axisY)`() {
+        val axes = computeStickAxes(0f, -1f)
+        assertEquals(Short.MAX_VALUE.toInt(), axes.axisY.toInt())
+    }
+
+    @Test
+    fun `touch down is wire stick-down`() {
+        val axes = computeStickAxes(0f, 1f)
+        assertTrue(axes.axisY < 0)
+    }
+
+    @Test
+    fun `a drag past the ring clamps to unit magnitude, direction kept`() {
+        val axes = computeStickAxes(3f, -4f)
+        val magnitude = kotlin.math.hypot(axes.dx, axes.dy)
+        assertEquals(1f, magnitude, 1e-4f)
+        assertEquals(0.6f, axes.dx, 1e-4f)
+        assertEquals(-0.8f, axes.dy, 1e-4f)
+    }
+
+    @Test
+    fun `a diagonal keeps both wire axes proportional`() {
+        val axes = computeStickAxes(0.5f, -0.5f)
+        assertEquals(abs(axes.axisX.toInt()), abs(axes.axisY.toInt()))
+        assertTrue(axes.axisX > 0)
+        assertTrue(axes.axisY > 0)
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/ui/common/StreamingScreenCoverageTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/common/StreamingScreenCoverageTest.kt
@@ -41,17 +41,25 @@ class StreamingScreenCoverageTest {
         assertTrue("onWindowFocusChanged" in declared)
     }
 
+    // Scaffolded screens inherit the overlays from screen_scaffold; a bespoke screen keeps
+    // its own CoordinatorLayout root and must carry the includes itself.
     @Test
-    fun `every activity layout includes the low power overlays`() {
+    fun `every full-screen activity layout includes the low power overlays`() {
         val missing =
             File(mainDir, "res")
                 .listFiles { dir -> dir.name.startsWith("layout") }
                 .orEmpty()
                 .flatMap { dir -> dir.listFiles { f -> f.name.startsWith("activity_") }.orEmpty().toList() }
                 .filterNot { it.name in exemptLayouts }
+                .filter { it.readText().contains("CoordinatorLayout") }
                 .filterNot { hasOverlayIncludes(it) }
                 .map { "${it.parentFile.name}/${it.name}" }
-        assertTrue("activity layouts without the low-power overlays: $missing", missing.isEmpty())
+        assertTrue("full-screen activity layouts without the low-power overlays: $missing", missing.isEmpty())
+    }
+
+    @Test
+    fun `the screen scaffold carries the low power overlays`() {
+        assertTrue(hasOverlayIncludes(File(mainDir, "res/layout/screen_scaffold.xml")))
     }
 
     private fun hasOverlayIncludes(file: File): Boolean {

--- a/app/src/test/java/com/tinkernorth/dish/ui/common/StreamingScreenCoverageTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/common/StreamingScreenCoverageTest.kt
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.common
+
+import com.tinkernorth.dish.ui.main.BaseInputOverlayActivity
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+// NativeUnavailableActivity is exempt (no native library to stream through);
+// MainActivity wires GamepadActivityHost itself on top of GameActivity.
+class StreamingScreenCoverageTest {
+    private val mainDir: File =
+        generateSequence(File(System.getProperty("user.dir")).absoluteFile) { it.parentFile }
+            .flatMap { sequenceOf(File(it, "src/main"), File(it, "app/src/main")) }
+            .first { File(it, "AndroidManifest.xml").exists() }
+
+    private val exemptActivities =
+        setOf(
+            "com.tinkernorth.dish.ui.main.NativeUnavailableActivity",
+            "com.tinkernorth.dish.ui.main.MainActivity",
+        )
+
+    private val exemptLayouts = setOf("activity_native_unavailable.xml")
+
+    @Test
+    fun `every manifest activity hosts gamepad streaming`() {
+        val missing =
+            manifestActivities()
+                .filterNot { it in exemptActivities }
+                .filterNot { hostsGamepad(Class.forName(it, false, javaClass.classLoader)) }
+        assertTrue("screens without a gamepad host: $missing", missing.isEmpty())
+    }
+
+    @Test
+    fun `main activity forwards gamepad events itself`() {
+        val main = Class.forName("com.tinkernorth.dish.ui.main.MainActivity", false, javaClass.classLoader)
+        val declared = main.declaredMethods.map { it.name }
+        assertTrue("dispatchKeyEvent" in declared)
+        assertTrue("dispatchGenericMotionEvent" in declared)
+        assertTrue("onWindowFocusChanged" in declared)
+    }
+
+    @Test
+    fun `every activity layout includes the low power overlays`() {
+        val missing =
+            File(mainDir, "res")
+                .listFiles { dir -> dir.name.startsWith("layout") }
+                .orEmpty()
+                .flatMap { dir -> dir.listFiles { f -> f.name.startsWith("activity_") }.orEmpty().toList() }
+                .filterNot { it.name in exemptLayouts }
+                .filterNot { hasOverlayIncludes(it) }
+                .map { "${it.parentFile.name}/${it.name}" }
+        assertTrue("activity layouts without the low-power overlays: $missing", missing.isEmpty())
+    }
+
+    private fun hasOverlayIncludes(file: File): Boolean {
+        val xml = file.readText()
+        return xml.contains("@layout/overlay_low_power") && xml.contains("@layout/overlay_low_power_chip")
+    }
+
+    private fun manifestActivities(): List<String> =
+        Regex("""<activity[^>]*android:name="([^"]+)"""")
+            .findAll(File(mainDir, "AndroidManifest.xml").readText())
+            .map { m -> m.groupValues[1].let { if (it.startsWith(".")) "com.tinkernorth.dish$it" else it } }
+            .toList()
+
+    private fun hostsGamepad(cls: Class<*>): Boolean =
+        BaseGamepadHostActivity::class.java.isAssignableFrom(cls) ||
+            BaseInputOverlayActivity::class.java.isAssignableFrom(cls)
+}

--- a/app/src/test/java/com/tinkernorth/dish/ui/connections/ConnectionsUiStateTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/connections/ConnectionsUiStateTest.kt
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.connections
+
+import com.tinkernorth.dish.composer.ConnectionKind
+import com.tinkernorth.dish.composer.ConnectionSummary
+import com.tinkernorth.dish.composer.LinkState
+import com.tinkernorth.dish.core.model.DiscoveredServer
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ConnectionsUiStateTest {
+    private fun summary(
+        id: String,
+        kind: ConnectionKind = ConnectionKind.SATELLITE,
+    ) = ConnectionSummary(
+        id = id,
+        kind = kind,
+        label = id,
+        detail = "",
+        live = LinkState.Saved,
+        boundSlotIds = emptyList(),
+    )
+
+    private fun server(machineId: String) =
+        DiscoveredServer(name = machineId, ip = "10.0.0.9", udpPort = 9876, pairPort = 1, httpPort = 1, machineId = machineId)
+
+    @Test
+    fun `known satellites come first, then unknown discovered servers`() {
+        val rows =
+            satelliteRows(
+                conns = listOf(summary("satellite:mid:aa")),
+                discovered = listOf(server("bb")),
+            )
+        assertEquals(2, rows.size)
+        assertEquals("satellite:mid:aa", (rows[0] as SatelliteRow.Known).summary.id)
+        assertEquals("bb", (rows[1] as SatelliteRow.Discovered).server.machineId)
+    }
+
+    @Test
+    fun `a discovered server already known under its stable id is not duplicated`() {
+        val rows =
+            satelliteRows(
+                conns = listOf(summary("satellite:mid:aa")),
+                discovered = listOf(server("aa")),
+            )
+        assertEquals(listOf<Class<*>>(SatelliteRow.Known::class.java), rows.map { it.javaClass })
+    }
+
+    @Test
+    fun `bluetooth summaries never appear as satellite rows and vice versa`() {
+        val conns = listOf(summary("satellite:mid:aa"), summary("bt:mac", kind = ConnectionKind.BLUETOOTH))
+        assertEquals(1, satelliteRows(conns, emptyList()).size)
+        assertEquals(listOf("bt:mac"), bluetoothSummaries(conns).map { it.id })
+    }
+
+    @Test
+    fun `no connections and no discoveries produce no rows`() {
+        assertEquals(emptyList<SatelliteRow>(), satelliteRows(emptyList(), emptyList()))
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/ui/diagnostics/DiagnosticsViewModelTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/diagnostics/DiagnosticsViewModelTest.kt
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.diagnostics
+
+import com.tinkernorth.dish.core.jni.PhysicalInputNative
+import com.tinkernorth.dish.source.store.LatencyProfilingStore
+import com.tinkernorth.dish.source.system.WifiLinkSource
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DiagnosticsViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val profilingEnabled = MutableStateFlow(false)
+    private val store =
+        mockk<LatencyProfilingStore> { every { state } returns profilingEnabled }
+    private val native =
+        mockk<PhysicalInputNative> {
+            justRun { setLatencyProbe(any()) }
+            every { hotPathBenchJson(false) } returns """{"rtt_us":{"n":4,"p50":6000.0}}"""
+        }
+    private val wifi = mockk<WifiLinkSource>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun viewModel() = DiagnosticsViewModel(store, native, wifi, Json { ignoreUnknownKeys = true })
+
+    @Test
+    fun `latency is off while profiling is disabled and no probe runs`() =
+        runTest(dispatcher.scheduler) {
+            val vm = viewModel()
+            val job = launch { vm.latency.collect {} }
+            dispatcher.scheduler.runCurrent()
+
+            assertEquals(DiagnosticsViewModel.LatencyUi.Off, vm.latency.value)
+            verify(exactly = 0) { native.setLatencyProbe(true) }
+            job.cancel()
+        }
+
+    @Test
+    fun `a collector with profiling on arms the probe and parses stats`() =
+        runTest(dispatcher.scheduler) {
+            profilingEnabled.value = true
+            val vm = viewModel()
+            val job = launch { vm.latency.collect {} }
+            dispatcher.scheduler.runCurrent()
+
+            verify { native.setLatencyProbe(true) }
+            val stats = vm.latency.value as DiagnosticsViewModel.LatencyUi.Stats
+            assertEquals(3.0, stats.panel.networkOneWayP50Ms!!, 1e-6)
+
+            job.cancel()
+            dispatcher.scheduler.runCurrent()
+            verify { native.setLatencyProbe(false) }
+        }
+
+    @Test
+    fun `unparseable native output reads as waiting, not a crash`() =
+        runTest(dispatcher.scheduler) {
+            every { native.hotPathBenchJson(false) } returns "garbage"
+            profilingEnabled.value = true
+            val vm = viewModel()
+            val job = launch { vm.latency.collect {} }
+            dispatcher.scheduler.runCurrent()
+
+            assertTrue(vm.latency.value is DiagnosticsViewModel.LatencyUi.Waiting)
+            job.cancel()
+        }
+
+    @Test
+    fun `turning profiling off mid-run disarms the probe`() =
+        runTest(dispatcher.scheduler) {
+            profilingEnabled.value = true
+            val vm = viewModel()
+            val job = launch { vm.latency.collect {} }
+            dispatcher.scheduler.runCurrent()
+
+            profilingEnabled.value = false
+            dispatcher.scheduler.runCurrent()
+
+            verify { native.setLatencyProbe(false) }
+            assertEquals(DiagnosticsViewModel.LatencyUi.Off, vm.latency.value)
+            job.cancel()
+        }
+}

--- a/app/src/test/java/com/tinkernorth/dish/ui/diagnostics/LatencyPanelTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/diagnostics/LatencyPanelTest.kt
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.diagnostics
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LatencyPanelTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `a full snapshot parses every field and halves the rtt`() {
+        val panel =
+            parseLatencyPanel(
+                """{"enabled":true,
+                    "stage1_hotpath_us":{"n":10,"p50":150.0,"p99":900.0},
+                    "urb_gap_us":{"n":10,"p50":4000.0,"p99":8000.0},
+                    "rtt_recent_us":[7000,3000],
+                    "rtt_us":{"n":32,"p50":6000.0,"p99":9000.0}}""",
+                json,
+            )!!
+        assertEquals(0.15, panel.phonePathP50Ms!!, 1e-6)
+        assertEquals(0.9, panel.phonePathP99Ms!!, 1e-6)
+        assertEquals(4.0, panel.pollingJitterP50Ms!!, 1e-6)
+        assertEquals(3.0, panel.networkOneWayP50Ms!!, 1e-6)
+        assertEquals(32, panel.rttSamples)
+        assertEquals(listOf(7f, 3f), panel.rttHistoryMs)
+    }
+
+    @Test
+    fun `an empty metric group parses to nulls, not zeros`() {
+        val panel = parseLatencyPanel("""{"enabled":true,"rtt_us":{"n":0}}""", json)!!
+        assertNull(panel.networkOneWayP50Ms)
+        assertNull(panel.phonePathP50Ms)
+        assertEquals(0, panel.rttSamples)
+    }
+
+    @Test
+    fun `garbage json parses to null`() {
+        assertNull(parseLatencyPanel("not json", json))
+    }
+
+    @Test
+    fun `a single rtt sample hides the sparkline history`() {
+        val panel = parseLatencyPanel("""{"rtt_recent_us":[5000]}""", json)!!
+        assertTrue(panel.rttHistoryMs.isEmpty())
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,12 +23,30 @@ gamepad / virtual pad / sensor
   encrypted UDP ───►  satellite server
 ```
 
-Controller events enter through `MainActivity.dispatchKeyEvent` /
-`dispatchGenericMotionEvent` (or the on-screen virtual pad), get
-normalised on the JVM, and cross into the native layer via
-`SatelliteNative`. The native side runs the encoder + `sendto` on the
-same thread the event arrived on. Discovery, motion, battery, and
+Framework controller events (Bluetooth pads, USB Standard) enter
+through the focused Activity's dispatch overrides. EVERY screen hosts
+them: standard screens extend `BaseGamepadHostActivity` (ui/common),
+which owns the `GamepadActivityHost` plumbing (dispatch forwarding,
+focus-loss release, keep-screen-on, the low-power dim);
+`MainActivity` wires the same host itself on top of `GameActivity`,
+and only `NativeUnavailableActivity` is exempt.
+`StreamingScreenCoverageTest` enforces this against the manifest.
+USB Direct never touches an Activity: native per-device poller
+threads read URBs and send straight to the wire. Events get
+normalised on the JVM, cross into the native layer via
+`SatelliteNative`, and the native side runs the encoder + `sendto` on
+the same thread the event arrived on. Discovery, motion, battery, and
 touchpad take the same JNI path with their own opcodes.
+
+Standard screens carry no chrome of their own:
+`BaseGamepadHostActivity.setScaffoldContent` inflates the screen's
+content layout into `@layout/screen_scaffold`, which holds the
+coordinator root and the low-power overlays exactly once. Bespoke
+screens (main, connections, configure-bindings, the input overlays)
+keep their own coordinator roots and must carry the overlay includes
+themselves. `DishNotifications` routes each post to the attachment
+whose owner most recently RESUMED, so a banner can never render on
+both sides of an activity transition.
 
 The REST control plane (pairing, the declarative session/controller
 routes, the catalog) **doesn't** go through JNI: TLS lives on the JVM
@@ -180,11 +198,20 @@ satellite, auto-reconnect) and the invariants that span more than one
 store. It does not derive state (that is a composer) and it is not a
 lifecycle actuator (that is a controller).
 
-- `ConnectionCoordinator` sequences `SlotBindingStore`,
-  `ControllerTypeStore`, and each `SatelliteConnection`, and re-exposes
+- `ConnectionCoordinator` records intent into `SlotBindingStore` and
+  `ControllerTypeStore` (type BEFORE binding, so the topology composer
+  never observes a binding without its type) and re-exposes
   `ConnectionsComposer.state` as `connections` directly: no
   coordinator-local mirror, which would create a two-writer race with
-  the composer's `onEach`.
+  the composer's `onEach`. It never touches a `SatelliteConnection`'s
+  slots: `SlotTopologyComposer` derives the desired topology
+  (connectionId -> slotId -> type) from the two stores, and
+  `SlotTopologyController` converges every live connection to it via
+  `SatelliteConnection.applyDesired`, the ONLY production write path
+  into a connection's slot map. A same-type remove+add pair in one
+  emission is read as a rename (a USB claim/release re-keying the
+  device id), preserving the controller index so the server-side pad
+  survives without an unplug/replug.
 - `SatelliteConnectionManager` owns the connect/pair/retry lifecycle
   and the live `SatelliteConnection` map.
 
@@ -271,6 +298,14 @@ analogue of `ComposerProbe` and `StateSourceProbe`.
 Rule: if a class both derives a value and effects something, split it
 (derive in a composer, effect in a controller) rather than collapsing
 the two.
+
+Rule: inputs keep moving while an actuator is stopped, so `apply`
+must reconcile fully from the current upstream value and never trust
+memory recorded before the stop. Cross-emission state (dedupe caches,
+last-seen sets) may only suppress redundant work, never substitute
+for looking at the world again on the post-start emission. The
+phantom-slot bug was exactly this: departed devices remembered in a
+set that a lifecycle stop reset.
 
 ## Capabilities
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -638,3 +638,14 @@ deeper), the error red can drop below AA. Compute before adopting.
 | Activity transitions | `app/src/main/res/anim/fade_through_enter.xml`, `fade_through_exit.xml` |
 | Navigation graph | `app/src/main/res/navigation/nav_graph.xml` |
 | Navigation wrapper | `app/src/main/java/com/tinkernorth/dish/ui/common/DishNavigator.kt` |
+
+## Naming
+
+- Layout files: `activity_*` for a full-screen root (CoordinatorLayout,
+  carries the low-power overlays) or a scaffold content layout inflated via
+  `setScaffoldContent`; `content-free` composites use their role
+  (`section_*`, `view_*`, `overlay_*`, `dialog_*`, feature-prefixed rows).
+- View ids: semantic names for containers and composites (`cardSupport`,
+  `sectionLatency`, `hostList`); a short type prefix only for leaf controls
+  where the type is the point (`tvTitle`, `btnApply`, `ivIcon`, `swDirect`).
+  Both exist in older layouts; new layouts follow this split.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,7 @@ turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines-test" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
+firebase-crashlytics-ndk = { group = "com.google.firebase", name = "firebase-crashlytics-ndk" }
 # firebase-analytics intentionally absent. See app/build.gradle.kts and PRIVACY.md
 # for the zero-analytics posture. Re-adding it requires policy and Data Safety updates.
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }


### PR DESCRIPTION
Three streaming-continuity fixes: every screen now hosts gamepad streaming and the wake/dim contract, stale slot bindings self-heal instead of re-creating phantom satellite pads forever, and the diagnostics latency readout reports current conditions instead of a since-arming blend.

## 1. Stream gamepad input and hold wake state on every screen (`5abe9f6`)

Only five screens installed `GamepadActivityHost`. Everywhere else:

- Framework-path controllers (Bluetooth, USB **Standard**) stopped streaming: their key/motion events fell through to the activity and drove UI focus navigation instead of reaching `SatelliteNative`. Most visible on Settings, Diagnostics, and the controller inspector.
- The controller inspector could not see framework-path devices at all, since nothing on that screen fed events into the native mirror it polls.
- `FLAG_KEEP_SCREEN_ON` and the low-power dim countdown disarmed while streaming, so the screen could time out mid-session.

USB Direct was unaffected (native reader threads are screen-independent), which is why this only showed in Standard mode.

Changes:

- New `BaseGamepadHostActivity` (ui/common) owns the host plumbing: dispatch forwarding, focus-loss release, unbuffered joystick dispatch, keep-screen-on, dim countdown, and dim cancel on stop. Subclasses call `installGamepadHost(binding.root)` after `setContentView`.
- Settings, Licenses, Diagnostics, InputInspector, Help, Donate, and all six Setup activities now extend it; ConnectionsActivity and ConfigureBindingsActivity migrate onto it, dropping duplicated copies.
- MainActivity keeps its own wiring (`GameActivity` superclass). NativeUnavailableActivity stays plain: no native library to stream through.
- Every activity layout (including the `sw600dp` variants of settings/donate/help) includes `overlay_low_power` and `overlay_low_power_chip`, which the host binds.
- `StreamingScreenCoverageTest` enforces the invariant: every manifest activity extends a gamepad-hosting base (explicit exemptions: MainActivity, NativeUnavailableActivity), MainActivity still declares its own dispatch overrides, and every `activity_*.xml` in every layout folder carries both overlay includes.

## 2. Sweep stale bindings so phantom satellite pads self-heal (`0776d5c`)

A device that departed while the binding observer was stopped (app backgrounded during a transport switch) was in neither `present` nor `lastBound`, so `reconcileSlots` never unbound it. Its slot stayed in the binding store and in `SatelliteConnection`'s declarative slot map, which re-registered a phantom pad on the satellite on **every reconnect** (the session PUT re-declares the full topology and the server applies it authoritatively), with no UI able to remove it since controller cards render from registry devices.

`reconcileSlots` now also treats any numeric binding whose device id the registry no longer knows as departed, emitting the same ordered Unbind/Forget/ReleaseHubBinding ops. Non-numeric logical slots (the on-screen controller) are exempt, matching the existing `slotExists` rule. The registry's 5 s disconnect grace and the claim path's add-before-bind ordering keep the sweep from racing live transport switches. Six new tests cover the sweep, the synthetic-id Forget skip, the virtual-slot exemption, dedup with the normal departed path, and departed-before-bind ordering.

Behavior note: a controller that departs now loses its binding for real once the grace passes, even if the app was backgrounded at the time, same as an in-foreground departure always did.

## 3. Windowed RTT with a probe mode so latency reads "now" (`30383d5`)

The network-latency figure was a percentile over every heartbeat since the profiling toggle was armed (and the toggle persists across launches), so idle-radio wakeup samples (tens of ms, one 2 s ping is worst-case Wi-Fi power-save traffic) blended with in-game samples (2-7 ms) and the number drifted for minutes.

- The RTT ring is now a 64-sample sliding window; stage-1 and URB-gap keep their accumulate-then-dump bench semantics for the adb bench tool.
- While the diagnostics latency panel is open, probe mode drops the heartbeat interval to 250 ms and clears the window on entry, so the readout converges in seconds and reflects only probe-era samples. Steady-state cadence stays the contractual 2000 ms; the death window stays ~10 s because the miss threshold scales with the interval; the server acks every ping unconditionally (`handleHeartbeat` has no rate policing), so this is protocol-safe.
- `markPingSent` no longer overwrites an in-flight ping's clock, which paired a late ack with a newer ping and read low.
- The panel refreshes at 1 Hz and shows the sample count (`~3.41 ms · last 64 pings`); the new string is translated in all five locales.

## Verification

- `StreamingScreenCoverageTest`, `PhysicalSlotBindingObserverTest`, `BindOpDedupeTest` green locally; full suite on CI.
- `:app:hiltJavaCompileDebug`, `:app:compileDebugUnitTestKotlin`, `:app:externalNativeBuildDebug` (new JNI symbol confirmed in `libsatellite.so` via llvm-nm), `:app:ktlintCheck`, `:app:detekt`, clang-format 22.1.4 all green.

## Notes for review

- Attaching the host also attaches the `DishNotifications` bus on every screen, so connection banners/snackbars now appear app-wide. That matches the bus design but widens exposure to the known banner-overlap quirk during activity transitions.
- With events consumed for streaming, a bound controller no longer d-pad-navigates Settings/Setup UI, the same trade-off Main/Connections already made.
- The latency probe deviates from the contract's steady-state cadence note ("2000 ms, not 250 ms") only while the diagnostics panel is armed and open; if that reads as too aggressive, dropping `HEARTBEAT_INTERVAL_PROBE_MS` to 500 ms is a one-line change.

## 4. Architecture follow-ups (root fixes behind the bugs above)

- **Derived slot topology (`0be67c1`)**: `SlotTopologyComposer` projects the desired satellite topology purely from `SlotBindingStore` + `ControllerTypeStore`; `SlotTopologyController` converges every live connection via `SatelliteConnection.applyDesired`, now the only production write path into a connection's slot map. `ConnectionCoordinator` records intent only. A USB claim/release resolves as an index-preserving rename from an atomic single-emission binding re-key, so mode switches stay wire-silent. This makes the phantom-pad class unrepresentable (the sweep from fix 2 remains as defense in depth). `AbstractController` now states the actuator rule: reconcile from current inputs on start, never from pre-stop memory.
- **Per-session RTT pairing (`0909b48`)**: the heartbeat ping clock lives on the `Session`, so concurrent satellites cannot cross-pair pings and acks.
- **Notification routing (`b4c896b`)**: posts route only to the most recently resumed attachment (resume-ordered stack with destroy fallback; deferred posts drain on next resume). Fixes the transition-overlap banner leak at the bus, superseding the per-screen mitigation concern flagged in the review notes.
- **Screen scaffold (`1a1a264`)**: `screen_scaffold.xml` owns the coordinator root and low-power overlays once; the 12 standard screens are content-only layouts inflated via `BaseGamepadHostActivity.setScaffoldContent`. Bespoke screens (main, connections, configure-bindings, input overlays) keep their own chrome. Coverage test updated accordingly.
- **Docs (`e400d6e`)**: `docs/architecture.md` catches up (per-screen input entry, topology flow, actuator rule, scaffold, notification routing).

Full CI mirror ran locally for the follow-ups: clang-format, ktlintCheck, detekt, :app:lint, complete :app:testDebugUnitTest, :app:assembleDebug, native build.
