### PR TITLE
feat: nudge a touch-capable USB pad on Standard toward Direct mode

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
@@ -331,13 +331,14 @@ class ControllerAdapter(
         }
 
         private fun touchpadFuncPill(row: Row): PillSpec {
+            if (row.pathCard?.suggestDirectForTouch == true) {
+                return PillSpec(ctx.getString(R.string.touchpad_needs_direct), R.drawable.ic_touchpad, PillTone.WARN)
+            }
             val mode = row.touchpad?.mode ?: TouchpadModeValue.OFF
-            val needsDirect = row.pathCard?.suggestDirectForTouch == true
             val valueRes =
-                when {
-                    needsDirect -> R.string.touchpad_mode_needs_direct
-                    mode == TouchpadModeValue.DS4 -> R.string.touchpad_mode_pad
-                    mode == TouchpadModeValue.MOUSE -> R.string.touchpad_mode_mouse
+                when (mode) {
+                    TouchpadModeValue.DS4 -> R.string.touchpad_mode_pad
+                    TouchpadModeValue.MOUSE -> R.string.touchpad_mode_mouse
                     else -> R.string.touchpad_mode_off
                 }
             val label =
@@ -347,12 +348,7 @@ class ControllerAdapter(
                     ctx.getString(valueRes),
                 )
             val icon = if (mode == TouchpadModeValue.MOUSE) R.drawable.ic_mouse else R.drawable.ic_touchpad
-            val tone =
-                when {
-                    needsDirect -> PillTone.WARN
-                    mode == TouchpadModeValue.OFF -> PillTone.OFF
-                    else -> PillTone.ON
-                }
+            val tone = if (mode == TouchpadModeValue.OFF) PillTone.OFF else PillTone.ON
             return PillSpec(label, icon, tone)
         }
 

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
@@ -44,6 +44,8 @@ interface SlotActionListener {
 
     fun onOpenTouchpad(slotId: String)
 
+    fun onSwitchToDirect(slotId: String)
+
     fun onManageDestinations()
 
     fun onReconnect(slotId: String)
@@ -323,24 +325,35 @@ class ControllerAdapter(
             }
 
             if (bound.kind == ConnectionKind.SATELLITE) {
-                val mode = row.touchpad?.mode ?: TouchpadModeValue.OFF
-                val valueRes =
-                    when (mode) {
-                        TouchpadModeValue.DS4 -> R.string.touchpad_mode_pad
-                        TouchpadModeValue.MOUSE -> R.string.touchpad_mode_mouse
-                        else -> R.string.touchpad_mode_off
-                    }
-                val label =
-                    ctx.getString(
-                        R.string.binding_func_value,
-                        ctx.getString(R.string.binding_func_touchpad),
-                        ctx.getString(valueRes),
-                    )
-                val icon = if (mode == TouchpadModeValue.MOUSE) R.drawable.ic_mouse else R.drawable.ic_touchpad
-                val tone = if (mode == TouchpadModeValue.OFF) PillTone.OFF else PillTone.ON
-                specs.add(PillSpec(label, icon, tone))
+                specs.add(touchpadFuncPill(row))
             }
             return specs
+        }
+
+        private fun touchpadFuncPill(row: Row): PillSpec {
+            val mode = row.touchpad?.mode ?: TouchpadModeValue.OFF
+            val needsDirect = row.pathCard?.suggestDirectForTouch == true
+            val valueRes =
+                when {
+                    needsDirect -> R.string.touchpad_mode_needs_direct
+                    mode == TouchpadModeValue.DS4 -> R.string.touchpad_mode_pad
+                    mode == TouchpadModeValue.MOUSE -> R.string.touchpad_mode_mouse
+                    else -> R.string.touchpad_mode_off
+                }
+            val label =
+                ctx.getString(
+                    R.string.binding_func_value,
+                    ctx.getString(R.string.binding_func_touchpad),
+                    ctx.getString(valueRes),
+                )
+            val icon = if (mode == TouchpadModeValue.MOUSE) R.drawable.ic_mouse else R.drawable.ic_touchpad
+            val tone =
+                when {
+                    needsDirect -> PillTone.WARN
+                    mode == TouchpadModeValue.OFF -> PillTone.OFF
+                    else -> PillTone.ON
+                }
+            return PillSpec(label, icon, tone)
         }
 
         private fun funcValue(
@@ -544,6 +557,15 @@ class ControllerAdapter(
                         kind = ActionKind.TOUCHPAD,
                     )
             }
+            if (bound.kind == ConnectionKind.SATELLITE && connected && row.pathCard?.suggestDirectForTouch == true) {
+                actions +=
+                    CardAction(
+                        R.drawable.ic_bolt,
+                        ctx.getString(R.string.card_switch_to_direct),
+                        outlined = false,
+                        kind = ActionKind.SWITCH_DIRECT,
+                    )
+            }
             actions +=
                 CardAction(
                     R.drawable.ic_tune,
@@ -561,6 +583,7 @@ class ControllerAdapter(
             when (kind) {
                 ActionKind.GAMEPAD -> listener.onOpenGamepad(slotId)
                 ActionKind.TOUCHPAD -> listener.onOpenTouchpad(slotId)
+                ActionKind.SWITCH_DIRECT -> listener.onSwitchToDirect(slotId)
                 ActionKind.CONFIGURE -> listener.onConfigure(slotId)
                 ActionKind.FIND_HOSTS -> listener.onManageDestinations()
             }
@@ -667,7 +690,7 @@ class ControllerAdapter(
         val kind: ActionKind,
     )
 
-    private enum class ActionKind { GAMEPAD, TOUCHPAD, CONFIGURE, FIND_HOSTS }
+    private enum class ActionKind { GAMEPAD, TOUCHPAD, SWITCH_DIRECT, CONFIGURE, FIND_HOSTS }
 
     private enum class EdgeState { NONE, HOST_LOST, INPUT_LOST, UNSTEADY }
 

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainActivity.kt
@@ -30,6 +30,7 @@ import com.tinkernorth.dish.source.lowpower.LowPowerSignal
 import com.tinkernorth.dish.source.notification.DishNotifications
 import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
 import com.tinkernorth.dish.source.system.LocalNetworkAccess
+import com.tinkernorth.dish.source.usb.PathChoice
 import com.tinkernorth.dish.source.usb.UsbGamepadManager
 import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.DishSpinnerDrawable
@@ -293,6 +294,10 @@ class MainActivity :
         val cid = slot.boundConnectionId ?: return
         if (state.touchpadBySlot[slotId]?.openable != true) return
         nav.toTouchpad(connectionId = cid, slotId = slotId)
+    }
+
+    override fun onSwitchToDirect(slotId: String) {
+        viewModel.setInputPath(slotId, PathChoice.Direct)
     }
 
     override fun onOpenGamepad(slotId: String) {

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MainViewModel.kt
@@ -242,6 +242,7 @@ class MainViewModel
                 needsReplug = device.needsReplug,
                 restoreStuck = device.restoreStuck,
                 directFailure = device.directFailure,
+                padHasTouchpad = native.modelHasTouchpad(vid, pid),
             )
         }
 

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/PathCard.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/PathCard.kt
@@ -38,6 +38,7 @@ data class PathCard(
     val restoreStuck: Boolean = false,
     // Why the last Direct claim failed, when not already covered by needsReplug/restoreStuck.
     val failure: DirectClaimFailure? = null,
+    val suggestDirectForTouch: Boolean = false,
 )
 
 object PathCardMapper {
@@ -53,6 +54,7 @@ object PathCardMapper {
         needsReplug: Boolean = false,
         restoreStuck: Boolean = false,
         directFailure: DirectClaimFailure? = null,
+        padHasTouchpad: Boolean = false,
     ): PathCard {
         // The card reflects the mode the controller is ACTUALLY in: Direct only when a synthetic is live
         // (claimed, not mid-release, not stuck). Badge and toggle both derive from this so they can never
@@ -64,6 +66,16 @@ object PathCardMapper {
                 !recognized -> PathRisk.GuessedLayout
                 else -> PathRisk.None
             }
+        // A pad's own trackpad streams only on Direct and has no phone-overlay fallback: nudge only when
+        // cleanly on Standard USB with Direct actually reachable (a recent failure is left to settle first).
+        val suggestDirectForTouch =
+            padHasTouchpad &&
+                transport == Transport.Usb &&
+                !isClaimedDirect &&
+                !restoring &&
+                !restoreStuck &&
+                !needsReplug &&
+                directFailure == null
         return PathCard(
             currentMode = if (onDirect) InputPathMode.Direct else InputPathMode.Standard,
             selected = if (onDirect) PathChoice.Direct else PathChoice.Standard,
@@ -78,6 +90,7 @@ object PathCardMapper {
             needsReplug = needsReplug,
             restoreStuck = restoreStuck,
             failure = directFailure,
+            suggestDirectForTouch = suggestDirectForTouch,
         )
     }
 }

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -73,7 +73,7 @@
     <string name="touchpad_mode_off">Isključeno</string>
     <string name="touchpad_mode_pad">Pad</string>
     <string name="touchpad_mode_mouse">Miš</string>
-    <string name="touchpad_mode_needs_direct">Treba Brzi</string>
+    <string name="touchpad_needs_direct">Dodirnoj ploči je potreban Brzi način</string>
     <string name="card_switch_to_direct">Prebaci na Brzi</string>
 
     <!-- Tekst statusa slota u ControllerAdapter (ispod imena). -->

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -73,6 +73,8 @@
     <string name="touchpad_mode_off">Isključeno</string>
     <string name="touchpad_mode_pad">Pad</string>
     <string name="touchpad_mode_mouse">Miš</string>
+    <string name="touchpad_mode_needs_direct">Treba Brzi</string>
+    <string name="card_switch_to_direct">Prebaci na Brzi</string>
 
     <!-- Tekst statusa slota u ControllerAdapter (ispod imena). -->
     <string name="slot_status_disconnecting">Prekidanje veze… %1$ds</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -72,6 +72,8 @@
     <string name="touchpad_mode_off">Aus</string>
     <string name="touchpad_mode_pad">Pad</string>
     <string name="touchpad_mode_mouse">Maus</string>
+    <string name="touchpad_mode_needs_direct">Direkt nötig</string>
+    <string name="card_switch_to_direct">Zu Direkt wechseln</string>
 
     <!-- Slot-Statustext im ControllerAdapter (unter dem Namen). -->
     <string name="slot_status_disconnecting">Trennt… %1$ds</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -72,7 +72,7 @@
     <string name="touchpad_mode_off">Aus</string>
     <string name="touchpad_mode_pad">Pad</string>
     <string name="touchpad_mode_mouse">Maus</string>
-    <string name="touchpad_mode_needs_direct">Direkt nötig</string>
+    <string name="touchpad_needs_direct">Touchpad benötigt Direkt-Modus</string>
     <string name="card_switch_to_direct">Zu Direkt wechseln</string>
 
     <!-- Slot-Statustext im ControllerAdapter (unter dem Namen). -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -74,6 +74,8 @@
     <string name="touchpad_mode_off">Apagado</string>
     <string name="touchpad_mode_pad">Pad</string>
     <string name="touchpad_mode_mouse">Ratón</string>
+    <string name="touchpad_mode_needs_direct">Requiere Directo</string>
+    <string name="card_switch_to_direct">Cambiar a Directo</string>
 
     <!-- Texto de estado del slot en ControllerAdapter (bajo el nombre). -->
     <string name="slot_status_disconnecting">Desconectando… %1$ds</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -74,7 +74,7 @@
     <string name="touchpad_mode_off">Apagado</string>
     <string name="touchpad_mode_pad">Pad</string>
     <string name="touchpad_mode_mouse">Ratón</string>
-    <string name="touchpad_mode_needs_direct">Requiere Directo</string>
+    <string name="touchpad_needs_direct">El panel táctil requiere el modo Directo</string>
     <string name="card_switch_to_direct">Cambiar a Directo</string>
 
     <!-- Texto de estado del slot en ControllerAdapter (bajo el nombre). -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -73,6 +73,8 @@
     <string name="touchpad_mode_off">Désactivé</string>
     <string name="touchpad_mode_pad">Pavé</string>
     <string name="touchpad_mode_mouse">Souris</string>
+    <string name="touchpad_mode_needs_direct">Nécessite Direct</string>
+    <string name="card_switch_to_direct">Passer en Direct</string>
 
     <!-- Texte du statut de l\'emplacement dans ControllerAdapter (sous le nom). -->
     <string name="slot_status_disconnecting">Déconnexion… %1$ds</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -73,7 +73,7 @@
     <string name="touchpad_mode_off">Désactivé</string>
     <string name="touchpad_mode_pad">Pavé</string>
     <string name="touchpad_mode_mouse">Souris</string>
-    <string name="touchpad_mode_needs_direct">Nécessite Direct</string>
+    <string name="touchpad_needs_direct">Le pavé tactile nécessite le mode Direct</string>
     <string name="card_switch_to_direct">Passer en Direct</string>
 
     <!-- Texte du statut de l\'emplacement dans ControllerAdapter (sous le nom). -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -74,6 +74,8 @@
     <string name="touchpad_mode_off">Desligado</string>
     <string name="touchpad_mode_pad">Pad</string>
     <string name="touchpad_mode_mouse">Mouse</string>
+    <string name="touchpad_mode_needs_direct">Requer Direto</string>
+    <string name="card_switch_to_direct">Mudar para Direto</string>
 
     <!-- Texto de status do slot no ControllerAdapter (abaixo do nome). -->
     <string name="slot_status_disconnecting">Desconectando… %1$ds</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -74,7 +74,7 @@
     <string name="touchpad_mode_off">Desligado</string>
     <string name="touchpad_mode_pad">Pad</string>
     <string name="touchpad_mode_mouse">Mouse</string>
-    <string name="touchpad_mode_needs_direct">Requer Direto</string>
+    <string name="touchpad_needs_direct">O touchpad precisa do modo Direto</string>
     <string name="card_switch_to_direct">Mudar para Direto</string>
 
     <!-- Texto de status do slot no ControllerAdapter (abaixo do nome). -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,7 +94,7 @@
     <string name="touchpad_mode_off">Off</string>
     <string name="touchpad_mode_pad">Pad</string>
     <string name="touchpad_mode_mouse">Mouse</string>
-    <string name="touchpad_mode_needs_direct">Needs Direct</string>
+    <string name="touchpad_needs_direct">Trackpad needs Direct mode</string>
     <string name="card_switch_to_direct">Switch to Direct</string>
     <!-- ControllerAdapter slot-status text (renders below the slot name). -->
     <string name="slot_status_disconnecting">Disconnecting… %1$ds</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,8 @@
     <string name="touchpad_mode_off">Off</string>
     <string name="touchpad_mode_pad">Pad</string>
     <string name="touchpad_mode_mouse">Mouse</string>
+    <string name="touchpad_mode_needs_direct">Needs Direct</string>
+    <string name="card_switch_to_direct">Switch to Direct</string>
     <!-- ControllerAdapter slot-status text (renders below the slot name). -->
     <string name="slot_status_disconnecting">Disconnecting… %1$ds</string>
     <string name="slot_status_routing_to">→ %1$s</string>

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/MainViewModelTest.kt
@@ -472,6 +472,49 @@ class MainViewModelTest {
         }
 
     @Test
+    fun `a routed touch-capable usb pad surfaces a direct suggestion on its card`() =
+        runTest(dispatcher) {
+            every { native.modelHasTouchpad(0x054C, 0x09CC) } returns true
+            devicesFlow.value = mapOf(80 to routed(80, 0x054C, 0x09CC))
+            dispatcher.scheduler.runCurrent()
+
+            val card = vm.uiState.value.pathCards["80"]
+            assertTrue(card?.suggestDirectForTouch == true)
+        }
+
+    @Test
+    fun `a routed pad with no trackpad gets no direct suggestion`() =
+        runTest(dispatcher) {
+            devicesFlow.value = mapOf(81 to routed(81, 0x045E, 0x028E))
+            dispatcher.scheduler.runCurrent()
+
+            val card = vm.uiState.value.pathCards["81"]
+            assertEquals(false, card?.suggestDirectForTouch)
+        }
+
+    @Test
+    fun `a touch-capable pad already on direct gets no suggestion`() =
+        runTest(dispatcher) {
+            every { native.modelHasTouchpad(0x054C, 0x09CC) } returns true
+            devicesFlow.value = mapOf(-2000 to synthetic(-2000, 0x054C, 0x09CC))
+            dispatcher.scheduler.runCurrent()
+
+            val card = vm.uiState.value.pathCards["-2000"]
+            assertEquals(false, card?.suggestDirectForTouch)
+        }
+
+    @Test
+    fun `a bluetooth touch-capable pad gets no direct suggestion`() =
+        runTest(dispatcher) {
+            every { native.modelHasTouchpad(0x054C, 0x09CC) } returns true
+            devicesFlow.value = mapOf(82 to routed(82, 0x054C, 0x09CC, transport = Transport.Bluetooth))
+            dispatcher.scheduler.runCurrent()
+
+            val card = vm.uiState.value.pathCards["82"]
+            assertEquals(false, card?.suggestDirectForTouch)
+        }
+
+    @Test
     fun `the virtual slot has no path card`() =
         runTest(dispatcher) {
             dispatcher.scheduler.runCurrent()

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/PathCardMapperTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/PathCardMapperTest.kt
@@ -23,6 +23,7 @@ class PathCardMapperTest {
         needsReplug: Boolean = false,
         restoreStuck: Boolean = false,
         directFailure: DirectClaimFailure? = null,
+        padHasTouchpad: Boolean = false,
     ) = PathCardMapper.map(
         isClaimedDirect = isClaimedDirect,
         transport = transport,
@@ -34,6 +35,7 @@ class PathCardMapperTest {
         needsReplug = needsReplug,
         restoreStuck = restoreStuck,
         directFailure = directFailure,
+        padHasTouchpad = padHasTouchpad,
     )
 
     @Test
@@ -115,5 +117,44 @@ class PathCardMapperTest {
         assertTrue(map(restoreStuck = true).restoreStuck)
         assertFalse(map().restoreStuck)
         assertTrue(map(needsReplug = true).needsReplug)
+    }
+
+    @Test
+    fun `a touch-capable usb pad on standard suggests switching to direct`() {
+        assertTrue(map(padHasTouchpad = true).suggestDirectForTouch)
+    }
+
+    @Test
+    fun `a pad with no trackpad never suggests direct`() {
+        assertFalse(map(padHasTouchpad = false).suggestDirectForTouch)
+    }
+
+    @Test
+    fun `a pad already claimed on direct does not suggest direct`() {
+        assertFalse(map(padHasTouchpad = true, isClaimedDirect = true).suggestDirectForTouch)
+    }
+
+    @Test
+    fun `a bluetooth trackpad pad does not suggest direct because bluetooth has no direct path`() {
+        assertFalse(map(padHasTouchpad = true, transport = Transport.Bluetooth).suggestDirectForTouch)
+    }
+
+    @Test
+    fun `transient path states suppress the direct suggestion`() {
+        assertFalse(map(padHasTouchpad = true, restoring = true).suggestDirectForTouch)
+        assertFalse(map(padHasTouchpad = true, restoreStuck = true).suggestDirectForTouch)
+        assertFalse(map(padHasTouchpad = true, needsReplug = true).suggestDirectForTouch)
+    }
+
+    @Test
+    fun `a recent direct claim failure suppresses the suggestion until it settles`() {
+        assertFalse(
+            map(padHasTouchpad = true, directFailure = DirectClaimFailure.PermissionDenied).suggestDirectForTouch,
+        )
+    }
+
+    @Test
+    fun `the direct suggestion defaults off`() {
+        assertFalse(map().suggestDirectForTouch)
     }
 }


### PR DESCRIPTION
## Why

A PlayStation pad's own trackpad only streams to the host on the **USB-Direct** path (the app claims the USB interface and reads raw HID reports). On the **Standard** (Android framework) path the trackpad isn't captured — and because the pad has its own trackpad, the app deliberately offers no on-screen touchpad overlay fallback (`TouchpadSource.NONE`). Net effect: a PS pad on Standard has a dead touchpad/mouse with nothing on the dashboard explaining why. Previously this was only hinted at passively, in a diagnostics-inspector string.

## What

Surface it as an actionable nudge on the controller card:

- The touchpad **function pill** reads **"Needs Direct"** (warning tone) instead of "Off" when a touch-capable pad is stuck on Standard.
- A **"Switch to Direct"** filled action appears on the card and triggers the switch.

The switch reuses the existing `MainViewModel.setInputPath(slotId, PathChoice.Direct)` → `UsbGamepadManager.setPathChoice(...)` path (the same one the Configure screen's Apply uses, `userInitiated = true` so the USB-permission prompt fires when needed). No path-switching logic is duplicated.

### Trigger predicate

Computed in `PathCardMapper.map` as `suggestDirectForTouch`, true only when the model has its own trackpad **and** it's cleanly on USB Standard with Direct reachable:

```
padHasTouchpad && transport == Usb && !isClaimedDirect
  && !restoring && !restoreStuck && !needsReplug && directFailure == null
```

`padHasTouchpad` comes from the native known-model DB (`modelHasTouchpad(vid,pid)`), so this automatically excludes:
- **Xbox / non-touch pads** — not in the touch model DB
- **Bluetooth pads** — no Direct path exists (would be a dead CTA)
- **Pads already on Direct** — `isClaimedDirect`
- **The virtual on-screen slot** — never gets a `PathCard`
- **Mid-switch / needs-replug / just-failed states** — left to settle first

The "Switch to Direct" action and the existing "Open touchpad" action are mutually exclusive by construction (a pad that sources its own trackpad is never phone-sourced, so its overlay is never openable), so the card never exceeds its filled-action budget.

## Tests

- `PathCardMapperTest` — 7 new cases covering every arm of the predicate (touch pad on Standard → on; no-trackpad, already-Direct, Bluetooth, transient states, recent failure, default → off).
- `MainViewModelTest` — 4 new cases asserting the flag reaches `pathCards` end-to-end from the native `modelHasTouchpad` wiring (routed touch pad → on; no-trackpad, already-Direct, Bluetooth → off).

## Local CI

All PR gates run locally and pass: `check-translations` (6 locales), `ktlintCheck`, `detekt`, `lint` (incl. `MissingTranslation`), `testDebugUnitTest`, `nativeTest` (174/174), `assembleDebug`. Instrumented/androidTest not run — no device/emulator available in this environment; the change is logic + render only and is fully covered by the JVM tests above.

## User-visible flows changed

- **Touch-capable USB pad on Standard, bound to a Satellite host:** touchpad pill now says "Needs Direct"; a "Switch to Direct" button appears and switches the path (prompting for USB permission on first use).
- **Every other configuration:** unchanged. No new UI for Xbox pads, Bluetooth, virtual slot, or pads already on Direct.