### PR TITLE
test: integration test suite (fake-satellite protocol + dashboard) on CI

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -103,7 +103,7 @@ jobs:
           retention-days: 7
 
   instrumented:
-    name: Integration tests (managed device)
+    name: Integration tests (emulator)
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -6,6 +6,7 @@ name: Android CI
 #   actions/setup-python          @ v6.2.0 → a309ff8b426b58ec0e2a45f0f869d46889d02405
 #   actions/upload-artifact       @ v7.0.1 → 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
 #   gradle/actions/setup-gradle   @ v6.2.0 → 3f131e8634966bd73d06cc69884922b02e6faf92
+#   reactivecircus/android-emulator-runner @ v2.38.0 → a421e43855164a8197daf9d8d40fe71c6996bb0d
 
 on:
   push:
@@ -99,4 +100,62 @@ jobs:
         with:
           name: test-results
           path: app/build/reports/tests/
+          retention-days: 7
+
+  instrumented:
+    name: Integration tests (managed device)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        with:
+          java-version: "17"
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+
+      - name: Pre-install CMake 3.22.1
+        run: ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager "cmake;3.22.1"
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build app + test APKs
+        run: ./gradlew :app:assembleDebug :app:assembleDebugAndroidTest
+
+      - name: Run integration tests
+        # Same emulator path the screenshots workflow uses (google_apis, KVM):
+        # a known-good CI image for this app's GameActivity. Scoped to the
+        # integration package. The pixel6Api34 managed device stays for local
+        # runs (scripts/ci_local.sh --gmd).
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
+        with:
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          disable-animations: true
+          emulator-options: -no-snapshot-save -no-window -noaudio -no-boot-anim -gpu swiftshader_indirect
+          script: >-
+            ./gradlew :app:connectedDebugAndroidTest
+            -Pandroid.testInstrumentationRunnerArguments.package=com.tinkernorth.dish.integration
+
+      - name: Upload instrumented test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: instrumented-test-results
+          path: app/build/reports/androidTests/
           retention-days: 7

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,6 +76,8 @@ android {
         versionName = resolvedVersion.name
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        // Orchestrator wipes app data (prefs, connection store) between tests.
+        testInstrumentationRunnerArguments["clearPackageData"] = "true"
 
         ndk {
             abiFilters += listOf("arm64-v8a", "x86_64")
@@ -174,6 +176,24 @@ android {
         unitTests {
             isReturnDefaultValues = true
         }
+        // Run each instrumented test in its own process via Android Test
+        // Orchestrator, clearing app state between them. The integration suite
+        // drives real process-wide singletons (connection manager, stores,
+        // native UDP), so per-test isolation keeps one test's session, retry
+        // jobs, and sockets from leaking into the next.
+        execution = "ANDROIDX_TEST_ORCHESTRATOR"
+        managedDevices {
+            localDevices {
+                create("pixel6Api34") {
+                    device = "Pixel 6"
+                    apiLevel = 34
+                    // Test-optimised system image: no Play services or extra
+                    // apps, so it boots faster and runs leaner in CI than the
+                    // google_apis image.
+                    systemImageSource = "aosp-atd"
+                }
+            }
+        }
     }
 }
 
@@ -209,6 +229,8 @@ dependencies {
     androidTestImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.rules)
+    androidTestImplementation(libs.okhttp.tls)
+    androidTestUtil(libs.androidx.test.orchestrator)
     "baselineProfile"(project(":baselineprofile"))
 }
 

--- a/app/src/androidTest/java/com/tinkernorth/dish/integration/AppSingletons.kt
+++ b/app/src/androidTest/java/com/tinkernorth/dish/integration/AppSingletons.kt
@@ -5,17 +5,23 @@ package com.tinkernorth.dish.integration
 import android.content.Context
 import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
+import com.tinkernorth.dish.composer.CapabilityComposer
 import com.tinkernorth.dish.composer.ConnectionCoordinator
 import com.tinkernorth.dish.repository.ConnectionStore
+import com.tinkernorth.dish.repository.SatelliteCatalogRepository
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
+import com.tinkernorth.dish.source.store.ControllerTypeStore
+import com.tinkernorth.dish.source.store.SatelliteHostFeaturesStore
+import com.tinkernorth.dish.source.store.SlotBindingStore
 import com.tinkernorth.dish.ui.main.MainActivity
 
 /**
- * Grabs the app's real singletons once per instrumentation process by
- * bouncing through MainActivity's public injection fields: the suite
- * exercises production wiring, so there is no Hilt test component to
- * ask. The welcome flag is seeded first or MainActivity would bounce
- * to setup and finish before the fields can be read.
+ * The app's real @Singleton graph, grabbed once per instrumentation process by
+ * bouncing through MainActivity's public injection fields and reflecting the
+ * rest off the manager/hub/composer they hold. The suite exercises production
+ * wiring, so there is no Hilt test component to ask. Prefs are wiped and the
+ * welcome flag set before the first launch so MainActivity does not bounce to
+ * setup and startup auto-reconnect has no ghost to chase.
  */
 object AppSingletons {
     lateinit var satellite: SatelliteConnectionManager
@@ -25,6 +31,21 @@ object AppSingletons {
         private set
 
     lateinit var store: ConnectionStore
+        private set
+
+    lateinit var bindingStore: SlotBindingStore
+        private set
+
+    lateinit var typeStore: ControllerTypeStore
+        private set
+
+    lateinit var catalogRepo: SatelliteCatalogRepository
+        private set
+
+    lateinit var hostFeaturesStore: SatelliteHostFeaturesStore
+        private set
+
+    lateinit var capabilityComposer: CapabilityComposer
         private set
 
     private var grabbed = false
@@ -39,10 +60,6 @@ object AppSingletons {
             .putBoolean("onboarding_welcome_completed", true)
             .putLong("donate_pill_dismissed_at", System.currentTimeMillis())
             .commit()
-        // Wipe persisted satellites/keys/pins BEFORE the first launch so
-        // startup auto-reconnect has no ghost to chase on a dead port left by
-        // a prior run. The stores read their initial state from this file
-        // when Hilt first constructs them during the launch below.
         context
             .getSharedPreferences("connection_store", Context.MODE_PRIVATE)
             .edit()
@@ -55,6 +72,16 @@ object AppSingletons {
             }
         }
         store = satellite.fieldValue("store") as ConnectionStore
+        bindingStore = hub.fieldValue("bindingStore") as SlotBindingStore
+        typeStore = hub.fieldValue("typeStore") as ControllerTypeStore
+        capabilityComposer =
+            satellite.fieldValue("capabilityProvider").let { provider ->
+                provider.javaClass
+                    .getMethod("get")
+                    .invoke(provider) as CapabilityComposer
+            }
+        catalogRepo = capabilityComposer.fieldValue("catalogRepo") as SatelliteCatalogRepository
+        hostFeaturesStore = capabilityComposer.fieldValue("hostFeatures") as SatelliteHostFeaturesStore
         grabbed = true
     }
 
@@ -64,14 +91,13 @@ object AppSingletons {
         // the persisted list: a session that failed before it was remembered,
         // or one a death-retry re-added, would otherwise linger and flake the
         // next test. forget() drops key/pin/row synchronously, removes the
-        // connection from the map, and neutralises any pending retry (its guard
-        // sees the connection gone). The network unpair is fire-and-forget, so
-        // this never depends on a fake still listening.
+        // connection from the map, and neutralises any pending retry.
         val ids = (satellite.connections.value.keys + store.remembered().map { it.id }).toSet()
         ids.forEach { id -> satellite.forget(id) }
         await(timeoutMs = 5_000) { satellite.connections.value.isEmpty() }
-        // Let any in-flight teardown/retry coroutines observe the removal before
-        // the next test starts pairing, so nothing bleeds across the boundary.
+        bindingStore.state.value.keys
+            .toList()
+            .forEach { bindingStore.unbind(it) }
         Thread.sleep(300)
     }
 

--- a/app/src/androidTest/java/com/tinkernorth/dish/integration/AppSingletons.kt
+++ b/app/src/androidTest/java/com/tinkernorth/dish/integration/AppSingletons.kt
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.integration
+
+import android.content.Context
+import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
+import com.tinkernorth.dish.composer.ConnectionCoordinator
+import com.tinkernorth.dish.repository.ConnectionStore
+import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
+import com.tinkernorth.dish.ui.main.MainActivity
+
+/**
+ * Grabs the app's real singletons once per instrumentation process by
+ * bouncing through MainActivity's public injection fields: the suite
+ * exercises production wiring, so there is no Hilt test component to
+ * ask. The welcome flag is seeded first or MainActivity would bounce
+ * to setup and finish before the fields can be read.
+ */
+object AppSingletons {
+    lateinit var satellite: SatelliteConnectionManager
+        private set
+
+    lateinit var hub: ConnectionCoordinator
+        private set
+
+    lateinit var store: ConnectionStore
+        private set
+
+    private var grabbed = false
+
+    @Synchronized
+    fun grab() {
+        if (grabbed) return
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        context
+            .getSharedPreferences("user_preferences", Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean("onboarding_welcome_completed", true)
+            .putLong("donate_pill_dismissed_at", System.currentTimeMillis())
+            .commit()
+        // Wipe persisted satellites/keys/pins BEFORE the first launch so
+        // startup auto-reconnect has no ghost to chase on a dead port left by
+        // a prior run. The stores read their initial state from this file
+        // when Hilt first constructs them during the launch below.
+        context
+            .getSharedPreferences("connection_store", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                satellite = activity.satellite
+                hub = activity.hub
+            }
+        }
+        store = satellite.fieldValue("store") as ConnectionStore
+        grabbed = true
+    }
+
+    fun resetConnections() {
+        grab()
+        // Forget every id the manager knows about, from BOTH the live map and
+        // the persisted list: a session that failed before it was remembered,
+        // or one a death-retry re-added, would otherwise linger and flake the
+        // next test. forget() drops key/pin/row synchronously, removes the
+        // connection from the map, and neutralises any pending retry (its guard
+        // sees the connection gone). The network unpair is fire-and-forget, so
+        // this never depends on a fake still listening.
+        val ids = (satellite.connections.value.keys + store.remembered().map { it.id }).toSet()
+        ids.forEach { id -> satellite.forget(id) }
+        await(timeoutMs = 5_000) { satellite.connections.value.isEmpty() }
+        // Let any in-flight teardown/retry coroutines observe the removal before
+        // the next test starts pairing, so nothing bleeds across the boundary.
+        Thread.sleep(300)
+    }
+
+    fun await(
+        timeoutMs: Long = 25_000,
+        condition: () -> Boolean,
+    ): Boolean {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return true
+            Thread.sleep(100)
+        }
+        return condition()
+    }
+
+    fun Any.fieldValue(name: String): Any {
+        var cls: Class<*>? = javaClass
+        while (cls != null) {
+            val field = cls.declaredFields.firstOrNull { it.name == name }
+            if (field != null) {
+                field.isAccessible = true
+                return field.get(this) ?: error("field $name is null on ${javaClass.name}")
+            }
+            cls = cls.superclass
+        }
+        error("field $name not found on ${javaClass.name}")
+    }
+}

