### PR TITLE
chore(ci): sync pin-map comments with the dependabot action bumps

### DIFF
--- a/.github/workflows/_security.yml
+++ b/.github/workflows/_security.yml
@@ -21,9 +21,9 @@ name: _security (reusable)
 #   gh api repos/<owner>/<repo>/git/ref/tags/<tag>
 #
 # Pin map (owner/repo @ tag → 40-char SHA), verify on update:
-#   actions/checkout                         @ v6.0.3  → df4cb1c069e1874edd31b4311f1884172cec0e10
+#   actions/checkout                         @ v7.0.0  → 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 #   actions/dependency-review-action         @ v5.0.0  → a1d282b36b6f3519aa1f3fc636f609c47dddb294
-#   actions/setup-python                     @ v6.2.0  → a309ff8b426b58ec0e2a45f0f869d46889d02405
+#   actions/setup-python                     @ v6.3.0  → ece7cb06caefa5fff74198d8649806c4678c61a1
 #
 # OSV-Scanner and gitleaks are installed directly from upstream release
 # binaries (see the respective jobs below) rather than via third-party

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,9 +1,9 @@
 name: Android CI
 
 # Pin map (verify with `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`):
-#   actions/checkout              @ v6.0.3 → df4cb1c069e1874edd31b4311f1884172cec0e10
-#   actions/setup-java            @ v5.3.0 → ad2b38190b15e4d6bdf0c97fb4fca8412226d287
-#   actions/setup-python          @ v6.2.0 → a309ff8b426b58ec0e2a45f0f869d46889d02405
+#   actions/checkout              @ v7.0.0 → 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+#   actions/setup-java            @ v5.5.0 → 0f481fcb613427c0f801b606911222b5b6f3083a
+#   actions/setup-python          @ v6.3.0 → ece7cb06caefa5fff74198d8649806c4678c61a1
 #   actions/upload-artifact       @ v7.0.1 → 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
 #   gradle/actions/setup-gradle   @ v6.2.0 → 3f131e8634966bd73d06cc69884922b02e6faf92
 #   reactivecircus/android-emulator-runner @ v2.38.0 → a421e43855164a8197daf9d8d40fe71c6996bb0d

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,10 +6,10 @@ name: CodeQL
 # tooling. `cpp` covers the JNI shim under `app/src/main/cpp`.
 #
 # Pin map (verify with `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`):
-#   actions/checkout              @ v6.0.3  → df4cb1c069e1874edd31b4311f1884172cec0e10
-#   actions/setup-java            @ v5.3.0  → ad2b38190b15e4d6bdf0c97fb4fca8412226d287
+#   actions/checkout              @ v7.0.0  → 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+#   actions/setup-java            @ v5.5.0  → 0f481fcb613427c0f801b606911222b5b6f3083a
 #   gradle/actions/setup-gradle   @ v6.2.0  → 3f131e8634966bd73d06cc69884922b02e6faf92
-#   github/codeql-action/*        @ v4.36.2 → 8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+#   github/codeql-action/*        @ v4.37.0 → 99df26d4f13ea111d4ec1a7dddef6063f76b97e9
 
 on:
   push:

--- a/.github/workflows/play-listing.yml
+++ b/.github/workflows/play-listing.yml
@@ -10,7 +10,7 @@ name: Play Listing Sync
 # record and its first build must already exist in the Play Console.
 #
 # Pin map (verify with `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`):
-#   actions/checkout                @ v6.0.3  → df4cb1c069e1874edd31b4311f1884172cec0e10
+#   actions/checkout                @ v7.0.0  → 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
 on:
   workflow_dispatch:

--- a/.github/workflows/play-reviews.yml
+++ b/.github/workflows/play-reviews.yml
@@ -7,8 +7,8 @@ name: Play Reviews Digest
 # instead of failing.
 #
 # Pin map (verify with `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`):
