### PR TITLE
fix: gate rumble/motion on the active path, not the model DB

### DIFF
--- a/app/src/main/cpp/satellite_jni.cpp
+++ b/app/src/main/cpp/satellite_jni.cpp
@@ -1137,6 +1137,16 @@ JNIEXPORT jboolean JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_mo
     return usbparsers::parserHasTouchpad(k->parser) ? JNI_TRUE : JNI_FALSE;
 }
 
+JNIEXPORT jboolean JNICALL
+Java_com_tinkernorth_dish_core_jni_SatelliteNative_modelFrameworkRumbleUnreliable(JNIEnv*, jobject,
+                                                                                  jint vid,
+                                                                                  jint pid) {
+    const usbparsers::KnownDevice* k =
+        usbparsers::lookupKnown((uint16_t)(vid & 0xFFFF), (uint16_t)(pid & 0xFFFF));
+    if (!k) return JNI_FALSE;
+    return usbparsers::parserFrameworkRumbleUnreliable(k->parser) ? JNI_TRUE : JNI_FALSE;
+}
+
 JNIEXPORT jlong JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_getDeviceUrbCount(
     JNIEnv*, jobject, jint deviceId) {
     return (jlong)usbhost::getUrbCount((int32_t)deviceId);

--- a/app/src/main/cpp/usb_parsers.cpp
+++ b/app/src/main/cpp/usb_parsers.cpp
@@ -441,6 +441,10 @@ bool parserHasRumble(Parser p) {
     return false;
 }
 
+// Symptom-named (not just `== SWITCH_PRO_USB`) so the list can grow if another proprietary family
+// exposes the same phantom framework vibrator.
+bool parserFrameworkRumbleUnreliable(Parser p) { return p == Parser::SWITCH_PRO_USB; }
+
 // Parser-level like parserHasImu: every device speaking the DS4/DualSense report format carries
 // the touch bytes, even the licensed sticks whose "pad" is only a click button. Those simply
 // never report a contact, so nothing streams.

--- a/app/src/main/cpp/usb_parsers.h
+++ b/app/src/main/cpp/usb_parsers.h
@@ -90,6 +90,11 @@ bool parserHasRumble(Parser p);
 
 bool parserHasTouchpad(Parser p);
 
+// True for families whose rumble the Android framework can't drive (the Switch Pro's proprietary
+// HD-rumble); a framework vibrator they expose is a false positive, so only the Direct path
+// actuates.
+bool parserFrameworkRumbleUnreliable(Parser p);
+
 // Pure: writes the index-th GIP init packet for an Xbox One InitKind into out (with the sequence
 // number at byte 2), returns its length or 0 when there are no more. runInit sends them in order.
 size_t buildGipInitPacket(InitKind init, int index, uint8_t seq, uint8_t* out, size_t outCap);

--- a/app/src/main/java/com/tinkernorth/dish/composer/CapabilityComposer.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/CapabilityComposer.kt
@@ -235,10 +235,17 @@ class CapabilityComposer
                 out += Feature.TOUCHPAD
                 out += Feature.MOUSE
             }
-            if (device.hasGyro || native.modelHasImu(device.vendorId, device.productId)) out += Feature.MOTION
-            if (device.hasRumble || native.modelHasRumble(device.vendorId, device.productId)) out += Feature.RUMBLE
+            if (deviceMotionAvailable(device)) out += Feature.MOTION
+            if (deviceRumbleAvailable(device)) out += Feature.RUMBLE
             return CapabilitySet(out)
         }
+
+        // A Direct synthetic has no framework InputDevice to probe, so its feedback comes from the native parser instead.
+        private fun deviceMotionAvailable(device: PhysicalGamepadRegistry.Device): Boolean =
+            if (device.isUsbSynthetic) native.modelHasImu(device.vendorId, device.productId) else device.hasGyro
+
+        private fun deviceRumbleAvailable(device: PhysicalGamepadRegistry.Device): Boolean =
+            if (device.isUsbSynthetic) native.modelHasRumble(device.vendorId, device.productId) else device.hasRumble
 
         private fun deviceTouchpadSource(device: PhysicalGamepadRegistry.Device): TouchpadSource =
             TouchpadRouting.sourceFor(

--- a/app/src/main/java/com/tinkernorth/dish/core/jni/PhysicalInputNative.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/jni/PhysicalInputNative.kt
@@ -24,6 +24,11 @@ class PhysicalInputNative
             productId: Int,
         ): Boolean = SatelliteNative.modelHasRumble(vendorId, productId)
 