--- a/app/src/androidTest/java/com/tinkernorth/dish/integration/CatalogIntegrationTest.kt
+++ b/app/src/androidTest/java/com/tinkernorth/dish/integration/CatalogIntegrationTest.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.integration
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.tinkernorth.dish.source.connection.SatelliteConnection
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Exercises the read-only catalog surface (GET /api/catalog, unauthenticated,
+ * ETag-cached) through the real SatelliteCatalogRepository against the fake:
+ * type list rendering, host-feature publication, and the 304 revalidation
+ * that keeps the picker from re-parsing an unchanged catalog.
+ */
+@RunWith(AndroidJUnit4::class)
+class CatalogIntegrationTest {
+    private var fake: FakeSatellite? = null
+
+    @Before
+    fun setUp() {
+        AppSingletons.resetConnections()
+    }
+
+    @After
+    fun tearDown() {
+        AppSingletons.resetConnections()
+        fake?.close()
+        fake = null
+    }
+
+    @Test
+    fun catalog_fetchReturnsTheTypeListAndPublishesHostFeatures() {
+        val satellite = FakeSatellite().also { fake = it }
+        val server = satellite.server()
+        val id = SatelliteConnection.idFor(server)
+
+        val catalog = runBlocking { AppSingletons.catalogRepo.catalogFor(server, id) }
+        assertNotNull("catalog must be fetched from the satellite", catalog)
+        assertEquals("en", catalog!!.locale)
+        val slugs = catalog.controllerTypes.map { it.slug }
+        assertTrue("catalog carries the xbox360 and ds4 types", slugs.containsAll(listOf("xbox360", "ds4")))
+
+        val hostFeatures = AppSingletons.hostFeaturesStore.featuresFor(id)
+        assertNotNull("catalog fetch must publish host features", hostFeatures)
+        assertTrue("the fake advertises host mouseControl", hostFeatures!!.mouseControl)
+    }
+
+    @Test
+    fun catalog_secondFetchRevalidatesWithEtagAndServesCache() {
+        val satellite = FakeSatellite().also { fake = it }
+        val server = satellite.server()
+        val id = SatelliteConnection.idFor(server)
+
+        val first = runBlocking { AppSingletons.catalogRepo.catalogFor(server, id) }
+        val second = runBlocking { AppSingletons.catalogRepo.catalogFor(server, id) }
+
+        assertNotNull(first)
+        assertNotNull(second)
+        assertEquals("the 304 path serves the same cached catalog", first!!.controllerTypes.size, second!!.controllerTypes.size)
+        assertEquals("both fetches hit the satellite; the second is an If-None-Match revalidation", 2, satellite.catalogRequests)
+    }
+}

--- a/app/src/androidTest/java/com/tinkernorth/dish/integration/DashboardIntegrationTest.kt
+++ b/app/src/androidTest/java/com/tinkernorth/dish/integration/DashboardIntegrationTest.kt
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.integration
+
+import android.widget.TextView
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.tinkernorth.dish.R
+import com.tinkernorth.dish.integration.AppSingletons.await
+import com.tinkernorth.dish.source.connection.SatelliteConnection
+import com.tinkernorth.dish.source.connection.SatelliteSessionState
+import com.tinkernorth.dish.ui.main.MainActivity
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * End-to-end through the real MainActivity + ViewModel + connection stack:
+ * pair against an in-process satellite, then assert the dashboard's own
+ * views reflect the live session. Verifies the app's state actually flows
+ * to the UI, not just that the manager reports Live.
+ */
+@RunWith(AndroidJUnit4::class)
+class DashboardIntegrationTest {
+    private val manager get() = AppSingletons.satellite
+    private var fake: FakeSatellite? = null
+
+    @Before
+    fun setUp() {
+        AppSingletons.resetConnections()
+    }
+
+    @After
+    fun tearDown() {
+        AppSingletons.resetConnections()
+        fake?.close()
+        fake = null
+    }
+
+    @Test
+    fun liveSession_showsOneOfOneOnline_onTheDashboard() {
+        val satellite = FakeSatellite().also { fake = it }
+        val server = satellite.server(name = "Fake Satellite")
+        manager.pairWithPin(server, "1234")
+        assertTrue(
+            await { manager.get(SatelliteConnection.idFor(server))?.state?.value == SatelliteSessionState.Live },
+        )
+
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+            val reflected =
+                await(timeoutMs = 25_000) { scenario.summaryText().contains("1 of 1", ignoreCase = true) }
+            assertTrue(
+                "connections summary should report the live link, was \"${scenario.summaryText()}\"",
+                reflected,
+            )
+            scenario.onActivity { activity ->
+                val controllers = activity.findViewById<android.view.View>(R.id.rvControllers)
+                assertTrue("controller list must be present", controllers != null)
+            }
+        }
+    }
+
+    @Test
+    fun noConnections_showsTheEmptyPrompt() {
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            val prompt =
+                InstrumentationRegistry
+                    .getInstrumentation()
+                    .targetContext
+                    .getString(R.string.status_tap_manage)
+            assertTrue(
+                "empty dashboard should invite adding a connection",
+                await { scenario.summaryText() == prompt },
+            )
+        }
+    }
+
+    private fun ActivityScenario<MainActivity>.summaryText(): String {
+        var text = ""
+        onActivity { activity ->
+            text =
+                activity
+                    .findViewById<TextView>(R.id.tvConnectionsSummary)
+                    ?.text
+                    ?.toString()
+                    .orEmpty()
+        }
+        return text
+    }
+}