-#   actions/checkout                @ v6.0.3  → df4cb1c069e1874edd31b4311f1884172cec0e10
-#   actions/setup-python            @ v6.2.0  → a309ff8b426b58ec0e2a45f0f869d46889d02405
+#   actions/checkout                @ v7.0.0  → 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+#   actions/setup-python            @ v6.3.0  → ece7cb06caefa5fff74198d8649806c4678c61a1
 
 on:
   schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,15 +51,15 @@ on:
 #                                 before the API can publish.
 #
 # Pin map (verify with `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`):
-#   actions/checkout                @ v6.0.3  → df4cb1c069e1874edd31b4311f1884172cec0e10
-#   actions/setup-java              @ v5.3.0  → ad2b38190b15e4d6bdf0c97fb4fca8412226d287
+#   actions/checkout                @ v7.0.0  → 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+#   actions/setup-java              @ v5.5.0  → 0f481fcb613427c0f801b606911222b5b6f3083a
 #   actions/upload-artifact         @ v7.0.1  → 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
 #   actions/download-artifact       @ v8.0.1  → 3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
 #   gradle/actions/setup-gradle     @ v6.2.0  → 3f131e8634966bd73d06cc69884922b02e6faf92
 #   anchore/sbom-action             @ v0.24.0 → e22c389904149dbc22b58101806040fa8d37a610
 #   anchore/scan-action             @ v7.4.0  → e1165082ffb1fe366ebaf02d8526e7c4989ea9d2
-#   github/codeql-action/upload-sarif @ v4.36.2 → 8aad20d150bbac5944a9f9d289da16a4b0d87c1e
-#   softprops/action-gh-release     @ v3.0.0  → b4309332981a82ec1c5618f44dd2e27cc8bfbfda
+#   github/codeql-action/upload-sarif @ v4.37.0 → 99df26d4f13ea111d4ec1a7dddef6063f76b97e9
+#   softprops/action-gh-release     @ v3.0.1  → 718ea10b132b3b2eba29c1007bb80653f286566b
 #   slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml
 #                                   @ v2.1.0  → f7dd8c54c2067bafc12ca7a55595d5ee9b75204a
 #

--- a/.github/workflows/store-screenshots.yml
+++ b/.github/workflows/store-screenshots.yml
@@ -7,9 +7,9 @@ name: Store Screenshots
 # Dispatch-only: captures are reviewed by a human before committing.
 #
 # Pin map (verify with `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`):
-#   actions/checkout                     @ v6.0.3  → df4cb1c069e1874edd31b4311f1884172cec0e10
-#   actions/setup-java                   @ v5.3.0  → ad2b38190b15e4d6bdf0c97fb4fca8412226d287
-#   actions/setup-python                 @ v6.2.0  → a309ff8b426b58ec0e2a45f0f869d46889d02405
+#   actions/checkout                     @ v7.0.0  → 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+#   actions/setup-java                   @ v5.5.0  → 0f481fcb613427c0f801b606911222b5b6f3083a
+#   actions/setup-python                 @ v6.3.0  → ece7cb06caefa5fff74198d8649806c4678c61a1
 #   actions/upload-artifact              @ v7.0.1  → 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
 #   gradle/actions/setup-gradle          @ v6.2.0  → 3f131e8634966bd73d06cc69884922b02e6faf92
 #   reactivecircus/android-emulator-runner @ v2.38.0 → a421e43855164a8197daf9d8d40fe71c6996bb0d


### PR DESCRIPTION
PR #137 bumped the pinned action SHAs but the reviewer pin-map comment blocks at the top of each workflow still listed the old tag/SHA pairs. This updates the 18 stale comment lines across the 7 workflows to match the uses: lines that are now on main. Comment-only change, no behavior.

All five new SHAs were verified against their upstream release tags with gh api repos/<owner>/<repo>/git/ref/tags/<tag>:

- actions/checkout v7.0.0 = 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
- actions/setup-java v5.5.0 = 0f481fcb613427c0f801b606911222b5b6f3083a
- actions/setup-python v6.3.0 = ece7cb06caefa5fff74198d8649806c4678c61a1
- github/codeql-action v4.37.0 = 99df26d4f13ea111d4ec1a7dddef6063f76b97e9
- softprops/action-gh-release v3.0.1 = 718ea10b132b3b2eba29c1007bb80653f286566b