### PR TITLE
fix: recover instead of dead-ending when USB setup can't resolve a slot

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupUsbActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupUsbActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.activity.addCallback
 import androidx.activity.viewModels
+import androidx.annotation.StringRes
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -13,6 +14,7 @@ import com.tinkernorth.dish.R
 import com.tinkernorth.dish.databinding.ActivitySetupUsbBinding
 import com.tinkernorth.dish.databinding.SetupChoiceRowBinding
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
+import com.tinkernorth.dish.source.usb.DirectClaimFailure
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.setupDishToolbar
@@ -58,6 +60,7 @@ class SetupUsbActivity : BaseGamepadHostActivity() {
                     when (event) {
                         is SetupUsbViewModel.Event.Proceed ->
                             nav.toSetupConnection(SetupFlow.INPUT_USB, event.slotId)
+                        is SetupUsbViewModel.Event.Recover -> showRecovery(event.reason)
                     }
                 }
             }
@@ -119,6 +122,27 @@ class SetupUsbActivity : BaseGamepadHostActivity() {
     private fun handleBack() {
         if (!viewModel.back()) finish()
     }
+
+    // Retry re-runs whichever mode the user is on (Direct from the grant step, Standard otherwise);
+    // start over / exit are handled by the dialog.
+    private fun showRecovery(reason: DirectClaimFailure?) {
+        val message = reason?.let { getString(reasonText(it)) }
+        SetupErrorDialog.show(this, message) {
+            when (viewModel.state.value.stage) {
+                SetupUsbViewModel.Stage.GRANTING -> viewModel.showPrompt()
+                else -> viewModel.chooseStandard()
+            }
+        }
+    }
+
+    @StringRes
+    private fun reasonText(reason: DirectClaimFailure): Int =
+        when (reason) {
+            DirectClaimFailure.Busy -> R.string.path_reason_busy
+            DirectClaimFailure.InitFailed -> R.string.path_reason_init_failed
+            DirectClaimFailure.PermissionDenied -> R.string.path_reason_permission_denied
+            DirectClaimFailure.Dropped -> R.string.path_needs_replug
+        }
 
     private fun visibleIf(condition: Boolean): Int = if (condition) View.VISIBLE else View.GONE
 }

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupUsbViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupUsbViewModel.kt
@@ -5,11 +5,13 @@ package com.tinkernorth.dish.ui.setup
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tinkernorth.dish.core.jni.PhysicalInputNative
+import com.tinkernorth.dish.source.usb.DirectClaimFailure
 import com.tinkernorth.dish.source.usb.PathChoice
 import com.tinkernorth.dish.source.usb.UsbController
 import com.tinkernorth.dish.source.usb.UsbGamepadManager
 import com.tinkernorth.dish.source.usb.UsbPhase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -27,10 +29,10 @@ import javax.inject.Inject
 // Stage 2 USB. Lists the connected USB gamepads (UsbGamepadManager only ever
 // tracks plugged-in, gamepad-shaped devices, so the list is "connected
 // controllers" by construction); tapping one commits it and moves to the mode
-// step. The wizard records the mode pick and waits out the Direct claim / system
-// permission; the manager owns the actual claim. The slot id handed forward is
-// the live device id (synthetic on Direct, framework on Standard), resolved
-// after the switch settles so the framework -> synthetic id swap can't strand it.
+// step. Either mode pick records the choice and waits the manager's path FSM
+// out; the slot handed forward is the live device id it lands on (synthetic on
+// Direct, framework on Standard). If it settles with no live id, the wizard
+// surfaces a recovery dialog instead of silently stranding the user.
 @HiltViewModel
 class SetupUsbViewModel
     @Inject
@@ -57,6 +59,11 @@ class SetupUsbViewModel
             data class Proceed(
                 val slotId: String,
             ) : Event
+
+            // The path settled with no usable slot; the Activity offers retry / start over / exit.
+            data class Recover(
+                val reason: DirectClaimFailure?,
+            ) : Event
         }
 
         private val _state = MutableStateFlow(State())
@@ -66,6 +73,7 @@ class SetupUsbViewModel
         val events: SharedFlow<Event> = _events.asSharedFlow()
 
         private var activeKey: Int? = null
