### PR TITLE
fix + chore: send-counter nonce-reuse guard; warning + CI-hygiene sweep

### DIFF
--- a/.github/workflows/_security.yml
+++ b/.github/workflows/_security.yml
@@ -74,6 +74,7 @@ jobs:
     if: ${{ inputs.action_pin_lint_enabled }}
     name: Action pin lint (40-char SHA required)
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -123,6 +124,7 @@ jobs:
     if: ${{ inputs.allowlist_expiry_enabled }}
     name: Vulnerability allowlist expiry check
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -166,6 +168,7 @@ jobs:
     if: ${{ inputs.osv_scan_paths != '' || inputs.osv_config != '' }}
     name: OSV-Scanner (vendored + manifest deps)
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -231,6 +234,7 @@ jobs:
     if: ${{ inputs.dependency_review_enabled && github.event_name == 'pull_request' }}
     name: Dependency review (GitHub advisory DB)
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -249,6 +253,7 @@ jobs:
     if: ${{ inputs.gitleaks_enabled }}
     name: Secret scan (gitleaks)
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Checkout (full history)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code

--- a/.github/workflows/play-listing.yml
+++ b/.github/workflows/play-listing.yml
@@ -31,6 +31,7 @@ jobs:
   sync-listing:
     name: Sync listing to Play
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - name: Gate on Play credentials
         id: gate

--- a/.github/workflows/play-reviews.yml
+++ b/.github/workflows/play-reviews.yml
@@ -22,6 +22,7 @@ jobs:
   digest:
     name: Reviews + vitals digest
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - name: Gate on Play credentials
         id: gate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
     name: Required release secrets gate
     needs: [gates]
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Verify keystore secrets are present for tagged releases
         env:
@@ -124,6 +125,7 @@ jobs:
     name: Build + sign APK/AAB
     needs: [gates, required-secrets]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -264,6 +266,7 @@ jobs:
     name: Upload AAB to Google Play
     needs: [release]
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -366,6 +369,7 @@ jobs:
     name: Harden artifacts (scan, SBOM, sign)
     needs: [release]
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write
@@ -502,6 +506,7 @@ jobs:
     name: Publish to GitHub Releases
     needs: [harden, provenance]
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -57,7 +57,10 @@ target_compile_definitions(sodium_static PRIVATE
     HAVE_POSIX_MEMALIGN=1
     HAVE_ARC4RANDOM=0
     HAVE_SYS_MMAN_H=1
-    # HAVE_SYSCONF: let libsodium query the page size, silencing its "Unknown page size" warning.
+    # HAVE_SYSCONF: sodium_mlock/guarded allocations round to the RUNTIME page
+    # size via sysconf(_SC_PAGESIZE) instead of a compiled-in guess — required
+    # for Android 15's 16 KB-page devices (and clears the "Unknown page size"
+    # build warning).
     HAVE_SYSCONF=1
     __STDC_LIMIT_MACROS=1
     __STDC_CONSTANT_MACROS=1

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 3.22.1)
 project(satellite)
 
+# libsodium is fetched below as a release tarball. Adopt CMP0135 (CMake >= 3.24)
+# so extracted files are stamped at extraction time — the modern default — which
+# also silences FetchContent's DOWNLOAD_EXTRACT_TIMESTAMP developer warning. The
+# guard keeps the pinned CMake 3.22.1 (whose policy set predates CMP0135) working.
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
 find_package(game-activity REQUIRED CONFIG)
 
 # ── libsodium (built from source via FetchContent) ──────────────────────────
@@ -52,6 +60,10 @@ target_compile_definitions(sodium_static PRIVATE
     HAVE_POSIX_MEMALIGN=1
     HAVE_ARC4RANDOM=0
     HAVE_SYS_MMAN_H=1
+    # bionic exposes sysconf(_SC_PAGESIZE) (a macro), so let libsodium query the
+    # page size at runtime — the branch ./configure normally selects. Without this
+    # it fell through to `#warning Unknown page size` and a hardcoded fallback.
+    HAVE_SYSCONF=1
     __STDC_LIMIT_MACROS=1
     __STDC_CONSTANT_MACROS=1
 )

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,10 +1,7 @@
 cmake_minimum_required(VERSION 3.22.1)
 project(satellite)
 
-# libsodium is fetched below as a release tarball. Adopt CMP0135 (CMake >= 3.24)
-# so extracted files are stamped at extraction time — the modern default — which
-# also silences FetchContent's DOWNLOAD_EXTRACT_TIMESTAMP developer warning. The
-# guard keeps the pinned CMake 3.22.1 (whose policy set predates CMP0135) working.
+# Adopt CMP0135 where available to silence FetchContent's DOWNLOAD_EXTRACT_TIMESTAMP warning.
 if(POLICY CMP0135)
   cmake_policy(SET CMP0135 NEW)
 endif()