+        fun modelFrameworkRumbleUnreliable(
+            vendorId: Int,
+            productId: Int,
+        ): Boolean = SatelliteNative.modelFrameworkRumbleUnreliable(vendorId, productId)
+
         fun modelHasTouchpad(
             vendorId: Int,
             productId: Int,

--- a/app/src/main/java/com/tinkernorth/dish/core/jni/SatelliteNative.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/jni/SatelliteNative.kt
@@ -183,6 +183,11 @@ object SatelliteNative {
         productId: Int,
     ): Boolean
 
+    external fun modelFrameworkRumbleUnreliable(
+        vendorId: Int,
+        productId: Int,
+    ): Boolean
+
     // Parser-level: true for the DS4/DualSense report families whose touch bytes the
     // USB-direct path parses and streams.
     external fun modelHasTouchpad(

--- a/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistry.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistry.kt
@@ -169,13 +169,18 @@ class PhysicalGamepadRegistry
             )
         }
 
-        private fun probeRumble(dev: InputDevice): Boolean =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        private fun probeRumble(dev: InputDevice): Boolean {
+            val vid = runCatching { dev.vendorId }.getOrDefault(0)
+            val pid = runCatching { dev.productId }.getOrDefault(0)
+            // The Switch Pro protocol exposes a framework vibrator Android can't drive; only Direct can.
+            if (native.modelFrameworkRumbleUnreliable(vid, pid)) return false
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 dev.vibratorManager.vibratorIds.isNotEmpty()
             } else {
                 @Suppress("DEPRECATION")
                 dev.vibrator?.hasVibrator() == true
             }
+        }
 
         private fun resolveTransport(
             name: String,
@@ -377,20 +382,29 @@ class PhysicalGamepadRegistry
                 return
             }
             cancelDisconnect(deviceId)
-            // Bluetooth Switch Pro Controllers enumerate sensors after onInputDeviceAdded; re-probe to catch the late gyro.
+            // Bluetooth Switch Pro Controllers enumerate sensors after onInputDeviceAdded; re-probe to catch a late gyro or vibrator.
             val nextHasGyro = PhysicalMotionProbe.hasGyro(deviceId)
+            val nextHasRumble = probeRumble(dev)
             val current = _devices.value[deviceId]
             val needsUpdate =
                 current == null ||
                     current.name != dev.name ||
                     current.isDisconnecting ||