+        private var pathJob: Job? = null
 
         init {
             usb.reconcileForeground()
@@ -74,8 +82,9 @@ class SetupUsbViewModel
 
         private fun onControllers(map: Map<Int, UsbController>) {
             val rows = map.values.map { Controller(vpk(it), it.name, "%04X:%04X".format(it.vendorId, it.productId)) }
-            // The controller we were configuring was unplugged: drop back to the list.
+            // The controller we were configuring was unplugged: abandon any in-flight switch and drop to the list.
             if (activeKey != null && map[activeKey] == null) {
+                pathJob?.cancel()
                 activeKey = null
                 _state.value = State(controllers = rows)
                 return
@@ -93,39 +102,40 @@ class SetupUsbViewModel
 
         fun chooseDirect() = _state.update { it.copy(stage = Stage.GRANTING) }
 
-        fun chooseStandard() {
-            val c = current() ?: return
-            usb.setPathChoice(c.vendorId, c.productId, PathChoice.Standard)
-            val slot = c.frameworkId?.toString() ?: c.syntheticId?.toString() ?: return
-            emitProceed(slot)
-        }
+        fun chooseStandard() = runPath(PathChoice.Standard)
 
-        // Direct shows the Android permission prompt and then claims; wait the FSM
-        // out (same settle predicate the configure screen uses) and proceed on
-        // whatever it lands on, falling back to Standard if Direct is refused.
-        fun showPrompt() {
-            val c = current() ?: return
-            val key = vpk(c)
+        // Direct shows the Android permission prompt and then claims; Standard just
+        // asks the framework layer to (re)bind. Both drive the manager's FSM and then
+        // wait it out to whatever slot it lands on.
+        fun showPrompt() = runPath(PathChoice.Direct)
+
+        private fun runPath(choice: PathChoice) {
+            if (pathJob?.isActive == true) return
+            val key = activeKey ?: return
+            val c = usb.controllers.value[key] ?: return
             _state.update { it.copy(working = true) }
-            viewModelScope.launch {
-                usb.setPathChoice(c.vendorId, c.productId, PathChoice.Direct)
-                withTimeoutOrNull(DIRECT_TIMEOUT_MS) {
-                    usb.controllers.first { settled(it[key]) }
+            pathJob =
+                viewModelScope.launch {
+                    try {
+                        usb.setPathChoice(c.vendorId, c.productId, choice)
+                        withTimeoutOrNull(timeoutFor(choice)) {
+                            usb.controllers.first { resolved(it[key]) }
+                        }
+                        // The user backed out or unplugged while we waited: don't navigate behind them.
+                        if (activeKey != key) return@launch
+                        val landed = usb.controllers.value[key]
+                        val slot = proceedSlot(landed)
+                        _events.emit(if (slot != null) Event.Proceed(slot) else Event.Recover(landed?.failure))
+                    } finally {
+                        _state.update { it.copy(working = false) }
+                    }
                 }
-                _state.update { it.copy(working = false) }
-                val landed = usb.controllers.value[key]
-                val slot =
-                    when (landed?.phase) {
-                        UsbPhase.Direct -> landed.syntheticId?.toString()
-                        else -> landed?.frameworkId?.toString()
-                    } ?: landed?.frameworkId?.toString() ?: landed?.syntheticId?.toString()
-                if (slot != null) emitProceed(slot)
-            }
         }
 
         // True for "back was handled in-flow"; the Activity finishes only when false.
-        fun back(): Boolean =
-            when (_state.value.stage) {
+        fun back(): Boolean {
+            pathJob?.cancel()
+            return when (_state.value.stage) {
                 Stage.MODE -> {
                     activeKey = null
                     _state.update { it.copy(stage = Stage.DETECTING) }
@@ -137,23 +147,33 @@ class SetupUsbViewModel
                 }
                 Stage.DETECTING -> false
             }
-
-        private fun current(): UsbController? = activeKey?.let { usb.controllers.value[it] }
-
-        private fun emitProceed(slotId: String) {
-            viewModelScope.launch { _events.emit(Event.Proceed(slotId)) }
         }
 
         private fun vpk(c: UsbController): Int = (c.vendorId shl 16) or (c.productId and 0xFFFF)
 
         private companion object {
             const val DIRECT_TIMEOUT_MS = 20_000L
+            const val STANDARD_TIMEOUT_MS = 8_000L
 
-            fun settled(c: UsbController?): Boolean =
+            fun timeoutFor(choice: PathChoice): Long = if (choice == PathChoice.Direct) DIRECT_TIMEOUT_MS else STANDARD_TIMEOUT_MS
+
+            // Stop waiting once the path has a live id, or has reached a dead end that never will. A Routed
+            // controller still pursuing Direct is mid-permission/claim, not settled, so keep waiting.
+            fun resolved(c: UsbController?): Boolean =
                 when (c?.phase) {
-                    UsbPhase.Direct, UsbPhase.NeedsReplug, UsbPhase.RestoreStuck -> true
-                    UsbPhase.Routed -> c.desired != PathChoice.Direct
+                    UsbPhase.Direct -> c.syntheticId != null
+                    UsbPhase.Routed -> c.desired != PathChoice.Direct && c.frameworkId != null
+                    UsbPhase.RestoreStuck, UsbPhase.NeedsReplug -> true
                     UsbPhase.Claiming, UsbPhase.AwaitingFramework, null -> false
+                }
+
+            // The live slot to hand forward. RestoreStuck's synthetic is a detached placeholder and
+            // NeedsReplug has none, so both return null and the caller recovers instead of stranding the user.
+            fun proceedSlot(c: UsbController?): String? =
+                when (c?.phase) {
+                    UsbPhase.Direct -> c.syntheticId?.toString()
+                    UsbPhase.Routed -> if (c.desired != PathChoice.Direct) c.frameworkId?.toString() else null
+                    else -> null
                 }
         }
     }

--- a/app/src/test/java/com/tinkernorth/dish/ui/setup/SetupUsbViewModelTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/setup/SetupUsbViewModelTest.kt
@@ -3,6 +3,7 @@
 package com.tinkernorth.dish.ui.setup
 
 import com.tinkernorth.dish.core.jni.PhysicalInputNative
+import com.tinkernorth.dish.source.usb.DirectClaimFailure
 import com.tinkernorth.dish.source.usb.PathChoice
 import com.tinkernorth.dish.source.usb.UsbController
 import com.tinkernorth.dish.source.usb.UsbGamepadManager
@@ -58,6 +59,7 @@ class SetupUsbViewModelTest {
         frameworkId: Int? = null,
         syntheticId: Int? = null,
         desired: PathChoice = PathChoice.Standard,
+        failure: DirectClaimFailure? = null,
         vid: Int = VID,
         pid: Int = PID,
     ) = UsbController(
@@ -68,6 +70,7 @@ class SetupUsbViewModelTest {
         frameworkId = frameworkId,
         syntheticId = syntheticId,
         desired = desired,
+        failure = failure,
     )
 
     private fun present(
@@ -189,6 +192,155 @@ class SetupUsbViewModelTest {
             dispatcher.scheduler.runCurrent()
 
             assertEquals(listOf<SetupUsbViewModel.Event>(SetupUsbViewModel.Event.Proceed("50")), events)
+        }
+
+    @Test
+    fun `granting direct waits through the permission prompt instead of proceeding on the framework`() =
+        runTest(dispatcher) {
+            present(frameworkId = 50)
+            dispatcher.scheduler.runCurrent()
+            vm.selectController(key())
+            // Permission not granted yet: the FSM stays Routed with desired=Direct while the system
+            // prompt is up. The wizard must wait for the claim, not navigate on the Standard slot.
+            every { usb.setPathChoice(VID, PID, PathChoice.Direct) } answers {
+                controllers.value =
+                    mapOf(key() to controller(UsbPhase.Routed, frameworkId = 50, desired = PathChoice.Direct))
+            }
+            val events = collectEvents()
+
+            vm.showPrompt()
+            dispatcher.scheduler.runCurrent()
+            assertTrue("must not proceed on the framework slot before the claim resolves", events.isEmpty())
+
+            controllers.value =
+                mapOf(key() to controller(UsbPhase.Direct, syntheticId = -1000, desired = PathChoice.Direct))
+            dispatcher.scheduler.runCurrent()
+
+            assertEquals(listOf<SetupUsbViewModel.Event>(SetupUsbViewModel.Event.Proceed("-1000")), events)
+        }
+
+    @Test
+    fun `choosing standard recovers when no framework slot ever resolves`() =
+        runTest(dispatcher) {
+            present(frameworkId = null)
+            dispatcher.scheduler.runCurrent()
+            vm.selectController(key())
+            val events = collectEvents()
+
+            vm.chooseStandard()
+            dispatcher.scheduler.runCurrent()
+            assertTrue("waits rather than recovering before the timeout", events.isEmpty())
+
+            dispatcher.scheduler.advanceTimeBy(9_000)
+            dispatcher.scheduler.runCurrent()
+
+            verify { usb.setPathChoice(VID, PID, PathChoice.Standard) }
+            assertEquals(listOf<SetupUsbViewModel.Event>(SetupUsbViewModel.Event.Recover(null)), events)
+            assertFalse(vm.state.value.working)
+        }
+
+    @Test
+    fun `choosing standard proceeds once the framework device enumerates`() =
+        runTest(dispatcher) {
+            present(frameworkId = null)
+            dispatcher.scheduler.runCurrent()
+            vm.selectController(key())
+            val events = collectEvents()
+
+            vm.chooseStandard()
+            dispatcher.scheduler.runCurrent()
+            assertTrue("waits rather than recovering while the framework is still absent", events.isEmpty())
+
+            controllers.value = mapOf(key() to controller(UsbPhase.Routed, frameworkId = 77))
+            dispatcher.scheduler.runCurrent()
+
+            assertEquals(listOf<SetupUsbViewModel.Event>(SetupUsbViewModel.Event.Proceed("77")), events)
+        }
+
+    @Test
+    fun `granting direct recovers when it lands on needs-replug`() =
+        runTest(dispatcher) {
+            present(frameworkId = 50)
+            dispatcher.scheduler.runCurrent()
+            vm.selectController(key())
+            every { usb.setPathChoice(VID, PID, PathChoice.Direct) } answers {
+                controllers.value =
+                    mapOf(key() to controller(UsbPhase.NeedsReplug, failure = DirectClaimFailure.Dropped))
+            }
+            val events = collectEvents()
+
+            vm.showPrompt()
+            dispatcher.scheduler.runCurrent()
+
+            assertEquals(
+                listOf<SetupUsbViewModel.Event>(SetupUsbViewModel.Event.Recover(DirectClaimFailure.Dropped)),
+                events,
+            )
+            assertFalse(vm.state.value.working)
+        }
+
+    @Test
+    fun `granting direct recovers rather than proceeding on a restore-stuck placeholder`() =
+        runTest(dispatcher) {
+            present(frameworkId = 50)
+            dispatcher.scheduler.runCurrent()
+            vm.selectController(key())
+            every { usb.setPathChoice(VID, PID, PathChoice.Direct) } answers {
+                controllers.value = mapOf(key() to controller(UsbPhase.RestoreStuck, syntheticId = -2000))
+            }
+            val events = collectEvents()
+
+            vm.showPrompt()
+            dispatcher.scheduler.runCurrent()
+
+            assertEquals(listOf<SetupUsbViewModel.Event>(SetupUsbViewModel.Event.Recover(null)), events)
+        }
+
+    @Test
+    fun `a second path attempt is ignored while one is in flight`() =
+        runTest(dispatcher) {
+            present(frameworkId = 50)
+            dispatcher.scheduler.runCurrent()
+            vm.selectController(key())
+            every { usb.setPathChoice(VID, PID, PathChoice.Direct) } answers {
+                controllers.value = mapOf(key() to controller(UsbPhase.Claiming, desired = PathChoice.Direct))
+            }
+            val events = collectEvents()
+
+            vm.showPrompt()
+            dispatcher.scheduler.runCurrent()
+            vm.showPrompt()
+            dispatcher.scheduler.runCurrent()
+
+            controllers.value =
+                mapOf(key() to controller(UsbPhase.Direct, syntheticId = -1000, desired = PathChoice.Direct))
+            dispatcher.scheduler.runCurrent()
+
+            assertEquals(listOf<SetupUsbViewModel.Event>(SetupUsbViewModel.Event.Proceed("-1000")), events)
+            verify(exactly = 1) { usb.setPathChoice(VID, PID, PathChoice.Direct) }
+        }
+
+    @Test
+    fun `backing out during an in-flight wait suppresses navigation`() =
+        runTest(dispatcher) {
+            present(frameworkId = 50)
+            dispatcher.scheduler.runCurrent()
+            vm.selectController(key())
+            vm.chooseDirect()
+            every { usb.setPathChoice(VID, PID, PathChoice.Direct) } answers {
+                controllers.value = mapOf(key() to controller(UsbPhase.Claiming, desired = PathChoice.Direct))
+            }
+            val events = collectEvents()
+
+            vm.showPrompt()
+            dispatcher.scheduler.runCurrent()
+            assertTrue(vm.back())
+
+            controllers.value =
+                mapOf(key() to controller(UsbPhase.Direct, syntheticId = -1000, desired = PathChoice.Direct))
+            dispatcher.scheduler.runCurrent()
+
+            assertTrue("a cancelled wait must not navigate", events.isEmpty())
         }
 
     @Test


### PR DESCRIPTION
## Problem

A user setting up an 8bitdo controller over USB reported that the wizard's "How should Dish read it?" screen was a dead end: **"USB Direct" prompts for USB access then doesn't advance**, and **"USB Standard" does nothing**. The only escape was "Skip".

Root cause is entirely in `SetupUsbViewModel`, which navigates only on `Event.Proceed`:

- `chooseStandard()` read a **stale, one-shot controller snapshot** and returned silently when the framework `InputDevice` hadn't enumerated yet (or its vid/pid never associated — common for XInput/xpad devices).
- `showPrompt()` had `if (slot != null) emitProceed(slot)` with **no else**, so a claim that settled with no slot (`NeedsReplug`) simply hung.

The mode screen had no error surface at all, unlike `SetupConfigureActivity`.

## Fix

- Unify both picks into `runPath(choice)`: set the path pref, wait the manager's path FSM out to a **resolvable** slot, then emit `Proceed` or a new `Event.Recover(reason)`.
- `SetupUsbActivity` turns `Recover` into the existing `SetupErrorDialog` (retry / start over / exit), reusing the already-translated `path_reason_*` / `path_needs_replug` strings — **no new strings**, so no translation debt.
- Slot resolution is **phase-aware**: `Direct → synthetic`, settled Standard → framework, `RestoreStuck`/`NeedsReplug` → recover. `RestoreStuck`'s synthetic is a detached placeholder (`releaseToFramework` already ran `native.detachUsbDevice`), so proceeding on it would strand the user two screens deeper.
- A `Routed` controller still pursuing Direct is treated as mid-permission (not settled), so tapping **Direct** waits for the claim instead of navigating on the Standard slot before the permission prompt is answered.
- A single in-flight guard + cancel-on-back/unplug + a post-wait active-key check prevent double-navigation and navigation-behind-the-user.

## Tests

- 7 new `SetupUsbViewModelTest` cases: standard-recovers-on-timeout, standard-proceeds-once-framework-enumerates, direct→needs-replug→recover, direct→restore-stuck→recover (the detached-placeholder guard), permission-wait, in-flight dedupe, and back-cancellation. The permission-wait test was verified to fail against the pre-fix predicate.
- Existing event tests updated for the now-async `chooseStandard`.
- Full local CI green: ktlint, detekt, lint, `testDebugUnitTest`, `nativeTest`, `assembleDebug`.

## Scope notes

- No instrumentation test: `UsbGamepadManager` is a constructor-injected `@Singleton` with no DI seam, the integration suite deliberately uses the real Hilt graph (no test component), and a headless emulator can't drive USB — so the branch logic is covered at the ViewModel unit layer. Activity wiring mirrors the shipped `SetupConfigureActivity` pattern.
- Out of scope (separate follow-ups): adding the 8bitdo Ultimate 2.4g's XInput VID:PID + a wireless init handshake to the native device table, and PlayStation-mode rumble (a satellite-side change).