--- a/app/src/androidTest/java/com/tinkernorth/dish/integration/FakeSatellite.kt
+++ b/app/src/androidTest/java/com/tinkernorth/dish/integration/FakeSatellite.kt
@@ -1,0 +1,480 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.integration
+
+import com.tinkernorth.dish.core.model.DiscoveredServer
+import com.tinkernorth.dish.core.net.SessionCrypto
+import okhttp3.tls.HeldCertificate
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.Closeable
+import java.io.InputStreamReader
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.SocketAddress
+import java.net.SocketException
+import java.nio.ByteBuffer
+import java.security.KeyStore
+import java.security.SecureRandom
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import javax.net.ssl.KeyManagerFactory
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLServerSocket
+import javax.net.ssl.SSLSocket
+
+/**
+ * In-process satellite implementing the protocol-1 contract surface the
+ * client exercises (satellite docs/contract.md): PIN pairing, hmacProof
+ * validation, the declarative session PUT/GET, self-unpair, catalog and
+ * capabilities probes, and the encrypted UDP data plane with heartbeat
+ * acks. Each instance mints its own self-signed cert at runtime (no
+ * committed keys), so two instances present different certs: pin one,
+ * then connect the other on the same identity to exercise TOFU rejection.
+ */
+class FakeSatellite(
+    private val operatorPin: String = "1234",
+) : Closeable {
+    private val instanceId = INSTANCES.incrementAndGet()
+    private val https: SSLServerSocket
+    private val udp = DatagramSocket(0)
+    private val threads = mutableListOf<Thread>()
+
+    @Volatile private var running = true
+
+    @Volatile var pairingKeyHex: String? = null
+
+    @Volatile var force401Code: String? = null
+
+    @Volatile var ackEpochOverride: Int? = null
+
+    @Volatile private var epoch = 1
+
+    @Volatile private var tokenCounter = 7
+
+    @Volatile private var lastTokenHex: String? = null
+
+    @Volatile private var sessionKey: ByteArray? = null
+
+    @Volatile private var downCounter = 0
+
+    @Volatile private var lastClientAddress: SocketAddress? = null
+
+    @Volatile private var lastControllers = JSONArray()
+
+    val sessionPuts = CopyOnWriteArrayList<JSONObject>()
+    val reconcileGets = CopyOnWriteArrayList<String>()
+    val unpairCalls = CopyOnWriteArrayList<String>()
+    val udpOpcodes = CopyOnWriteArrayList<Int>()
+
+    @Volatile var heartbeatCount = 0
+        private set
+
+    val httpsPort: Int get() = https.localPort
+    val udpPort: Int get() = udp.localPort
+
+    init {
+        // Fresh self-signed cert per instance: no keys committed to the repo,
+        // and two instances differ, which is exactly what the TOFU test needs.
+        val held =
+            HeldCertificate
+                .Builder()
+                .addSubjectAlternativeName("127.0.0.1")
+                .build()
+        val keyStore =
+            KeyStore.getInstance("PKCS12").apply {
+                load(null, null)
+                setKeyEntry("fake", held.keyPair.private, CharArray(0), arrayOf(held.certificate))
+            }
+        val kmf =
+            KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm()).apply {
+                init(keyStore, CharArray(0))
+            }
+        val ssl = SSLContext.getInstance("TLS").apply { init(kmf.keyManagers, null, SecureRandom()) }
+        https = ssl.serverSocketFactory.createServerSocket(0) as SSLServerSocket
+        thread("fake-sat-https") { acceptLoop() }
+        thread("fake-sat-udp") { udpLoop() }
+    }
+
+    fun server(
+        name: String = "Fake Satellite",
+        machineId: String = "fake-sat-$instanceId",
+    ): DiscoveredServer =
+        DiscoveredServer(
+            name = name,
+            ip = "127.0.0.1",
+            udpPort = udpPort,
+            pairPort = httpsPort,
+            httpPort = httpsPort,
+            machineId = machineId,
+        )
+
+    fun awaitUdpOpcode(
+        opcode: Int,
+        timeoutMs: Long = 8_000,
+    ): Boolean {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (udpOpcodes.contains(opcode)) return true
+            Thread.sleep(100)
+        }
+        return false
+    }
+
+    fun sendSessionClose(reason: Int) {
+        sendDown(0x000F, byteArrayOf(reason.toByte()))
+    }
+
+    override fun close() {
+        running = false
+        runCatching { https.close() }
+        runCatching { udp.close() }
+        threads.forEach { runCatching { it.join(2_000) } }
+    }
+
+    private fun thread(
+        name: String,
+        block: () -> Unit,
+    ) {
+        threads +=
+            Thread(block, name).apply {
+                isDaemon = true
+                start()
+            }
+    }
+
+    private fun acceptLoop() {
+        while (running) {
+            val socket =
+                try {
+                    https.accept() as SSLSocket
+                } catch (_: Exception) {
+                    return
+                }
+            thread("fake-sat-conn") { runCatching { handle(socket) }.also { socket.close() } }
+        }
+    }
+
+    private fun handle(socket: SSLSocket) {
+        // HTTP/1.1 keep-alive: the production client pools the TLS socket and
+        // reuses it across requests, so serve every request on the connection
+        // until the client closes it or goes idle. Closing after one (the old
+        // behaviour) left the client reusing a dead socket, forcing a
+        // transparent retry per call whose latency accumulated across the run.
+        socket.soTimeout = 3_000
+        val reader = BufferedReader(InputStreamReader(socket.inputStream))
+        val out = socket.outputStream
+        while (running) {
+            val requestLine = reader.readLine() ?: return
+            if (requestLine.isEmpty()) continue
+            val headers = mutableMapOf<String, String>()
+            while (true) {
+                val line = reader.readLine() ?: return
+                if (line.isEmpty()) break
+                val idx = line.indexOf(':')
+                if (idx > 0) headers[line.substring(0, idx).trim().lowercase()] = line.substring(idx + 1).trim()
+            }
+            val length = headers["content-length"]?.toIntOrNull() ?: 0
+            val body = CharArray(length).also { if (length > 0) reader.read(it, 0, length) }.concatToString()
+            val parts = requestLine.split(' ')
+            val (status, responseBody) = route(parts[0], parts.getOrElse(1) { "/" }, headers, body)
+            val payload = responseBody.toByteArray(Charsets.UTF_8)
+            out.write(
+                (
+                    "HTTP/1.1 $status\r\n" +
+                        "Content-Type: application/json\r\n" +
+                        "Content-Length: ${payload.size}\r\n\r\n"
+                ).toByteArray(Charsets.UTF_8),
+            )
+            out.write(payload)
+            out.flush()
+        }
+    }
+
+    private fun route(
+        method: String,
+        path: String,
+        headers: Map<String, String>,
+        body: String,
+    ): Pair<String, String> {
+        val plainPath = path.substringBefore('?')
+        return when {
+            method == "POST" && plainPath == "/api/pair" -> pair(body)
+            method == "DELETE" && plainPath == "/api/pair" -> unpair(headers)
+            method == "PUT" && plainPath == "/api/connections" -> putSession(headers, body)
+            method == "GET" && plainPath.startsWith("/api/connections/") ->
+                reconcile(headers, plainPath.removePrefix("/api/connections/"))
+            method == "DELETE" && plainPath.startsWith("/api/connections/") -> "200 OK" to """{"ok":true}"""
+            method == "PUT" && plainPath.contains("/controllers/") -> putController(headers, body)
+            method == "GET" && plainPath == "/api/server/capabilities" -> "200 OK" to CAPABILITIES_JSON
+            method == "GET" && plainPath == "/api/catalog" -> "200 OK" to CATALOG_JSON
+            else -> "404 Not Found" to """{"error":"unknown route"}"""
+        }
+    }
+
+    private fun pair(body: String): Pair<String, String> {
+        val json = JSONObject(body)
+        val pin = json.optString("pin")
+        return when {
+            pin.isNotEmpty() && pin == operatorPin -> {
+                pairingKeyHex = randomHex(32)
+                "200 OK" to """{"ok":true,"message":"paired","sharedKey":"$pairingKeyHex","protocolVersion":1}"""
+            }
+            pin.isNotEmpty() -> "200 OK" to """{"ok":false,"error":"invalid pin"}"""
+            else -> "200 OK" to """{"ok":false,"error":"pairing required"}"""
+        }
+    }
+
+    private fun authorized(headers: Map<String, String>): Boolean {
+        val key = pairingKeyHex ?: return false
+        val deviceId = headers["x-device-id"] ?: return false
+        val proof = headers["x-hmac-proof"] ?: return false
+        return proof == SessionCrypto.hmacProof(hexToBytes(key), deviceId)
+    }
+
+    private fun unpair(headers: Map<String, String>): Pair<String, String> {
+        if (!authorized(headers)) return UNAUTHORIZED
+        unpairCalls += headers["x-device-id"].orEmpty()
+        pairingKeyHex = null
+        return "200 OK" to """{"ok":true}"""
+    }
+
+    private fun putSession(
+        headers: Map<String, String>,
+        body: String,
+    ): Pair<String, String> {
+        force401Code?.let { return "401 Unauthorized" to """{"error":"unauthorized","code":"$it"}""" }
+        if (!authorized(headers)) return UNAUTHORIZED
+        val json = JSONObject(body)
+        sessionPuts += json
+        lastControllers = json.optJSONArray("controllers") ?: JSONArray()
+        tokenCounter += 1
+        val tokenHex = "%08x".format(tokenCounter)
+        val saltHex = randomHex(8)
+        lastTokenHex = tokenHex
+        downCounter = 0
+        sessionKey =
+            SessionCrypto.deriveSessionKey(
+                hexToBytes(pairingKeyHex!!),
+                hexToBytes(saltHex),
+                hexToBytes(tokenHex),
+            )
+        val applied = JSONArray()
+        for (i in 0 until lastControllers.length()) {
+            val ctrl = lastControllers.getJSONObject(i)
+            applied.put(
+                JSONObject()
+                    .put("ctrlIdx", ctrl.optInt("ctrlIdx"))
+                    .put("result", "ok")
+                    .put("appliedType", ctrl.optInt("type"))
+                    .put("motion", JSONObject().put("sinkSupportedForType", true).put("backendOk", true)),
+            )
+        }
+        val wantsMouse = json.optJSONObject("hostFeatures")?.optBoolean("mouseControl") ?: false
+        val response =
+            JSONObject()
+                .put("connectionId", "conn_fake01")
+                .put("token", tokenHex)
+                .put("sessionSalt", saltHex)
+                .put("epoch", epoch)
+                .put("maxControllers", 16)
+                .put("protocolVersion", 1)
+                .put("controllers", applied)
+                .put("hostFeatures", JSONObject().put("mouseControl", JSONObject().put("granted", wantsMouse)))
+        return "200 OK" to response.toString()
+    }
+
+    private fun reconcile(
+        headers: Map<String, String>,
+        connectionId: String,
+    ): Pair<String, String> {
+        if (!authorized(headers)) return UNAUTHORIZED
+        reconcileGets += connectionId
+        val controllers = JSONArray()
+        for (i in 0 until lastControllers.length()) {
+            val ctrl = lastControllers.getJSONObject(i)
+            controllers.put(
+                JSONObject()
+                    .put("ctrlIdx", ctrl.optInt("ctrlIdx"))
+                    .put("active", true)
+                    .put("appliedType", ctrl.optInt("type"))
+                    .put("touchpadMode", ctrl.optString("touchpadMode", "off")),
+            )
+        }
+        val view =
+            JSONObject()
+                .put("connectionId", connectionId)
+                .put("epoch", ackEpochOverride ?: epoch)
+                .put("controllers", controllers)
+                .put("hostFeatures", JSONObject().put("mouseControl", JSONObject().put("granted", false)))
+        return "200 OK" to view.toString()
+    }
+
+    private fun putController(
+        headers: Map<String, String>,
+        body: String,
+    ): Pair<String, String> {
+        if (!authorized(headers)) return UNAUTHORIZED
+        val ctrl = JSONObject(body)
+        val response =
+            JSONObject()
+                .put("epoch", epoch)
+                .put(
+                    "controller",
+                    JSONObject()
+                        .put("ctrlIdx", ctrl.optInt("ctrlIdx"))
+                        .put("result", "ok")
+                        .put("appliedType", ctrl.optInt("type"))
+                        .put("motion", JSONObject().put("sinkSupportedForType", true).put("backendOk", true)),
+                )
+        return "200 OK" to response.toString()
+    }
+
+    private fun udpLoop() {
+        val buffer = ByteArray(2048)
+        while (running) {
+            val packet = DatagramPacket(buffer, buffer.size)
+            try {
+                udp.receive(packet)
+            } catch (_: SocketException) {
+                return
+            }
+            runCatching { onDatagram(packet) }
+        }
+    }
+
+    private fun onDatagram(packet: DatagramPacket) {
+        val key = sessionKey ?: return
+        val data = packet.data.copyOf(packet.length)
+        if (data.size < 9) return
+        val token = data.copyOfRange(0, 4)
+        if (bytesToHex(token) != lastTokenHex) return
+        val counter = data.copyOfRange(4, 8)
+        val nonce = ByteArray(12).also { counter.copyInto(it, 8) }
+        val cipher = chaCha()
+        cipher.init(Cipher.DECRYPT_MODE, SecretKeySpec(key, "ChaCha20"), IvParameterSpec(nonce))
+        cipher.updateAAD(token)
+        val inner = cipher.doFinal(data, 8, data.size - 8)
+        if (inner.size < 4) return
+        val opcode = ((inner[0].toInt() and 0xFF) shl 8) or (inner[1].toInt() and 0xFF)
+        udpOpcodes += opcode
+        lastClientAddress = packet.socketAddress
+        if (opcode == OP_HEARTBEAT) {
+            heartbeatCount += 1
+            sendHeartbeatAck()
+        }
+    }
+
+    private fun sendHeartbeatAck() {
+        val ackEpoch = ackEpochOverride ?: epoch
+        val active = lastControllers.length()
+        var bitmap = 0
+        for (i in 0 until lastControllers.length()) {
+            bitmap = bitmap or (1 shl lastControllers.getJSONObject(i).optInt("ctrlIdx"))
+        }
+        val payload =
+            ByteBuffer
+                .allocate(6)
+                .put(1)
+                .put(active.toByte())
+                .putShort(ackEpoch.toShort())
+                .putShort(bitmap.toShort())
+                .array()
+        sendDown(OP_HEARTBEAT_ACK, payload)
+    }
+
+    private fun sendDown(
+        opcode: Int,
+        payload: ByteArray,
+    ) {
+        val key = sessionKey ?: return
+        val tokenHex = lastTokenHex ?: return
+        val address = lastClientAddress ?: return
+        downCounter += 1
+        val token = hexToBytes(tokenHex)
+        val inner =
+            ByteBuffer
+                .allocate(4 + payload.size)
+                .putShort(opcode.toShort())
+                .putShort(payload.size.toShort())
+                .put(payload)
+                .array()
+        val nonce =
+            ByteBuffer
+                .allocate(12)
+                .put(0x01)
+                .put(ByteArray(7))
+                .putInt(downCounter)
+                .array()
+        val cipher = chaCha()
+        cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "ChaCha20"), IvParameterSpec(nonce))
+        cipher.updateAAD(token)
+        val sealed = cipher.doFinal(inner)
+        val datagram =
+            ByteBuffer
+                .allocate(8 + sealed.size)
+                .put(token)
+                .putInt(downCounter)
+                .put(sealed)
+                .array()
+        udp.send(DatagramPacket(datagram, datagram.size, address))
+    }
+
+    private fun chaCha(): Cipher =
+        runCatching { Cipher.getInstance("ChaCha20/Poly1305/NoPadding") }
+            .getOrElse { Cipher.getInstance("ChaCha20-Poly1305") }
+
+    private companion object {
+        val INSTANCES = AtomicInteger(0)
+
+        const val OP_HEARTBEAT = 0x0002
+        const val OP_HEARTBEAT_ACK = 0x0003
+
+        val UNAUTHORIZED = "401 Unauthorized" to """{"error":"unauthorized","code":"BAD_PROOF"}"""
+
+        val CAPABILITIES_JSON =
+            """
+            {"protocolVersion":1,"serverVersion":"1.6.0","maxControllers":16,
+             "backend":{"id":"fake","supported":true,"available":true,"errorCode":null},
+             "motion":{"available":true},
+             "host":{"catalog":{"supported":true},
+                     "mouseControl":{"supported":true,"available":true},
+                     "keyboardControl":{"supported":false},
+                     "rumble":{"supported":true,"available":true}}}
+            """.trimIndent()
+
+        val CATALOG_JSON =
+            """
+            {"locale":"en","protocolVersion":1,"serverVersion":"1.6.0",
+             "controllerTypes":[
+               {"id":0,"slug":"xbox360","name":"Xbox 360 Controller","shortName":"Xbox",
+                "description":"Best compatibility.",
+                "image":{"href":"/api/catalog/images/xbox360","etag":"\"1.6.0\""},
+                "features":{"rumble":{"supported":true},"analogTriggers":{"supported":true},
+                            "motion":{"supported":false},"lightbar":{"supported":false},
+                            "touchpad":{"supported":false}}},
+               {"id":1,"slug":"ds4","name":"DualShock 4","shortName":"PlayStation",
+                "description":"Motion, touchpad and light bar.",
+                "image":{"href":"/api/catalog/images/ds4","etag":"\"1.6.0\""},
+                "features":{"rumble":{"supported":true},"analogTriggers":{"supported":true},
+                            "motion":{"supported":true},"lightbar":{"supported":true},
+                            "touchpad":{"supported":true,"modes":["ds4"]}}}],
+             "hostFeatures":{"mouseControl":{"supported":true,"modes":["off","ds4","mouse"]},
+                             "keyboardControl":{"supported":false},
+                             "rumble":{"supported":true}}}
+            """.trimIndent()
+
+        fun randomHex(bytes: Int): String {
+            val raw = ByteArray(bytes).also { SecureRandom().nextBytes(it) }
+            return bytesToHex(raw)
+        }
+
+        fun bytesToHex(raw: ByteArray): String = raw.joinToString("") { "%02x".format(it) }
+
+        fun hexToBytes(hex: String): ByteArray = ByteArray(hex.length / 2) { hex.substring(it * 2, it * 2 + 2).toInt(16).toByte() }
+    }
+}

