### PR TITLE
fix: gate local-network access for Android 17 (Local Network Protections)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,8 +7,7 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
 
-    <!-- Android 17 (API 37) blocks LAN access (mDNS + UDP discovery, direct connect)
-         until granted. Older OSes get it implicitly via INTERNET. -->
+    <!-- Android 17+ gates LAN discovery/connect; older OSes imply it via INTERNET. -->
     <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,12 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+
+    <!-- Android 17 (API 37) gates LAN access behind a runtime grant (Local Network
+         Protections). Satellite discovery is mDNS + UDP and the app connects directly
+         to the box, so it needs this. Older OSes get implicit access via INTERNET. -->
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
+
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <!-- CONNECTED_DEVICE (not DATA_SYNC) fits a user-facing controller-to-host session. -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,9 +7,8 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
 
-    <!-- Android 17 (API 37) gates LAN access behind a runtime grant (Local Network
-         Protections). Satellite discovery is mDNS + UDP and the app connects directly
-         to the box, so it needs this. Older OSes get implicit access via INTERNET. -->
+    <!-- Android 17 (API 37) blocks LAN access (mDNS + UDP discovery, direct connect)
+         until granted. Older OSes get it implicitly via INTERNET. -->
     <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/app/src/main/java/com/tinkernorth/dish/composer/ConnectionCoordinator.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/ConnectionCoordinator.kt
@@ -2,6 +2,7 @@
 
 package com.tinkernorth.dish.composer
 
+import android.content.Context
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.repository.ConnectionStore
 import com.tinkernorth.dish.source.bluetooth.BluetoothGamepadRegistry
@@ -12,6 +13,8 @@ import com.tinkernorth.dish.source.store.ControllerTypeStore
 import com.tinkernorth.dish.source.store.SatelliteHostFeaturesStore
 import com.tinkernorth.dish.source.store.SatelliteHostRuntimeStore
 import com.tinkernorth.dish.source.store.SlotBindingStore