@@ -60,9 +57,7 @@ target_compile_definitions(sodium_static PRIVATE
     HAVE_POSIX_MEMALIGN=1
     HAVE_ARC4RANDOM=0
     HAVE_SYS_MMAN_H=1
-    # bionic exposes sysconf(_SC_PAGESIZE) (a macro), so let libsodium query the
-    # page size at runtime — the branch ./configure normally selects. Without this
-    # it fell through to `#warning Unknown page size` and a hardcoded fallback.
+    # HAVE_SYSCONF: let libsodium query the page size, silencing its "Unknown page size" warning.
     HAVE_SYSCONF=1
     __STDC_LIMIT_MACROS=1
     __STDC_CONSTANT_MACROS=1

--- a/app/src/main/cpp/satellite_jni.cpp
+++ b/app/src/main/cpp/satellite_jni.cpp
@@ -32,6 +32,7 @@
 #include "dispatch.h"
 #include "gamepad_input.h"
 #include "hotpath_latency.h"
+#include "send_counter.h"
 #include "thread_priority.h"
 #include "usb_host.h"
 #include "usb_parsers.h"
@@ -83,7 +84,8 @@ struct Session {
     struct sockaddr_in dest = {};
     uint8_t token[4] = {};
     uint8_t key[32] = {}; // per-session key (HKDF-derived in Kotlin), never the pairing key
-    std::atomic<uint32_t> counter{1};
+    // 64-bit so exhaustion goes silent instead of wrapping (send_counter.h).
+    std::atomic<uint64_t> counter{1};
     // Linux UDP sendto is thread-safe per-socket; userspace lock would only serialise stalls.
 
     std::thread heartbeatThread;
@@ -462,7 +464,8 @@ static bool sendEncrypted(Session* s, uint16_t msgType, const uint8_t* payload,
     putBE16(inner + 2, payloadLen);
     if (payloadLen > 0) memcpy(inner + 4, payload, payloadLen);
 
-    uint32_t ctr = s->counter.fetch_add(1, std::memory_order_relaxed);
+    uint32_t ctr = 0;
+    if (!dish_counter::acquireSendCounter(s->counter, &ctr)) return false;
 
     // Nonce: dir(1) | 0×7 | counter(4 BE). The direction byte keeps this
     // direction's nonces disjoint from the server's under the shared key.
@@ -755,6 +758,13 @@ JNIEXPORT jint JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_getSes
     auto s = getSession(handle);
     if (!s) return -1;
     return s->closeReason.load(std::memory_order_acquire);
+}
+
+JNIEXPORT jlong JNICALL
+Java_com_tinkernorth_dish_core_jni_SatelliteNative_getSendCounter(JNIEnv*, jobject, jint handle) {
+    auto s = getSession(handle);
+    if (!s) return 0;
+    return (jlong)dish_counter::sendCounterView(s->counter);
 }
 
 JNIEXPORT jint JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_getVigemAvailable(

--- a/app/src/main/cpp/send_counter.h
+++ b/app/src/main/cpp/send_counter.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+namespace dish_counter {
+
+// Counters never wrap (contract §Crypto): sealing two plaintexts under one
+// (key, nonce) would be catastrophic. 64-bit storage so exhaustion parks the
+// sender silent instead of wrapping the 32-bit wire field into nonce reuse.
+inline constexpr uint64_t kCounterMaxWire = 0xFFFFFFFFull;
+
+// Draws the next wire counter; false once the 32-bit space is exhausted (the
+// caller must go silent, never send). A drawn value is never repeated.
+inline bool acquireSendCounter(std::atomic<uint64_t>& counter, uint32_t* out) {
+    const uint64_t seq = counter.fetch_add(1, std::memory_order_relaxed);
+    if (seq > kCounterMaxWire) return false;
+    *out = static_cast<uint32_t>(seq);
+    return true;
+}
+
+// Clamped, not truncated, for the Kotlin re-key poll: past exhaustion it must
+// keep reading re-PUT needed, never wrap under the threshold.
+inline uint32_t sendCounterView(const std::atomic<uint64_t>& counter) {
+    const uint64_t v = counter.load(std::memory_order_relaxed);
+    return v > kCounterMaxWire ? static_cast<uint32_t>(kCounterMaxWire) : static_cast<uint32_t>(v);
+}
+
+} // namespace dish_counter

--- a/app/src/main/java/com/tinkernorth/dish/composer/PhysicalReachabilityComposer.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/PhysicalReachabilityComposer.kt
@@ -31,7 +31,7 @@ class PhysicalReachabilityComposer
                 // registrations (every auto-reconnect) are picked up.
                 val slotFlows = conns.values.map { it.slots }
                 val slotsTrigger: Flow<Unit> =
-                    if (slotFlows.isEmpty()) flowOf(Unit) else combine(slotFlows) { Unit }
+                    if (slotFlows.isEmpty()) flowOf(Unit) else combine(slotFlows) { }
                 combine(
                     registry.devices,
                     hub.bindings,
@@ -91,7 +91,7 @@ internal object PhysicalReachability {
         connections.flatMapLatest { conns ->
             val slotFlows = conns.values.map { it.slots }
             val slotsTrigger: Flow<Unit> =
-                if (slotFlows.isEmpty()) flowOf(Unit) else combine(slotFlows) { Unit }
+                if (slotFlows.isEmpty()) flowOf(Unit) else combine(slotFlows) { }
             combine(devices, bindings, summaries, slotsTrigger) { devs, binds, summ, _ ->
                 PhysicalReachabilityComposer.resolve(devs.keys, binds, summ, conns)
             }

--- a/app/src/main/java/com/tinkernorth/dish/core/jni/ControllerRepository.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/jni/ControllerRepository.kt
@@ -50,6 +50,8 @@ class ControllerRepository
 
         fun getSessionCloseReason(handle: Int): Int = SatelliteNative.getSessionCloseReason(handle)
 
+        fun getSendCounter(handle: Int): Long = SatelliteNative.getSendCounter(handle)
+
         @Suppress("LongParameterList")
         fun sendMotion(
             handle: Int,

--- a/app/src/main/java/com/tinkernorth/dish/core/jni/SatelliteNative.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/jni/SatelliteNative.kt
@@ -90,6 +90,10 @@ object SatelliteNative {
     // Terminal: the session is gone server-side the moment this is non-negative.
     external fun getSessionCloseReason(handle: Int): Int
 
+    // Send counter for the proactive re-key poll. Clamped at 0xFFFFFFFF past
+    // exhaustion so it can never read below the re-PUT threshold again.
+    external fun getSendCounter(handle: Int): Long
+
     external fun getVigemAvailable(handle: Int): Int
 
     external fun getActiveControllerCount(handle: Int): Int

--- a/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalSlotBindingObserver.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalSlotBindingObserver.kt
@@ -200,7 +200,7 @@ class PhysicalSlotBindingObserver
                 // Outer Map only re-emits on session add/remove; slotsTrigger re-pushes when a session's slot flips `registered`.
                 val slotFlows = conns.values.map { it.slots }
                 val slotsTrigger: Flow<Unit> =
-                    if (slotFlows.isEmpty()) flowOf(Unit) else combine(slotFlows) { Unit }
+                    if (slotFlows.isEmpty()) flowOf(Unit) else combine(slotFlows) { }
                 combine(
                     registry.devices,
                     hub.bindings,

--- a/app/src/main/java/com/tinkernorth/dish/source/bluetooth/AndroidHidProxyClient.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/bluetooth/AndroidHidProxyClient.kt
@@ -121,7 +121,7 @@ class AndroidHidProxyClient(
             val hid = hidDevice ?: return false
             val device = connectedDevice ?: return false
             // Strip report-id byte into per-thread scratch: sendReport takes it separately from the payload.
-            val payload = payloadScratch.get()
+            val payload = payloadScratch.get() ?: return false
             System.arraycopy(report, 1, payload, 0, REPORT_SIZE - 1)
             hid.sendReport(device, REPORT_ID, payload)
         }.getOrDefault(false)

--- a/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnection.kt
@@ -20,6 +20,12 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
+// Contract §Crypto: counters never wrap; clients SHOULD re-PUT once their send
+// counter crosses 0xF0000000. Rotating token/salt/key restarts the counter at 1.
+internal const val COUNTER_REPUSH_THRESHOLD = 0xF000_0000L
+
+internal fun counterNeedsRepush(sendCounter: Long): Boolean = sendCounter >= COUNTER_REPUSH_THRESHOLD
+
 /**
  * One satellite session. Slots are DECLARATIVE: this class holds the desired
  * descriptor per slot plus the applied state the satellite last confirmed;
@@ -105,7 +111,8 @@ class SatelliteConnection(
      * response. [onDead] fires on heartbeat death; [onClosedByServer] on an
      * authenticated close-notify (immediate, no death-timeout wait);
      * [onReconcileNeeded] when the heartbeat-ack epoch/bitmap stops matching
-     * what we believe is applied.
+     * what we believe is applied; [onRekeyNeeded] once per session when the
+     * send counter crosses the re-PUT threshold.
      */
     internal fun markConnected(
         handle: Int,
@@ -116,6 +123,7 @@ class SatelliteConnection(
         onDead: () -> Unit,
         onClosedByServer: (reason: Int) -> Unit = { onDead() },
         onReconcileNeeded: () -> Unit = {},
+        onRekeyNeeded: () -> Unit = {},
         onApplyFailures: (failures: List<ControllerApplyDto>) -> Unit = {},
     ) {
         if (_state.value != SatelliteSessionState.Linking) return
@@ -139,6 +147,7 @@ class SatelliteConnection(
         aliveJob =
             scope.launch {
                 var consecutiveMisses = 0
+                var rekeyRequested = false
                 while (isActive) {
                     delay(ALIVE_POLL_MS)
                     // An authenticated close-notify is terminal NOW: the
@@ -156,6 +165,7 @@ class SatelliteConnection(
                         }
                         consecutiveMisses = 0
                         checkReconcile(onReconcileNeeded)
+                        rekeyRequested = checkRekey(rekeyRequested, onRekeyNeeded)
                         continue
                     }
                     consecutiveMisses += 1
@@ -184,6 +194,20 @@ class SatelliteConnection(
         if (serverEpoch != lastAppliedEpoch || (serverBitmap >= 0 && serverBitmap != expectedBitmap)) {
             onReconcileNeeded()
         }
+    }
+
+    // Proactive re-key before the send counter can exhaust (contract §Crypto:
+    // re-PUT past 0xF0000000). Single-shot per crossing: the re-PUT rotates the
+    // token/key and restarts the counter, which re-arms the latch. A session
+    // that exhausts anyway goes silent natively and heals via heartbeat death.
+    private fun checkRekey(
+        alreadyRequested: Boolean,
+        onRekeyNeeded: () -> Unit,
+    ): Boolean {
+        val snap = live ?: return alreadyRequested
+        if (!counterNeedsRepush(controllerRepo.getSendCounter(snap.handle))) return false
+        if (!alreadyRequested) onRekeyNeeded()
+        return true
     }
 
     private fun registeredBitmap(): Int {

--- a/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManager.kt
@@ -542,6 +542,7 @@ class SatelliteConnectionManager
                 },
                 onClosedByServer = { reason -> handleServerClose(conn, server, reason) },
                 onReconcileNeeded = { scope.launch(ioDispatcher) { reconcile(conn, server) } },
+                onRekeyNeeded = { scope.launch(ioDispatcher) { rekey(conn, server) } },
                 onApplyFailures = { failures ->
                     scope.launch {
                         _events.emit(
@@ -661,6 +662,20 @@ class SatelliteConnectionManager
             } finally {
                 reconcileInFlight.remove(id)
             }
+        }
+
+        // The send counter crossed the re-PUT threshold: converge with a fresh
+        // session PUT for new token/salt/key (counter back to 1). Reconcile
+        // can't carry this — its matched-view early-exit adopts the epoch
+        // without rotating anything.
+        private suspend fun rekey(
+            conn: SatelliteConnection,
+            server: DiscoveredServer,
+        ) {
+            if (conn.state.value != SatelliteSessionState.Live) return
+            conn.markDisconnected()
+            conn.markConnecting()
+            openSession(conn, server, ConnectIntent.RETRY_AFTER_DEATH)
         }
 
         // Single-slot converge while the session is live (PUT .../controllers/{idx}).

--- a/app/src/main/java/com/tinkernorth/dish/source/notification/DishNotifications.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/notification/DishNotifications.kt
@@ -190,11 +190,11 @@ class DishNotifications
 
             owner.lifecycle.addObserver(
                 object : DefaultLifecycleObserver {
-                    override fun onResume(o: LifecycleOwner) {
+                    override fun onResume(owner: LifecycleOwner) {
                         activate(attachment)
                     }
 
-                    override fun onDestroy(o: LifecycleOwner) {
+                    override fun onDestroy(owner: LifecycleOwner) {
                         drop(attachment)
                         attachment.dismissAll()
                     }

--- a/app/src/main/java/com/tinkernorth/dish/source/usb/UsbGamepadManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/usb/UsbGamepadManager.kt
@@ -484,7 +484,7 @@ class UsbGamepadManager
         private fun friendlyName(device: UsbDevice): String {
             val known = native.lookupKnownModelName(device.vendorId, device.productId)
             if (known.isNotEmpty()) return known
-            val product = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) device.productName else null
+            val product = device.productName
             return product?.takeIf { it.isNotBlank() } ?: device.deviceName
         }
 

--- a/app/src/main/java/com/tinkernorth/dish/ui/common/DishLoaders.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/DishLoaders.kt
@@ -91,7 +91,7 @@ class DishSpinnerDrawable(
         strokePaint.color = tinted
     }
 
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
     override fun getOpacity(): Int = PixelFormat.TRANSLUCENT
 
     override fun start() {
@@ -173,7 +173,7 @@ class DishDotsDrawable(
         fillPaint.color = tinted
     }
 
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
     override fun getOpacity(): Int = PixelFormat.TRANSLUCENT
 
     override fun start() {
@@ -269,7 +269,7 @@ class DishBarDrawable(
         trackPaint.alpha = (0.22f * 255f).toInt()
     }
 
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
     override fun getOpacity(): Int = PixelFormat.TRANSLUCENT
 
     override fun start() {

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsActivity.kt
@@ -10,6 +10,7 @@ import androidx.activity.viewModels
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.core.view.isEmpty
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -151,7 +152,7 @@ class ConfigureBindingsActivity : BaseGamepadHostActivity() {
                 fc.inflateBindingPill(getString(R.string.binding_func_touchpad), R.drawable.ic_touchpad, PillTone.CAP),
             )
         }
-        if (fc.childCount == 0) fc.addView(noneValue(fc))
+        if (fc.isEmpty()) fc.addView(noneValue(fc))
     }
 
     private fun bindDestinationSection(

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
@@ -79,7 +79,7 @@ internal fun motionRateUserFacingOn(
     cap.inputOk(Feature.MOTION) &&
         cap.userWants(Feature.MOTION) &&
         boundStatus?.kind == ConnectionKind.SATELLITE &&
-        boundStatus?.live == LinkState.Connected &&
+        boundStatus.live == LinkState.Connected &&
         cap.typeOk(Feature.MOTION) &&
         Feature.MOTION !in cap.runtimeDown
 
@@ -261,7 +261,7 @@ class ControllerAdapter(
                 }
             val specs = mutableListOf(PillSpec(ctx.getString(label), icon, PillTone.FACT))
             // The Direct/Standard mode chip only applies once a USB controller is on a known path.
-            if (isUsb && kind != null && card != null) specs.add(usbModeSpec(card))
+            if (isUsb && kind != null) specs.add(usbModeSpec(card))
             return specs
         }
 

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
@@ -180,7 +180,7 @@ class GamepadOverlayActivity :
             capability.inputOk(Feature.MOTION) &&
                 capability.userWants(Feature.MOTION) &&
                 summary?.kind == ConnectionKind.SATELLITE &&
-                summary?.live == LinkState.Connected
+                summary.live == LinkState.Connected
         if (effective && !motionSource.isStreaming) {
             motionSource.start { sample, deltaUs ->
                 inputRateStore.recordMotionSample(VIRTUAL_SLOT_ID)

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupBluetoothHostViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupBluetoothHostViewModel.kt
@@ -249,7 +249,6 @@ class SetupBluetoothHostViewModel
             // Don't keep advertising once the wizard goes away unless we already
             // bonded and finished (the dashboard owns the live session from here).
             if (!proceeded) stopActive()
-            super.onCleared()
         }
 
         private fun emitDone(

--- a/app/src/test/cpp/CMakeLists.txt
+++ b/app/src/test/cpp/CMakeLists.txt
@@ -67,8 +67,18 @@ target_include_directories(usb_hid_descriptor_test PRIVATE "${SATELLITE_CPP}")
 target_compile_options(usb_hid_descriptor_test PRIVATE -Wall -Wextra -Wpedantic)
 target_link_libraries(usb_hid_descriptor_test PRIVATE GTest::gtest_main)
 
+# UDP send-counter exhaustion guard: the header the JNI send path draws every
+# wire counter from (no wrap into ChaCha20 nonce reuse, contract §Crypto).
+add_executable(send_counter_test
+    send_counter_test.cpp
+)
+target_include_directories(send_counter_test PRIVATE "${SATELLITE_CPP}")
+target_compile_options(send_counter_test PRIVATE -Wall -Wextra -Wpedantic)
+target_link_libraries(send_counter_test PRIVATE GTest::gtest_main)
+
 include(GoogleTest)
 gtest_discover_tests(gamepad_input_test)
 gtest_discover_tests(wire_encoders_test)
 gtest_discover_tests(usb_parsers_test)
 gtest_discover_tests(usb_hid_descriptor_test)
+gtest_discover_tests(send_counter_test)

--- a/app/src/test/cpp/send_counter_test.cpp
+++ b/app/src/test/cpp/send_counter_test.cpp
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "send_counter.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdint>
+#include <vector>
+
+// The send path (sendEncrypted) draws every wire counter through
+// acquireSendCounter and returns without sending when it refuses, so these
+// pins ARE the no-nonce-reuse guarantee: no wrapped counter can reach the
+// wire because no wrapped counter is ever handed out.
+
+TEST(AcquireSendCounter, DrawsSequentialValuesStartingAtSessionInitial) {
+    std::atomic<uint64_t> counter{1};
+    uint32_t ctr = 0;
+    ASSERT_TRUE(dish_counter::acquireSendCounter(counter, &ctr));
+    EXPECT_EQ(ctr, 1u);
+    ASSERT_TRUE(dish_counter::acquireSendCounter(counter, &ctr));
+    EXPECT_EQ(ctr, 2u);
+    ASSERT_TRUE(dish_counter::acquireSendCounter(counter, &ctr));
+    EXPECT_EQ(ctr, 3u);
+}
+
+TEST(AcquireSendCounter, UsesTheFullWireSpaceThenGoesSilent) {
+    std::atomic<uint64_t> counter{0xFFFFFFFEull};
+    uint32_t ctr = 0;
+    ASSERT_TRUE(dish_counter::acquireSendCounter(counter, &ctr));
+    EXPECT_EQ(ctr, 0xFFFFFFFEu);
+    ASSERT_TRUE(dish_counter::acquireSendCounter(counter, &ctr));
+    EXPECT_EQ(ctr, 0xFFFFFFFFu); // last usable wire value
+    EXPECT_FALSE(dish_counter::acquireSendCounter(counter, &ctr));
+}
+
+TEST(AcquireSendCounter, NeverRepeatsAValueUnderOneKeyAcrossExhaustion) {
+    std::atomic<uint64_t> counter{0xFFFFFFFDull};
+    std::vector<uint32_t> drawn;
+    for (int i = 0; i < 8; i++) {
+        uint32_t ctr = 0;
+        if (dish_counter::acquireSendCounter(counter, &ctr)) drawn.push_back(ctr);
+    }
+    // The unguarded u32 fetch_add would have kept drawing here: 0, 1, 2 …
+    // reusing (key, nonce) pairs from the start of the session.
+    ASSERT_EQ(drawn.size(), 3u);
+    for (size_t i = 1; i < drawn.size(); i++) EXPECT_GT(drawn[i], drawn[i - 1]);
+}
+
+TEST(AcquireSendCounter, RefusalLeavesTheOutputUntouched) {
+    std::atomic<uint64_t> counter{0x100000000ull};
+    uint32_t ctr = 0xDEADBEEFu;
+    EXPECT_FALSE(dish_counter::acquireSendCounter(counter, &ctr));
+    EXPECT_EQ(ctr, 0xDEADBEEFu);
+}
+
+TEST(SendCounterView, ReportsTheLiveValueBelowExhaustion) {
+    std::atomic<uint64_t> counter{5};
+    EXPECT_EQ(dish_counter::sendCounterView(counter), 5u);
+    counter.store(0xF0000000ull);
+    EXPECT_EQ(dish_counter::sendCounterView(counter), 0xF0000000u);
+}
+
+TEST(SendCounterView, ClampsAtWireMaxPastExhaustionSoRekeyStaysDue) {
+    std::atomic<uint64_t> counter{0xFFFFFFFFull};
+    uint32_t ctr = 0;
+    ASSERT_TRUE(dish_counter::acquireSendCounter(counter, &ctr));
+    // Keep drawing past exhaustion: the view must clamp at the wire max, never
+    // wrap back under the 0xF0000000 re-key threshold the Kotlin poll compares
+    // against.
+    for (int i = 0; i < 4; i++) {
+        EXPECT_FALSE(dish_counter::acquireSendCounter(counter, &ctr));
+        EXPECT_EQ(dish_counter::sendCounterView(counter), 0xFFFFFFFFu);
+    }
+}
+
+TEST(SendCounterView, RestartsAtOneAfterARekeyReset) {
+    std::atomic<uint64_t> counter{0x100000007ull};
+    counter.store(1); // setConnectionParams: counters restart per (token, key)
+    EXPECT_EQ(dish_counter::sendCounterView(counter), 1u);
+    uint32_t ctr = 0;
+    EXPECT_TRUE(dish_counter::acquireSendCounter(counter, &ctr));
+    EXPECT_EQ(ctr, 1u);
+}

--- a/app/src/test/java/com/tinkernorth/dish/hotpath/input/RumbleRouterTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/hotpath/input/RumbleRouterTest.kt
@@ -22,8 +22,6 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-// JVM stub reports SDK_INT=0, driving the legacy vibrator path; production suppresses the same.
-@Suppress("DEPRECATION")
 class RumbleRouterTest {
     private fun slot(index: Int) = SatelliteConnection.SlotBinding(controllerIndex = index, controllerType = 0, registered = true)
 
@@ -192,6 +190,7 @@ class RumbleRouterTest {
         val rumbleEnabled =
             mockk<RumbleEnabledStore> { every { isEnabled(any()) } returns rumbleOn }
 
+        @Suppress("DEPRECATION") // VIBRATOR_SERVICE: the SDK_INT=0 legacy path resolves it
         private val context =
             mockk<Context>(relaxed = true) {
                 every { getSystemService(Context.VIBRATOR_SERVICE) } returns vibrator
@@ -221,6 +220,7 @@ class RumbleRouterTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Vibrator.vibrate(Long): what the SDK_INT=0 legacy path calls
     fun `dispatch suppresses the phone vibrator when the virtual slot is rumble-off`() {
         val h = DispatchHarness(slotId = VIRTUAL_SLOT_ID, controllerIndex = 0, rumbleOn = false)
 
@@ -232,6 +232,7 @@ class RumbleRouterTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Vibrator.vibrate(Long): what the SDK_INT=0 legacy path calls
     fun `dispatch actuates the phone vibrator when the virtual slot is rumble-on`() {
         val h = DispatchHarness(slotId = VIRTUAL_SLOT_ID, controllerIndex = 0, rumbleOn = true)
 
@@ -262,6 +263,7 @@ class RumbleRouterTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Vibrator.vibrate(Long): what the SDK_INT=0 legacy path calls
     fun `dispatch consults the gate with the framework device id and suppresses when off`() {
         val h = DispatchHarness(slotId = "1234", controllerIndex = 0, rumbleOn = false)
 

--- a/app/src/test/java/com/tinkernorth/dish/hotpath/input/RumbleRouterTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/hotpath/input/RumbleRouterTest.kt
@@ -22,6 +22,11 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+// The JVM unit-test stub reports SDK_INT = 0, so the router — and therefore these
+// doubles/verifications — drive the legacy single-vibrator path (Context.VIBRATOR_SERVICE,
+// Vibrator.vibrate(Long)). Production RumbleRouter suppresses the same platform
+// deprecations at each guarded call site; mirror that convention for the test.
+@Suppress("DEPRECATION")
 class RumbleRouterTest {
     private fun slot(index: Int) = SatelliteConnection.SlotBinding(controllerIndex = index, controllerType = 0, registered = true)
 

--- a/app/src/test/java/com/tinkernorth/dish/hotpath/input/RumbleRouterTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/hotpath/input/RumbleRouterTest.kt
@@ -22,10 +22,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-// The JVM unit-test stub reports SDK_INT = 0, so the router — and therefore these
-// doubles/verifications — drive the legacy single-vibrator path (Context.VIBRATOR_SERVICE,
-// Vibrator.vibrate(Long)). Production RumbleRouter suppresses the same platform
-// deprecations at each guarded call site; mirror that convention for the test.
+// JVM stub reports SDK_INT=0, driving the legacy vibrator path; production suppresses the same.
 @Suppress("DEPRECATION")
 class RumbleRouterTest {
     private fun slot(index: Int) = SatelliteConnection.SlotBinding(controllerIndex = index, controllerType = 0, registered = true)

--- a/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothConnectionsTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothConnectionsTest.kt
@@ -19,6 +19,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+// Exercises the SDK-guarded legacy Intent.getParcelableExtra(String) path (the JVM
+// unit-test stub reports SDK_INT = 0). Production BluetoothConnections suppresses the
+// same platform deprecation at its guarded call site; mirror that convention here.
+@Suppress("DEPRECATION")
 class BluetoothConnectionsTest {
     private val context = mockk<Context>(relaxed = true)
     private val receiverSlot = slot<BroadcastReceiver>()

--- a/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothConnectionsTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothConnectionsTest.kt
@@ -19,8 +19,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-// JVM stub reports SDK_INT=0, driving the legacy getParcelableExtra path; production suppresses the same.
-@Suppress("DEPRECATION")
 class BluetoothConnectionsTest {
     private val context = mockk<Context>(relaxed = true)
     private val receiverSlot = slot<BroadcastReceiver>()
@@ -41,6 +39,7 @@ class BluetoothConnectionsTest {
         unmockkAll()
     }
 
+    // One-arg getParcelableExtra: the JVM stub's SDK_INT=0 drives the legacy path.
     @Suppress("DEPRECATION")
     private fun aclEvent(
         action: String,

--- a/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothConnectionsTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothConnectionsTest.kt
@@ -19,9 +19,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-// Exercises the SDK-guarded legacy Intent.getParcelableExtra(String) path (the JVM
-// unit-test stub reports SDK_INT = 0). Production BluetoothConnections suppresses the
-// same platform deprecation at its guarded call site; mirror that convention here.
+// JVM stub reports SDK_INT=0, driving the legacy getParcelableExtra path; production suppresses the same.
 @Suppress("DEPRECATION")
 class BluetoothConnectionsTest {
     private val context = mockk<Context>(relaxed = true)

--- a/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothDeviceScannerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothDeviceScannerTest.kt
@@ -24,7 +24,11 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+// Exercises the SDK-guarded legacy Intent.getParcelableExtra(String) path (the JVM
+// unit-test stub reports SDK_INT = 0). Production BluetoothDeviceScanner suppresses the
+// same platform deprecation at its guarded call site; mirror that convention here.
 @OptIn(ExperimentalCoroutinesApi::class)
+@Suppress("DEPRECATION")
 class BluetoothDeviceScannerTest {
     private lateinit var context: Context
     private lateinit var adapter: BluetoothAdapter

--- a/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothDeviceScannerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothDeviceScannerTest.kt
@@ -24,9 +24,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-// Exercises the SDK-guarded legacy Intent.getParcelableExtra(String) path (the JVM
-// unit-test stub reports SDK_INT = 0). Production BluetoothDeviceScanner suppresses the
-// same platform deprecation at its guarded call site; mirror that convention here.
+// JVM stub reports SDK_INT=0, driving the legacy getParcelableExtra path; production suppresses the same.
 @OptIn(ExperimentalCoroutinesApi::class)
 @Suppress("DEPRECATION")
 class BluetoothDeviceScannerTest {

--- a/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothDeviceScannerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/bluetooth/BluetoothDeviceScannerTest.kt
@@ -24,9 +24,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-// JVM stub reports SDK_INT=0, driving the legacy getParcelableExtra path; production suppresses the same.
 @OptIn(ExperimentalCoroutinesApi::class)
-@Suppress("DEPRECATION")
 class BluetoothDeviceScannerTest {
     private lateinit var context: Context
     private lateinit var adapter: BluetoothAdapter
@@ -60,6 +58,8 @@ class BluetoothDeviceScannerTest {
         return device
     }
 
+    // One-arg getParcelableExtra: the JVM stub's SDK_INT=0 drives the legacy path.
+    @Suppress("DEPRECATION")
     private fun foundIntent(device: BluetoothDevice?): Intent {
         val intent = mockk<Intent>(relaxed = true)
         every { intent.action } returns BluetoothDevice.ACTION_FOUND

--- a/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManagerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManagerTest.kt
@@ -123,14 +123,18 @@ class SatelliteConnectionManagerTest {
             val mgr = manager()
             val events = mutableListOf<ConnectionEvent>()
             val collector = scope.launch { mgr.events.collect { events += it } }
-            block(mgr, events)
-            // A live session's heartbeat poll reschedules itself forever, so
-            // the scheduler can never go idle while one exists. Tear all
-            // sessions down before the final drain.
-            mgr.connections.value.keys
-                .forEach(mgr::disconnect)
-            scope.testScheduler.advanceUntilIdle()
-            collector.cancel()
+            try {
+                block(mgr, events)
+            } finally {
+                // A live session's heartbeat poll reschedules itself forever, so
+                // the scheduler can never go idle while one exists. Tear all
+                // sessions down before the final drain — on assertion failure
+                // too, or the drain spins virtual time into OOM.
+                mgr.connections.value.keys
+                    .forEach(mgr::disconnect)
+                scope.testScheduler.advanceUntilIdle()
+                collector.cancel()
+            }
         }
 
     @Test
@@ -673,6 +677,43 @@ class SatelliteConnectionManagerTest {
             assertEquals(SatelliteSessionState.Live, conn.state.value)
             coVerify(exactly = 1) { discoveryRepo.getSession(any(), any(), any(), any(), any()) }
             coVerify(exactly = 1) { discoveryRepo.putSession(any(), any(), any(), any(), any(), any(), any()) }
+        }
+
+    @Test
+    fun `crossing the re-key threshold re-PUTs the session for fresh token and keys`() =
+        runMgrTest { mgr, _ ->
+            every { store.satelliteSharedKey(serverId) } returns "aa".repeat(32)
+            coEvery {
+                discoveryRepo.putSession(any(), any(), any(), any(), any(), any(), any())
+            } returns
+                ok(
+                    """{"connectionId":"conn_1","token":"00000001","sessionSalt":"0102030405060708",""" +
+                        """"epoch":1,"controllers":[],"hostFeatures":{"mouseControl":{"granted":false}}}""",
+                )
+            every { controllerRepo.openSocket(any(), any()) } returns 5
+            // Mirror the native contract: installing fresh params restarts the counter.
+            var sendCounter = 1L
+            every { controllerRepo.getSendCounter(any()) } answers { sendCounter }
+            every { controllerRepo.setConnectionParams(any(), any(), any()) } answers { sendCounter = 1L }
+
+            mgr.connect(server)
+            scope.testScheduler.runCurrent()
+            assertEquals(SatelliteSessionState.Live, mgr.get(serverId)?.state?.value)
+            coVerify(exactly = 1) { discoveryRepo.putSession(any(), any(), any(), any(), any(), any(), any()) }
+
+            sendCounter = COUNTER_REPUSH_THRESHOLD
+            scope.testScheduler.advanceTimeBy(1100) // one alive-poll tick
+            scope.testScheduler.runCurrent()
+
+            // Exactly one full re-PUT: fresh token/salt/key installed, session Live again.
+            coVerify(exactly = 2) { discoveryRepo.putSession(any(), any(), any(), any(), any(), any(), any()) }
+            verify(exactly = 2) { controllerRepo.setConnectionParams(5, any(), any()) }
+            assertEquals(SatelliteSessionState.Live, mgr.get(serverId)?.state?.value)
+
+            // The rotated counter sits back under the threshold: no re-PUT storm.
+            scope.testScheduler.advanceTimeBy(5000)
+            scope.testScheduler.runCurrent()
+            coVerify(exactly = 2) { discoveryRepo.putSession(any(), any(), any(), any(), any(), any(), any()) }
         }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionTest.kt
@@ -109,6 +109,7 @@ class SatelliteConnectionTest {
         clearAllMocks()
     }
 
+    @Suppress("LongParameterList")
     private fun connectLive(
         target: SatelliteConnection = conn,
         handle: Int = 7,
@@ -118,6 +119,7 @@ class SatelliteConnectionTest {
         onDead: () -> Unit = {},
         onClosedByServer: (Int) -> Unit = {},
         onReconcileNeeded: () -> Unit = {},
+        onRekeyNeeded: () -> Unit = {},
         onApplyFailures: (List<ControllerApplyDto>) -> Unit = {},
     ) {
         target.markConnecting()
@@ -130,6 +132,7 @@ class SatelliteConnectionTest {
             onDead = onDead,
             onClosedByServer = onClosedByServer,
             onReconcileNeeded = onReconcileNeeded,
+            onRekeyNeeded = onRekeyNeeded,
             onApplyFailures = onApplyFailures,
         )
     }
@@ -557,6 +560,62 @@ class SatelliteConnectionTest {
 
             scope.advanceTimeBy(3100)
             assertEquals(0, reconciles)
+        }
+
+    @Test
+    fun `counterNeedsRepush fires once the send counter crosses 0xF0000000`() {
+        assertFalse(counterNeedsRepush(1L))
+        assertFalse(counterNeedsRepush(0xEFFF_FFFFL))
+        assertTrue(counterNeedsRepush(0xF000_0000L))
+        assertTrue(counterNeedsRepush(0xFFFF_FFFFL))
+    }
+
+    @Test
+    fun `send counter at the re-PUT threshold fires onRekeyNeeded exactly once`() =
+        connTest {
+            every { repo.isConnectionAlive(any()) } returns true
+            every { repo.getSendCounter(any()) } returns COUNTER_REPUSH_THRESHOLD
+
+            var rekeys = 0
+            connectLive(onRekeyNeeded = { rekeys++ })
+
+            // Several alive-poll ticks: the latch must not re-fire while the
+            // rotation is still in flight (a re-PUT per tick would storm the server).
+            scope.advanceTimeBy(4100)
+            assertEquals(1, rekeys)
+        }
+
+    @Test
+    fun `send counter below the re-PUT threshold never requests a re-key`() =
+        connTest {
+            every { repo.isConnectionAlive(any()) } returns true
+            every { repo.getSendCounter(any()) } returns COUNTER_REPUSH_THRESHOLD - 1
+
+            var rekeys = 0
+            connectLive(onRekeyNeeded = { rekeys++ })
+
+            scope.advanceTimeBy(3100)
+            assertEquals(0, rekeys)
+        }
+
+    @Test
+    fun `re-key latch re-arms only after the rotation restarts the counter`() =
+        connTest {
+            every { repo.isConnectionAlive(any()) } returns true
+            var counter = COUNTER_REPUSH_THRESHOLD
+            every { repo.getSendCounter(any()) } answers { counter }
+
+            var rekeys = 0
+            connectLive(onRekeyNeeded = { rekeys++ })
+
+            scope.advanceTimeBy(2100)
+            assertEquals(1, rekeys)
+
+            counter = 1L // rotation installed fresh params, counter restarted
+            scope.advanceTimeBy(1100)
+            counter = COUNTER_REPUSH_THRESHOLD
+            scope.advanceTimeBy(1100)
+            assertEquals(2, rekeys)
         }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/source/system/BluetoothBondMonitorTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/system/BluetoothBondMonitorTest.kt
@@ -19,9 +19,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 
-// Exercises the SDK-guarded legacy Intent.getParcelableExtra(String) path (the JVM
-// unit-test stub reports SDK_INT = 0). Production BluetoothBondMonitor suppresses the
-// same platform deprecation at its guarded call site; mirror that convention here.
+// JVM stub reports SDK_INT=0, driving the legacy getParcelableExtra path; production suppresses the same.
 @Suppress("DEPRECATION")
 class BluetoothBondMonitorTest {
     private lateinit var context: Context

--- a/app/src/test/java/com/tinkernorth/dish/source/system/BluetoothBondMonitorTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/system/BluetoothBondMonitorTest.kt
@@ -19,8 +19,6 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 
-// JVM stub reports SDK_INT=0, driving the legacy getParcelableExtra path; production suppresses the same.
-@Suppress("DEPRECATION")
 class BluetoothBondMonitorTest {
     private lateinit var context: Context
     private lateinit var store: ConnectionStore
@@ -69,6 +67,8 @@ class BluetoothBondMonitorTest {
         return intent
     }
 
+    // One-arg getParcelableExtra: the JVM stub's SDK_INT=0 drives the legacy path.
+    @Suppress("DEPRECATION")
     private fun intentForAction(
         action: String,
         mac: String,
@@ -114,6 +114,7 @@ class BluetoothBondMonitorTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // one-arg getParcelableExtra, as in intentForAction
     fun `KEY_MISSING with no EXTRA_DEVICE is ignored`() {
         val intent =
             mockk<Intent>(relaxed = true) {

--- a/app/src/test/java/com/tinkernorth/dish/source/system/BluetoothBondMonitorTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/system/BluetoothBondMonitorTest.kt
@@ -19,6 +19,10 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 
+// Exercises the SDK-guarded legacy Intent.getParcelableExtra(String) path (the JVM
+// unit-test stub reports SDK_INT = 0). Production BluetoothBondMonitor suppresses the
+// same platform deprecation at its guarded call site; mirror that convention here.
+@Suppress("DEPRECATION")
 class BluetoothBondMonitorTest {
     private lateinit var context: Context
     private lateinit var store: ConnectionStore


### PR DESCRIPTION
## Summary

Two layers on one branch (maintainer's one-branch preference for the 2026-07-20 fix wave):

1. **Warning + CI-hygiene sweep** (`fa1c35e`, `9bd9cac`, `f897948`, `da24efe`): clears the compiler/native/lint warnings surfaced by the last green CI build and a full uncached local gate run, and caps workflow jobs with runtime timeouts. No dependency-version changes.
2. **Fix-wave security fix + sweep follow-ups** (`c802f8e`, `090574b`, `bbd5d4a`, `7bacf09`): a serious UDP send-counter wrap fix (ChaCha20 nonce reuse), plus review follow-ups on the sweep itself. **The branch is no longer behavior-neutral** — `c802f8e` changes the crypto send path and session lifecycle.

## What changed

**SERIOUS fix: send-counter wrap → nonce reuse (`c802f8e`)**
- `satellite_jni.cpp` drew the ChaCha20-Poly1305 nonce counter from a `uint32 fetch_add` with no exhaustion guard: at 2^32 packets in one unbroken session it wrapped and re-sealed under reused (key, nonce) pairs until heartbeat death (contract §Crypto forbids exactly this; horizon ~50 days at 1 kHz).
- Mirrors dish-mac / dish-linux: the send path draws from a 64-bit counter (`send_counter.h`) and goes **silent** past 2^32−1; `getSendCounter()` clamps at the wire max; the 1 Hz Kotlin alive-poll fires a single-shot `onRekeyNeeded` once the counter crosses `0xF0000000` (`counterNeedsRepush`); the manager re-PUTs the session for fresh token/salt/key, restarting the counter at 1 long before exhaustion.
- Tests: 7 host gtests pin the guard across the exhaustion boundary (silence, no counter value ever repeats under one key, clamped view — all fail against the old wrap semantics); 5 JVM tests pin the threshold predicate, the single-shot latch + re-arm, and the manager re-PUT installing fresh params exactly once. `runMgrTest` now tears sessions down in a `finally` (an assertion failure used to skip teardown and spin the virtual-time drain into OOM).

**Sweep follow-ups (review findings on this PR)**
- `090574b` — the sweep's class-wide test `@Suppress("DEPRECATION")` did **not** match production (which scopes to the call site) and would have masked any new deprecation in those classes. Narrowed to the exact legacy call sites in `RumbleRouterTest`, `BluetoothConnectionsTest`, `BluetoothDeviceScannerTest`, `BluetoothBondMonitorTest`.
- `bbd5d4a` — the sweep claimed every job was capped, but the five `_security.yml` jobs had no `timeout-minutes`. Capped at 10 min each (warm runtimes 5–10 s). The sibling repos' copies of the shared file are still uncapped — cross-repo sync is a follow-up.
- `7bacf09` — `HAVE_SYSCONF=1` was justified only as warning-silencing; it is a behavior change to libsodium (runtime page size via `sysconf` for `sodium_mlock`/guarded allocations — what Android 15's 16 KB-page devices need). The comment now says so. Not exercisable in the host gtest harness; on-device coverage rides the emulator integration suite.

**Native / build (`fa1c35e`)**
- `CMP0135` policy set explicitly (`NEW`), removing the `DOWNLOAD_EXTRACT_TIMESTAMP` FetchContent dev warning.
- `HAVE_SYSCONF=1` for the vendored libsodium build (see `7bacf09` above for the real rationale). NDK debug build is **0 native warnings**.

**Kotlin + Android Lint (`9bd9cac`)** — 12 production Kotlin compiler warnings cleared (these were hidden in CI by the Gradle build cache; an uncached `--rerun-tasks` compile surfaces them): unused expression results, override param-name mismatches, deprecated-override annotations on mandatory `Drawable.getOpacity()` overrides, a K2 always-true condition, unnecessary safe-calls after smart-casts, and one Java platform-type nullability. Plus 3 Lint fixes: `EmptySuperCall`, `ObsoleteSdkInt`, `UseKtx`.

**Workflow hygiene (`f897948`)** — added `timeout-minutes` to the dish-android-owned jobs (build 30, play-listing 20, play-reviews 15, release jobs 10–60); `bbd5d4a` completes the claim for `_security.yml`. All 13 action pin-map `tag→SHA` comments verified against upstream (none stale). 40-char SHA pins kept.

**Comment trim (`da24efe`)** — sweep-added comments cut to terse why-only house style.

## Test evidence (branch head `7bacf09`)

All CI gates re-run locally at this head: clang-format (22.1.5 local vs 22.1.4 CI pin — no diffs), Play-metadata lint, ktlint + detekt, Android Lint, **1,542 JVM unit tests (0 failures)**, **166/166 native tests**, `assembleDebug` + `assembleDebugAndroidTest` — all green; native build and all touched Kotlin files warning-clean. Fail-before verified for the counter fix: neutering the guard fails 4 native tests; neutering the predicate fails 3 connection tests + the manager re-PUT test.

## Deliberately deferred (out of scope)

- **Parked #142 dependency group** (AGP 9.3.0 / Kotlin 2.4.10 / firebaseBom 34.16.0) — CodeQL CLI rejects Kotlin 2.4.10; the 2 `AndroidGradlePluginVersion` + 1 `GradleDependency` Lint warnings stay until CodeQL supports it.
- **116-item Lint backlog** (UnusedResources, ContentDescription, i18n, etc.) — pre-existing, regression-risky to churn en masse; recommend a dedicated QA-reviewed cleanup.
- **15 pre-existing test/main warnings** (deprecated internal `PhysicalReachability` object usages, 2 USELESS_CAST, platform-nullability) — pre-date this branch; naive fixes trade one warning for another; recommend a focused pass.
- **Plugin-internal Gradle deprecations** (ktlint/detekt/baselineprofile) — not fixable in first-party build scripts.
- Strict mode (`allWarningsAsErrors` / lint `warningsAsErrors`) is **not** enabled yet — recommended once the above land and the tree is fully clean.
- `_security.yml` timeout caps for the sibling repos' copies of the shared workflow — sync convention follow-up.

## Unverified

- The instrumented **FakeSatellite integration suite** (`connectedDebugAndroidTest`) runs only on an emulator/CI — this PR's CI run is the arbiter. The re-key path itself is unit-tested at the JNI-boundary seam; the end-to-end rotation against a live satellite rides the existing session-PUT integration coverage.
- Local gates ran under the Android Studio JBR (JDK 21; no JDK 17 on the build host) with bytecode target JVM 17; CI uses temurin 17. No JDK-21-only warnings were observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