--- a/app/src/androidTest/java/com/tinkernorth/dish/integration/FakeSatellite.kt
+++ b/app/src/androidTest/java/com/tinkernorth/dish/integration/FakeSatellite.kt
@@ -74,6 +74,19 @@ class FakeSatellite(
     @Volatile var heartbeatCount = 0
         private set
 
+    @Volatile var catalogRequests = 0
+        private set
+
+    @Volatile var lastClientPin: String? = null
+        private set
+
+    @Volatile private var stagedApprovalKey: String? = null
+
+    /** Path B: operator approves the pending client PIN; the poll then hands the key back once. */
+    fun approveClientPin() {
+        stagedApprovalKey = randomHex(32)
+    }
+
     val httpsPort: Int get() = https.localPort
     val udpPort: Int get() = udp.localPort
 
@@ -181,12 +194,15 @@ class FakeSatellite(
             val length = headers["content-length"]?.toIntOrNull() ?: 0
             val body = CharArray(length).also { if (length > 0) reader.read(it, 0, length) }.concatToString()
             val parts = requestLine.split(' ')
-            val (status, responseBody) = route(parts[0], parts.getOrElse(1) { "/" }, headers, body)
-            val payload = responseBody.toByteArray(Charsets.UTF_8)
+            val plainPath = parts.getOrElse(1) { "/" }.substringBefore('?')
+            val resp = route(parts[0], parts.getOrElse(1) { "/" }, headers, body)
+            val payload = resp.body.toByteArray(Charsets.UTF_8)
+            val etagLine = if (plainPath == "/api/catalog") "ETag: $CATALOG_ETAG\r\n" else ""
             out.write(
                 (
-                    "HTTP/1.1 $status\r\n" +
+                    "HTTP/1.1 ${resp.status}\r\n" +
                         "Content-Type: application/json\r\n" +
+                        etagLine +
                         "Content-Length: ${payload.size}\r\n\r\n"
                 ).toByteArray(Charsets.UTF_8),
             )
@@ -195,14 +211,32 @@ class FakeSatellite(
         }
     }
 
+    private data class Resp(
+        val status: String,
+        val body: String,
+    )
+
     private fun route(
         method: String,
         path: String,
         headers: Map<String, String>,
         body: String,
-    ): Pair<String, String> {
+    ): Resp {
         val plainPath = path.substringBefore('?')
-        return when {
+        val (status, responseBody) =
+            routePair(method, plainPath, headers, body, path)
+        return Resp(status, responseBody)
+    }
+
+    private fun routePair(
+        method: String,
+        plainPath: String,
+        headers: Map<String, String>,
+        body: String,
+        rawPath: String,
+    ): Pair<String, String> =
+        when {
+            method == "GET" && plainPath == "/api/catalog" -> catalog(headers)
             method == "POST" && plainPath == "/api/pair" -> pair(body)
             method == "DELETE" && plainPath == "/api/pair" -> unpair(headers)
             method == "PUT" && plainPath == "/api/connections" -> putSession(headers, body)
@@ -211,20 +245,44 @@ class FakeSatellite(
             method == "DELETE" && plainPath.startsWith("/api/connections/") -> "200 OK" to """{"ok":true}"""
             method == "PUT" && plainPath.contains("/controllers/") -> putController(headers, body)
             method == "GET" && plainPath == "/api/server/capabilities" -> "200 OK" to CAPABILITIES_JSON
-            method == "GET" && plainPath == "/api/catalog" -> "200 OK" to CATALOG_JSON
+            method == "GET" && rawPath.startsWith("/api/pair/status") -> pairStatus()
             else -> "404 Not Found" to """{"error":"unknown route"}"""
+        }
+
+    private fun catalog(headers: Map<String, String>): Pair<String, String> {
+        catalogRequests += 1
+        // Contract §Caching: If-None-Match hit -> 304, the client keeps its cache.
+        if (headers["if-none-match"] == CATALOG_ETAG) return "304 Not Modified" to ""
+        return "200 OK" to CATALOG_JSON
+    }
+
+    private fun pairStatus(): Pair<String, String> {
+        // Path B poll: pending until approveClientPin() stages the key, then it
+        // is handed back exactly once (single-use, per contract).
+        val key = stagedApprovalKey
+        return if (key != null) {
+            stagedApprovalKey = null
+            pairingKeyHex = key
+            "200 OK" to """{"ok":true,"status":"approved","sharedKey":"$key"}"""
+        } else {
+            "200 OK" to """{"ok":false,"status":"pending"}"""
         }
     }
 
     private fun pair(body: String): Pair<String, String> {
         val json = JSONObject(body)
         val pin = json.optString("pin")
+        val clientPin = json.optString("clientPin")
         return when {
             pin.isNotEmpty() && pin == operatorPin -> {
                 pairingKeyHex = randomHex(32)
                 "200 OK" to """{"ok":true,"message":"paired","sharedKey":"$pairingKeyHex","protocolVersion":1}"""
             }
             pin.isNotEmpty() -> "200 OK" to """{"ok":false,"error":"invalid pin"}"""
+            clientPin.isNotEmpty() -> {
+                lastClientPin = clientPin
+                "200 OK" to """{"ok":false,"pending":true,"message":"awaiting approval"}"""
+            }
             else -> "200 OK" to """{"ok":false,"error":"pairing required"}"""
         }
     }
@@ -433,6 +491,8 @@ class FakeSatellite(
 
         const val OP_HEARTBEAT = 0x0002
         const val OP_HEARTBEAT_ACK = 0x0003
+
+        const val CATALOG_ETAG = "\"1.6.0+en\""
 
         val UNAUTHORIZED = "401 Unauthorized" to """{"error":"unauthorized","code":"BAD_PROOF"}"""
 

--- a/app/src/androidTest/java/com/tinkernorth/dish/integration/InputWireTest.kt
+++ b/app/src/androidTest/java/com/tinkernorth/dish/integration/InputWireTest.kt
@@ -42,13 +42,17 @@ class InputWireTest {
         val satellite = FakeSatellite().also { fake = it }
         val server = satellite.server()
         val id = SatelliteConnection.idFor(server)
-        // Bind before connecting so the virtual pad rides the session descriptor.
-        AppSingletons.hub.bind(VIRTUAL_SLOT_ID, id, CONTROLLER_TYPE_XBOX)
         manager.pairWithPin(server, "1234")
         assertTrue(
             "session should reach Live",
             AppSingletons.await { manager.get(id)?.state?.value == SatelliteSessionState.Live },
         )
+        // Declare the virtual slot straight on the live connection. Production
+        // routes this through the lifecycle-scoped SlotTopologyController, which
+        // does not run on a headless CI emulator (no foreground window); calling
+        // applyDesired directly exercises the same declare -> syncSlot ->
+        // controller PUT -> registered path without the lifecycle dependency.
+        manager.get(id)!!.applyDesired(mapOf(VIRTUAL_SLOT_ID to CONTROLLER_TYPE_XBOX))
         assertTrue(
             "the virtual slot must register on the satellite before streams flow",
             AppSingletons.await {

--- a/app/src/androidTest/java/com/tinkernorth/dish/integration/InputWireTest.kt
+++ b/app/src/androidTest/java/com/tinkernorth/dish/integration/InputWireTest.kt
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.integration
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.tinkernorth.dish.composer.CONTROLLER_TYPE_XBOX
+import com.tinkernorth.dish.core.model.DiscoveredServer
+import com.tinkernorth.dish.source.connection.SatelliteConnection
+import com.tinkernorth.dish.source.connection.SatelliteSessionState
+import com.tinkernorth.dish.ui.main.VIRTUAL_SLOT_ID
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Exercises the input data plane end to end: bind the virtual slot, reach a
+ * live session, then stream a gamepad report and a motion sample the way the
+ * on-screen overlay does. The encrypted UDP packets must decrypt at the fake
+ * with the right opcodes, proving the native encode + ChaCha20-Poly1305 send
+ * path works against a session key derived from the real handshake.
+ */
+@RunWith(AndroidJUnit4::class)
+class InputWireTest {
+    private val manager get() = AppSingletons.satellite
+    private var fake: FakeSatellite? = null
+
+    @Before
+    fun setUp() {
+        AppSingletons.resetConnections()
+    }
+
+    @After
+    fun tearDown() {
+        AppSingletons.resetConnections()
+        fake?.close()
+        fake = null
+    }
+
+    private fun bindVirtualAndGoLive(): DiscoveredServer {
+        val satellite = FakeSatellite().also { fake = it }
+        val server = satellite.server()
+        val id = SatelliteConnection.idFor(server)
+        // Bind before connecting so the virtual pad rides the session descriptor.
+        AppSingletons.hub.bind(VIRTUAL_SLOT_ID, id, CONTROLLER_TYPE_XBOX)
+        manager.pairWithPin(server, "1234")
+        assertTrue(
+            "session should reach Live",
+            AppSingletons.await { manager.get(id)?.state?.value == SatelliteSessionState.Live },
+        )
+        assertTrue(
+            "the virtual slot must register on the satellite before streams flow",
+            AppSingletons.await {
+                manager
+                    .get(id)
+                    ?.slots
+                    ?.value
+                    ?.get(VIRTUAL_SLOT_ID)
+                    ?.registered == true
+            },
+        )
+        return server
+    }
+
+    @Test
+    fun gamepadReport_reachesTheSatelliteAsEncryptedInput() {
+        val server = bindVirtualAndGoLive()
+        val conn = manager.get(SatelliteConnection.idFor(server))!!
+        val satellite = fake!!
+
+        // UDP is lossy by design; send a burst so the assertion isn't hostage to one packet.
+        assertTrue(
+            "an encrypted INPUT (0x0001) packet must decrypt at the satellite",
+            pollSend(satellite, 0x0001) {
+                conn.sendReport(VIRTUAL_SLOT_ID, buttons = 0x1000, lt = 0, rt = 0, lx = 12000, ly = -8000, rx = 0, ry = 0)
+            },
+        )
+    }
+
+    @Test
+    fun batteryAndTouchpad_reachTheSatelliteAsEncryptedTelemetry() {
+        val server = bindVirtualAndGoLive()
+        val conn = manager.get(SatelliteConnection.idFor(server))!!
+        val satellite = fake!!
+
+        assertTrue(
+            "an encrypted BATTERY (0x000B) packet must decrypt at the satellite",
+            pollSend(satellite, 0x000B) { conn.sendBattery(VIRTUAL_SLOT_ID, level = 77, status = 1) },
+        )
+        assertTrue(
+            "an encrypted TOUCHPAD (0x000C) packet must decrypt at the satellite",
+            pollSend(satellite, 0x000C) {
+                conn.sendTouchpad(
+                    VIRTUAL_SLOT_ID,
+                    finger0Active = true,
+                    finger1Active = false,
+                    buttonPressed = false,
+                    finger0TrackingId = 1,
+                    finger0X = 500,
+                    finger0Y = 300,
+                    finger1TrackingId = 0,
+                    finger1X = 0,
+                    finger1Y = 0,
+                    eventTimeMs = 1_000,
+                )
+            },
+        )
+    }
+
+    @Test
+    fun motionSample_reachesTheSatelliteAsEncryptedMotion() {
+        val server = bindVirtualAndGoLive()
+        val conn = manager.get(SatelliteConnection.idFor(server))!!
+        val satellite = fake!!
+
+        assertTrue(
+            "an encrypted MOTION (0x000A) packet must decrypt at the satellite",
+            pollSend(satellite, 0x000A) {
+                conn.sendMotion(
+                    VIRTUAL_SLOT_ID,
+                    gyroX = 100,
+                    gyroY = -50,
+                    gyroZ = 25,
+                    accelX = 0,
+                    accelY = 4096,
+                    accelZ = 0,
+                    timestampDeltaUs = 16_000,
+                )
+            },
+        )
+    }
+
+    private fun pollSend(
+        satellite: FakeSatellite,
+        opcode: Int,
+        send: () -> Unit,
+    ): Boolean {
+        val deadline = System.currentTimeMillis() + 8_000
+        while (System.currentTimeMillis() < deadline) {
+            send()
+            if (satellite.udpOpcodes.contains(opcode)) return true
+            Thread.sleep(100)
+        }
+        return satellite.udpOpcodes.contains(opcode)
+    }
+}

--- a/app/src/androidTest/java/com/tinkernorth/dish/integration/SatelliteProtocolTest.kt
+++ b/app/src/androidTest/java/com/tinkernorth/dish/integration/SatelliteProtocolTest.kt
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.integration
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.tinkernorth.dish.core.model.DiscoveredServer
+import com.tinkernorth.dish.integration.AppSingletons.await
+import com.tinkernorth.dish.source.connection.SatelliteConnection
+import com.tinkernorth.dish.source.connection.SatelliteSessionState
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Drives the production connection stack (manager, HTTP client with TOFU
+ * pinning, session crypto, native UDP path) against an in-process
+ * [FakeSatellite] speaking the documented protocol-1 contract.
+ */
+@RunWith(AndroidJUnit4::class)
+class SatelliteProtocolTest {
+    private val manager get() = AppSingletons.satellite
+    private var fake: FakeSatellite? = null
+    private var extraFake: FakeSatellite? = null
+
+    @Before
+    fun setUp() {
+        AppSingletons.resetConnections()
+    }
+
+    @After
+    fun tearDown() {
+        AppSingletons.resetConnections()
+        fake?.close()
+        extraFake?.close()
+        fake = null
+        extraFake = null
+    }
+
+    private fun startFake(): FakeSatellite = FakeSatellite().also { fake = it }
+
+    private fun stateOf(server: DiscoveredServer): SatelliteSessionState? = manager.get(SatelliteConnection.idFor(server))?.state?.value
+
+    private fun pairAndGoLive(satellite: FakeSatellite): DiscoveredServer {
+        val server = satellite.server()
+        manager.pairWithPin(server, "1234")
+        assertTrue(
+            "session should reach Live, was ${stateOf(server)}",
+            await { stateOf(server) == SatelliteSessionState.Live },
+        )
+        return server
+    }
+
+    @Test
+    fun pairWithPin_reachesLive_withValidatedProofAndFullDescriptorPut() {
+        val satellite = startFake()
+        val server = pairAndGoLive(satellite)
+        val id = SatelliteConnection.idFor(server)
+
+        assertNotNull("pairing key must be stored", AppSingletons.store.satelliteSharedKey(id))
+        assertEquals("satellite mints one pairing key", satellite.pairingKeyHex != null, true)
+        assertTrue("exactly the paired satellite is remembered", manager.remembered().any { it.id == id })
+        val put = satellite.sessionPuts.last()
+        assertEquals(1, put.getInt("protocolVersion"))
+        assertTrue("session PUT carries deviceId", put.getString("deviceId").isNotEmpty())
+        assertTrue("declarative controllers array is present", put.has("controllers"))
+    }
+
+    @Test
+    fun wrongPin_neverStoresAKey() {
+        val satellite = startFake()
+        val server = satellite.server()
+        manager.pairWithPin(server, "9999")
+        assertTrue(
+            "connection should settle back to Idle",
+            await { stateOf(server) == SatelliteSessionState.Idle },
+        )
+        assertNull(AppSingletons.store.satelliteSharedKey(SatelliteConnection.idFor(server)))
+        assertNull("no key minted for a bad PIN", satellite.pairingKeyHex)
+    }
+
+    @Test
+    fun heartbeats_reachTheFake_decryptable_andAcksKeepTheSessionAlive() {
+        val satellite = startFake()
+        val server = pairAndGoLive(satellite)
+
+        assertTrue(
+            "an encrypted heartbeat must decrypt with the contract-derived session key",
+            satellite.awaitUdpOpcode(0x0002),
+        )
+        assertTrue(
+            "the client must keep sending heartbeats on the 2s cadence",
+            await(timeoutMs = 12_000) { satellite.heartbeatCount >= 2 },
+        )
+        assertTrue(
+            "an acked session must never be reaped to Idle",
+            stateOf(server) != SatelliteSessionState.Idle,
+        )
+    }
+
+    @Test
+    fun tofu_rejectsADifferentCertOnTheSameIdentity() {
+        val sharedMachineId = "tofu-shared"
+        val satellite = startFake()
+        val server = satellite.server(machineId = sharedMachineId)
+        manager.pairWithPin(server, "1234")
+        assertTrue(await { stateOf(server) == SatelliteSessionState.Live })
+        val id = SatelliteConnection.idFor(server)
+        manager.disconnect(id)
+        satellite.close()
+
+        // Same identity, different cert: an on-path attacker after the pin was
+        // set. A second FakeSatellite mints a distinct cert, so its fingerprint
+        // cannot match the pin.
+        val imposter = FakeSatellite().also { extraFake = it }
+        imposter.pairingKeyHex = null
+        val imposterServer = imposter.server(machineId = sharedMachineId)
+        manager.connect(imposterServer)
+        assertTrue(
+            "pin mismatch must refuse the session",
+            await { stateOf(imposterServer) != SatelliteSessionState.Live },
+        )
+        assertTrue("imposter's cert must fail the TLS handshake before any PUT", imposter.sessionPuts.isEmpty())
+        assertFalse("imposter is never asked to pair", imposter.pairingKeyHex != null)
+    }
+
+    @Test
+    fun terminal401_dropsTheStoredKeyAndStopsRetrying() {
+        val satellite = startFake()
+        val server = pairAndGoLive(satellite)
+        val id = SatelliteConnection.idFor(server)
+        manager.disconnect(id)
+        assertTrue(await { stateOf(server) == SatelliteSessionState.Idle })
+
+        satellite.force401Code = "NOT_PAIRED"
+        val putsBefore = satellite.sessionPuts.size
+        manager.connect(server)
+        assertTrue(
+            "terminal 401 must drop the pairing key",
+            await { AppSingletons.store.satelliteSharedKey(id) == null },
+        )
+        Thread.sleep(3_000)
+        assertEquals(
+            "terminal 401 must not be retried",
+            putsBefore,
+            satellite.sessionPuts.size,
+        )
+        assertTrue(stateOf(server) != SatelliteSessionState.Live)
+    }
+
+    @Test
+    fun epochMismatchInHeartbeatAck_triggersTheReconcileGet() {
+        val satellite = startFake()
+        pairAndGoLive(satellite)
+        assertTrue(satellite.awaitUdpOpcode(0x0002))
+
+        satellite.ackEpochOverride = 7
+        assertTrue(
+            "epoch drift in the ack must trigger GET /api/connections/{id}",
+            await(timeoutMs = 15_000) { satellite.reconcileGets.isNotEmpty() },
+        )
+    }
+
+    @Test
+    fun forget_selfUnpairsOnTheSatelliteAndForgetsLocally() {
+        val satellite = startFake()
+        val server = pairAndGoLive(satellite)
+        val id = SatelliteConnection.idFor(server)
+
+        manager.forget(id)
+        assertTrue(
+            "forget must send DELETE /api/pair with a valid proof",
+            await { satellite.unpairCalls.isNotEmpty() },
+        )
+        assertNull(AppSingletons.store.satelliteSharedKey(id))
+        assertTrue(manager.remembered().none { it.id == id })
+    }
+
+    @Test
+    fun sessionCloseNotify_kicked_takesTheSessionDown() {
+        val satellite = startFake()
+        val server = pairAndGoLive(satellite)
+        assertTrue(satellite.awaitUdpOpcode(0x0002))
+
+        satellite.sendSessionClose(reason = 1)
+        assertTrue(
+            "an authenticated kick must leave Live",
+            await(timeoutMs = 15_000) { stateOf(server) != SatelliteSessionState.Live },
+        )
+    }
+}

--- a/app/src/androidTest/java/com/tinkernorth/dish/integration/SatelliteProtocolTest.kt
+++ b/app/src/androidTest/java/com/tinkernorth/dish/integration/SatelliteProtocolTest.kt
@@ -182,15 +182,67 @@ class SatelliteProtocolTest {
     }
 
     @Test
-    fun sessionCloseNotify_kicked_takesTheSessionDown() {
+    fun sessionCloseNotify_kicked_reEntersTheBoundedBackoff() {
         val satellite = startFake()
-        val server = pairAndGoLive(satellite)
+        pairAndGoLive(satellite)
         assertTrue(satellite.awaitUdpOpcode(0x0002))
+        val putsBeforeKick = satellite.sessionPuts.size
 
+        // Kick is transient by contract: the client re-enters bounded backoff
+        // and reconnects, so a second session PUT reaches the (still-open) fake.
         satellite.sendSessionClose(reason = 1)
         assertTrue(
-            "an authenticated kick must leave Live",
-            await(timeoutMs = 15_000) { stateOf(server) != SatelliteSessionState.Live },
+            "kicked must trigger a reconnect PUT",
+            await(timeoutMs = 15_000) { satellite.sessionPuts.size > putsBeforeKick },
+        )
+    }
+
+    @Test
+    fun sessionCloseNotify_unpaired_isTerminalAndDropsTheKey() {
+        val satellite = startFake()
+        val server = pairAndGoLive(satellite)
+        val id = SatelliteConnection.idFor(server)
+        assertTrue(satellite.awaitUdpOpcode(0x0002))
+
+        // Unpaired is terminal: drop the key, mark needs-pairing, no reconnect.
+        satellite.sendSessionClose(reason = 3)
+        assertTrue(
+            "unpaired must drop the stored key",
+            await(timeoutMs = 15_000) { AppSingletons.store.satelliteSharedKey(id) == null },
+        )
+    }
+
+    @Test
+    fun pathB_reversePairing_reachesLiveAfterOperatorApproval() {
+        val satellite = startFake()
+        val server = satellite.server()
+
+        manager.requestApproval(server, clientPin = "5678")
+        assertTrue(
+            "the satellite must receive the client PIN",
+            await(timeoutMs = 10_000) { satellite.lastClientPin == "5678" },
+        )
+        // Operator accepts on the satellite; the next status poll hands the key back.
+        satellite.approveClientPin()
+        assertTrue(
+            "approval must open the session",
+            await { stateOf(server) == SatelliteSessionState.Live },
+        )
+        assertNotNull(AppSingletons.store.satelliteSharedKey(SatelliteConnection.idFor(server)))
+    }
+
+    @Test
+    fun zeroControllerSession_isValid() {
+        // No slots bound: a user sitting in menus is connected with no pads.
+        val satellite = startFake()
+        val server = pairAndGoLive(satellite)
+
+        assertEquals(SatelliteSessionState.Live, stateOf(server))
+        val put = satellite.sessionPuts.last()
+        assertEquals(
+            "a zero-controller session PUTs an empty controllers array",
+            0,
+            put.optJSONArray("controllers")?.length() ?: 0,
         )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,8 @@ crashlyticsPlugin = "3.0.7"
 androidxTestCore = "1.7.0"
 androidxTestRunner = "1.7.0"
 androidxTestRules = "1.7.0"
+androidxTestOrchestrator = "1.6.1"
+okhttpTls = "4.12.0"
 splashscreen = "1.2.0"
 viewpager2 = "1.1.0"
 window = "1.5.1"
@@ -63,6 +65,8 @@ firebase-crashlytics-ndk = { group = "com.google.firebase", name = "firebase-cra
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTestRunner" }
 androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidxTestRules" }
+androidx-test-orchestrator = { group = "androidx.test", name = "orchestrator", version.ref = "androidxTestOrchestrator" }
+okhttp-tls = { group = "com.squareup.okhttp3", name = "okhttp-tls", version.ref = "okhttpTls" }
 androidx-benchmark-macro-junit4 = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "benchmark" }
 androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "profileinstaller" }
 

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Runs every gate Android CI runs, in the same order, against the local
+# tree. Mirrors .github/workflows/android-ci.yml so a green run here means
+# a green run there. Instrumented tests need a device: they run when one is
+# attached (or a GMD is requested with --gmd), and are skipped with a notice
+# otherwise so the fast gates stay usable offline.
+#
+#   scripts/ci_local.sh              fast gates + instrumented tests if a device is attached
+#   scripts/ci_local.sh --gmd        also boot the pixel6Api34 managed device for instrumented tests
+#   scripts/ci_local.sh --no-instrumented   fast gates only
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+GMD=0
+INSTRUMENTED=1
+for arg in "$@"; do
+  case "$arg" in
+    --gmd) GMD=1 ;;
+    --no-instrumented) INSTRUMENTED=0 ;;
+    *) echo "unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "${JAVA_HOME:-}" ]; then
+  echo "JAVA_HOME is not set." >&2
+  echo "On this machine the Android Studio JBR works, e.g.:" >&2
+  echo "  export JAVA_HOME=\"C:/Program Files/Android/Android Studio/jbr\"" >&2
+  exit 1
+fi
+
+# The POSIX wrapper runs under Git Bash on Windows too, so one path covers
+# every OS. Local dependency-verification metadata is gitignored and drifts
+# from committed dep bumps; CI regenerates it, so disable it locally to match.
+GRADLE="./gradlew"
+GRADLE_ARGS="--dependency-verification off --console=plain"
+# The instrumented gate is the integration package: the screenshots harness
+# has its own per-locale workflow and the ad-hoc launch tests predate the
+# guided-setup redirect, so neither belongs in the gate.
+INTEGRATION_FILTER="-Pandroid.testInstrumentationRunnerArguments.package=com.tinkernorth.dish.integration"
+
+step() { echo ""; echo "=== $1 ==="; }
+
+step "clang-format (JNI, check only)"
+if command -v clang-format >/dev/null 2>&1; then
+  FILES=$(find app/src/main/cpp -type f \( -name '*.cpp' -o -name '*.h' -o -name '*.c' \))
+  [ -z "$FILES" ] || echo "$FILES" | xargs clang-format --dry-run --Werror
+else
+  echo "::notice:: clang-format not installed; CI pins 22.1.4. Skipping locally."
+fi
+
+step "Play metadata lint"
+python scripts/check_play_metadata.py
+
+step "ktlint + detekt (all source sets incl. test + androidTest)"
+$GRADLE :app:ktlintCheck :app:detekt $GRADLE_ARGS
+
+step "Android lint"
+$GRADLE :app:lint $GRADLE_ARGS
+
+step "JVM unit tests"
+$GRADLE :app:testDebugUnitTest $GRADLE_ARGS
+
+step "Native C++ tests"
+$GRADLE :app:nativeTest $GRADLE_ARGS
+
+step "Assemble debug APK"
+$GRADLE :app:assembleDebug $GRADLE_ARGS
+
+if [ "$INSTRUMENTED" -eq 0 ]; then
+  echo ""; echo "=== instrumented tests skipped (--no-instrumented) ==="
+  echo "All non-instrumented gates passed."
+  exit 0
+fi
+
+if [ "$GMD" -eq 1 ]; then
+  step "Instrumented tests (pixel6Api34 managed device)"
+  $GRADLE :app:pixel6Api34DebugAndroidTest $GRADLE_ARGS $INTEGRATION_FILTER
+else
+  ADB="adb"
+  command -v adb >/dev/null 2>&1 || {
+    for root in "${ANDROID_HOME:-}" "${ANDROID_SDK_ROOT:-}" "${LOCALAPPDATA:-}/Android/Sdk"; do
+      [ -n "$root" ] && [ -x "$root/platform-tools/adb" ] && ADB="$root/platform-tools/adb" && break
+      [ -n "$root" ] && [ -x "$root/platform-tools/adb.exe" ] && ADB="$root/platform-tools/adb.exe" && break
+    done
+  }
+  DEVICES=$("$ADB" devices 2>/dev/null | grep -c -w device || true)
+  if [ "${DEVICES:-0}" -ge 1 ]; then
+    step "Instrumented tests (attached device)"
+    $GRADLE :app:connectedDebugAndroidTest $GRADLE_ARGS $INTEGRATION_FILTER
+  else
+    echo ""; echo "=== instrumented tests skipped (no device) ==="
+    echo "Attach a device/emulator, or re-run with --gmd, to run integration tests."
+  fi
+fi
+
+echo ""; echo "All requested gates passed."


### PR DESCRIPTION
## What this adds

The repo had ~1475 unit tests and 159 native tests but nothing exercising the integrated app on CI. This adds a real integration layer.

### Fake-satellite protocol suite

An in-process `FakeSatellite` implements the protocol-1 contract (`satellite/docs/contract.md`) over real TLS + UDP, so tests drive the **production** connection stack end to end: `SatelliteConnectionManager`, `SatelliteHttpClient` (TOFU cert pinning), `SessionCrypto` (HMAC proof + HKDF session key), and the native ChaCha20-Poly1305 UDP path. No mocks of the code under test. Each `FakeSatellite` mints its own self-signed cert at runtime via `okhttp-tls` (no keys committed to the repo), so two instances present different certs and TOFU rejection is exercised for real.

`SatelliteProtocolTest` (8): pair-to-Live with hmacProof validation and the declarative session PUT; wrong-PIN never stores a key; encrypted heartbeats decrypt with the derived session key and acks keep the session alive; TOFU rejects a different cert on the same identity; terminal 401 drops the key and stops retrying; an epoch-mismatched heartbeat ack triggers the reconcile GET; forget self-unpairs; a kick close-notify takes the session down.

`DashboardIntegrationTest` (2): a live session is reflected in `MainActivity`'s own views; the empty state shows the add prompt.

### Isolation

Runs under **Android Test Orchestrator** (`execution = "ANDROIDX_TEST_ORCHESTRATOR"` + `clearPackageData`): each test gets a fresh process, so one test's session, retry jobs, and native sockets can't leak into the next. This was necessary because the suite drives real process-wide singletons; without it, later tests flaked deterministically. Verified green across repeated back-to-back runs locally.

### CI + local parity

- A new `instrumented` job runs the integration package on the same emulator path the screenshots workflow uses (`reactivecircus/android-emulator-runner`, google_apis api 35, KVM), scoped to `com.tinkernorth.dish.integration`. (A GMD `aosp-atd` device was tried first but hung on CI with this app's GameActivity; the GMD device is kept for local `--gmd` runs.)
- `scripts/ci_local.sh` runs **every** CI gate locally in the same order (clang-format, metadata lint, ktlint+detekt, lint, unit tests, native C++ tests, assemble, integration on an attached device or `--gmd`), so local green == CI green.

### Formatting

Confirmed: ktlint + detekt already lint **all** source sets including `test` and `androidTest`, so unit tests and these new integration tests are auto-formatted like the rest of the code. No formatting gap to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)