+import com.tinkernorth.dish.source.system.LocalNetworkAccess
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -39,6 +42,7 @@ data class ConnectionSummary(
 @Singleton
 class ConnectionCoordinator
     @Inject
+    @Suppress("LongParameterList")
     constructor(
         private val satellite: SatelliteConnectionManager,
         private val bt: BluetoothGamepadRegistry,
@@ -49,6 +53,7 @@ class ConnectionCoordinator
         private val hostRuntimeStore: SatelliteHostRuntimeStore,
         private val composer: ConnectionsComposer,
         private val gamepadRegistry: PhysicalGamepadRegistry,
+        @ApplicationContext private val context: Context,
     ) {
         val bindings: StateFlow<Map<String, String>> = bindingStore.state
         val satTypes: StateFlow<Map<Pair<String, String>, Int>> = typeStore.state
@@ -177,10 +182,14 @@ class ConnectionCoordinator
             }
 
         fun autoReconnectAll() {
-            for (remembered in store.remembered()) {
-                val existing = satellite.get(remembered.id)
-                if (existing?.state?.value != SatelliteSessionState.Live) {
-                    satellite.connect(remembered.toDiscovered(), ConnectIntent.AUTO_RECONNECT)
+            // Android 17 blocks the satellite sockets until ACCESS_LOCAL_NETWORK is granted, so a
+            // pre-grant attempt just fails with EPERM. An Activity requests it (Main/Connections/Setup).
+            if (LocalNetworkAccess.isGranted(context)) {
+                for (remembered in store.remembered()) {
+                    val existing = satellite.get(remembered.id)
+                    if (existing?.state?.value != SatelliteSessionState.Live) {
+                        satellite.connect(remembered.toDiscovered(), ConnectIntent.AUTO_RECONNECT)
+                    }
                 }
             }
             val btHosts = store.rememberedBt()

--- a/app/src/main/java/com/tinkernorth/dish/composer/ConnectionCoordinator.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/ConnectionCoordinator.kt
@@ -2,7 +2,6 @@
 
 package com.tinkernorth.dish.composer
 
-import android.content.Context
 import com.tinkernorth.dish.hotpath.input.PhysicalGamepadRegistry
 import com.tinkernorth.dish.repository.ConnectionStore
 import com.tinkernorth.dish.source.bluetooth.BluetoothGamepadRegistry
@@ -13,8 +12,6 @@ import com.tinkernorth.dish.source.store.ControllerTypeStore
 import com.tinkernorth.dish.source.store.SatelliteHostFeaturesStore
 import com.tinkernorth.dish.source.store.SatelliteHostRuntimeStore
 import com.tinkernorth.dish.source.store.SlotBindingStore
-import com.tinkernorth.dish.source.system.LocalNetworkAccess
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -42,7 +39,6 @@ data class ConnectionSummary(
 @Singleton
 class ConnectionCoordinator
     @Inject
-    @Suppress("LongParameterList")
     constructor(
         private val satellite: SatelliteConnectionManager,
         private val bt: BluetoothGamepadRegistry,
@@ -53,7 +49,6 @@ class ConnectionCoordinator
         private val hostRuntimeStore: SatelliteHostRuntimeStore,
         private val composer: ConnectionsComposer,
         private val gamepadRegistry: PhysicalGamepadRegistry,
-        @ApplicationContext private val context: Context,
     ) {
         val bindings: StateFlow<Map<String, String>> = bindingStore.state
         val satTypes: StateFlow<Map<Pair<String, String>, Int>> = typeStore.state
@@ -182,14 +177,10 @@ class ConnectionCoordinator
             }
 
         fun autoReconnectAll() {
-            // Android 17 blocks the satellite sockets until ACCESS_LOCAL_NETWORK is granted, so a
-            // pre-grant attempt just fails with EPERM. An Activity requests it (Main/Connections/Setup).
-            if (LocalNetworkAccess.isGranted(context)) {
-                for (remembered in store.remembered()) {
-                    val existing = satellite.get(remembered.id)
-                    if (existing?.state?.value != SatelliteSessionState.Live) {
-                        satellite.connect(remembered.toDiscovered(), ConnectIntent.AUTO_RECONNECT)
-                    }
+            for (remembered in store.remembered()) {
+                val existing = satellite.get(remembered.id)
+                if (existing?.state?.value != SatelliteSessionState.Live) {
+                    satellite.connect(remembered.toDiscovered(), ConnectIntent.AUTO_RECONNECT)
                 }
             }
             val btHosts = store.rememberedBt()

--- a/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManager.kt
@@ -22,6 +22,7 @@ import com.tinkernorth.dish.di.IoDispatcher
 import com.tinkernorth.dish.repository.ConnectionStore
 import com.tinkernorth.dish.repository.RememberedSatellite
 import com.tinkernorth.dish.source.store.SatelliteMotionBackendStatusStore
+import com.tinkernorth.dish.source.system.LocalNetworkAccess
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -213,6 +214,9 @@ class SatelliteConnectionManager
             server: DiscoveredServer,
             intent: ConnectIntent = ConnectIntent.USER_INITIATED,
         ) {
+            // Android 17 blocks the LAN sockets until ACCESS_LOCAL_NETWORK is granted; only a
+            // user-initiated connect (from a screen that prompts) may attempt before the grant.
+            if (intent != ConnectIntent.USER_INITIATED && !LocalNetworkAccess.isGranted(context)) return
             val id = SatelliteConnection.idFor(server)
             if (intent == ConnectIntent.USER_INITIATED) retryAttempts.remove(id)
             // Atomic find-or-create: prevents two concurrent first-time connects allocating duplicates.

--- a/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManager.kt
@@ -214,8 +214,7 @@ class SatelliteConnectionManager
             server: DiscoveredServer,
             intent: ConnectIntent = ConnectIntent.USER_INITIATED,
         ) {
-            // Android 17 blocks the LAN sockets until ACCESS_LOCAL_NETWORK is granted; only a
-            // user-initiated connect (from a screen that prompts) may attempt before the grant.
+            // Only user-initiated connects (which prompt) may open LAN sockets before the Android 17 grant.
             if (intent != ConnectIntent.USER_INITIATED && !LocalNetworkAccess.isGranted(context)) return
             val id = SatelliteConnection.idFor(server)
             if (intent == ConnectIntent.USER_INITIATED) retryAttempts.remove(id)

--- a/app/src/main/java/com/tinkernorth/dish/source/system/LocalNetworkAccess.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/system/LocalNetworkAccess.kt
@@ -7,26 +7,22 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.content.ContextCompat
 
-// Android 17 (API 37) enforces Local Network Protections: mDNS/UDP/raw-socket
-// access to the LAN is blocked until the user grants ACCESS_LOCAL_NETWORK. That
-// gate covers everything the satellite transport does — NsdManager discovery, UDP
-// discovery/streaming, and the direct socket connect — so without the grant the OS
-// interrupts scanning with its own "choose a device" picker. Earlier releases keep
-// implicit LAN access via INTERNET, so on them this is a no-op and callers scan as before.
+// Android 17 (API 37) blocks LAN access — mDNS, UDP, direct sockets — until the user
+// grants ACCESS_LOCAL_NETWORK. Older OSes keep implicit access via INTERNET, a no-op here.
 object LocalNetworkAccess {
-    // Referenced as the platform string rather than a Manifest.permission constant:
-    // the constant isn't stable across the preview SDKs the app compiles against, and
-    // this is also exactly what AndroidManifest.xml declares.
+    // Platform string, not a Manifest.permission constant: the constant isn't stable
+    // across the preview SDKs we compile against.
     const val PERMISSION: String = "android.permission.ACCESS_LOCAL_NETWORK"
 
-    // First release to enforce LNP by default. A literal, not VERSION_CODES, because
-    // the matching codename constant isn't final across preview SDK revisions.
     private const val ENFORCED_SDK = 37
 
-    fun isEnforced(): Boolean = Build.VERSION.SDK_INT >= ENFORCED_SDK
+    // sdkInt injectable for tests.
+    fun isEnforced(sdkInt: Int = Build.VERSION.SDK_INT): Boolean = sdkInt >= ENFORCED_SDK
 
-    // True when the grant isn't needed (older OS) or has already been given.
-    fun isGranted(context: Context): Boolean =
-        !isEnforced() ||
+    fun isGranted(
+        context: Context,
+        sdkInt: Int = Build.VERSION.SDK_INT,
+    ): Boolean =
+        !isEnforced(sdkInt) ||
             ContextCompat.checkSelfPermission(context, PERMISSION) == PackageManager.PERMISSION_GRANTED
 }

--- a/app/src/main/java/com/tinkernorth/dish/source/system/LocalNetworkAccess.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/system/LocalNetworkAccess.kt
@@ -7,16 +7,12 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.content.ContextCompat
 
-// Android 17 (API 37) blocks LAN access — mDNS, UDP, direct sockets — until the user
-// grants ACCESS_LOCAL_NETWORK. Older OSes keep implicit access via INTERNET, a no-op here.
+// Android 17 (API 37) gates LAN access; older OSes imply it via INTERNET, so this no-ops there.
 object LocalNetworkAccess {
-    // Platform string, not a Manifest.permission constant: the constant isn't stable
-    // across the preview SDKs we compile against.
     const val PERMISSION: String = "android.permission.ACCESS_LOCAL_NETWORK"
 
     private const val ENFORCED_SDK = 37
 
-    // sdkInt injectable for tests.
     fun isEnforced(sdkInt: Int = Build.VERSION.SDK_INT): Boolean = sdkInt >= ENFORCED_SDK
 
     fun isGranted(

--- a/app/src/main/java/com/tinkernorth/dish/source/system/LocalNetworkAccess.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/system/LocalNetworkAccess.kt
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.system
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+// Android 17 (API 37) enforces Local Network Protections: mDNS/UDP/raw-socket
+// access to the LAN is blocked until the user grants ACCESS_LOCAL_NETWORK. That
+// gate covers everything the satellite transport does — NsdManager discovery, UDP
+// discovery/streaming, and the direct socket connect — so without the grant the OS
+// interrupts scanning with its own "choose a device" picker. Earlier releases keep
+// implicit LAN access via INTERNET, so on them this is a no-op and callers scan as before.
+object LocalNetworkAccess {
+    // Referenced as the platform string rather than a Manifest.permission constant:
+    // the constant isn't stable across the preview SDKs the app compiles against, and
+    // this is also exactly what AndroidManifest.xml declares.
+    const val PERMISSION: String = "android.permission.ACCESS_LOCAL_NETWORK"
+
+    // First release to enforce LNP by default. A literal, not VERSION_CODES, because
+    // the matching codename constant isn't final across preview SDK revisions.
+    private const val ENFORCED_SDK = 37
+
+    fun isEnforced(): Boolean = Build.VERSION.SDK_INT >= ENFORCED_SDK
+
+    // True when the grant isn't needed (older OS) or has already been given.
+    fun isGranted(context: Context): Boolean =
+        !isEnforced() ||
+            ContextCompat.checkSelfPermission(context, PERMISSION) == PackageManager.PERMISSION_GRANTED
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
@@ -154,7 +154,6 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
     private var networkBannerId: Long? = null
     private var localNetworkBannerId: Long? = null
 
-    // Ask once per screen entry (Android 17+); after that the banner is the way back in.
     private var localNetworkPrompted = false
 
     private var btPermissionSnackbar: Snackbar? = null
@@ -983,7 +982,6 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
             }
     }
 
-    // Android 17+ blocks the scan until ACCESS_LOCAL_NETWORK is granted; deny falls back to the banner.
     private fun ensureLocalNetworkThenDiscover(userInitiated: Boolean = false) {
         if (LocalNetworkAccess.isGranted(this)) {
             dismissLocalNetworkBanner()

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
@@ -154,8 +154,7 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
     private var networkBannerId: Long? = null
     private var localNetworkBannerId: Long? = null
 
-    // Prompt for local-network access once per screen entry (Android 17+); after that the
-    // banner is the way back in, so returning to the screen doesn't re-fire the OS dialog.
+    // Ask once per screen entry (Android 17+); after that the banner is the way back in.
     private var localNetworkPrompted = false
 
     private var btPermissionSnackbar: Snackbar? = null
@@ -984,10 +983,7 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
             }
     }
 
-    // Local Network Protections (Android 17+): scanning for and connecting to a satellite
-    // are both LAN access, blocked until the user grants ACCESS_LOCAL_NETWORK. Ask on the
-    // first scan after entering the screen; if denied, a persistent banner explains the
-    // empty list and routes to app settings. On older OSes isGranted() is always true.
+    // Android 17+ blocks the scan until ACCESS_LOCAL_NETWORK is granted; deny falls back to the banner.
     private fun ensureLocalNetworkThenDiscover(userInitiated: Boolean = false) {
         if (LocalNetworkAccess.isGranted(this)) {
             dismissLocalNetworkBanner()

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
@@ -54,6 +54,7 @@ import com.tinkernorth.dish.source.system.BluetoothAdapterStateObserver
 import com.tinkernorth.dish.source.system.BluetoothPermissionBannerDecision
 import com.tinkernorth.dish.source.system.BluetoothPermissionBannerVariant
 import com.tinkernorth.dish.source.system.BluetoothPermissionStateObserver
+import com.tinkernorth.dish.source.system.LocalNetworkAccess
 import com.tinkernorth.dish.source.system.NetworkState
 import com.tinkernorth.dish.source.system.NetworkStateObserver
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
@@ -151,6 +152,11 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
 
     private var btAdapterBannerId: Long? = null
     private var networkBannerId: Long? = null
+    private var localNetworkBannerId: Long? = null
+
+    // Prompt for local-network access once per screen entry (Android 17+); after that the
+    // banner is the way back in, so returning to the screen doesn't re-fire the OS dialog.
+    private var localNetworkPrompted = false
 
     private var btPermissionSnackbar: Snackbar? = null
     private var btPermissionShownVariant: BluetoothPermissionBannerVariant? = null
@@ -204,6 +210,18 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
             }
             btRegistry.start(pending.tempId, pending.profile, pending.autoConnectMac)
             armDiscoverabilityExpiryTimer(pending.tempId)
+        }
+
+    private val localNetworkPermissionLauncher =
+        registerForActivityResult(
+            ActivityResultContracts.RequestPermission(),
+        ) { granted ->
+            if (granted) {
+                dismissLocalNetworkBanner()
+                satellite.startDiscovery()
+            } else {
+                showLocalNetworkBanner()
+            }
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -309,7 +327,7 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
 
     override fun onStart() {
         super.onStart()
-        satellite.startDiscovery()
+        ensureLocalNetworkThenDiscover()
     }
 
     private fun setupList() {
@@ -320,7 +338,7 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
                 R.string.action_scan,
                 secondaryActionLabel = R.string.action_add,
                 onSecondaryAction = ::showAddSatelliteDialog,
-            ) { satellite.startDiscovery() }
+            ) { ensureLocalNetworkThenDiscover(userInitiated = true) }
         bluetoothHeader =
             SectionHeaderAdapter(
                 R.drawable.ic_bluetooth,
@@ -964,6 +982,54 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
                         durationMs = DishNotification.DURATION_PERSISTENT,
                     )
             }
+    }
+
+    // Local Network Protections (Android 17+): scanning for and connecting to a satellite
+    // are both LAN access, blocked until the user grants ACCESS_LOCAL_NETWORK. Ask on the
+    // first scan after entering the screen; if denied, a persistent banner explains the
+    // empty list and routes to app settings. On older OSes isGranted() is always true.
+    private fun ensureLocalNetworkThenDiscover(userInitiated: Boolean = false) {
+        if (LocalNetworkAccess.isGranted(this)) {
+            dismissLocalNetworkBanner()
+            satellite.startDiscovery()
+            return
+        }
+        if (userInitiated || !localNetworkPrompted) {
+            localNetworkPrompted = true
+            localNetworkPermissionLauncher.launch(LocalNetworkAccess.PERMISSION)
+        } else {
+            showLocalNetworkBanner()
+        }
+    }
+
+    private fun showLocalNetworkBanner() {
+        if (localNetworkBannerId != null) return
+        localNetworkBannerId =
+            notifications.warn(
+                glyph = R.drawable.ic_satellite_off,
+                title = getString(R.string.notif_local_network_title),
+                body = getString(R.string.notif_local_network_body),
+                action =
+                    DishNotification.Action(
+                        label = getString(R.string.action_open_settings),
+                    ) { openAppDetailsSettings() },
+                key = "local-network-permission",
+                durationMs = DishNotification.DURATION_PERSISTENT,
+            )
+    }
+
+    private fun dismissLocalNetworkBanner() {
+        localNetworkBannerId?.let { notifications.dismiss(it) }
+        localNetworkBannerId = null
+    }
+
+    private fun openAppDetailsSettings() {
+        val intent =
+            Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                data = "package:$packageName".toUri()
+            }
+        runCatching { startActivity(intent) }
+            .onFailure { startActivity(Intent(Settings.ACTION_SETTINGS)) }
     }
 
     private fun armDiscoverabilityExpiryTimer(connId: String) {

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.view.KeyEvent
 import android.view.MotionEvent
 import android.widget.LinearLayout
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.isVisible
@@ -28,6 +29,7 @@ import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.lowpower.LowPowerSignal
 import com.tinkernorth.dish.source.notification.DishNotifications
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
+import com.tinkernorth.dish.source.system.LocalNetworkAccess
 import com.tinkernorth.dish.source.usb.UsbGamepadManager
 import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.DishSpinnerDrawable
@@ -71,6 +73,26 @@ class MainActivity :
     private val connectionsSpinner by lazy {
         DishSpinnerDrawable(this, resources.getDimensionPixelSize(R.dimen.icon_battery))
     }
+
+    private var localNetworkRequested = false
+
+    private val localNetworkPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            if (granted) {
+                hub.autoReconnectAll()
+            } else {
+                notifications.warn(
+                    glyph = R.drawable.ic_satellite_off,
+                    title = getString(R.string.notif_local_network_title),
+                    body = getString(R.string.notif_local_network_body),
+                    action =
+                        DishNotification.Action(
+                            label = getString(R.string.action_open),
+                        ) { nav.toConnections() },
+                    key = "local-network-permission",
+                )
+            }
+        }
 
     // Held by installSplashScreen()'s keep-on-screen gate; cleared either by the first
     // MainUiState render or the SPLASH_HOLD_MAX_MS fallback so a stalled ViewModel can't pin
@@ -127,7 +149,17 @@ class MainActivity :
         super.onResume()
         if (!com.tinkernorth.dish.DishApplication.nativeLoadFailed) {
             usbGamepadManager.reconcileForeground()
+            ensureLocalNetworkForReconnect()
         }
+    }
+
+    // Foreground auto-reconnect (ConnectionForegroundObserver) runs off an Activity and can't prompt,
+    // so ask here — otherwise a remembered satellite fails silently on Android 17.
+    private fun ensureLocalNetworkForReconnect() {
+        if (localNetworkRequested || LocalNetworkAccess.isGranted(this)) return
+        if (satellite.remembered().isEmpty()) return
+        localNetworkRequested = true
+        localNetworkPermissionLauncher.launch(LocalNetworkAccess.PERMISSION)
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
@@ -153,8 +153,7 @@ class MainActivity :
         }
     }
 
-    // Foreground auto-reconnect (ConnectionForegroundObserver) runs off an Activity and can't prompt,
-    // so ask here — otherwise a remembered satellite fails silently on Android 17.
+    // The reconnect observer runs off an Activity and can't prompt; ask here or Android 17 fails it silently.
     private fun ensureLocalNetworkForReconnect() {
         if (localNetworkRequested || LocalNetworkAccess.isGranted(this)) return
         if (satellite.remembered().isEmpty()) return

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConnectionActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConnectionActivity.kt
@@ -54,7 +54,6 @@ class SetupConnectionActivity : BaseGamepadHostActivity() {
     private var pinDialog: PairPinDialog? = null
     private var pairingServer: DiscoveredServer? = null
 
-    // Pending action resumed when the grant returns (mirrors onDiscoverableResult).
     private var onLocalNetworkGranted: (() -> Unit)? = null
 
     private val localNetworkPermissionLauncher =
@@ -227,8 +226,7 @@ class SetupConnectionActivity : BaseGamepadHostActivity() {
         startActivity(Intent(Intent.ACTION_VIEW, getString(R.string.url_github).toUri()))
     }
 
-    // Request before scanning so a pre-grant (blocked) scan can't shadow the real one via
-    // the manager's single-flight guard.
+    // Request before scanning: a pre-grant blocked scan would shadow the real one via the single-flight guard.
     private fun withLocalNetwork(action: () -> Unit) {
         if (LocalNetworkAccess.isGranted(this)) {
             action()

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConnectionActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConnectionActivity.kt
@@ -54,8 +54,7 @@ class SetupConnectionActivity : BaseGamepadHostActivity() {
     private var pinDialog: PairPinDialog? = null
     private var pairingServer: DiscoveredServer? = null
 
-    // Mirrors ConnectionsActivity's onDiscoverableResult: the pending action runs when the
-    // grant returns, so the satellite-card tap and the Rescan button resume differently.
+    // Pending action resumed when the grant returns (mirrors onDiscoverableResult).
     private var onLocalNetworkGranted: (() -> Unit)? = null
 
     private val localNetworkPermissionLauncher =
@@ -228,10 +227,8 @@ class SetupConnectionActivity : BaseGamepadHostActivity() {
         startActivity(Intent(Intent.ACTION_VIEW, getString(R.string.url_github).toUri()))
     }
 
-    // Runs [action] once LAN access is available: immediately on older OSes or when already
-    // granted, otherwise after the Android 17 local-network prompt. Requesting before the
-    // scan avoids a pre-grant (blocked) scan shadowing the real one via the manager's
-    // single-flight guard.
+    // Request before scanning so a pre-grant (blocked) scan can't shadow the real one via
+    // the manager's single-flight guard.
     private fun withLocalNetwork(action: () -> Unit) {
         if (LocalNetworkAccess.isGranted(this)) {
             action()

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConnectionActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConnectionActivity.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.activity.addCallback
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
@@ -21,6 +22,7 @@ import com.tinkernorth.dish.databinding.SetupChoiceRowBinding
 import com.tinkernorth.dish.databinding.SetupHostRowBinding
 import com.tinkernorth.dish.source.connection.PairingApproval
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
+import com.tinkernorth.dish.source.system.LocalNetworkAccess
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.setupDishToolbar
@@ -52,6 +54,23 @@ class SetupConnectionActivity : BaseGamepadHostActivity() {
     private var pinDialog: PairPinDialog? = null
     private var pairingServer: DiscoveredServer? = null
 
+    // Mirrors ConnectionsActivity's onDiscoverableResult: the pending action runs when the
+    // grant returns, so the satellite-card tap and the Rescan button resume differently.
+    private var onLocalNetworkGranted: (() -> Unit)? = null
+
+    private val localNetworkPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            val resume = onLocalNetworkGranted
+            onLocalNetworkGranted = null
+            if (granted) {
+                resume?.invoke()
+            } else {
+                SetupErrorDialog.show(this, getString(R.string.setup_conn_local_network_denied)) {
+                    withLocalNetwork(resume ?: { viewModel.startDiscovery() })
+                }
+            }
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = setScaffoldContent(ActivitySetupConnectionBinding::inflate)
@@ -66,7 +85,7 @@ class SetupConnectionActivity : BaseGamepadHostActivity() {
             R.string.setup_conn_satellite_title,
             R.string.setup_conn_satellite_body,
             R.string.setup_conn_satellite_badge,
-        ) { viewModel.chooseSatellite() }
+        ) { withLocalNetwork { viewModel.chooseSatellite() } }
         bindChoice(
             binding.cardBluetoothHost,
             R.drawable.ic_bluetooth,
@@ -76,7 +95,7 @@ class SetupConnectionActivity : BaseGamepadHostActivity() {
         ) { nav.toSetupBluetoothHost(inputType, slotId) }
 
         binding.btnBack.setOnClickListener { handleBack() }
-        binding.btnRescan.setOnClickListener { viewModel.startDiscovery() }
+        binding.btnRescan.setOnClickListener { withLocalNetwork { viewModel.startDiscovery() } }
         binding.btnGetSatellite.setOnClickListener { openGitHub() }
 
         onBackPressedDispatcher.addCallback(this) { handleBack() }
@@ -202,11 +221,24 @@ class SetupConnectionActivity : BaseGamepadHostActivity() {
             dialog.showError(message)
             return
         }
-        SetupErrorDialog.show(this, message) { viewModel.startDiscovery() }
+        SetupErrorDialog.show(this, message) { withLocalNetwork { viewModel.startDiscovery() } }
     }
 
     private fun openGitHub() {
         startActivity(Intent(Intent.ACTION_VIEW, getString(R.string.url_github).toUri()))
+    }
+
+    // Runs [action] once LAN access is available: immediately on older OSes or when already
+    // granted, otherwise after the Android 17 local-network prompt. Requesting before the
+    // scan avoids a pre-grant (blocked) scan shadowing the real one via the manager's
+    // single-flight guard.
+    private fun withLocalNetwork(action: () -> Unit) {
+        if (LocalNetworkAccess.isGranted(this)) {
+            action()
+            return
+        }
+        onLocalNetworkGranted = action
+        localNetworkPermissionLauncher.launch(LocalNetworkAccess.PERMISSION)
     }
 
     private fun bindChoice(

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -214,6 +214,8 @@
     <string name="notif_no_network_body">Povežite se na isti Wi-Fi kao i vaš satelit.</string>
     <string name="notif_cellular_only_title">Samo mobilni podaci</string>
     <string name="notif_cellular_only_body">Sateliti žive na vašem Wi-Fi LAN-u, ne na mobilnim podacima.</string>
+    <string name="notif_local_network_title">Potreban pristup lokalnoj mreži</string>
+    <string name="notif_local_network_body">Dish pronalazi satelite na vašem Wi-Fi-ju i povezuje se s njima. Dozvolite pristup lokalnoj mreži za skeniranje.</string>
     <string name="notif_bind_first_title">Prvo povežite jednu vezu</string>
     <string name="notif_pairing_needed_title">Potrebno uparivanje</string>
     <string name="notif_pairing_needed_body">Otvorite Veze da unesete PIN za %1$s.</string>

--- a/app/src/main/res/values-bs/strings_setup.xml
+++ b/app/src/main/res/values-bs/strings_setup.xml
@@ -69,6 +69,7 @@
     <string name="setup_conn_status_needs_pairing">Potrebno uparivanje, PIN</string>
     <string name="setup_conn_status_connected">Povezan</string>
     <string name="setup_conn_status_reconnecting">Ponovno povezivanje</string>
+    <string name="setup_conn_local_network_denied">Dish treba pristup lokalnoj mreži da pronađe satelite na vašem Wi-Fi-ju. Dozvolite ga za nastavak.</string>
     <string name="setup_conn_missing_title">Ne vidite svoj PC?</string>
     <string name="setup_conn_missing_body">Instalirajte besplatnu Satellite aplikaciju na njega.</string>
     <string name="setup_conn_get_satellite">Preuzmi Satellite na GitHub-u</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -215,6 +215,8 @@
     <string name="notif_no_network_body">Verbinde dich mit demselben WLAN wie dein Satellit.</string>
     <string name="notif_cellular_only_title">Nur mobile Daten</string>
     <string name="notif_cellular_only_body">Satelliten leben in deinem WLAN-LAN, nicht in den mobilen Daten.</string>
+    <string name="notif_local_network_title">Zugriff auf lokales Netzwerk nötig</string>
+    <string name="notif_local_network_body">Dish findet Satelliten in deinem WLAN und verbindet sich mit ihnen. Erlaube den Zugriff auf das lokale Netzwerk, um zu suchen.</string>
     <string name="notif_bind_first_title">Erst eine Verbindung verknüpfen</string>
     <string name="notif_pairing_needed_title">Kopplung nötig</string>
     <string name="notif_pairing_needed_body">Öffne Verbindungen, um den PIN für %1$s einzugeben.</string>

--- a/app/src/main/res/values-de/strings_setup.xml
+++ b/app/src/main/res/values-de/strings_setup.xml
@@ -75,6 +75,7 @@
     <string name="setup_conn_status_needs_pairing">Kopplung nötig, PIN</string>
     <string name="setup_conn_status_connected">Verbunden</string>
     <string name="setup_conn_status_reconnecting">Verbindet erneut</string>
+    <string name="setup_conn_local_network_denied">Dish braucht Zugriff auf das lokale Netzwerk, um Satelliten in deinem WLAN zu finden. Erlaube ihn, um fortzufahren.</string>
     <string name="setup_conn_missing_title">Siehst du deinen PC nicht?</string>
     <string name="setup_conn_missing_body">Installiere die kostenlose Satellite-App darauf.</string>
     <string name="setup_conn_get_satellite">Satellite auf GitHub holen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -217,6 +217,8 @@
     <string name="notif_no_network_body">Conéctate a la misma Wi-Fi que tu satélite.</string>
     <string name="notif_cellular_only_title">Solo datos móviles</string>
     <string name="notif_cellular_only_body">Los satélites viven en tu LAN Wi-Fi, no en los datos móviles.</string>
+    <string name="notif_local_network_title">Se necesita acceso a la red local</string>
+    <string name="notif_local_network_body">Dish encuentra satélites en tu Wi-Fi y se conecta a ellos. Permite el acceso a la red local para buscar.</string>
     <string name="notif_bind_first_title">Enlaza una conexión primero</string>
     <string name="notif_pairing_needed_title">Emparejamiento necesario</string>
     <string name="notif_pairing_needed_body">Abre Conexiones para introducir el PIN de %1$s.</string>

--- a/app/src/main/res/values-es/strings_setup.xml
+++ b/app/src/main/res/values-es/strings_setup.xml
@@ -69,6 +69,7 @@
     <string name="setup_conn_status_needs_pairing">Necesita emparejamiento, PIN</string>
     <string name="setup_conn_status_connected">Conectado</string>
     <string name="setup_conn_status_reconnecting">Reconectando</string>
+    <string name="setup_conn_local_network_denied">Dish necesita acceso a la red local para encontrar satélites en tu Wi-Fi. Permítelo para continuar.</string>
     <string name="setup_conn_missing_title">¿No ves tu PC?</string>
     <string name="setup_conn_missing_body">Instala en él la app gratuita Satellite.</string>
     <string name="setup_conn_get_satellite">Consigue Satellite en GitHub</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -216,6 +216,8 @@
     <string name="notif_no_network_body">Connectez-vous au même Wi-Fi que votre satellite.</string>
     <string name="notif_cellular_only_title">Données mobiles uniquement</string>
     <string name="notif_cellular_only_body">Les satellites vivent sur votre LAN Wi-Fi, pas sur les données mobiles.</string>
+    <string name="notif_local_network_title">Accès au réseau local requis</string>
+    <string name="notif_local_network_body">Dish trouve les satellites sur votre Wi-Fi et s\'y connecte. Autorisez l\'accès au réseau local pour scanner.</string>
     <string name="notif_bind_first_title">Liez d\'abord une connexion</string>
     <string name="notif_pairing_needed_title">Appairage requis</string>
     <string name="notif_pairing_needed_body">Ouvrez Connexions pour saisir le PIN de %1$s.</string>

--- a/app/src/main/res/values-fr/strings_setup.xml
+++ b/app/src/main/res/values-fr/strings_setup.xml
@@ -74,6 +74,7 @@
     <string name="setup_conn_status_needs_pairing">Appairage requis, PIN</string>
     <string name="setup_conn_status_connected">Connecté</string>
     <string name="setup_conn_status_reconnecting">Reconnexion…</string>
+    <string name="setup_conn_local_network_denied">Dish a besoin d\'un accès au réseau local pour trouver des satellites sur votre Wi-Fi. Autorisez-le pour continuer.</string>
     <string name="setup_conn_missing_title">Vous ne voyez pas votre PC ?</string>
     <string name="setup_conn_missing_body">Installez-y l\'app Satellite gratuite.</string>
     <string name="setup_conn_get_satellite">Obtenir Satellite sur GitHub</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -217,6 +217,8 @@
     <string name="notif_no_network_body">Conecte-se ao mesmo Wi-Fi do seu satélite.</string>
     <string name="notif_cellular_only_title">Somente dados móveis</string>
     <string name="notif_cellular_only_body">Satélites vivem na sua LAN Wi-Fi, não nos dados móveis.</string>
+    <string name="notif_local_network_title">Acesso à rede local necessário</string>
+    <string name="notif_local_network_body">O Dish encontra satélites no seu Wi-Fi e se conecta a eles. Permita o acesso à rede local para buscar.</string>
     <string name="notif_bind_first_title">Vincule uma conexão primeiro</string>
     <string name="notif_pairing_needed_title">Pareamento necessário</string>
     <string name="notif_pairing_needed_body">Abra Conexões para digitar o PIN de %1$s.</string>

--- a/app/src/main/res/values-pt-rBR/strings_setup.xml
+++ b/app/src/main/res/values-pt-rBR/strings_setup.xml
@@ -69,6 +69,7 @@
     <string name="setup_conn_status_needs_pairing">Precisa parear, PIN</string>
     <string name="setup_conn_status_connected">Conectado</string>
     <string name="setup_conn_status_reconnecting">Reconectando</string>
+    <string name="setup_conn_local_network_denied">O Dish precisa de acesso à rede local para encontrar satélites no seu Wi-Fi. Permita para continuar.</string>
     <string name="setup_conn_missing_title">Não vê seu PC?</string>
     <string name="setup_conn_missing_body">Instale o app gratuito Satellite nele.</string>
     <string name="setup_conn_get_satellite">Obter o Satellite no GitHub</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -252,6 +252,8 @@
     <string name="notif_no_network_body">Connect to the same Wi-Fi as your satellite.</string>
     <string name="notif_cellular_only_title">Mobile data only</string>
     <string name="notif_cellular_only_body">Satellites live on your Wi-Fi LAN, not on mobile data.</string>
+    <string name="notif_local_network_title">Local network access needed</string>
+    <string name="notif_local_network_body">Dish finds and connects to satellites on your Wi-Fi. Allow local network access to scan.</string>
     <string name="notif_bind_first_title">Bind a connection first</string>
     <string name="notif_pairing_needed_title">Pairing needed</string>
     <string name="notif_pairing_needed_body">Open Connections to enter the PIN for %1$s.</string>

--- a/app/src/main/res/values/strings_setup.xml
+++ b/app/src/main/res/values/strings_setup.xml
@@ -75,6 +75,7 @@
     <string name="setup_conn_status_needs_pairing">Needs pairing, PIN</string>
     <string name="setup_conn_status_connected">Connected</string>
     <string name="setup_conn_status_reconnecting">Reconnecting</string>
+    <string name="setup_conn_local_network_denied">Dish needs local network access to find satellites on your Wi-Fi. Allow it to continue.</string>
     <string name="setup_conn_missing_title">Don\'t see your PC?</string>
     <string name="setup_conn_missing_body">Install the free Satellite app on it.</string>
     <string name="setup_conn_get_satellite">Get Satellite on GitHub</string>

--- a/app/src/test/java/com/tinkernorth/dish/composer/ConnectionCoordinatorTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/ConnectionCoordinatorTest.kt
@@ -13,8 +13,11 @@ import com.tinkernorth.dish.source.connection.ConnectIntent
 import com.tinkernorth.dish.source.connection.SatelliteConnection
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.connection.SatelliteSessionState
+import com.tinkernorth.dish.source.system.LocalNetworkAccess
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,6 +26,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -79,6 +83,11 @@ class ConnectionCoordinatorTest {
         scope = TestScope(StandardTestDispatcher())
     }
 
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
     private fun fakeStringContext(): Context {
         val ctx = mockk<Context>(relaxed = true)
         every { ctx.getString(com.tinkernorth.dish.R.string.bt_transient_acquiring) } returns
@@ -131,6 +140,7 @@ class ConnectionCoordinatorTest {
                 hostRuntimeStore = hostRuntimeStore,
                 composer = composer,
                 gamepadRegistry = gamepadRegistry,
+                context = mockk(relaxed = true),
             )
         scope.testScheduler.runCurrent()
         return hub
@@ -575,6 +585,22 @@ class ConnectionCoordinatorTest {
         verify {
             satellite.connect(match { it.ip == "2.2.2.2" }, ConnectIntent.AUTO_RECONNECT)
         }
+    }
+
+    @Test
+    fun `autoReconnectAll skips satellites when local network access is missing`() {
+        mockkObject(LocalNetworkAccess)
+        every { LocalNetworkAccess.isGranted(any(), any()) } returns false
+        satEntriesFlow.value =
+            listOf(
+                RememberedSatellite(id = "s:idle", name = "I", ip = "2.2.2.2", udpPort = 4, pairPort = 5, httpPort = 6),
+            )
+        every { satellite.get("s:idle") } returns null
+        val hub = buildHub()
+
+        hub.autoReconnectAll()
+
+        verify(exactly = 0) { satellite.connect(any(), ConnectIntent.AUTO_RECONNECT) }
     }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/composer/ConnectionCoordinatorTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/ConnectionCoordinatorTest.kt
@@ -13,11 +13,8 @@ import com.tinkernorth.dish.source.connection.ConnectIntent
 import com.tinkernorth.dish.source.connection.SatelliteConnection
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.connection.SatelliteSessionState
-import com.tinkernorth.dish.source.system.LocalNetworkAccess
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkObject
-import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,7 +23,6 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -83,11 +79,6 @@ class ConnectionCoordinatorTest {
         scope = TestScope(StandardTestDispatcher())
     }
 
-    @After
-    fun tearDown() {
-        unmockkAll()
-    }
-
     private fun fakeStringContext(): Context {
         val ctx = mockk<Context>(relaxed = true)
         every { ctx.getString(com.tinkernorth.dish.R.string.bt_transient_acquiring) } returns
@@ -140,7 +131,6 @@ class ConnectionCoordinatorTest {
                 hostRuntimeStore = hostRuntimeStore,
                 composer = composer,
                 gamepadRegistry = gamepadRegistry,
-                context = mockk(relaxed = true),
             )
         scope.testScheduler.runCurrent()
         return hub
@@ -585,22 +575,6 @@ class ConnectionCoordinatorTest {
         verify {
             satellite.connect(match { it.ip == "2.2.2.2" }, ConnectIntent.AUTO_RECONNECT)
         }
-    }
-
-    @Test
-    fun `autoReconnectAll skips satellites when local network access is missing`() {
-        mockkObject(LocalNetworkAccess)
-        every { LocalNetworkAccess.isGranted(any(), any()) } returns false
-        satEntriesFlow.value =
-            listOf(
-                RememberedSatellite(id = "s:idle", name = "I", ip = "2.2.2.2", udpPort = 4, pairPort = 5, httpPort = 6),
-            )
-        every { satellite.get("s:idle") } returns null
-        val hub = buildHub()
-
-        hub.autoReconnectAll()
-
-        verify(exactly = 0) { satellite.connect(any(), ConnectIntent.AUTO_RECONNECT) }
     }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManagerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/connection/SatelliteConnectionManagerTest.kt
@@ -12,10 +12,13 @@ import com.tinkernorth.dish.core.net.HttpReply
 import com.tinkernorth.dish.repository.ConnectionStore
 import com.tinkernorth.dish.repository.RememberedSatellite
 import com.tinkernorth.dish.source.store.SatelliteMotionBackendStatusStore
+import com.tinkernorth.dish.source.system.LocalNetworkAccess
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
@@ -428,6 +431,23 @@ class SatelliteConnectionManagerTest {
             scope.testScheduler.advanceUntilIdle()
 
             assertTrue(events.any { it is ConnectionEvent.Error })
+        }
+
+    @Test
+    fun `AUTO_RECONNECT is refused before any handshake when local network access is missing`() =
+        runMgrTest { mgr, _ ->
+            mockkObject(LocalNetworkAccess)
+            every { LocalNetworkAccess.isGranted(any(), any()) } returns false
+            try {
+                mgr.connect(server, ConnectIntent.AUTO_RECONNECT)
+                scope.testScheduler.advanceUntilIdle()
+
+                coVerify(exactly = 0) { discoveryRepo.pair(any(), any(), any(), any(), any()) }
+                verify(exactly = 0) { controllerRepo.openSocket(any(), any()) }
+                assertNull(mgr.get(serverId))
+            } finally {
+                unmockkObject(LocalNetworkAccess)
+            }
         }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/source/system/LocalNetworkAccessTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/system/LocalNetworkAccessTest.kt
@@ -26,7 +26,6 @@ class LocalNetworkAccessTest {
 
     @Test
     fun `permission is the platform ACCESS_LOCAL_NETWORK string`() {
-        // Must match the manifest declaration verbatim.
         assertEquals("android.permission.ACCESS_LOCAL_NETWORK", LocalNetworkAccess.PERMISSION)
     }
 
@@ -42,7 +41,6 @@ class LocalNetworkAccessTest {
     fun `pre-enforcement OS is granted without checking the runtime permission`() {
         mockkStatic(ContextCompat::class)
         assertTrue(LocalNetworkAccess.isGranted(context, sdkInt = 36))
-        // Older OSes have implicit LAN access via INTERNET, so we must not gate on the grant.
         verify(exactly = 0) { ContextCompat.checkSelfPermission(any(), any()) }
     }
 

--- a/app/src/test/java/com/tinkernorth/dish/source/system/LocalNetworkAccessTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/system/LocalNetworkAccessTest.kt
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.source.system
+
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LocalNetworkAccessTest {
+    private val context = mockk<Context>(relaxed = true)
+
+    @After
+    fun tearDown() {
+        unmockkStatic(ContextCompat::class)
+    }
+
+    @Test
+    fun `permission is the platform ACCESS_LOCAL_NETWORK string`() {
+        // Must match the manifest declaration verbatim.
+        assertEquals("android.permission.ACCESS_LOCAL_NETWORK", LocalNetworkAccess.PERMISSION)
+    }
+
+    @Test
+    fun `enforcement boundary is API 37`() {
+        assertFalse(LocalNetworkAccess.isEnforced(24))
+        assertFalse(LocalNetworkAccess.isEnforced(36))
+        assertTrue(LocalNetworkAccess.isEnforced(37))
+        assertTrue(LocalNetworkAccess.isEnforced(40))
+    }
+
+    @Test
+    fun `pre-enforcement OS is granted without checking the runtime permission`() {
+        mockkStatic(ContextCompat::class)
+        assertTrue(LocalNetworkAccess.isGranted(context, sdkInt = 36))
+        // Older OSes have implicit LAN access via INTERNET, so we must not gate on the grant.
+        verify(exactly = 0) { ContextCompat.checkSelfPermission(any(), any()) }
+    }
+
+    @Test
+    fun `enforcing OS is granted when the permission is held`() {
+        mockkStatic(ContextCompat::class)
+        every { ContextCompat.checkSelfPermission(context, LocalNetworkAccess.PERMISSION) } returns
+            PackageManager.PERMISSION_GRANTED
+        assertTrue(LocalNetworkAccess.isGranted(context, sdkInt = 37))
+    }
+
+    @Test
+    fun `enforcing OS is not granted when the permission is denied`() {
+        mockkStatic(ContextCompat::class)
+        every { ContextCompat.checkSelfPermission(context, LocalNetworkAccess.PERMISSION) } returns
+            PackageManager.PERMISSION_DENIED
+        assertFalse(LocalNetworkAccess.isGranted(context, sdkInt = 37))
+    }
+}


### PR DESCRIPTION
## What
On Android 17 (API 37 — our `targetSdk`/`compileSdk`) the app couldn't reach satellites: **scanning** popped a system **"Choose a device to connect"** picker, and a returning user's **remembered satellite silently failed to reconnect**. This restores normal connectivity behind a single one-time permission prompt.

## Why
Android 17 enforces **Local Network Protections**: mDNS/UDP/raw-socket LAN access is blocked until the user grants `ACCESS_LOCAL_NETWORK`. The app neither declared nor requested it, so:
- **Discovery** (mDNS via `NsdManager`) fell back to the OS per-device picker.
- **Auto-reconnect** (`autoReconnectAll()`, fired from a process-lifecycle observer on app foreground) and any direct socket connect failed with **EPERM** — no picker, no prompt, silent.

We take the **blanket-permission** path rather than the `NsdManager` `FLAG_SHOW_PICKER` path, because local-network access is spread across discovery, UDP streaming, direct connect-by-IP, manual add, and reconnect; the picker would only bless picker-obtained addresses.

## How
**Core**
- Declare `ACCESS_LOCAL_NETWORK` in the manifest.
- New `LocalNetworkAccess` helper: one place for the API-37 gate + permission string; a no-op on older OSes (implicit LAN access via `INTERNET`). `sdkInt` is injectable for tests.

**Request at each entry point that first needs the network**
- **MainActivity** (launcher): on first resume, if a remembered satellite exists and the permission is missing, prompt up front — so returning users reconnect from the home screen instead of failing silently. Grant → `autoReconnectAll()`; deny → a notification pointing to Connections.
- **ConnectionsActivity**: request on the first scan when entering; deny → a persistent banner that opens app settings; self-heals on return once granted.
- **SetupConnectionActivity**: request *before* the scan via a pending-resume callback (mirrors `onDiscoverableResult`), so a pre-grant blocked scan can't shadow the real one through the manager's single-flight guard; deny → the setup error dialog.

**Gate the automatic path**
- `SatelliteConnectionManager.connect()`: refuse any non-user-initiated connect (auto-reconnect + death-retries) until the permission is granted — a lifecycle observer can't itself request a permission, so this kills the silent EPERM until an Activity has prompted. Streaming on the overlays is covered transitively: no grant → no connection → nothing to stream.

**i18n**
- Translations for the 3 new strings across bs/de/es/fr/pt-rBR (`MissingTranslation` is a lint error in this project).

## Resulting flow (Android 17+)
- **Returning user w/ remembered satellite:** open app → one-time *"Allow Dish to find and connect to devices on your local network?"* on the home screen → grant → auto-reconnects. Deny → notification → Connections.
- **New user:** Setup → Satellite card → prompt → scan/pair as before.
- **Connections:** prompts on entry for the scan; no more OS device-picker.
- One app-global permission: grant once anywhere, granted everywhere; no per-screen re-prompts.
- **Older OSes:** unaffected — the gate short-circuits.

## Tests
- `LocalNetworkAccessTest` (JUnit4 + MockK): enforcement boundary at API 37, pre-enforcement granted without touching the permission, granted/denied on an enforcing OS.
- `SatelliteConnectionManagerTest`: new case — an `AUTO_RECONNECT` is refused before any handshake or socket when local-network access is missing.

## Verification
Local, all green: `compileDebugKotlin`, `ktlintCheck`, `detekt`, `lintDebug`, `testDebugUnitTest`.

⚠️ Enforcement is device-side on Android 17+; older OSes short-circuit. Not yet exercised on a live API-37 device — the launch-time prompt, deny→notification, and grant-from-settings paths are worth a manual smoke test on an emulator/device before merge.