-                    current.hasGyro != nextHasGyro
+                    current.hasGyro != nextHasGyro ||
+                    current.hasRumble != nextHasRumble
             if (needsUpdate) {
                 if (current?.hasGyro != nextHasGyro) {
                     Log.i(
                         TAG,
                         "pad $deviceId (${dev.name}) hasGyro re-probed: " +
                             "${current?.hasGyro} -> $nextHasGyro",
+                    )
+                }
+                if (current?.hasRumble != nextHasRumble) {
+                    Log.i(
+                        TAG,
+                        "pad $deviceId (${dev.name}) hasRumble re-probed: " +
+                            "${current?.hasRumble} -> $nextHasRumble",
                     )
                 }
                 _devices.update { it + (deviceId to makeRoutedDevice(deviceId, dev)) }

--- a/app/src/main/java/com/tinkernorth/dish/ui/diagnostics/InputInspectorActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/diagnostics/InputInspectorActivity.kt
@@ -8,13 +8,17 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.tinkernorth.dish.R
+import com.tinkernorth.dish.composer.CapabilityComposer
 import com.tinkernorth.dish.core.jni.PhysicalInputNative
+import com.tinkernorth.dish.core.model.Feature
 import com.tinkernorth.dish.databinding.ActivityInputInspectorBinding
 import com.tinkernorth.dish.hotpath.input.RumbleRouter
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
@@ -25,6 +29,8 @@ class InputInspectorActivity : BaseGamepadHostActivity() {
     @Inject lateinit var physicalInputNative: PhysicalInputNative
 
     @Inject lateinit var rumbleRouter: RumbleRouter
+
+    @Inject lateinit var capabilityComposer: CapabilityComposer
 
     @Inject lateinit var json: Json
 
@@ -58,6 +64,25 @@ class InputInspectorActivity : BaseGamepadHostActivity() {
         binding.btnRumbleBoth.setOnClickListener { buzz(strong = TEST_MAGNITUDE, weak = TEST_MAGNITUDE) }
 
         pollWhileStarted()
+        gateRumbleControls()
+    }
+
+    // Dead when the slot's path can't actuate rumble, so the buttons never imply feedback that won't fire.
+    private fun gateRumbleControls() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                capabilityComposer.state
+                    .map { it[deviceId.toString()]?.inputOk(Feature.RUMBLE) ?: false }
+                    .distinctUntilChanged()
+                    .collect { canRumble ->
+                        for (button in listOf(binding.btnRumbleWeak, binding.btnRumbleStrong, binding.btnRumbleBoth)) {
+                            button.isEnabled = canRumble
+                            // The Dish button styles don't grey their fill on disable, so dim explicitly.
+                            button.alpha = if (canRumble) 1f else DISABLED_BUTTON_ALPHA
+                        }
+                    }
+            }
+        }
     }
 
     override fun onStart() {
@@ -199,6 +224,9 @@ class InputInspectorActivity : BaseGamepadHostActivity() {
         private const val RANGE_CAPTURE_MS = 8000L
         private const val TEST_MAGNITUDE = 48000
         private const val TEST_BUZZ_MS = 400
+
+        // Material disabled emphasis; the Dish button styles don't dim their own fill.
+        private const val DISABLED_BUTTON_ALPHA = 0.38f
 
         // Wire scales (contract): gyro full scale 2000 deg/s, accel full scale 4 g.
         private const val GYRO_DPS_MAX = 2000f

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsViewModel.kt
@@ -543,14 +543,15 @@ class ConfigureBindingsViewModel
             val isUsb = device?.transport != Transport.Bluetooth
             val vid = device?.vendorId ?: 0
             val pid = device?.productId ?: 0
+            val caps = capabilityComposer.capabilityFor(slotId)
             return BindingSnapshot(
                 slotId = slotId,
                 name = device?.name ?: "",
                 link = if (isUsb) BindingLink.USB else BindingLink.BLUETOOTH,
                 directCapable = isUsb,
                 directVerified = native.isKnownFastLaneModel(vid, pid),
-                hasRumble = (device?.hasRumble ?: false) || native.modelHasRumble(vid, pid),
-                hasGyro = (device?.hasGyro ?: false) || native.modelHasImu(vid, pid),
+                hasRumble = caps.inputOk(Feature.RUMBLE),
+                hasGyro = caps.inputOk(Feature.MOTION),
                 hasTouchpad = native.modelHasTouchpad(vid, pid),
                 bound = bound,
                 directPollHz = device?.pollRateHz ?: 0,

--- a/app/src/test/cpp/usb_parsers_test.cpp
+++ b/app/src/test/cpp/usb_parsers_test.cpp
@@ -17,6 +17,7 @@ using usbparsers::decodeReport;
 using usbparsers::InitKind;
 using usbparsers::parsePsCalibration;
 using usbparsers::Parser;
+using usbparsers::parserFrameworkRumbleUnreliable;
 using usbparsers::parserHasImu;
 using usbparsers::parserHasRumble;
 using usbparsers::ParserState;
@@ -231,6 +232,18 @@ TEST(RumbleCapability, FamiliesWithoutBuildersReportFalse) {
     EXPECT_FALSE(parserHasRumble(Parser::STADIA));
     EXPECT_FALSE(parserHasRumble(Parser::GENERIC_HID_GAMEPAD));
     EXPECT_FALSE(parserHasRumble(Parser::NONE));
+}
+
+TEST(FrameworkRumble, SwitchProProtocolIsUnreliable) {
+    EXPECT_TRUE(parserFrameworkRumbleUnreliable(Parser::SWITCH_PRO_USB));
+}
+
+TEST(FrameworkRumble, OtherRumbleFamiliesAreTrusted) {
+    EXPECT_FALSE(parserFrameworkRumbleUnreliable(Parser::XINPUT_360));
+    EXPECT_FALSE(parserFrameworkRumbleUnreliable(Parser::XBOX_ONE_GIP));
+    EXPECT_FALSE(parserFrameworkRumbleUnreliable(Parser::DUALSHOCK4));
+    EXPECT_FALSE(parserFrameworkRumbleUnreliable(Parser::DUALSENSE));
+    EXPECT_FALSE(parserFrameworkRumbleUnreliable(Parser::NONE));
 }
 
 // Guards the refactor that moved I/O out: a non-Xbox decoder still works through decodeReport.

--- a/app/src/test/java/com/tinkernorth/dish/composer/CapabilityComposerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/CapabilityComposerTest.kt
@@ -166,8 +166,9 @@ class CapabilityComposerTest {
         }
 
     @Test
-    fun `physical slot controller layer unions Device caps with native model lookups`() =
+    fun `a framework pad trusts the OS probe and ignores the model DB`() =
         composerTest {
+            // Switch Pro USB on Standard: the model knows the motor, the framework exposes no actuator.
             val devices = MutableStateFlow(mapOf(9 to device(9, hasGyro = false, hasRumble = false)))
             val composer =
                 composerFor(
@@ -183,12 +184,108 @@ class CapabilityComposerTest {
             testScheduler.runCurrent()
 
             val controller = composer.capabilityFor("9").controller
-            // Device reports neither, but the native model DB does: the union wins.
-            assertTrue(Feature.MOTION in controller)
-            assertTrue(Feature.RUMBLE in controller)
-            // The phone screen sources touchpad and mouse alongside any physical pad.
+            assertFalse(Feature.MOTION in controller)
+            assertFalse(Feature.RUMBLE in controller)
+            // The phone screen still sources touchpad and mouse alongside any physical pad.
             assertTrue(Feature.TOUCHPAD in controller)
             assertTrue(Feature.MOUSE in controller)
+        }
+
+    @Test
+    fun `a framework pad advertises rumble and motion the OS probe confirms`() =
+        composerTest {
+            val devices = MutableStateFlow(mapOf(9 to device(9, hasGyro = true, hasRumble = true)))
+            val composer =
+                composerFor(
+                    phoneAvailable = false,
+                    devices = devices,
+                    bindings = MutableStateFlow(emptyMap()),
+                    connections = MutableStateFlow(emptyList()),
+                    scope = backgroundScope,
+                    modelHasImu = false,
+                    modelHasRumble = false,
+                )
+            composer.probe(this)
+            testScheduler.runCurrent()
+
+            val controller = composer.capabilityFor("9").controller
+            assertTrue(Feature.MOTION in controller)
+            assertTrue(Feature.RUMBLE in controller)
+        }
+
+    @Test
+    fun `a USB-direct synthetic advertises rumble and motion from the model DB`() =
+        composerTest {
+            val devices =
+                MutableStateFlow(
+                    mapOf(-1000 to device(-1000, hasGyro = false, hasRumble = false, isUsbSynthetic = true)),
+                )
+            val composer =
+                composerFor(
+                    phoneAvailable = false,
+                    devices = devices,
+                    bindings = MutableStateFlow(emptyMap()),
+                    connections = MutableStateFlow(emptyList()),
+                    scope = backgroundScope,
+                    modelHasImu = true,
+                    modelHasRumble = true,
+                )
+            composer.probe(this)
+            testScheduler.runCurrent()
+
+            val controller = composer.capabilityFor("-1000").controller
+            assertTrue(Feature.MOTION in controller)
+            assertTrue(Feature.RUMBLE in controller)
+        }
+
+    @Test
+    fun `a USB-direct synthetic whose model lacks feedback advertises neither`() =
+        composerTest {
+            val devices = MutableStateFlow(mapOf(-1000 to device(-1000, isUsbSynthetic = true)))
+            val composer =
+                composerFor(
+                    phoneAvailable = false,
+                    devices = devices,
+                    bindings = MutableStateFlow(emptyMap()),
+                    connections = MutableStateFlow(emptyList()),
+                    scope = backgroundScope,
+                    modelHasImu = false,
+                    modelHasRumble = false,
+                )
+            composer.probe(this)
+            testScheduler.runCurrent()
+
+            val controller = composer.capabilityFor("-1000").controller
+            assertFalse(Feature.MOTION in controller)
+            assertFalse(Feature.RUMBLE in controller)
+        }
+
+    @Test
+    fun `capabilityForCandidate hides rumble for a Standard Switch Pro the framework cannot actuate`() =
+        composerTest {
+            // Type and host both carry rumble, so only the controller layer gates it off.
+            val devices =
+                MutableStateFlow(mapOf(7 to device(7, vendorId = 0x057E, productId = 0x2009, hasRumble = false)))
+            val composer =
+                composerFor(
+                    phoneAvailable = false,
+                    devices = devices,
+                    bindings = MutableStateFlow(emptyMap()),
+                    connections = MutableStateFlow(emptyList()),
+                    scope = backgroundScope,
+                    modelHasRumble = true,
+                )
+            composer.probe(this)
+            testScheduler.runCurrent()
+
+            val caps =
+                composer.capabilityForCandidate(
+                    slotId = "7",
+                    candidateType = CONTROLLER_TYPE_PLAYSTATION,
+                    candidateHostKind = ConnectionKind.SATELLITE,
+                    candidateHostId = "sat-A",
+                )
+            assertFalse(caps.isAvailable(Feature.RUMBLE))
         }
 
     @Test


### PR DESCRIPTION
## Problem

A Switch Pro over USB advertised rumble on **Standard** and **Bluetooth** (and left the input inspector's rumble test buttons enabled), but only **Direct** actually rumbled.

## Root causes

**1. The capability layer ORed two path-specific signals.** `CapabilityComposer.deviceControllerLayer` and `ConfigureBindingsViewModel` computed rumble as `device.hasRumble || native.modelHasRumble(...)`. The framework probe is authoritative for Standard/Bluetooth; the model DB (`parserHasRumble`) only for Direct. ORing let the Direct-only capability leak onto the framework paths.

**2. The framework probe is itself a false positive for the Switch protocol.** `vibratorManager.vibratorIds` is non-empty for a Switch Pro — Android registers a vibrator — but it can't drive Nintendo's proprietary HD-rumble, which only our Direct path speaks. So even after fixing (1), `device.hasRumble` stayed `true` and the framework paths still advertised rumble that never fires.

## Fix

- **Per-path resolution** (mirrors `MainViewModel`'s existing split): a Direct synthetic reads the parser DB, a framework pad reads the OS probe. `CapabilityComposer` is the single source of truth; the bindings VM reads it, and the inspector disables its rumble buttons when the path can't rumble.
- **Suppress the false-positive probe at its source** (`probeRumble`) for models the native DB maps to the `SWITCH_PRO_USB` parser — the Pro, Joy-Con Charging Grip, and Online controllers, plus any future Switch-protocol device — via a new `modelFrameworkRumbleUnreliable` lookup (mirrors `modelHasRumble`). `device.hasRumble` is now truthful for every downstream surface (PathCard, composer, bindings, wizard, inspector); Direct still works through the model DB.
- Re-probe the vibrator in `onInputDeviceChanged`, symmetric with the existing late-gyro re-probe.

Net: rumble shows only where it fires — Direct for Switch-protocol pads; framework for Xbox/PlayStation where the OS actually drives it.

## Why the parser, not the Nintendo vendor

Keying on `SWITCH_PRO_USB` (the native model DB's parser field) targets the exact cause — the proprietary protocol — and covers the whole family without a hand-maintained VID:PID list that could drift from the DB.

## Tests

- `usb_parsers_test.cpp`: `parserFrameworkRumbleUnreliable` true for `SWITCH_PRO_USB`, false for the Xbox/PlayStation families.
- `CapabilityComposerTest`: per-path matrix (framework trusts the probe / ignores the model DB; synthetic reads the model DB; end-to-end `capabilityForCandidate` for a Standard Switch Pro).

## Local CI — all green

clang-format · check_play_metadata · ktlintCheck · detekt · lint · testDebugUnitTest · nativeTest (168/168) · assembleDebug. Emulator `instrumented` job runs in CI (no local device attached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)