### PR TITLE
feat: Steam Controller over USB Direct (boot-interface ranking, device restore on release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ four repos share a version number.
   native USB and HID decoding, including a generic HID descriptor parser,
   DualShock 4 and DualSense motion, Switch Pro motion, and Xbox 360
   wireless rumble. Imported models are recognized but flagged unverified.
+- Steam Controller over USB Direct (wired and dongle): sticks, triggers,
+  buttons, motion, and the right trackpad as a right stick. While claimed
+  it no longer doubles as a mouse and keyboard for the phone, and it is
+  put back the way it was when released. Unverified on hardware, so it
+  stays opt-in and is never auto-claimed.
 - Tri-zone controller cards: a read-only report card (connection,
   destination, emulated type, functions) plus a dedicated Configure
   bindings screen. Binding changes are staged and applied explicitly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,15 @@ four repos share a version number.
 - Steam Controller over USB Direct (wired and dongle): sticks, triggers,
   buttons, motion, and the right trackpad as a right stick. While claimed
   it no longer doubles as a mouse and keyboard for the phone, and it is
-  put back the way it was when released. Unverified on hardware, so it
-  stays opt-in and is never auto-claimed.
+  put back the way it was when released. Switching it back to Standard
+  settles instantly instead of ending in a false "restore failed" banner,
+  a pad that drops off the dongle no longer leaves its last input held,
+  and one that reconnects is set up again automatically. Unverified on
+  hardware, so it stays opt-in and is never auto-claimed.
+- The streaming notification now also keeps Dish alive while a USB
+  controller is held in Direct mode, so a backgrounded app can always
+  hand the pad back properly, and its Stop action releases those
+  controllers too.
 - Tri-zone controller cards: a read-only report card (connection,
   destination, emulated type, functions) plus a dedicated Configure
   bindings screen. Binding changes are staged and applied explicitly

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -41,7 +41,14 @@ freely, subject to the following restrictions:
 3. This notice may not be removed or altered from any source distribution.
 ```
 
-Upstream: https://github.com/libsdl-org/SDL (`src/joystick/controller_list.h`)
+The Steam Controller state-packet layout, button bit assignments, trigger full-scale, pad
+rotation angle, feature-report framing, and setting/message identifiers in the same file follow
+SDL's `src/joystick/hidapi/SDL_hidapi_steam.c` and the Valve-authored headers beside it
+(`src/joystick/hidapi/steam/controller_structs.h` and `controller_constants.h`, Copyright (C)
+2020-2021 Valve Corporation). Protocol facts only; no SDL code is compiled in.
+
+Upstream: https://github.com/libsdl-org/SDL (`src/joystick/controller_list.h`,
+`src/joystick/hidapi/steam/`)
 
 ## Linux kernel input/HID drivers: USB-direct rumble and motion math
 
@@ -58,6 +65,8 @@ project's parsers:
   accel 8192 units per g), from `drivers/hid/hid-playstation.c`.
 - Switch Pro HD-rumble amplitude table, from `drivers/hid/hid-nintendo.c`
   (`joycon_encode_rumble`, `joycon_rumble_amplitudes`).
+- Steam Controller stand-alone-mode message sequence and its EPIPE retry, from
+  `drivers/hid/hid-steam.c` (`steam_set_lizard_mode`, `steam_send_report`).
 
 The Linux kernel is licensed GPL-2.0-only. Upstream:
 https://github.com/torvalds/linux

--- a/app/src/main/cpp/satellite_jni.cpp
+++ b/app/src/main/cpp/satellite_jni.cpp
@@ -1122,6 +1122,16 @@ JNIEXPORT jboolean JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_mo
     return usbparsers::parserHasImu(k->parser) ? JNI_TRUE : JNI_FALSE;
 }
 
+JNIEXPORT jboolean JNICALL
+Java_com_tinkernorth_dish_core_jni_SatelliteNative_modelExpectsFrameworkGamepad(JNIEnv*, jobject,
+                                                                                jint vid,
+                                                                                jint pid) {
+    return usbparsers::modelExpectsFrameworkGamepad((uint16_t)(vid & 0xFFFF),
+                                                    (uint16_t)(pid & 0xFFFF))
+               ? JNI_TRUE
+               : JNI_FALSE;
+}
+
 JNIEXPORT jboolean JNICALL Java_com_tinkernorth_dish_core_jni_SatelliteNative_modelHasRumble(
     JNIEnv*, jobject, jint vid, jint pid) {
     const usbparsers::KnownDevice* k =

--- a/app/src/main/cpp/usb_host.cpp
+++ b/app/src/main/cpp/usb_host.cpp
@@ -41,6 +41,7 @@ struct DeviceCtx {
     uint8_t epOut = 0;
     int interfaceNumber = 0;
     usbparsers::Parser parser = usbparsers::Parser::NONE;
+    usbparsers::InitKind init = usbparsers::InitKind::NONE;
     std::string modelName;
     std::string parserName;
     usbparsers::ParserState stickRange;
@@ -170,9 +171,23 @@ void pollLoop(std::shared_ptr<DeviceCtx> ctx) {
                 hotpath::markInputRead(); // stage-1 start: a fresh input report is in hand
                 ctx->urbCount.fetch_add(1, std::memory_order_relaxed);
                 memset(&scratch, 0, sizeof(scratch));
-                if (usbparsers::decodeReport(ctx->parser, completed->buf.data(),
-                                             (size_t)reaped->actual_length, scratch,
-                                             &ctx->stickRange)) {
+                usbparsers::WirelessEvent wev = usbparsers::checkWirelessEvent(
+                    ctx->parser, completed->buf.data(), (size_t)reaped->actual_length);
+                if (wev != usbparsers::WirelessEvent::NONE) {
+                    // Both directions publish neutral: a departed pad must not keep its last input
+                    // latched, and a returning pad rebooted, so any held stick memory is stale.
+                    ctx->stickRange.steamStickX = 0;
+                    ctx->stickRange.steamStickY = 0;
+                    dispatch::applyUsbReport(ctx->syntheticDeviceId, scratch);
+                    if (wev == usbparsers::WirelessEvent::CONNECT) {
+                        // The reboot wiped the quiet-mode settings, so re-run the attach init or
+                        // the pad streams without motion while its lizard keyboard leaks through.
+                        usbparsers::runInit(ctx->fd, ctx->interfaceNumber, ctx->epOut, ctx->parser,
+                                            ctx->init);
+                    }
+                } else if (usbparsers::decodeReport(ctx->parser, completed->buf.data(),
+                                                    (size_t)reaped->actual_length, scratch,
+                                                    &ctx->stickRange)) {
                     dispatch::applyUsbReport(ctx->syntheticDeviceId, scratch);
 
                     int64_t nowNs = 0;
@@ -394,6 +409,7 @@ AttachResult attachDevice(int fd, uint16_t vid, uint16_t pid, int interfaceNumbe
     ctx->epOut = epOut;
     ctx->interfaceNumber = interfaceNumber;
     ctx->parser = parser;
+    ctx->init = init;
     ctx->modelName = modelName;
     ctx->parserName = usbparsers::parserName(parser);
     if (parser == usbparsers::Parser::GENERIC_HID_GAMEPAD) {

--- a/app/src/main/cpp/usb_host.cpp
+++ b/app/src/main/cpp/usb_host.cpp
@@ -263,6 +263,7 @@ void shutdownLocked(const std::shared_ptr<DeviceCtx>& ctx) {
     }
     // outMtx so an in-flight sendRumble finishes before the fd it is writing to is closed.
     std::lock_guard<std::mutex> lock(ctx->outMtx);
+    usbparsers::runTeardown(ctx->fd, ctx->interfaceNumber, ctx->parser);
     releaseAndReattach(ctx->fd, ctx->interfaceNumber);
     if (ctx->fd >= 0) {
         ::close(ctx->fd);
@@ -363,9 +364,12 @@ AttachResult attachDevice(int fd, uint16_t vid, uint16_t pid, int interfaceNumbe
         }
     }
 
-    if (!usbparsers::runInit(fd, epOut, parser, init)) {
+    // Both bail-outs below run teardown first: a partly-applied init still changed the device, and
+    // handing it back that way leaves it useless to its owner outside this app.
+    if (!usbparsers::runInit(fd, interfaceNumber, epOut, parser, init)) {
         LOGI("attach %04X:%04X (%s): init failed, falling back to routed", vid, pid,
              modelName.c_str());
+        usbparsers::runTeardown(fd, interfaceNumber, parser);
         releaseAndReattach(fd, interfaceNumber);
         ::close(fd);
         return out;
@@ -374,6 +378,7 @@ AttachResult attachDevice(int fd, uint16_t vid, uint16_t pid, int interfaceNumbe
     if (!probeDecodable(fd, epIn, epInMaxPacket, parser)) {
         LOGI("attach %04X:%04X (%s): no parseable reports, releasing to framework", vid, pid,
              modelName.c_str());
+        usbparsers::runTeardown(fd, interfaceNumber, parser);
         releaseAndReattach(fd, interfaceNumber);
         ::close(fd);
         return out;

--- a/app/src/main/cpp/usb_parsers.cpp
+++ b/app/src/main/cpp/usb_parsers.cpp
@@ -501,11 +501,13 @@ bool bulkWrite(int fd, uint8_t epOut, const uint8_t* data, size_t len, unsigned 
 }
 
 constexpr size_t kFeatureReportBytes = 64;
-constexpr int kFeatureReportAttempts = 10;
+constexpr int kFeatureReportAttempts = 25;
 constexpr unsigned kFeatureReportRetryUs = 20000;
 
 // SET_REPORT(Feature, report id 0), always a full 64-byte buffer. EPIPE here is the wireless
 // dongle under load, not a real failure; SDL and hid-steam both retry it rather than give up.
+// hid-steam allows 50 tries; the cap is lower here so that even a wholly unresponsive device
+// finishes init and teardown well inside the Kotlin side's 4s path-transition timeout.
 bool sendFeatureReport(int fd, int interfaceNumber, const uint8_t* data, size_t len) {
     if (interfaceNumber < 0 || len > kFeatureReportBytes) return false;
     uint8_t buf[kFeatureReportBytes] = {};
@@ -1258,6 +1260,10 @@ size_t buildSteamConfigPacket(SteamConfig stage, int index, uint8_t* out, size_t
                                              0x07, 0x00, 0x30, 0x18, 0x00};
     static const uint8_t kDefaultMappings[] = {0x85, 0x00};
     static const uint8_t kDefaultSettings[] = {0x8E, 0x00};
+    // Loading the defaults does not by itself hand the right pad back as a mouse: SDL follows it
+    // with an explicit right trackpad mode = absolute mouse, and leaving that out is the one way
+    // this teardown could still return a pad its owner cannot use.
+    static const uint8_t kRestoreMouse[] = {0x87, 0x03, 0x08, 0x00, 0x00};
 
     struct Pkt {
         const uint8_t* data;
@@ -1266,10 +1272,14 @@ size_t buildSteamConfigPacket(SteamConfig stage, int index, uint8_t* out, size_t
     static const Pkt kQuietSeq[] = {{kClearMappings, sizeof(kClearMappings)},
                                     {kQuietSettings, sizeof(kQuietSettings)}};
     static const Pkt kRestoreSeq[] = {{kDefaultMappings, sizeof(kDefaultMappings)},
-                                      {kDefaultSettings, sizeof(kDefaultSettings)}};
+                                      {kDefaultSettings, sizeof(kDefaultSettings)},
+                                      {kRestoreMouse, sizeof(kRestoreMouse)}};
 
-    if (index < 0 || index >= 2) return 0;
-    const Pkt* seqArr = stage == SteamConfig::QUIET ? kQuietSeq : kRestoreSeq;
+    const bool quiet = stage == SteamConfig::QUIET;
+    const Pkt* seqArr = quiet ? kQuietSeq : kRestoreSeq;
+    const int seqLen = quiet ? (int)(sizeof(kQuietSeq) / sizeof(kQuietSeq[0]))
+                             : (int)(sizeof(kRestoreSeq) / sizeof(kRestoreSeq[0]));
+    if (index < 0 || index >= seqLen) return 0;
     size_t len = seqArr[index].len;
     if (len > outCap) return 0;
     memcpy(out, seqArr[index].data, len);

--- a/app/src/main/cpp/usb_parsers.cpp
+++ b/app/src/main/cpp/usb_parsers.cpp
@@ -174,8 +174,9 @@ static const KnownDevice kKnown[] = {
     {0x18D1, 0x9400, "Google Stadia Controller", Parser::STADIA, InitKind::NONE},
 };
 
-// Device IDs below are a curated subset of SDL's src/joystick/controller_list.h (zlib license,
-// Copyright (C) Valve Corporation; see THIRD_PARTY.md). They are NOT hardware-verified here:
+// Device IDs below are a curated subset of SDL's src/joystick/controller_list.h and its hidapi
+// drivers (zlib license, Copyright (C) Valve Corporation; see THIRD_PARTY.md). They are NOT
+// hardware-verified here:
 // lookupKnown recognises them (name + the family parser) and the user can opt into Direct, where
 // probeDecodable still guards the byte layout, but isVerifiedFastLane returns false for them so
 // auto-claim never silently moves an untested model onto Direct. Bluetooth-only PIDs, USB-differs
@@ -376,6 +377,10 @@ static const KnownDevice kImported[] = {
     {0x1532, 0x1012, "Razer Kitsune", Parser::DUALSENSE, InitKind::NONE},
     {0x3285, 0x0D18, "Nacon Revolution 5 Pro (PS5 dongle)", Parser::DUALSENSE, InitKind::NONE},
     {0x3285, 0x0D19, "Nacon Revolution 5 Pro (PS5 wired)", Parser::DUALSENSE, InitKind::NONE},
+
+    {0x28DE, 0x1102, "Valve Steam Controller", Parser::STEAM_CONTROLLER, InitKind::STEAM_QUIET},
+    {0x28DE, 0x1142, "Valve Steam Controller (dongle)", Parser::STEAM_CONTROLLER,
+     InitKind::STEAM_QUIET},
 };
 
 template <size_t N>
@@ -435,6 +440,8 @@ const char* parserName(Parser p) {
         return "Stadia protocol";
     case Parser::GENERIC_HID_GAMEPAD:
         return "Generic HID gamepad";
+    case Parser::STEAM_CONTROLLER:
+        return "Steam Controller protocol";
     case Parser::NONE:
         return "Unknown";
     }
@@ -442,7 +449,8 @@ const char* parserName(Parser p) {
 }
 
 bool parserHasImu(Parser p) {
-    return p == Parser::SWITCH_PRO_USB || p == Parser::DUALSHOCK4 || p == Parser::DUALSENSE;
+    return p == Parser::SWITCH_PRO_USB || p == Parser::DUALSHOCK4 || p == Parser::DUALSENSE ||
+           p == Parser::STEAM_CONTROLLER;
 }
 
 bool parserHasRumble(Parser p) {
@@ -454,6 +462,9 @@ bool parserHasRumble(Parser p) {
     case Parser::DUALSENSE:
     case Parser::SWITCH_PRO_USB:
         return true;
+    // The Steam Controller has no rumble motors, only trackpad voice coils driven by pulse trains;
+    // its simple-rumble command is Steam Deck firmware only.
+    case Parser::STEAM_CONTROLLER:
     case Parser::STADIA:
     case Parser::GENERIC_HID_GAMEPAD:
     case Parser::NONE:
@@ -487,6 +498,33 @@ bool bulkWrite(int fd, uint8_t epOut, const uint8_t* data, size_t len, unsigned 
         return false;
     }
     return (size_t)n == len;
+}
+
+constexpr size_t kFeatureReportBytes = 64;
+constexpr int kFeatureReportAttempts = 10;
+constexpr unsigned kFeatureReportRetryUs = 20000;
+
+// SET_REPORT(Feature, report id 0), always a full 64-byte buffer. EPIPE here is the wireless
+// dongle under load, not a real failure; SDL and hid-steam both retry it rather than give up.
+bool sendFeatureReport(int fd, int interfaceNumber, const uint8_t* data, size_t len) {
+    if (interfaceNumber < 0 || len > kFeatureReportBytes) return false;
+    uint8_t buf[kFeatureReportBytes] = {};
+    memcpy(buf, data, len);
+    for (int attempt = 0; attempt < kFeatureReportAttempts; attempt++) {
+        struct usbdevfs_ctrltransfer ct = {};
+        ct.bRequestType = 0x21;            // OUT | Class | Interface
+        ct.bRequest = 0x09;                // SET_REPORT
+        ct.wValue = (uint16_t)(0x03 << 8); // Feature report, id 0
+        ct.wIndex = (uint16_t)interfaceNumber;
+        ct.wLength = (uint16_t)sizeof(buf);
+        ct.timeout = 250;
+        ct.data = buf;
+        if (ioctl(fd, USBDEVFS_CONTROL, &ct) >= 0) return true;
+        if (errno != EPIPE) break;
+        usleep(kFeatureReportRetryUs);
+    }
+    LOGE("SET_REPORT 0x%02X to iface %d failed: %s", data[0], interfaceNumber, strerror(errno));
+    return false;
 }
 #endif
 
@@ -933,6 +971,130 @@ bool decodeStadia(const uint8_t* buf, size_t len, DeviceState& s) {
     return true;
 }
 
+// Steam Controller state packet, layout from SDL's src/joystick/hidapi/steam headers (zlib,
+// Copyright (C) Valve Corporation; see THIRD_PARTY.md). Buttons occupy the low 24 bits of a 64-bit
+// field whose bytes 3 and 4 are the analog triggers.
+constexpr uint32_t kSteamRightBumper = 0x000004;
+constexpr uint32_t kSteamLeftBumper = 0x000008;
+constexpr uint32_t kSteamNorth = 0x000010;
+constexpr uint32_t kSteamEast = 0x000020;
+constexpr uint32_t kSteamWest = 0x000040;
+constexpr uint32_t kSteamSouth = 0x000080;
+constexpr uint32_t kSteamDpadUp = 0x000100;
+constexpr uint32_t kSteamDpadRight = 0x000200;
+constexpr uint32_t kSteamDpadLeft = 0x000400;
+constexpr uint32_t kSteamDpadDown = 0x000800;
+constexpr uint32_t kSteamMenu = 0x001000;
+constexpr uint32_t kSteamGuide = 0x002000;
+constexpr uint32_t kSteamEscape = 0x004000;
+constexpr uint32_t kSteamLeftPadClicked = 0x020000;
+constexpr uint32_t kSteamRightPadClicked = 0x040000;
+constexpr uint32_t kSteamLeftPadFinger = 0x080000;
+constexpr uint32_t kSteamRightPadFinger = 0x100000;
+constexpr uint32_t kSteamStickButton = 0x400000;
+constexpr uint32_t kSteamLeftPadAndStick = 0x800000;
+
+constexpr size_t kSteamStateLen = 48;
+constexpr uint8_t kSteamStateType = 0x01;
+constexpr int32_t kSteamTriggerMaxAnalog = 26000;
+// 15 degrees in Q16; the pads sit rotated on the shell and SDL applies the same correction.
+constexpr int32_t kSteamPadCos = 63303;
+constexpr int32_t kSteamPadSin = 16962;
+
+int16_t steamClampI16(int64_t v) {
+    if (v > 32767) return 32767;
+    if (v < -32768) return -32768;
+    return (int16_t)v;
+}
+
+uint8_t steamTriggerToWire(uint8_t raw) {
+    int32_t v = ((int32_t)raw << 7) | raw;
+    if (v > kSteamTriggerMaxAnalog) v = kSteamTriggerMaxAnalog;
+    return (uint8_t)((v * 255) / kSteamTriggerMaxAnalog);
+}
+
+// SDL adds a further +1000 to each axis while a finger is down. That is harmless for a touch
+// surface but would park a stick off centre, so it is deliberately not carried over.
+void steamRotatePad(int32_t x, int32_t y, int16_t& outX, int16_t& outY) {
+    outX = steamClampI16(((int64_t)kSteamPadCos * x - (int64_t)kSteamPadSin * y) / 65536);
+    outY = steamClampI16(((int64_t)kSteamPadSin * x + (int64_t)kSteamPadCos * y) / 65536);
+}
+
+// Steam reports gyro over +-2000 deg/s and accel over +-2g; the wire wants deg/s / 2000 and g / 4.
+int16_t steamGyroToWire(int32_t raw) { return steamClampI16((int64_t)raw * 32767 / 32768); }
+
+int16_t steamAccelToWire(int32_t raw) { return steamClampI16((int64_t)raw * 32767 / 65536); }
+
+bool decodeSteamController(const uint8_t* buf, size_t len, DeviceState& s, ParserState& st) {
+    if (len < kSteamStateLen) return false;
+    if (buf[0] != 0x01 || buf[1] != 0x00) return false;
+    if (buf[2] != kSteamStateType) return false;
+
+    const uint32_t btn = (uint32_t)buf[8] | ((uint32_t)buf[9] << 8) | ((uint32_t)buf[10] << 16);
+
+    uint16_t b = 0;
+    if (btn & kSteamSouth) b |= XUSB_A;
+    if (btn & kSteamEast) b |= XUSB_B;
+    if (btn & kSteamWest) b |= XUSB_X;
+    if (btn & kSteamNorth) b |= XUSB_Y;
+    if (btn & kSteamLeftBumper) b |= XUSB_LB;
+    if (btn & kSteamRightBumper) b |= XUSB_RB;
+    if (btn & kSteamMenu) b |= XUSB_BACK;
+    if (btn & kSteamEscape) b |= XUSB_START;
+    if (btn & kSteamGuide) b |= XUSB_GUIDE;
+    if (btn & kSteamDpadUp) b |= XUSB_DPAD_UP;
+    if (btn & kSteamDpadDown) b |= XUSB_DPAD_DOWN;
+    if (btn & kSteamDpadLeft) b |= XUSB_DPAD_LEFT;
+    if (btn & kSteamDpadRight) b |= XUSB_DPAD_RIGHT;
+    if (btn & kSteamRightPadClicked) b |= XUSB_THUMB_R;
+
+    s.bLT = steamTriggerToWire(buf[11]);
+    s.bRT = steamTriggerToWire(buf[12]);
+
+    // One pair of axes carries either the stick or the left pad. The finger-down bit says which;
+    // the interleave bit means pad frames alternate with stick frames worth holding on to.
+    const bool padOnLeft = (btn & kSteamLeftPadFinger) != 0;
+    const bool interleaved = (btn & kSteamLeftPadAndStick) != 0;
+    if (!padOnLeft) {
+        st.steamStickX = rdLe16(buf, 16);
+        st.steamStickY = rdLe16(buf, 18);
+        // With no live pad the firmware reports a stick click as a left-pad click.
+        if (!interleaved && (btn & kSteamLeftPadClicked)) b |= XUSB_THUMB_L;
+    } else if (!interleaved) {
+        st.steamStickX = 0;
+        st.steamStickY = 0;
+    }
+    if (btn & kSteamStickButton) b |= XUSB_THUMB_L;
+    s.wButtons = b;
+    s.sLX = st.steamStickX;
+    s.sLY = st.steamStickY;
+
+    if (btn & kSteamRightPadFinger) {
+        steamRotatePad(rdLe16(buf, 20), rdLe16(buf, 22), s.sRX, s.sRY);
+    } else {
+        s.sRX = 0;
+        s.sRY = 0;
+    }
+
+    const int16_t ax = rdLe16(buf, 28);
+    const int16_t ay = rdLe16(buf, 30);
+    const int16_t az = rdLe16(buf, 32);
+    const int16_t gx = rdLe16(buf, 34);
+    const int16_t gy = rdLe16(buf, 36);
+    const int16_t gz = rdLe16(buf, 38);
+    // An all-zero block means the IMU setting never took; publishing it would stream a dead sensor.
+    if ((ax | ay | az | gx | gy | gz) != 0) {
+        s.gyroX = steamGyroToWire(gx);
+        s.gyroY = steamGyroToWire(gz);
+        s.gyroZ = steamGyroToWire(gy);
+        s.accelX = steamAccelToWire(ax);
+        s.accelY = steamAccelToWire(az);
+        s.accelZ = steamAccelToWire(-(int32_t)ay);
+        s.motionValid = true;
+    }
+    return true;
+}
+
 // Switch Pro HD-rumble amplitude codes from the Linux hid-nintendo table; frequency held at the
 // neutral default so a coarse strong/weak motor still encodes a faithful buzz. See docs/rumble.md.
 struct SwitchAmpCode {
@@ -1007,6 +1169,8 @@ bool decodeReport(Parser p, const uint8_t* buf, size_t len, DeviceState& s, Pars
         return sticks != nullptr && decodeSwitchProUsb(buf, len, s, *sticks);
     case Parser::STADIA:
         return decodeStadia(buf, len, s);
+    case Parser::STEAM_CONTROLLER:
+        return sticks != nullptr && decodeSteamController(buf, len, s, *sticks);
     case Parser::GENERIC_HID_GAMEPAD:
         return sticks != nullptr && sticks->hidLayout.valid
                    ? usbhid::decodeFromLayout(buf, len, s, sticks->hidLayout)
@@ -1085,6 +1249,33 @@ size_t buildGipInitPacket(InitKind init, int index, uint8_t seq, uint8_t* out, s
     return len;
 }
 
+size_t buildSteamConfigPacket(SteamConfig stage, int index, uint8_t* out, size_t outCap) {
+    // Framing is {message id, payload length, payload}. Message ids and the choice of the shortest
+    // working sequence follow the Linux hid-steam driver.
+    static const uint8_t kClearMappings[] = {0x81, 0x00};
+    // Left and right trackpad mode = none (kills mouse emulation), IMU mode = raw accel | raw gyro.
+    static const uint8_t kQuietSettings[] = {0x87, 0x09, 0x07, 0x07, 0x00, 0x08,
+                                             0x07, 0x00, 0x30, 0x18, 0x00};
+    static const uint8_t kDefaultMappings[] = {0x85, 0x00};
+    static const uint8_t kDefaultSettings[] = {0x8E, 0x00};
+
+    struct Pkt {
+        const uint8_t* data;
+        size_t len;
+    };
+    static const Pkt kQuietSeq[] = {{kClearMappings, sizeof(kClearMappings)},
+                                    {kQuietSettings, sizeof(kQuietSettings)}};
+    static const Pkt kRestoreSeq[] = {{kDefaultMappings, sizeof(kDefaultMappings)},
+                                      {kDefaultSettings, sizeof(kDefaultSettings)}};
+
+    if (index < 0 || index >= 2) return 0;
+    const Pkt* seqArr = stage == SteamConfig::QUIET ? kQuietSeq : kRestoreSeq;
+    size_t len = seqArr[index].len;
+    if (len > outCap) return 0;
+    memcpy(out, seqArr[index].data, len);
+    return len;
+}
+
 // Per-device rumble output reports. Motor convention: strong = large/low-frequency (left), weak =
 // small/high-frequency (right), both wire-scale 0..65535. Report layouts and sources (Linux xpad,
 // hid-playstation, hid-nintendo) are documented in docs/rumble.md.
@@ -1158,6 +1349,7 @@ size_t buildRumbleReport(Parser p, uint16_t strong, uint16_t weak, uint8_t seq, 
         switchEncodeMotor(&out[2], strong);
         switchEncodeMotor(&out[6], weak);
         return 10;
+    case Parser::STEAM_CONTROLLER:
     case Parser::STADIA:
     case Parser::GENERIC_HID_GAMEPAD:
     case Parser::NONE:
@@ -1167,10 +1359,25 @@ size_t buildRumbleReport(Parser p, uint16_t strong, uint16_t weak, uint8_t seq, 
 }
 
 #ifdef __ANDROID__
-bool runInit(int fd, uint8_t epOut, Parser p, InitKind init) {
+bool runInit(int fd, int interfaceNumber, uint8_t epOut, Parser p, InitKind init) {
     switch (init) {
     case InitKind::NONE:
         return true;
+    case InitKind::STEAM_QUIET: {
+        (void)p;
+        (void)epOut;
+        uint8_t buf[16];
+        for (int i = 0;; i++) {
+            size_t n = buildSteamConfigPacket(SteamConfig::QUIET, i, buf, sizeof(buf));
+            if (n == 0) break;
+            if (!sendFeatureReport(fd, interfaceNumber, buf, n)) {
+                LOGE("Steam Controller: quiet-mode packet %d failed", i);
+                return false;
+            }
+        }
+        LOGI("Steam Controller quiet-mode sequence sent");
+        return true;
+    }
     case InitKind::XBOX_ONE_POWERON:
     case InitKind::XBOX_ONE_S: {
         // GIP init: power-on tells the pad to start sending input reports; the rest of the sequence
@@ -1237,6 +1444,17 @@ bool runInit(int fd, uint8_t epOut, Parser p, InitKind init) {
     }
     }
     return false;
+}
+
+void runTeardown(int fd, int interfaceNumber, Parser p) {
+    if (p != Parser::STEAM_CONTROLLER) return;
+    uint8_t buf[16];
+    for (int i = 0;; i++) {
+        size_t n = buildSteamConfigPacket(SteamConfig::RESTORE, i, buf, sizeof(buf));
+        if (n == 0) break;
+        sendFeatureReport(fd, interfaceNumber, buf, n);
+    }
+    LOGI("Steam Controller restored to stand-alone mode");
 }
 
 bool runRumble(int fd, uint8_t epOut, Parser p, uint16_t strong, uint16_t weak, uint8_t seq) {

--- a/app/src/main/cpp/usb_parsers.cpp
+++ b/app/src/main/cpp/usb_parsers.cpp
@@ -401,6 +401,11 @@ bool isVerifiedFastLane(uint16_t vid, uint16_t pid) {
     return k != nullptr && k->parser != Parser::NONE;
 }
 
+bool modelExpectsFrameworkGamepad(uint16_t vid, uint16_t pid) {
+    const KnownDevice* k = lookupKnown(vid, pid);
+    return k == nullptr || k->parser != Parser::STEAM_CONTROLLER;
+}
+
 constexpr uint8_t kIfClassVendor = 0xFF;
 constexpr uint8_t kXInputSubclass = 0x5D;
 constexpr uint8_t kXInputProtocol = 0x01;
@@ -998,6 +1003,9 @@ constexpr uint32_t kSteamLeftPadAndStick = 0x800000;
 
 constexpr size_t kSteamStateLen = 48;
 constexpr uint8_t kSteamStateType = 0x01;
+constexpr uint8_t kSteamWirelessType = 0x03;
+constexpr uint8_t kSteamWirelessDisconnect = 0x01;
+constexpr uint8_t kSteamWirelessConnect = 0x02;
 constexpr int32_t kSteamTriggerMaxAnalog = 26000;
 // 15 degrees in Q16; the pads sit rotated on the shell and SDL applies the same correction.
 constexpr int32_t kSteamPadCos = 63303;
@@ -1181,6 +1189,23 @@ bool decodeReport(Parser p, const uint8_t* buf, size_t len, DeviceState& s, Pars
         return false;
     }
     return false;
+}
+
+// Event framing and the one-byte payload values follow the Linux hid-steam driver
+// (steam_raw_event, ID_CONTROLLER_WIRELESS).
+WirelessEvent checkWirelessEvent(Parser p, const uint8_t* buf, size_t len) {
+    if (p != Parser::STEAM_CONTROLLER) return WirelessEvent::NONE;
+    if (len < 5) return WirelessEvent::NONE;
+    if (buf[0] != 0x01 || buf[1] != 0x00) return WirelessEvent::NONE;
+    if (buf[2] != kSteamWirelessType || buf[3] != 0x01) return WirelessEvent::NONE;
+    switch (buf[4]) {
+    case kSteamWirelessDisconnect:
+        return WirelessEvent::DISCONNECT;
+    case kSteamWirelessConnect:
+        return WirelessEvent::CONNECT;
+    default:
+        return WirelessEvent::NONE;
+    }
 }
 
 bool decodeGenericHidGamepad(const uint8_t* buf, size_t len, DeviceState& s) {

--- a/app/src/main/cpp/usb_parsers.h
+++ b/app/src/main/cpp/usb_parsers.h
@@ -22,6 +22,7 @@ enum class Parser : uint8_t {
     GENERIC_HID_GAMEPAD = 7,
     // Same input report as XINPUT_360, but rumble needs the wrapped wireless-receiver frame.
     XINPUT_360_WIRELESS = 8,
+    STEAM_CONTROLLER = 9,
 };
 
 enum class InitKind : uint8_t {
@@ -30,6 +31,16 @@ enum class InitKind : uint8_t {
     SWITCH_PRO_HANDSHAKE = 2,
     // Xbox One S / Elite Series 2 want the GIP set-mode packet on top of the universal sequence.
     XBOX_ONE_S = 3,
+    // Steam Controller: stop the firmware's stand-alone keyboard/mouse emulation and enable the
+    // IMU.
+    STEAM_QUIET = 4,
+};
+
+// Which direction a Steam Controller config sequence runs. QUIET is sent at attach; RESTORE must
+// run on every exit path or the pad stays mute as a desktop mouse after we hand it back.
+enum class SteamConfig : uint8_t {
+    QUIET = 0,
+    RESTORE = 1,
 };
 
 struct KnownDevice {
@@ -82,6 +93,9 @@ struct ParserState {
     // Filled at attach for DUALSHOCK4 / DUALSENSE when the calibration report reads; invalid
     // otherwise.
     PsImuCalib psImu;
+    // Steam Controller stick, held across the frames where the shared left axes carry pad data.
+    int16_t steamStickX = 0;
+    int16_t steamStickY = 0;
 };
 
 const KnownDevice* lookupKnown(uint16_t vid, uint16_t pid);
@@ -108,7 +122,15 @@ bool parserFrameworkRumbleUnreliable(Parser p);
 // number at byte 2), returns its length or 0 when there are no more. runInit sends them in order.
 size_t buildGipInitPacket(InitKind init, int index, uint8_t seq, uint8_t* out, size_t outCap);
 
-bool runInit(int fd, uint8_t epOut, Parser p, InitKind init);
+// Pure: writes the index-th Steam Controller feature report for a config direction into out,
+// returns its length or 0 when there are no more. Payload only; the caller frames it as a
+// SET_REPORT.
+size_t buildSteamConfigPacket(SteamConfig stage, int index, uint8_t* out, size_t outCap);
+
+bool runInit(int fd, int interfaceNumber, uint8_t epOut, Parser p, InitKind init);
+
+// Undoes runInit's device-side changes. No-op for families that never changed the device.
+void runTeardown(int fd, int interfaceNumber, Parser p);
 
 bool runRumble(int fd, uint8_t epOut, Parser p, uint16_t strong, uint16_t weak, uint8_t seq);
 

--- a/app/src/main/cpp/usb_parsers.h
+++ b/app/src/main/cpp/usb_parsers.h
@@ -43,6 +43,15 @@ enum class SteamConfig : uint8_t {
     RESTORE = 1,
 };
 
+// Wireless dongle connect/disconnect events that arrive on the same endpoint as input reports.
+// They never decode as state, so without them a departed pad would keep its last published input
+// latched and a returning pad (fresh boot, settings gone) would stream without its quiet-mode init.
+enum class WirelessEvent : uint8_t {
+    NONE = 0,
+    CONNECT = 1,
+    DISCONNECT = 2,
+};
+
 struct KnownDevice {
     uint16_t vid;
     uint16_t pid;
@@ -105,6 +114,11 @@ Classification classifyDevice(uint16_t vid, uint16_t pid, uint8_t ifClass, uint8
 
 bool isVerifiedFastLane(uint16_t vid, uint16_t pid);
 
+// Whether releasing this model back to Standard produces a framework gamepad InputDevice. False
+// for the Steam Controller, whose stand-alone identity is a keyboard and mouse: a release that
+// waited for a framework gamepad would always time out into a false "restore stuck".
+bool modelExpectsFrameworkGamepad(uint16_t vid, uint16_t pid);
+
 const char* parserName(Parser p);
 
 bool parserHasImu(Parser p);
@@ -141,6 +155,10 @@ size_t buildRumbleReport(Parser p, uint16_t strong, uint16_t weak, uint8_t seq, 
 
 bool decodeReport(Parser p, const uint8_t* buf, size_t len, gamepad::DeviceState& s,
                   ParserState* sticks);
+
+// Pure: classifies a report as a wireless connect/disconnect event for families that interleave
+// them with input (the Steam Controller dongle). NONE for every other parser and packet.
+WirelessEvent checkWirelessEvent(Parser p, const uint8_t* buf, size_t len);
 
 bool decodeGenericHidGamepad(const uint8_t* buf, size_t len, gamepad::DeviceState& s);
 

--- a/app/src/main/java/com/tinkernorth/dish/composer/StreamingService.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/StreamingService.kt
@@ -18,6 +18,8 @@ import com.tinkernorth.dish.DishApplication
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.source.bluetooth.BluetoothGamepadRegistry
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
+import com.tinkernorth.dish.source.usb.UsbGamepadManager
+import com.tinkernorth.dish.source.usb.directClaimCount
 import com.tinkernorth.dish.ui.main.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -37,6 +39,8 @@ class StreamingService : Service() {
 
     @Inject lateinit var btRegistry: BluetoothGamepadRegistry
 
+    @Inject lateinit var usbGamepadManager: UsbGamepadManager
+
     private var observerJob: Job? = null
 
     override fun onCreate() {
@@ -45,9 +49,14 @@ class StreamingService : Service() {
         // Refused foreground start: the service is already stopping, so don't wire observers that would
         // notify for a service that never entered the foreground.
         if (!startForegroundInitial()) return
+        // Held Direct claims keep the service up on their own: WakeState zeroes the slot count when
+        // the app leaves the foreground, but a claimed pad still needs this process alive for its
+        // eventual device-side restore. Collected in the process scope so a background unplug or
+        // release still reaches the stopSelf below.
         observerJob =
-            combine(wakeState.streamingSlotCount, hub.connections) { count, conns -> count to conns }
-                .onEach { (count, conns) -> refresh(count, conns) }
+            combine(wakeState.streamingSlotCount, hub.connections, usbGamepadManager.controllers) { count, conns, controllers ->
+                Triple(count, conns, controllers.directClaimCount())
+            }.onEach { (count, conns, claims) -> refresh(count, conns, claims) }
                 .launchIn(wakeStateScope())
     }
 
@@ -66,7 +75,15 @@ class StreamingService : Service() {
     ): Int {
         if (intent?.action == ACTION_STOP_ALL) {
             stopAllSessions()
+            // Stop means all of it: release held Direct claims too, so each pad gets its
+            // device-side restore instead of staying captured by a process about to idle out.
+            usbGamepadManager.releaseAllDirect()
             stopSelf()
+        } else if (observerJob != null) {
+            // A repeat startForegroundService (the controller re-asserting after a foreground
+            // return) obliges another startForeground call; against a live service it just
+            // refreshes the notification.
+            startForegroundInitial()
         }
         // START_NOT_STICKY: tightly coupled to process state; an OS-respawned bare service helps nobody.
         return START_NOT_STICKY
@@ -89,8 +106,9 @@ class StreamingService : Service() {
     private fun refresh(
         count: Int,
         conns: List<ConnectionSummary>,
+        directClaims: Int,
     ) {
-        if (count <= 0) {
+        if (count <= 0 && directClaims <= 0) {
             // Belt-and-braces against out-of-order emissions so notification never reads "0 streaming".
             stopSelf()
             return
@@ -104,6 +122,8 @@ class StreamingService : Service() {
         nm.notify(NOTIFICATION_ID, notification)
     }
 
+    // With no active stream the service is alive only for held Direct claims, so a zero count
+    // reads as the claim-hold body rather than "0 streaming".
     private fun build(
         count: Int,
         primaryLabel: String?,
@@ -125,7 +145,12 @@ class StreamingService : Service() {
                 PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
             )
         val hostLabel = primaryLabel ?: getString(R.string.satellite_fallback_name)
-        val body = resources.getQuantityString(R.plurals.streaming_notification_body, count, count, hostLabel)
+        val body =
+            if (count > 0) {
+                resources.getQuantityString(R.plurals.streaming_notification_body, count, count, hostLabel)
+            } else {
+                getString(R.string.streaming_notification_body_usb_hold)
+            }
         return NotificationCompat
             .Builder(this, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_dish_connected)

--- a/app/src/main/java/com/tinkernorth/dish/composer/StreamingServiceController.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/StreamingServiceController.kt
@@ -8,9 +8,12 @@ import android.os.Build
 import android.util.Log
 import androidx.lifecycle.LifecycleOwner
 import com.tinkernorth.dish.architecture.abstracts.AbstractController
+import com.tinkernorth.dish.source.usb.UsbGamepadManager
+import com.tinkernorth.dish.source.usb.directClaimCount
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -20,11 +23,17 @@ class StreamingServiceController
     constructor(
         @ApplicationContext private val context: Context,
         private val wakeState: WakeStateController,
+        private val usbGamepadManager: UsbGamepadManager,
         scope: CoroutineScope,
     ) : AbstractController<Int>(scope) {
         private var running = false
 
-        override fun upstream(): Flow<Int> = wakeState.streamingSlotCount
+        // Held Direct claims count alongside streaming slots: a claimed pad has been reconfigured at
+        // the device level, and only a live process can run the restore that hands it back.
+        override fun upstream(): Flow<Int> =
+            combine(wakeState.streamingSlotCount, usbGamepadManager.controllers) { slots, controllers ->
+                slots + controllers.directClaimCount()
+            }
 
         override fun apply(value: Int) {
             val shouldRun = value > 0
@@ -35,9 +44,19 @@ class StreamingServiceController
             }
         }
 
+        // The service may have stopped itself while collection was down (claims released in the
+        // background), so re-derive `running` from the fresh post-start emission; a redundant start
+        // against a live service is harmless.
+        override fun onStarting() {
+            running = false
+        }
+
         override fun onStop(owner: LifecycleOwner) {
             cancelCollection()
-            if (running) stopService()
+            // WakeState zeroes the slot count on process stop, but a held claim keeps the service
+            // (and with it the process) alive; the service watches the claims itself and exits when
+            // the last one goes.
+            if (running && usbGamepadManager.controllers.value.directClaimCount() == 0) stopService()
         }
 
         private fun startService() {

--- a/app/src/main/java/com/tinkernorth/dish/core/jni/PhysicalInputNative.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/jni/PhysicalInputNative.kt
@@ -34,6 +34,11 @@ class PhysicalInputNative
             productId: Int,
         ): Boolean = SatelliteNative.modelHasTouchpad(vendorId, productId)
 
+        fun modelExpectsFrameworkGamepad(
+            vendorId: Int,
+            productId: Int,
+        ): Boolean = SatelliteNative.modelExpectsFrameworkGamepad(vendorId, productId)
+
         fun lookupKnownModelName(
             vendorId: Int,
             productId: Int,

--- a/app/src/main/java/com/tinkernorth/dish/core/jni/SatelliteNative.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/jni/SatelliteNative.kt
@@ -199,6 +199,13 @@ object SatelliteNative {
         productId: Int,
     ): Boolean
 
+    // False for models whose Standard identity is a keyboard/mouse (the Steam Controller): no
+    // framework gamepad re-enumerates after a release, so nothing should wait for one.
+    external fun modelExpectsFrameworkGamepad(
+        vendorId: Int,
+        productId: Int,
+    ): Boolean
+
     external fun lookupKnownModelName(
         vendorId: Int,
         productId: Int,

--- a/app/src/main/java/com/tinkernorth/dish/source/usb/UsbGamepadManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/usb/UsbGamepadManager.kt
@@ -131,6 +131,14 @@ class UsbGamepadManager
             applyEvent(vpk(vendorId, productId), UsbEvent.Choose(choice, userInitiated = true))
         }
 
+        // The streaming notification's Stop action: release every held claim so each pad gets its
+        // device-side restore and is handed back before the service exits. Main thread only.
+        fun releaseAllDirect() {
+            for ((key, c) in _controllers.value) {
+                if (c.phase == UsbPhase.Direct) applyEvent(key, UsbEvent.Choose(PathChoice.Standard, userInitiated = true))
+            }
+        }
+
         private val receiver =
             object : BroadcastReceiver() {
                 override fun onReceive(
@@ -176,6 +184,7 @@ class UsbGamepadManager
                                     frameworkId = fwId,
                                     hasPermission = usbManager.hasPermission(device),
                                     desired = resolvePath(vid, pid),
+                                    frameworkExpected = native.modelExpectsFrameworkGamepad(vid, pid),
                                 ).withCapturedBinding(fwId)
                         )
                 }
@@ -250,6 +259,9 @@ class UsbGamepadManager
                 UsbEffect.RequestPermission -> usbDevices[key]?.let { requestPermission(it) }
                 is UsbEffect.BindFramework -> bindTo(fx.frameworkId, c.connId, c.type)
                 is UsbEffect.RemoveSynthetic -> {
+                    // Idempotent after a Release already detached; on a physical unplug it is the only
+                    // path that reaps the native poller and its fd instead of stranding them.
+                    native.detachUsbDevice(fx.syntheticId)
                     claimedConns.remove(key)?.let { runCatching { it.connection.close() } }
                     registry.removeUsbSynthetic(fx.syntheticId)
                 }

--- a/app/src/main/java/com/tinkernorth/dish/source/usb/UsbGamepadManager.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/usb/UsbGamepadManager.kt
@@ -495,7 +495,14 @@ class UsbGamepadManager
 
         private fun gameInterfaceRank(intf: UsbInterface): Int {
             val cls = intf.interfaceClass
-            if (cls == UsbConstants.USB_CLASS_HID) return RANK_HID
+            if (cls == UsbConstants.USB_CLASS_HID) {
+                // A pad that also emulates a keyboard/mouse (the Steam Controller does, and lists
+                // them first) is never driven from its boot-protocol interfaces.
+                val bootHumanInterface =
+                    intf.interfaceSubclass == HID_BOOT_SUBCLASS &&
+                        (intf.interfaceProtocol == HID_KEYBOARD_PROTOCOL || intf.interfaceProtocol == HID_MOUSE_PROTOCOL)
+                return if (bootHumanInterface) RANK_HID_BOOT else RANK_HID
+            }
             if (cls != UsbConstants.USB_CLASS_VENDOR_SPEC) return RANK_NONE
             val sub = intf.interfaceSubclass
             val proto = intf.interfaceProtocol
@@ -558,11 +565,16 @@ class UsbGamepadManager
             const val GIP_SUBCLASS = 0x47
             const val GIP_PROTOCOL = 0xD0
 
+            const val HID_BOOT_SUBCLASS = 0x01
+            const val HID_KEYBOARD_PROTOCOL = 0x01
+            const val HID_MOUSE_PROTOCOL = 0x02
+
             const val RANK_NONE = 0
-            const val RANK_VENDOR_FALLBACK = 1
-            const val RANK_HID = 2
-            const val RANK_GIP = 3
-            const val RANK_XINPUT = 4
+            const val RANK_HID_BOOT = 1
+            const val RANK_VENDOR_FALLBACK = 2
+            const val RANK_HID = 3
+            const val RANK_GIP = 4
+            const val RANK_XINPUT = 5
         }
     }
 

--- a/app/src/main/java/com/tinkernorth/dish/source/usb/UsbPathMachine.kt
+++ b/app/src/main/java/com/tinkernorth/dish/source/usb/UsbPathMachine.kt
@@ -34,6 +34,10 @@ data class UsbController(
     // Why the last Direct claim failed; remembered between the failure and the Standard re-settle so the
     // re-enumerated framework card can show the cause.
     val failure: DirectClaimFailure? = null,
+    // Whether releasing to Standard re-enumerates a framework gamepad. False for models whose
+    // stand-alone identity is a keyboard/mouse (the Steam Controller): waiting for a framework
+    // device that never comes would strand every release in RestoreStuck, so those settle at once.
+    val frameworkExpected: Boolean = true,
 )
 
 sealed interface UsbEvent {
@@ -228,7 +232,7 @@ private fun reduceClaiming(
                 listOf(UsbEffect.EndHold, UsbEffect.ClearFailure),
             )
         is UsbEvent.ClaimFailed ->
-            if (event.frameworkStolen) {
+            if (event.frameworkStolen && c.frameworkExpected) {
                 // Kernel HID driver was detached by the claim; wait for the framework device to come
                 // back so we can settle on Standard (and surface the reason once it does).
                 Reduction(
@@ -236,10 +240,11 @@ private fun reduceClaiming(
                     listOf(UsbEffect.StartTimeout),
                 )
             } else {
-                // Open/claim was rejected without ever stealing the interface, so the framework slot is
-                // still live; drop straight back to Standard and say why Direct didn't happen. Persist
-                // Standard too, or the failed pick is silently re-attempted on every reconnect (mirrors
-                // the permission-denied path).
+                // Either the open/claim was rejected without ever stealing the interface (the framework
+                // slot is still live), or this model never re-enumerates as a framework gamepad, so there
+                // is nothing to wait for; drop straight back to Standard and say why Direct didn't happen.
+                // Persist Standard too, or the failed pick is silently re-attempted on every reconnect
+                // (mirrors the permission-denied path).
                 Reduction(
                     c.copy(phase = UsbPhase.Routed, desired = PathChoice.Standard, syntheticId = null, failure = event.reason),
                     buildList {
@@ -262,12 +267,33 @@ private fun reduceDirect(
     when (event) {
         is UsbEvent.Choose ->
             if (event.choice == PathChoice.Standard) {
-                // Release the interface but keep the synthetic as a held placeholder while the framework
-                // device comes back; if it doesn't we stop in RestoreStuck and let the user choose.
-                Reduction(
-                    c.copy(phase = UsbPhase.AwaitingFramework, userInitiated = event.userInitiated, failure = null),
-                    listOf(UsbEffect.Release, UsbEffect.StartTimeout),
-                )
+                if (c.frameworkExpected) {
+                    // Release the interface but keep the synthetic as a held placeholder while the framework
+                    // device comes back; if it doesn't we stop in RestoreStuck and let the user choose.
+                    Reduction(
+                        c.copy(phase = UsbPhase.AwaitingFramework, userInitiated = event.userInitiated, failure = null),
+                        listOf(UsbEffect.Release, UsbEffect.StartTimeout),
+                    )
+                } else {
+                    // No framework gamepad follows this release, so there is nothing to wait for:
+                    // the device-side restore in Release is the whole hand-back.
+                    Reduction(
+                        c.copy(
+                            phase = UsbPhase.Routed,
+                            desired = PathChoice.Standard,
+                            frameworkId = null,
+                            syntheticId = null,
+                            userInitiated = event.userInitiated,
+                            failure = null,
+                        ),
+                        buildList {
+                            add(UsbEffect.Release)
+                            c.syntheticId?.let { add(UsbEffect.RemoveSynthetic(it)) }
+                            add(UsbEffect.SetPref(PathChoice.Standard))
+                            add(UsbEffect.ClearFailure)
+                        },
+                    )
+                }
             } else {
                 stay(c.copy(desired = PathChoice.Direct))
             }
@@ -398,3 +424,7 @@ private fun reduceNeedsReplug(
         is UsbEvent.PermissionGranted -> stay(c.copy(hasPermission = true))
         else -> stay(c)
     }
+
+// How many controllers currently hold a Direct claim. The foreground service keys off this so the
+// process (and the device restore a release runs) survives backgrounding while a pad is claimed.
+fun Map<Int, UsbController>.directClaimCount(): Int = values.count { it.phase == UsbPhase.Direct }

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -248,6 +248,7 @@
         <item quantity="few">%1$d kontrolera strimaju na %2$s</item>
         <item quantity="other">%1$d kontrolera strima na %2$s</item>
     </plurals>
+    <string name="streaming_notification_body_usb_hold">USB kontroler zadržan u brzom načinu</string>
     <string name="streaming_notification_stop">Zaustavi</string>
 
     <!-- Rezervni ekran kada nativno učitavanje ne uspije. -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -248,6 +248,7 @@
         <item quantity="one">%1$d Controller streamt an %2$s</item>
         <item quantity="other">%1$d Controller streamen an %2$s</item>
     </plurals>
+    <string name="streaming_notification_body_usb_hold">USB-Controller im Direktmodus gehalten</string>
     <string name="streaming_notification_stop">Stoppen</string>
 
     <!-- Fallback-Bildschirm, wenn das native Laden fehlschlägt. -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -251,6 +251,7 @@
         <item quantity="many">%1$d mandos transmiten a %2$s</item>
         <item quantity="other">%1$d mandos transmiten a %2$s</item>
     </plurals>
+    <string name="streaming_notification_body_usb_hold">Mando USB retenido en modo directo</string>
     <string name="streaming_notification_stop">Detener</string>
 
     <!-- Pantalla de respaldo cuando falla la carga nativa. -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -250,6 +250,7 @@
         <item quantity="many">%1$d manettes diffusent vers %2$s</item>
         <item quantity="other">%1$d manettes diffusent vers %2$s</item>
     </plurals>
+    <string name="streaming_notification_body_usb_hold">Manette USB maintenue en mode direct</string>
     <string name="streaming_notification_stop">Arrêter</string>
 
     <!-- Écran de repli quand le chargement natif échoue. -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -251,6 +251,7 @@
         <item quantity="many">%1$d controles transmitindo para %2$s</item>
         <item quantity="other">%1$d controles transmitindo para %2$s</item>
     </plurals>
+    <string name="streaming_notification_body_usb_hold">Controle USB mantido no modo direto</string>
     <string name="streaming_notification_stop">Parar</string>
 
     <!-- Tela de fallback quando o carregamento nativo falha. -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -296,6 +296,8 @@
         <item quantity="one">%1$d controller streaming to %2$s</item>
         <item quantity="other">%1$d controllers streaming to %2$s</item>
     </plurals>
+    <!-- Body while nothing is streaming but a USB controller is still claimed in Direct mode. -->
+    <string name="streaming_notification_body_usb_hold">USB controller held in Direct mode</string>
     <string name="streaming_notification_stop">Stop</string>
 
     <!-- Native-load fatal fallback. -->

--- a/app/src/test/cpp/usb_parsers_test.cpp
+++ b/app/src/test/cpp/usb_parsers_test.cpp
@@ -987,7 +987,16 @@ TEST(SteamConfigPackets, RestoreSequencePutsTheDeviceBack) {
     EXPECT_EQ(0x85, buf[0]);
     ASSERT_EQ(2u, buildSteamConfigPacket(SteamConfig::RESTORE, 1, buf, sizeof(buf)));
     EXPECT_EQ(0x8E, buf[0]);
-    EXPECT_EQ(0u, buildSteamConfigPacket(SteamConfig::RESTORE, 2, buf, sizeof(buf)));
+
+    // Loading the defaults leaves the right pad silent, so mouse mode is restored by name.
+    ASSERT_EQ(5u, buildSteamConfigPacket(SteamConfig::RESTORE, 2, buf, sizeof(buf)));
+    EXPECT_EQ(0x87, buf[0]);
+    EXPECT_EQ(0x03, buf[1]);
+    EXPECT_EQ(0x08, buf[2]); // right trackpad mode
+    EXPECT_EQ(0x00, buf[3]); // = absolute mouse
+    EXPECT_EQ(0x00, buf[4]);
+
+    EXPECT_EQ(0u, buildSteamConfigPacket(SteamConfig::RESTORE, 3, buf, sizeof(buf)));
 }
 
 TEST(SteamConfigPackets, RefusesToOverrunACallerBuffer) {

--- a/app/src/test/cpp/usb_parsers_test.cpp
+++ b/app/src/test/cpp/usb_parsers_test.cpp
@@ -26,9 +26,11 @@ using gamepad::XUSB_Y;
 using usbparsers::buildGipInitPacket;
 using usbparsers::buildRumbleReport;
 using usbparsers::buildSteamConfigPacket;
+using usbparsers::checkWirelessEvent;
 using usbparsers::decodeReport;
 using usbparsers::InitKind;
 using usbparsers::isVerifiedFastLane;
+using usbparsers::modelExpectsFrameworkGamepad;
 using usbparsers::parsePsCalibration;
 using usbparsers::Parser;
 using usbparsers::parserFrameworkRumbleUnreliable;
@@ -38,6 +40,7 @@ using usbparsers::parserHasTouchpad;
 using usbparsers::ParserState;
 using usbparsers::PsImuCalib;
 using usbparsers::SteamConfig;
+using usbparsers::WirelessEvent;
 
 namespace {
 
@@ -1003,4 +1006,96 @@ TEST(SteamConfigPackets, RefusesToOverrunACallerBuffer) {
     uint8_t small[4];
     EXPECT_EQ(0u, buildSteamConfigPacket(SteamConfig::QUIET, 1, small, sizeof(small)));
     EXPECT_EQ(0u, buildSteamConfigPacket(SteamConfig::QUIET, -1, small, sizeof(small)));
+}
+
+namespace {
+
+// Dongle wireless event framing per hid-steam: header {version u16, type, payload length},
+// payload byte 0x01 = disconnected, 0x02 = connected.
+std::vector<uint8_t> steamWirelessEvent(uint8_t payload) {
+    std::vector<uint8_t> r(64, 0);
+    r[0] = 0x01;
+    r[1] = 0x00;
+    r[2] = 0x03; // ID_CONTROLLER_WIRELESS
+    r[3] = 0x01; // payload length
+    r[4] = payload;
+    return r;
+}
+
+} // namespace
+
+TEST(SteamWireless, ConnectAndDisconnectEventsClassify) {
+    auto disc = steamWirelessEvent(0x01);
+    EXPECT_EQ(WirelessEvent::DISCONNECT,
+              checkWirelessEvent(Parser::STEAM_CONTROLLER, disc.data(), disc.size()));
+
+    auto conn = steamWirelessEvent(0x02);
+    EXPECT_EQ(WirelessEvent::CONNECT,
+              checkWirelessEvent(Parser::STEAM_CONTROLLER, conn.data(), conn.size()));
+}
+
+// The issue and the fix as a pair: a wireless event never decodes as input (so on its own the last
+// published state would stay latched), and the classifier is what routes it to the host instead.
+TEST(SteamWireless, WirelessEventNeverDecodesAsInputButStillClassifies) {
+    ParserState st;
+    DeviceState s;
+    auto disc = steamWirelessEvent(0x01);
+    EXPECT_FALSE(decodeReport(Parser::STEAM_CONTROLLER, disc.data(), disc.size(), s, &st));
+    EXPECT_NE(WirelessEvent::NONE,
+              checkWirelessEvent(Parser::STEAM_CONTROLLER, disc.data(), disc.size()));
+}
+
+TEST(SteamWireless, InputStateIsNotAWirelessEvent) {
+    ParserState st;
+    DeviceState s;
+    auto state = steamState(kBtnSouth);
+    EXPECT_EQ(WirelessEvent::NONE,
+              checkWirelessEvent(Parser::STEAM_CONTROLLER, state.data(), state.size()));
+    EXPECT_TRUE(decodeReport(Parser::STEAM_CONTROLLER, state.data(), state.size(), s, &st));
+}
+
+TEST(SteamWireless, RejectsMalformedEvents) {
+    auto shortEvent = steamWirelessEvent(0x02);
+    shortEvent.resize(4);
+    EXPECT_EQ(WirelessEvent::NONE,
+              checkWirelessEvent(Parser::STEAM_CONTROLLER, shortEvent.data(), shortEvent.size()));
+
+    auto badVersion = steamWirelessEvent(0x02);
+    badVersion[0] = 0x02;
+    EXPECT_EQ(WirelessEvent::NONE,
+              checkWirelessEvent(Parser::STEAM_CONTROLLER, badVersion.data(), badVersion.size()));
+
+    auto badPayloadLen = steamWirelessEvent(0x02);
+    badPayloadLen[3] = 0x02;
+    EXPECT_EQ(WirelessEvent::NONE, checkWirelessEvent(Parser::STEAM_CONTROLLER,
+                                                      badPayloadLen.data(), badPayloadLen.size()));
+
+    auto unknownPayload = steamWirelessEvent(0x03);
+    EXPECT_EQ(
+        WirelessEvent::NONE,
+        checkWirelessEvent(Parser::STEAM_CONTROLLER, unknownPayload.data(), unknownPayload.size()));
+
+    // ID_CONTROLLER_STATUS (battery) shares the endpoint but is not a connect event.
+    auto battery = steamWirelessEvent(0x02);
+    battery[2] = 0x04;
+    EXPECT_EQ(WirelessEvent::NONE,
+              checkWirelessEvent(Parser::STEAM_CONTROLLER, battery.data(), battery.size()));
+}
+
+TEST(SteamWireless, OtherParsersNeverSeeWirelessEvents) {
+    auto conn = steamWirelessEvent(0x02);
+    EXPECT_EQ(WirelessEvent::NONE,
+              checkWirelessEvent(Parser::XINPUT_360, conn.data(), conn.size()));
+    EXPECT_EQ(WirelessEvent::NONE, checkWirelessEvent(Parser::DUALSENSE, conn.data(), conn.size()));
+    EXPECT_EQ(WirelessEvent::NONE, checkWirelessEvent(Parser::NONE, conn.data(), conn.size()));
+}
+
+// A released Steam Controller settles as a keyboard/mouse, never a framework gamepad; every other
+// model (and anything unknown) keeps the wait-for-re-enumeration contract.
+TEST(SteamClassify, OnlySteamModelsSettleWithoutAFrameworkGamepad) {
+    EXPECT_FALSE(modelExpectsFrameworkGamepad(0x28DE, 0x1102));
+    EXPECT_FALSE(modelExpectsFrameworkGamepad(0x28DE, 0x1142));
+    EXPECT_TRUE(modelExpectsFrameworkGamepad(0x045E, 0x028E));
+    EXPECT_TRUE(modelExpectsFrameworkGamepad(0x054C, 0x05C4));
+    EXPECT_TRUE(modelExpectsFrameworkGamepad(0x1234, 0x5678));
 }

--- a/app/src/test/cpp/usb_parsers_test.cpp
+++ b/app/src/test/cpp/usb_parsers_test.cpp
@@ -10,18 +10,34 @@
 using gamepad::DeviceState;
 using gamepad::XUSB_A;
 using gamepad::XUSB_B;
+using gamepad::XUSB_BACK;
+using gamepad::XUSB_DPAD_DOWN;
+using gamepad::XUSB_DPAD_LEFT;
+using gamepad::XUSB_DPAD_RIGHT;
+using gamepad::XUSB_DPAD_UP;
 using gamepad::XUSB_GUIDE;
+using gamepad::XUSB_LB;
+using gamepad::XUSB_RB;
+using gamepad::XUSB_START;
+using gamepad::XUSB_THUMB_L;
+using gamepad::XUSB_THUMB_R;
+using gamepad::XUSB_X;
+using gamepad::XUSB_Y;
 using usbparsers::buildGipInitPacket;
 using usbparsers::buildRumbleReport;
+using usbparsers::buildSteamConfigPacket;
 using usbparsers::decodeReport;
 using usbparsers::InitKind;
+using usbparsers::isVerifiedFastLane;
 using usbparsers::parsePsCalibration;
 using usbparsers::Parser;
 using usbparsers::parserFrameworkRumbleUnreliable;
 using usbparsers::parserHasImu;
 using usbparsers::parserHasRumble;
+using usbparsers::parserHasTouchpad;
 using usbparsers::ParserState;
 using usbparsers::PsImuCalib;
+using usbparsers::SteamConfig;
 
 namespace {
 
@@ -691,4 +707,291 @@ TEST(ClassifyDevice, HidInterfaceClassifiesAsGenericHid) {
 TEST(ClassifyDevice, UnknownVendorInterfaceFallsBackToGeneric) {
     auto c = usbparsers::classifyDevice(0x1234, 0x5678, 0xFF, 0x99, 0x99);
     EXPECT_EQ(c.parser, Parser::GENERIC_HID_GAMEPAD);
+}
+
+namespace {
+
+constexpr uint32_t kBtnRightBumper = 0x000004;
+constexpr uint32_t kBtnLeftBumper = 0x000008;
+constexpr uint32_t kBtnNorth = 0x000010;
+constexpr uint32_t kBtnEast = 0x000020;
+constexpr uint32_t kBtnWest = 0x000040;
+constexpr uint32_t kBtnSouth = 0x000080;
+constexpr uint32_t kBtnDpadUp = 0x000100;
+constexpr uint32_t kBtnDpadRight = 0x000200;
+constexpr uint32_t kBtnMenu = 0x001000;
+constexpr uint32_t kBtnGuide = 0x002000;
+constexpr uint32_t kBtnEscape = 0x004000;
+constexpr uint32_t kBtnLeftPadClicked = 0x020000;
+constexpr uint32_t kBtnRightPadClicked = 0x040000;
+constexpr uint32_t kBtnLeftPadFinger = 0x080000;
+constexpr uint32_t kBtnRightPadFinger = 0x100000;
+constexpr uint32_t kBtnStickButton = 0x400000;
+constexpr uint32_t kBtnLeftPadAndStick = 0x800000;
+
+std::vector<uint8_t> steamState(uint32_t buttons = 0) {
+    std::vector<uint8_t> r(64, 0);
+    r[0] = 0x01; // report version, u16 LE
+    r[1] = 0x00;
+    r[2] = 0x01; // ID_CONTROLLER_STATE
+    r[3] = 44;   // payload length
+    r[8] = (uint8_t)(buttons & 0xFF);
+    r[9] = (uint8_t)((buttons >> 8) & 0xFF);
+    r[10] = (uint8_t)((buttons >> 16) & 0xFF);
+    return r;
+}
+
+bool decodeSteam(const std::vector<uint8_t>& buf, DeviceState& s, ParserState& st) {
+    return decodeReport(Parser::STEAM_CONTROLLER, buf.data(), buf.size(), s, &st);
+}
+
+} // namespace
+
+TEST(SteamClassify, WiredAndDongleResolveToQuietInit) {
+    auto wired = usbparsers::classifyDevice(0x28DE, 0x1102, 0x03, 0x00, 0x00);
+    EXPECT_EQ(Parser::STEAM_CONTROLLER, wired.parser);
+    EXPECT_EQ(InitKind::STEAM_QUIET, wired.init);
+    EXPECT_STREQ("Valve Steam Controller", wired.name);
+
+    auto dongle = usbparsers::classifyDevice(0x28DE, 0x1142, 0x03, 0x00, 0x00);
+    EXPECT_EQ(Parser::STEAM_CONTROLLER, dongle.parser);
+    EXPECT_EQ(InitKind::STEAM_QUIET, dongle.init);
+}
+
+TEST(SteamClassify, IsNotAVerifiedFastLaneModel) {
+    EXPECT_FALSE(isVerifiedFastLane(0x28DE, 0x1102));
+    EXPECT_FALSE(isVerifiedFastLane(0x28DE, 0x1142));
+}
+
+TEST(SteamClassify, AdvertisesImuButNeitherRumbleNorTouchpad) {
+    EXPECT_TRUE(parserHasImu(Parser::STEAM_CONTROLLER));
+    EXPECT_FALSE(parserHasRumble(Parser::STEAM_CONTROLLER));
+    EXPECT_FALSE(parserHasTouchpad(Parser::STEAM_CONTROLLER));
+    EXPECT_FALSE(parserFrameworkRumbleUnreliable(Parser::STEAM_CONTROLLER));
+
+    uint8_t buf[64];
+    EXPECT_EQ(0u, buildRumbleReport(Parser::STEAM_CONTROLLER, 0xFFFF, 0xFFFF, 0, buf, sizeof(buf)));
+}
+
+TEST(SteamDecode, RejectsShortWrongVersionAndWrongType) {
+    ParserState st;
+    DeviceState s;
+    auto shortPacket = steamState();
+    shortPacket.resize(47);
+    EXPECT_FALSE(decodeSteam(shortPacket, s, st));
+
+    auto badVersion = steamState();
+    badVersion[0] = 0x02;
+    EXPECT_FALSE(decodeSteam(badVersion, s, st));
+
+    // The dongle interleaves wireless connect/disconnect events onto the same endpoint.
+    auto wirelessEvent = steamState();
+    wirelessEvent[2] = 0x03;
+    EXPECT_FALSE(decodeSteam(wirelessEvent, s, st));
+}
+
+TEST(SteamDecode, FaceAndShoulderButtonsMapByPosition) {
+    ParserState st;
+    DeviceState s;
+    ASSERT_TRUE(decodeSteam(steamState(kBtnSouth | kBtnEast | kBtnWest | kBtnNorth), s, st));
+    EXPECT_TRUE(s.wButtons & XUSB_A);
+    EXPECT_TRUE(s.wButtons & XUSB_B);
+    EXPECT_TRUE(s.wButtons & XUSB_X);
+    EXPECT_TRUE(s.wButtons & XUSB_Y);
+
+    DeviceState shoulders;
+    ASSERT_TRUE(decodeSteam(steamState(kBtnLeftBumper | kBtnRightBumper), shoulders, st));
+    EXPECT_TRUE(shoulders.wButtons & XUSB_LB);
+    EXPECT_TRUE(shoulders.wButtons & XUSB_RB);
+}
+
+TEST(SteamDecode, MenuEscapeAndSteamMapToBackStartGuide) {
+    ParserState st;
+    DeviceState s;
+    ASSERT_TRUE(decodeSteam(steamState(kBtnMenu | kBtnEscape | kBtnGuide), s, st));
+    EXPECT_TRUE(s.wButtons & XUSB_BACK);
+    EXPECT_TRUE(s.wButtons & XUSB_START);
+    EXPECT_TRUE(s.wButtons & XUSB_GUIDE);
+}
+
+TEST(SteamDecode, DpadBitsMapDirectly) {
+    ParserState st;
+    DeviceState s;
+    ASSERT_TRUE(decodeSteam(steamState(kBtnDpadUp | kBtnDpadRight), s, st));
+    EXPECT_TRUE(s.wButtons & XUSB_DPAD_UP);
+    EXPECT_TRUE(s.wButtons & XUSB_DPAD_RIGHT);
+    EXPECT_FALSE(s.wButtons & XUSB_DPAD_DOWN);
+    EXPECT_FALSE(s.wButtons & XUSB_DPAD_LEFT);
+}
+
+TEST(SteamDecode, TriggersScaleAndSaturateBeforeTheRawRail) {
+    ParserState st;
+    DeviceState s;
+    auto r = steamState();
+    r[11] = 0;
+    r[12] = 100;
+    ASSERT_TRUE(decodeSteam(r, s, st));
+    EXPECT_EQ(0, s.bLT);
+    EXPECT_EQ(126, s.bRT);
+
+    // Valve's full scale is 26000 of a possible 32895, so the throw tops out before the raw rail.
+    r[11] = 202;
+    r[12] = 255;
+    ASSERT_TRUE(decodeSteam(r, s, st));
+    EXPECT_EQ(255, s.bLT);
+    EXPECT_EQ(255, s.bRT);
+}
+
+TEST(SteamDecode, LeftAxesAreTheStickWhenNoFingerIsOnThePad) {
+    ParserState st;
+    DeviceState s;
+    auto r = steamState();
+    setLe16(r, 16, -8000);
+    setLe16(r, 18, 12000);
+    ASSERT_TRUE(decodeSteam(r, s, st));
+    EXPECT_EQ(-8000, s.sLX);
+    EXPECT_EQ(12000, s.sLY);
+}
+
+TEST(SteamDecode, StickHoldsItsValueAcrossAnInterleavedPadFrame) {
+    ParserState st;
+    DeviceState s;
+    auto stickFrame = steamState();
+    setLe16(stickFrame, 16, 5000);
+    setLe16(stickFrame, 18, -6000);
+    ASSERT_TRUE(decodeSteam(stickFrame, s, st));
+
+    auto padFrame = steamState(kBtnLeftPadFinger | kBtnLeftPadAndStick);
+    setLe16(padFrame, 16, 30000);
+    setLe16(padFrame, 18, 30000);
+    DeviceState next;
+    ASSERT_TRUE(decodeSteam(padFrame, next, st));
+    EXPECT_EQ(5000, next.sLX);
+    EXPECT_EQ(-6000, next.sLY);
+}
+
+TEST(SteamDecode, StickCentresWhenThePadTakesOverWithoutInterleaving) {
+    ParserState st;
+    DeviceState s;
+    auto stickFrame = steamState();
+    setLe16(stickFrame, 16, 5000);
+    ASSERT_TRUE(decodeSteam(stickFrame, s, st));
+
+    auto padFrame = steamState(kBtnLeftPadFinger);
+    setLe16(padFrame, 16, 30000);
+    DeviceState next;
+    ASSERT_TRUE(decodeSteam(padFrame, next, st));
+    EXPECT_EQ(0, next.sLX);
+    EXPECT_EQ(0, next.sLY);
+}
+
+TEST(SteamDecode, LeftPadClickIsAStickClickWhileThePadIsIdle) {
+    ParserState st;
+    DeviceState s;
+    ASSERT_TRUE(decodeSteam(steamState(kBtnLeftPadClicked), s, st));
+    EXPECT_TRUE(s.wButtons & XUSB_THUMB_L);
+
+    // With a finger actually on the pad the click belongs to the pad, not the stick.
+    DeviceState onPad;
+    ASSERT_TRUE(decodeSteam(steamState(kBtnLeftPadClicked | kBtnLeftPadFinger), onPad, st));
+    EXPECT_FALSE(onPad.wButtons & XUSB_THUMB_L);
+}
+
+TEST(SteamDecode, StickAndRightPadClicksMapToThumbButtons) {
+    ParserState st;
+    DeviceState s;
+    ASSERT_TRUE(decodeSteam(steamState(kBtnStickButton | kBtnRightPadClicked), s, st));
+    EXPECT_TRUE(s.wButtons & XUSB_THUMB_L);
+    EXPECT_TRUE(s.wButtons & XUSB_THUMB_R);
+}
+
+TEST(SteamDecode, RightPadDrivesTheRightStickThroughTheShellRotation) {
+    ParserState st;
+    DeviceState s;
+    auto r = steamState(kBtnRightPadFinger);
+    setLe16(r, 20, 10000);
+    setLe16(r, 22, 0);
+    ASSERT_TRUE(decodeSteam(r, s, st));
+    EXPECT_EQ(9659, s.sRX);
+    EXPECT_EQ(2588, s.sRY);
+}
+
+TEST(SteamDecode, RightStickRecentresWhenTheFingerLifts) {
+    ParserState st;
+    DeviceState s;
+    auto held = steamState(kBtnRightPadFinger);
+    setLe16(held, 20, 20000);
+    setLe16(held, 22, 20000);
+    ASSERT_TRUE(decodeSteam(held, s, st));
+    ASSERT_NE(0, s.sRX);
+
+    // Pad coordinates are meaningless once the finger lifts, so the stick must not stay deflected.
+    auto lifted = steamState();
+    setLe16(lifted, 20, 20000);
+    setLe16(lifted, 22, 20000);
+    DeviceState next;
+    ASSERT_TRUE(decodeSteam(lifted, next, st));
+    EXPECT_EQ(0, next.sRX);
+    EXPECT_EQ(0, next.sRY);
+}
+
+TEST(SteamDecode, ImuRotatesOntoTheWireAxisOrderAndScale) {
+    ParserState st;
+    DeviceState s;
+    auto r = steamState();
+    setLe16(r, 28, 1000); // accel x
+    setLe16(r, 30, 2000); // accel y
+    setLe16(r, 32, 3000); // accel z
+    setLe16(r, 34, 4000); // gyro x
+    setLe16(r, 36, 5000); // gyro y
+    setLe16(r, 38, 6000); // gyro z
+    ASSERT_TRUE(decodeSteam(r, s, st));
+    EXPECT_TRUE(s.motionValid);
+    EXPECT_EQ(3999, s.gyroX);
+    EXPECT_EQ(5999, s.gyroY);
+    EXPECT_EQ(4999, s.gyroZ);
+    EXPECT_EQ(499, s.accelX);
+    EXPECT_EQ(1499, s.accelY);
+    EXPECT_EQ(-999, s.accelZ);
+}
+
+TEST(SteamDecode, SilentImuBlockDoesNotPublishMotion) {
+    ParserState st;
+    DeviceState s;
+    ASSERT_TRUE(decodeSteam(steamState(kBtnSouth), s, st));
+    EXPECT_FALSE(s.motionValid);
+}
+
+TEST(SteamConfigPackets, QuietSequenceClearsMappingsThenWritesSettings) {
+    uint8_t buf[16];
+    ASSERT_EQ(2u, buildSteamConfigPacket(SteamConfig::QUIET, 0, buf, sizeof(buf)));
+    EXPECT_EQ(0x81, buf[0]);
+    EXPECT_EQ(0x00, buf[1]);
+
+    ASSERT_EQ(11u, buildSteamConfigPacket(SteamConfig::QUIET, 1, buf, sizeof(buf)));
+    EXPECT_EQ(0x87, buf[0]);
+    EXPECT_EQ(0x09, buf[1]);
+    EXPECT_EQ(0x07, buf[2]); // left trackpad mode
+    EXPECT_EQ(0x07, buf[3]); // = none
+    EXPECT_EQ(0x08, buf[5]); // right trackpad mode
+    EXPECT_EQ(0x07, buf[6]); // = none
+    EXPECT_EQ(0x30, buf[8]); // imu mode
+    EXPECT_EQ(0x18, buf[9]); // = raw accel | raw gyro
+
+    EXPECT_EQ(0u, buildSteamConfigPacket(SteamConfig::QUIET, 2, buf, sizeof(buf)));
+}
+
+TEST(SteamConfigPackets, RestoreSequencePutsTheDeviceBack) {
+    uint8_t buf[16];
+    ASSERT_EQ(2u, buildSteamConfigPacket(SteamConfig::RESTORE, 0, buf, sizeof(buf)));
+    EXPECT_EQ(0x85, buf[0]);
+    ASSERT_EQ(2u, buildSteamConfigPacket(SteamConfig::RESTORE, 1, buf, sizeof(buf)));
+    EXPECT_EQ(0x8E, buf[0]);
+    EXPECT_EQ(0u, buildSteamConfigPacket(SteamConfig::RESTORE, 2, buf, sizeof(buf)));
+}
+
+TEST(SteamConfigPackets, RefusesToOverrunACallerBuffer) {
+    uint8_t small[4];
+    EXPECT_EQ(0u, buildSteamConfigPacket(SteamConfig::QUIET, 1, small, sizeof(small)));
+    EXPECT_EQ(0u, buildSteamConfigPacket(SteamConfig::QUIET, -1, small, sizeof(small)));
 }

--- a/app/src/test/java/com/tinkernorth/dish/composer/StreamingServiceControllerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/StreamingServiceControllerTest.kt
@@ -6,6 +6,9 @@ import android.content.Context
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
+import com.tinkernorth.dish.source.usb.UsbController
+import com.tinkernorth.dish.source.usb.UsbGamepadManager
+import com.tinkernorth.dish.source.usb.UsbPhase
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -25,17 +28,35 @@ class StreamingServiceControllerTest {
 
     private val scope = TestScope(StandardTestDispatcher())
     private val slots = MutableStateFlow(0)
+    private val claims = MutableStateFlow<Map<Int, UsbController>>(emptyMap())
     private val wakeState =
         mockk<WakeStateController> {
             every { streamingSlotCount } returns slots
         }
+    private val usbGamepadManager =
+        mockk<UsbGamepadManager> {
+            every { controllers } returns claims
+        }
 
-    private fun start(context: Context) {
-        val controller = StreamingServiceController(context, wakeState, scope)
+    private fun directClaim(): Map<Int, UsbController> =
+        mapOf(
+            1 to
+                UsbController(
+                    vendorId = 0x28DE,
+                    productId = 0x1102,
+                    name = "Valve Steam Controller",
+                    phase = UsbPhase.Direct,
+                    syntheticId = -1000,
+                ),
+        )
+
+    private fun start(context: Context): TestOwner {
+        val controller = StreamingServiceController(context, wakeState, usbGamepadManager, scope)
         val owner = TestOwner()
         owner.registry.addObserver(controller)
         owner.registry.currentState = Lifecycle.State.STARTED
         scope.testScheduler.runCurrent()
+        return owner
     }
 
     @Test
@@ -65,5 +86,72 @@ class StreamingServiceControllerTest {
             scope.testScheduler.runCurrent()
 
             verify { context.startService(any()) }
+        }
+
+    @Test
+    fun `a direct claim alone starts the service`() =
+        runTest(scope.testScheduler) {
+            val context = mockk<Context>(relaxed = true)
+            start(context)
+
+            claims.value = directClaim()
+            scope.testScheduler.runCurrent()
+
+            verify { context.startService(any()) }
+        }
+
+    // The claimed pad has been reconfigured at the device level; only a live process can run the
+    // restore a later release performs, so backgrounding must not drop the service that keeps it.
+    @Test
+    fun `process stop with a held claim keeps the service running`() =
+        runTest(scope.testScheduler) {
+            val context = mockk<Context>(relaxed = true)
+            val owner = start(context)
+
+            slots.value = 1
+            claims.value = directClaim()
+            scope.testScheduler.runCurrent()
+
+            owner.registry.currentState = Lifecycle.State.CREATED
+            scope.testScheduler.runCurrent()
+
+            verify(exactly = 0) { context.stopService(any()) }
+        }
+
+    @Test
+    fun `process stop without claims stops the service`() =
+        runTest(scope.testScheduler) {
+            val context = mockk<Context>(relaxed = true)
+            val owner = start(context)
+
+            slots.value = 1
+            scope.testScheduler.runCurrent()
+
+            owner.registry.currentState = Lifecycle.State.CREATED
+            scope.testScheduler.runCurrent()
+
+            verify { context.stopService(any()) }
+        }
+
+    // The service can stop itself while collection is down (claims released in the background), so
+    // a foreground return must re-derive instead of trusting the stale running flag.
+    @Test
+    fun `a foreground return re-asserts the service for work still held`() =
+        runTest(scope.testScheduler) {
+            val context = mockk<Context>(relaxed = true)
+            val owner = start(context)
+
+            claims.value = directClaim()
+            scope.testScheduler.runCurrent()
+            verify(exactly = 1) { context.startService(any()) }
+
+            owner.registry.currentState = Lifecycle.State.CREATED
+            scope.testScheduler.runCurrent()
+            owner.registry.currentState = Lifecycle.State.STARTED
+            scope.testScheduler.runCurrent()
+
+            // A second start against a live service is a harmless refresh; against one that
+            // self-stopped in the background it is the restart that keeps the claim protected.
+            verify(exactly = 2) { context.startService(any()) }
         }
 }

--- a/app/src/test/java/com/tinkernorth/dish/source/usb/UsbGamepadManagerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/usb/UsbGamepadManagerTest.kt
@@ -249,6 +249,109 @@ class UsbGamepadManagerTest {
         }
     }
 
+    private fun hidInterface(
+        ifaceId: Int,
+        subclass: Int,
+        protocol: Int,
+        epInAddress: Int,
+    ): UsbInterface {
+        val epIn =
+            mockk<UsbEndpoint> {
+                every { type } returns UsbConstants.USB_ENDPOINT_XFER_INT
+                every { direction } returns UsbConstants.USB_DIR_IN
+                every { address } returns epInAddress
+                every { maxPacketSize } returns 64
+                every { interval } returns 4
+            }
+        return mockk {
+            every { interfaceClass } returns UsbConstants.USB_CLASS_HID
+            every { interfaceSubclass } returns subclass
+            every { interfaceProtocol } returns protocol
+            every { id } returns ifaceId
+            every { endpointCount } returns 1
+            every { getEndpoint(0) } returns epIn
+        }
+    }
+
+    // Boot keyboard and mouse first, the way a Steam Controller enumerates: ranking every HID
+    // interface alike would claim the keyboard and stream decoded key bytes as gamepad state.
+    private fun keyboardMousePadComposite(): UsbDevice {
+        val keyboard = hidInterface(ifaceId = 0, subclass = 0x01, protocol = 0x01, epInAddress = 0x81)
+        val mouse = hidInterface(ifaceId = 1, subclass = 0x01, protocol = 0x02, epInAddress = 0x82)
+        val pad = hidInterface(ifaceId = 2, subclass = 0x00, protocol = 0x00, epInAddress = 0x83)
+        return mockk {
+            every { vendorId } returns vid
+            every { productId } returns pid
+            every { deviceName } returns "composite-hid"
+            every { interfaceCount } returns 3
+            every { getInterface(0) } returns keyboard
+            every { getInterface(1) } returns mouse
+            every { getInterface(2) } returns pad
+        }
+    }
+
+    private fun bootKeyboardOnly(): UsbDevice {
+        val keyboard = hidInterface(ifaceId = 0, subclass = 0x01, protocol = 0x01, epInAddress = 0x81)
+        return mockk {
+            every { vendorId } returns vid
+            every { productId } returns pid
+            every { deviceName } returns "boot-only"
+            every { interfaceCount } returns 1
+            every { getInterface(0) } returns keyboard
+        }
+    }
+
+    private fun expectAttach(dev: UsbDevice): UsbGamepadManager {
+        val conn = mockConn()
+        every { usbManager.openDevice(dev) } returns conn
+        every { conn.claimInterface(any(), true) } returns true
+        every {
+            native.attachUsbDevice(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        } returns -1000
+        return buildManagerForDevice(dev)
+    }
+
+    @Test
+    fun `claims the controller interface of a composite pad, not its boot keyboard or mouse`() {
+        val dev = keyboardMousePadComposite()
+        expectAttach(dev).tryDirectMode(vid, pid)
+        verify {
+            native.attachUsbDevice(
+                fd = any(),
+                vendorId = vid,
+                productId = pid,
+                interfaceNumber = 2,
+                endpointIn = 0x83,
+                endpointInMaxPacket = any(),
+                endpointOut = any(),
+                interfaceClass = UsbConstants.USB_CLASS_HID,
+                interfaceSubclass = 0x00,
+                interfaceProtocol = 0x00,
+            )
+        }
+    }
+
+    // Deprioritised, not disqualified: a device with nothing else must still be claimable.
+    @Test
+    fun `falls back to a boot interface when the device offers no other`() {
+        val dev = bootKeyboardOnly()
+        expectAttach(dev).tryDirectMode(vid, pid)
+        verify {
+            native.attachUsbDevice(
+                fd = any(),
+                vendorId = vid,
+                productId = pid,
+                interfaceNumber = 0,
+                endpointIn = 0x81,
+                endpointInMaxPacket = any(),
+                endpointOut = any(),
+                interfaceClass = UsbConstants.USB_CLASS_HID,
+                interfaceSubclass = 0x01,
+                interfaceProtocol = 0x01,
+            )
+        }
+    }
+
     // A real registry so directFailureFor genuinely reflects what markDirectFailed recorded, instead of
     // relying on stubbing the read back (the guard is integration, not a single mocked return).
     private fun realRegistry(): PhysicalGamepadRegistry {

--- a/app/src/test/java/com/tinkernorth/dish/source/usb/UsbGamepadManagerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/usb/UsbGamepadManagerTest.kt
@@ -98,6 +98,9 @@ class UsbGamepadManagerTest {
         every { usbManager.hasPermission(device) } returns true
         every { registry.devices } returns MutableStateFlow(emptyMap())
         every { native.lookupKnownModelName(vid, pid) } returns "Pad"
+        // The relaxed default (false) is the keyboard-settling exception; almost every model
+        // re-enumerates as a framework gamepad, so pin the common case.
+        every { native.modelExpectsFrameworkGamepad(vid, pid) } returns true
         // Relaxed mocks hand back the first enum constant for an enum return even when it is nullable, so
         // an unstubbed choiceFor would read as Direct and short-circuit resolvePath. Pin it to "no pick".
         every { pathPrefs.choiceFor(vid, pid) } returns null
@@ -172,6 +175,57 @@ class UsbGamepadManagerTest {
         verify { registry.addUsbSynthetic(-1000, "Pad", any(), any(), vid, pid) }
     }
 
+    private fun claimTo(syntheticId: Int): UsbGamepadManager {
+        val conn = mockConn()
+        every { usbManager.openDevice(device) } returns conn
+        every { conn.claimInterface(any(), true) } returns true
+        every { hub.bindings } returns MutableStateFlow(emptyMap())
+        every { hub.satTypes } returns MutableStateFlow(emptyMap())
+        every {
+            native.attachUsbDevice(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        } returns syntheticId
+        return buildManager()
+    }
+
+    @Test
+    fun `releasing a claimed pad that re-enumerates waits for the framework`() {
+        val m = claimTo(-1000)
+        m.tryDirectMode(vid, pid)
+        m.setPathChoice(vid, pid, PathChoice.Standard)
+        assertEquals(UsbPhase.AwaitingFramework, m.controllers.value[key]?.phase)
+        verify { native.detachUsbDevice(-1000) }
+    }
+
+    // The Steam Controller settles as keyboard/mouse, so no framework gamepad ever re-enumerates
+    // after a release; waiting for one would strand every release in RestoreStuck with a false
+    // "restore failed" banner.
+    @Test
+    fun `releasing a keyboard-settling pad settles standard immediately`() {
+        val m = claimTo(-1000)
+        every { native.modelExpectsFrameworkGamepad(vid, pid) } returns false
+        m.tryDirectMode(vid, pid)
+        assertEquals(UsbPhase.Direct, m.controllers.value[key]?.phase)
+        m.setPathChoice(vid, pid, PathChoice.Standard)
+        assertEquals(UsbPhase.Routed, m.controllers.value[key]?.phase)
+        assertNull(m.controllers.value[key]?.syntheticId)
+        // Release detaches once and the RemoveSynthetic cleanup detaches again (idempotent
+        // natively); the second call is what the physical-unplug path relies on, since unplug
+        // emits RemoveSynthetic without a preceding Release.
+        verify(exactly = 2) { native.detachUsbDevice(-1000) }
+        verify { registry.removeUsbSynthetic(-1000) }
+    }
+
+    @Test
+    fun `stop-all releases every held direct claim with its device restore`() {
+        val m = claimTo(-1000)
+        every { native.modelExpectsFrameworkGamepad(vid, pid) } returns false
+        m.tryDirectMode(vid, pid)
+        m.releaseAllDirect()
+        assertEquals(UsbPhase.Routed, m.controllers.value[key]?.phase)
+        verify { native.detachUsbDevice(-1000) }
+        verify { pathPrefs.setChoice(vid, pid, PathChoice.Standard) }
+    }
+
     private fun vendorInterface(
         ifaceId: Int,
         subclass: Int,
@@ -217,6 +271,7 @@ class UsbGamepadManagerTest {
         every { usbManager.hasPermission(dev) } returns true
         every { registry.devices } returns MutableStateFlow(emptyMap())
         every { native.lookupKnownModelName(vid, pid) } returns "Pad"
+        every { native.modelExpectsFrameworkGamepad(vid, pid) } returns true
         every { pathPrefs.choiceFor(vid, pid) } returns null
         val scope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
         return UsbGamepadManager(ctx, registry, Provider { hub }, notifications, scope, native, pathPrefs)
@@ -367,6 +422,7 @@ class UsbGamepadManagerTest {
         every { usbManager.deviceList } returns hashMapOf("d" to device)
         every { usbManager.hasPermission(device) } returns true
         every { native.lookupKnownModelName(vid, pid) } returns "Pad"
+        every { native.modelExpectsFrameworkGamepad(vid, pid) } returns true
         every { pathPrefs.choiceFor(vid, pid) } returns null
         val scope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
         return UsbGamepadManager(ctx, reg, Provider { hub }, notifications, scope, native, pathPrefs)

--- a/app/src/test/java/com/tinkernorth/dish/source/usb/UsbPathMachineTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/usb/UsbPathMachineTest.kt
@@ -18,6 +18,7 @@ class UsbPathMachineTest {
         userInitiated: Boolean = false,
         connId: String? = null,
         failure: DirectClaimFailure? = null,
+        frameworkExpected: Boolean = true,
     ) = UsbController(
         vendorId = 0x045E,
         productId = 0x028E,
@@ -30,6 +31,7 @@ class UsbPathMachineTest {
         userInitiated = userInitiated,
         connId = connId,
         failure = failure,
+        frameworkExpected = frameworkExpected,
     )
 
     // ── Routed ───────────────────────────────────────────────────────────────
@@ -160,6 +162,47 @@ class UsbPathMachineTest {
         assertEquals(listOf(UsbEffect.StartTimeout), r.effects)
     }
 
+    // Stealing the interface is irrelevant when no framework gamepad exists to re-enumerate: waiting
+    // would only time out into a false "needs replug", so the failure settles Standard directly.
+    @Test
+    fun `claiming + stolen failure with no framework identity drops straight to standard`() {
+        val r =
+            reduce(
+                controller(UsbPhase.Claiming, userInitiated = true, frameworkExpected = false),
+                UsbEvent.ClaimFailed(DirectClaimFailure.InitFailed, frameworkStolen = true),
+            )
+        assertEquals(UsbPhase.Routed, r.next?.phase)
+        assertEquals(PathChoice.Standard, r.next?.desired)
+        assertEquals(DirectClaimFailure.InitFailed, r.next?.failure)
+        assertEquals(
+            listOf(
+                UsbEffect.EndHold,
+                UsbEffect.SetPref(PathChoice.Standard),
+                UsbEffect.MarkFailure(DirectClaimFailure.InitFailed),
+                UsbEffect.Notify(UsbNotice.SwitchToDirectFailed),
+            ),
+            r.effects,
+        )
+    }
+
+    @Test
+    fun `claiming + auto stolen failure with no framework identity is silent`() {
+        val r =
+            reduce(
+                controller(UsbPhase.Claiming, userInitiated = false, frameworkExpected = false),
+                UsbEvent.ClaimFailed(DirectClaimFailure.InitFailed, frameworkStolen = true),
+            )
+        assertEquals(UsbPhase.Routed, r.next?.phase)
+        assertEquals(
+            listOf(
+                UsbEffect.EndHold,
+                UsbEffect.SetPref(PathChoice.Standard),
+                UsbEffect.MarkFailure(DirectClaimFailure.InitFailed),
+            ),
+            r.effects,
+        )
+    }
+
     // ── Direct ───────────────────────────────────────────────────────────────
 
     @Test
@@ -169,6 +212,58 @@ class UsbPathMachineTest {
         assertEquals(-1000, r.next?.syntheticId)
         assertNull(r.next?.failure)
         assertEquals(listOf(UsbEffect.Release, UsbEffect.StartTimeout), r.effects)
+    }
+
+    // The strand this guards against: a model that never re-enumerates as a framework gamepad (the
+    // Steam Controller settles as keyboard/mouse) would sit in AwaitingFramework until the timeout
+    // dumped every single release into RestoreStuck with a false "restore failed" banner.
+    @Test
+    fun `direct + choose standard with no framework identity settles routed at once`() {
+        val r =
+            reduce(
+                controller(UsbPhase.Direct, syntheticId = -1000, frameworkExpected = false),
+                UsbEvent.Choose(PathChoice.Standard, userInitiated = true),
+            )
+        assertEquals(UsbPhase.Routed, r.next?.phase)
+        assertEquals(PathChoice.Standard, r.next?.desired)
+        assertNull(r.next?.syntheticId)
+        assertNull(r.next?.frameworkId)
+        assertNull(r.next?.failure)
+        assertEquals(
+            listOf(
+                UsbEffect.Release,
+                UsbEffect.RemoveSynthetic(-1000),
+                UsbEffect.SetPref(PathChoice.Standard),
+                UsbEffect.ClearFailure,
+            ),
+            r.effects,
+        )
+    }
+
+    @Test
+    fun `a release with no framework identity never starts the stuck-detection timer`() {
+        val r =
+            reduce(
+                controller(UsbPhase.Direct, syntheticId = -1000, frameworkExpected = false),
+                UsbEvent.Choose(PathChoice.Standard, userInitiated = true),
+            )
+        assertFalse(r.effects.contains(UsbEffect.StartTimeout))
+        // A stray Timeout (a stale timer from an earlier transition) must be a no-op on the settled state.
+        val afterTimeout = reduce(r.next!!, UsbEvent.Timeout)
+        assertEquals(UsbPhase.Routed, afterTimeout.next?.phase)
+        assertTrue(afterTimeout.effects.isEmpty())
+    }
+
+    @Test
+    fun `a released model with no framework identity can opt straight back into direct`() {
+        val released =
+            reduce(
+                controller(UsbPhase.Direct, syntheticId = -1000, hasPermission = true, frameworkExpected = false),
+                UsbEvent.Choose(PathChoice.Standard, userInitiated = true),
+            ).next!!
+        val r = reduce(released, UsbEvent.Choose(PathChoice.Direct, userInitiated = true))
+        assertEquals(UsbPhase.Claiming, r.next?.phase)
+        assertEquals(listOf(UsbEffect.ClearFailure, UsbEffect.BeginHold, UsbEffect.Claim), r.effects)
     }
 
     // ── AwaitingFramework ────────────────────────────────────────────────────
@@ -381,14 +476,34 @@ class UsbPathMachineTest {
                 UsbEvent.ClaimFailed(DirectClaimFailure.InitFailed, frameworkStolen = true),
                 UsbEvent.Timeout,
             )
-        for (phase in UsbPhase.values()) {
-            for (e in events) {
-                val held = phase == UsbPhase.Direct || phase == UsbPhase.RestoreStuck
-                // The assertion is that no (phase x event) throws; a surviving controller keeps a phase.
-                val r = reduce(controller(phase, syntheticId = if (held) -1000 else null), e)
-                assertTrue(r.next == null || r.next.name.isNotEmpty())
+        for (expected in listOf(true, false)) {
+            for (phase in UsbPhase.values()) {
+                for (e in events) {
+                    val held = phase == UsbPhase.Direct || phase == UsbPhase.RestoreStuck
+                    // The assertion is that no (phase x event) throws; a surviving controller keeps a phase.
+                    val r =
+                        reduce(
+                            controller(phase, syntheticId = if (held) -1000 else null, frameworkExpected = expected),
+                            e,
+                        )
+                    assertTrue(r.next == null || r.next.name.isNotEmpty())
+                }
             }
         }
+    }
+
+    @Test
+    fun `direct claim count sees only direct-phase controllers`() {
+        val map =
+            mapOf(
+                1 to controller(UsbPhase.Direct, syntheticId = -1000),
+                2 to controller(UsbPhase.Claiming),
+                3 to controller(UsbPhase.RestoreStuck, syntheticId = -1001),
+                4 to controller(UsbPhase.Routed),
+                5 to controller(UsbPhase.Direct, syntheticId = -1002, frameworkExpected = false),
+            )
+        assertEquals(2, map.directClaimCount())
+        assertEquals(0, emptyMap<Int, UsbController>().directClaimCount())
     }
 
     @Test

--- a/docs/usb-direct-mode-followups.md
+++ b/docs/usb-direct-mode-followups.md
@@ -148,6 +148,18 @@ exit paths. Listed in `kImported`, so Direct is opt-in and never auto-claimed.
 - Dongle-specific behaviour: `ID_CONTROLLER_WIRELESS` connect/disconnect events arrive on the same
   endpoint and are currently rejected by the decoder rather than driving connect state.
 
+**Known limitation, the dongle reaches one slot:** the wired pad enumerates as mouse, keyboard,
+pad; the dongle enumerates as keyboard then four pad interfaces, one per paired controller.
+`findInterruptInPair` breaks a rank tie by taking the first candidate, so only the first slot is
+ever claimed. A pad paired to another slot fails `probeDecodable` and falls back to routed, which
+is safe but looks like "Direct failed". Reaching the others means attaching each candidate in turn
+rather than picking one up front.
+
+The interface pick also assumes the emulated keyboard and mouse declare the HID boot subclass.
+`hid-steam` deliberately does not rely on that, distinguishing the real pad by its report
+descriptor instead. If the assumption is wrong the config packets go to the wrong interface, stall,
+and the claim falls back to routed after roughly a second.
+
 **Deliberately absent:**
 - Rumble. The pad has no motors, only trackpad voice coils driven by `ID_TRIGGER_HAPTIC_PULSE`
   pulse trains; the simple rumble command is Steam Deck firmware only, and `hid-steam` gates force

--- a/docs/usb-direct-mode-followups.md
+++ b/docs/usb-direct-mode-followups.md
@@ -133,8 +133,25 @@ work or stay silent; none receives a malformed report.
 
 **Status:** Implemented from SDL and `hid-steam` (see `THIRD_PARTY.md`), never run against the
 hardware. `Parser::STEAM_CONTROLLER` decodes the state packet; `InitKind::STEAM_QUIET` stops the
-firmware's stand-alone keyboard/mouse emulation at attach and `runTeardown` restores it on all three
-exit paths. Listed in `kImported`, so Direct is opt-in and never auto-claimed.
+firmware's stand-alone keyboard/mouse emulation at attach and `runTeardown` restores it on every
+exit path that still has the device, physical unplug included (the unplug path detaches the native
+device too, so the attempt is made even though an unplugged wired pad has already lost the volatile
+settings with its power). The restore loads the firmware's stand-alone defaults, not a snapshot of
+the pre-claim state; that is deliberate and mirrors SDL's close sequence, and Steam re-pushes its
+own configuration whenever the pad reconnects to it. Listed in `kImported`, so Direct is opt-in and
+never auto-claimed.
+
+Because the released pad re-enumerates as a keyboard and mouse, never as a framework gamepad, the
+path FSM settles Standard immediately on release (`frameworkExpected` in `UsbPathMachine`) instead
+of waiting for a re-enumeration that cannot come and stranding in RestoreStuck. The foreground
+service also stays up while any Direct claim is held, so backgrounding the app does not leave the
+process (and the pending restore) at the mercy of the low-memory killer.
+
+Dongle connect/disconnect events (`ID_CONTROLLER_WIRELESS`, same endpoint as input) are classified
+by `checkWirelessEvent`: a disconnect publishes a neutral state, since a powering-off pad would
+otherwise leave its last input latched on the wire, plausibly the held Steam button of the
+power-off gesture; a connect re-runs the quiet init, since the pad rebooted into stand-alone
+defaults and would stream without motion while its lizard keyboard leaked into the phone.
 
 **Unverified and worth checking first:**
 - IMU axis order and signs. Gyro is mapped pitch/yaw/roll from raw X/Z/Y and accel from X/Z/-Y,
@@ -144,9 +161,10 @@ exit paths. Listed in `kImported`, so Direct is opt-in and never auto-claimed.
   radius or response curve may be needed.
 - Whether the settings survive an unplug. They are assumed volatile. A wired pad powers down when
   unplugged, but a controller left paired to the dongle stays powered, so an app kill between attach
-  and teardown could leave it mute as a desktop mouse until it sleeps.
-- Dongle-specific behaviour: `ID_CONTROLLER_WIRELESS` connect/disconnect events arrive on the same
-  endpoint and are currently rejected by the decoder rather than driving connect state.
+  and teardown leaves it mute as a desktop mouse until its own power cycle (hold the Steam button)
+  or until the relaunched app re-claims it.
+- The wireless event framing and the reconnect re-init, which follow `hid-steam` but have never
+  seen a real dongle.
 
 **Known limitation, the dongle reaches one slot:** the wired pad enumerates as mouse, keyboard,
 pad; the dongle enumerates as keyboard then four pad interfaces, one per paired controller.
@@ -170,8 +188,11 @@ and the claim falls back to routed after roughly a second.
   framework as a gamepad.
 
 **Where:** `app/src/main/cpp/usb_parsers.cpp` (`decodeSteamController`, `buildSteamConfigPacket`,
-`runInit`, `runTeardown`), `app/src/main/cpp/usb_host.cpp` (`attachDevice`, `shutdownLocked`),
-`app/src/main/java/.../source/usb/UsbGamepadManager.kt` (`gameInterfaceRank`).
+`checkWirelessEvent`, `modelExpectsFrameworkGamepad`, `runInit`, `runTeardown`),
+`app/src/main/cpp/usb_host.cpp` (`attachDevice`, `pollLoop`, `shutdownLocked`),
+`app/src/main/java/.../source/usb/UsbPathMachine.kt` (`frameworkExpected`),
+`app/src/main/java/.../source/usb/UsbGamepadManager.kt` (`gameInterfaceRank`, `releaseAllDirect`),
+`app/src/main/java/.../composer/StreamingServiceController.kt` (claim-hold).
 
 **Acceptance:** A wired Steam Controller picked as Direct streams sticks, triggers, buttons and
 motion, drives nothing on the phone while claimed, and works as a desktop mouse again after being

--- a/docs/usb-direct-mode-followups.md
+++ b/docs/usb-direct-mode-followups.md
@@ -126,3 +126,41 @@ counter handling, and sources are in `docs/rumble.md`.
 **Acceptance:** A claimed USB-direct pad of each verified family rumbles on `MSG_RUMBLE` and stops on
 the 0,0 packet (or the safety auto-stop), with no effect on input latency. Unverified families either
 work or stay silent; none receives a malformed report.
+
+---
+
+## 8. Steam Controller (implemented, needs hardware verification)
+
+**Status:** Implemented from SDL and `hid-steam` (see `THIRD_PARTY.md`), never run against the
+hardware. `Parser::STEAM_CONTROLLER` decodes the state packet; `InitKind::STEAM_QUIET` stops the
+firmware's stand-alone keyboard/mouse emulation at attach and `runTeardown` restores it on all three
+exit paths. Listed in `kImported`, so Direct is opt-in and never auto-claimed.
+
+**Unverified and worth checking first:**
+- IMU axis order and signs. Gyro is mapped pitch/yaw/roll from raw X/Z/Y and accel from X/Z/-Y,
+  following SDL's sensor block; the same signs are unverified for the Switch Pro (item 2).
+- Right pad as right stick. It recentres on lift and carries SDL's 15-degree shell rotation but not
+  SDL's extra +1000 offset, which would park the stick off centre. Feel is untested; an outer
+  radius or response curve may be needed.
+- Whether the settings survive an unplug. They are assumed volatile. A wired pad powers down when
+  unplugged, but a controller left paired to the dongle stays powered, so an app kill between attach
+  and teardown could leave it mute as a desktop mouse until it sleeps.
+- Dongle-specific behaviour: `ID_CONTROLLER_WIRELESS` connect/disconnect events arrive on the same
+  endpoint and are currently rejected by the decoder rather than driving connect state.
+
+**Deliberately absent:**
+- Rumble. The pad has no motors, only trackpad voice coils driven by `ID_TRIGGER_HAPTIC_PULSE`
+  pulse trains; the simple rumble command is Steam Deck firmware only, and `hid-steam` gates force
+  feedback on the Deck quirk. `parserHasRumble` is false, so nothing is advertised.
+- The grip buttons, which have no XUSB equivalent.
+- Streaming either trackpad over `MSG_TOUCHPAD`, which would double-actuate against the right stick.
+- Bluetooth. The pad speaks Valve's own BLE protocol, not HID over GATT, so it never reaches the
+  framework as a gamepad.
+
+**Where:** `app/src/main/cpp/usb_parsers.cpp` (`decodeSteamController`, `buildSteamConfigPacket`,
+`runInit`, `runTeardown`), `app/src/main/cpp/usb_host.cpp` (`attachDevice`, `shutdownLocked`),
+`app/src/main/java/.../source/usb/UsbGamepadManager.kt` (`gameInterfaceRank`).
+
+**Acceptance:** A wired Steam Controller picked as Direct streams sticks, triggers, buttons and
+motion, drives nothing on the phone while claimed, and works as a desktop mouse again after being
+unplugged or switched back to Standard.

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,6 @@ org.gradle.configuration-cache=true
 kotlin.code.style=official
 
 android.useAndroidX=true
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
## What

Adds Steam Controller support (wired `28DE:1102` and the wireless dongle `28DE:1142`) to USB Direct mode, along with the two pieces of shared machinery that supporting it needed: generic boot-interface ranking, and a device-restore hook that runs when a claim is released.

## Why this pad only works on Direct

The Steam Controller ships in stand-alone ("lizard") mode, emulating a keyboard and a mouse. Its actual game interface is vendor-defined HID with no gamepad usages, so Android never enumerates it as a gamepad and `PhysicalGamepadRegistry` has nothing to bind.

That makes this different from every other model in the catalog. For DualSense or Switch Pro, Direct is an upgrade over the framework path. Here it is the difference between the controller working and not existing on the platform at all.

## Commits

| | |
|---|---|
| `28ea71c` | `feat: Steam Controller over USB Direct` |
| `6e53f32` | `build: parallel Tooling Model Builders for faster IDE sync` |
| `39ea725` | `fix: hand the Steam Controller's right pad back as a mouse on teardown` |
| `b92dfe4` | `fix: Steam Controller release, unplug, and dongle-drop lifecycle` |
| `a3b7957` | `feat: keep the foreground service up while a Direct claim is held` |

## What is included

### 1. Steam Controller decode

`Parser::STEAM_CONTROLLER` decodes the 48-byte state packet: buttons, dpad, analog triggers (Valve's 26000 full scale, so the throw saturates before the raw rail), the left stick, the right trackpad as a right stick, and the IMU.

Two decode details worth review:

- The left stick and left trackpad **share one pair of axes**. `STEAM_LEFTPAD_FINGERDOWN` selects which, and `STEAM_LEFTPAD_AND_JOYSTICK` means frames alternate, so the stick value is held in `ParserState` across pad frames. Matches `FormatStatePacketUntilGyro`, including the firmware quirk where a stick click arrives as a left-pad click while the pad is idle.
- The right pad carries SDL's 15° shell rotation but **not** its extra `+1000` offset, which is fine for a touch surface but would park a stick off centre. It recentres on lift, since pad coordinates are meaningless with no finger down.

The IMU block self-gates: an all-zero accel and gyro read means the sensor enable never took, and publishing it would stream a dead sensor, so `motionValid` stays false.

### 2. Stand-alone mode off at attach, restored on release

Switched off at attach (`ID_CLEAR_DIGITAL_MAPPINGS`, then one `ID_SET_SETTINGS_VALUES` carrying both trackpad modes and the IMU enable) through a new `runTeardown` hook that runs on **all three** exit paths, including both `attachDevice` bail-outs where a partly-applied init has already changed the device.

This is the first parser in the codebase whose init *persistently reconfigures* the device rather than kicking it into a mode, so the restore path carries more weight than usual: skipping it hands a user back a controller that no longer works as a desktop mouse, from an operation that visibly did nothing. Restore therefore mirrors SDL's `CloseSteamController` rather than `hid-steam`, which stops one packet earlier: after `ID_LOAD_DEFAULT_SETTINGS` it re-sets the right trackpad to absolute mouse by name, because loading the defaults does not reliably bring mouse mode back on its own.

Feature-report writes retry on `EPIPE` the way SDL and `hid-steam` both do, since that is the wireless dongle under load rather than a real failure. The retry budget is capped at 25 tries rather than `hid-steam`'s 50: at 20ms apart, 50 would let a wholly unresponsive device spend 2s in init plus 3s in teardown and overrun `UsbGamepadManager`'s 4s `TRANSITION_TIMEOUT_MS`, turning a clean fallback into a spurious needs-replug. A persistent failure is reported as the existing `DirectClaimFailure.InitFailed` and the claim is released. It deliberately does **not** degrade to "streaming works but the pad is also typing into your phone", which nothing in the model represents and the user could not diagnose.

The IMU enable shares a packet with the trackpad-mode writes on purpose: there is no path where the pad goes quiet but motion stays off, which would advertise a sensor that never reports.

`runTeardown` is a general hook, not a Steam special case. It is a no-op for every family that never changed the device, and it is where a Switch Pro mode restore would go if that is ever wanted.

### 3. Interface ranking, generalised

`gameInterfaceRank` scored every HID-class interface alike, which is correct for every model shipped so far because none of them lead with emulated human-interface devices. A pad that does needs the picker to tell them apart: without it, `findInterruptInPair` keeps the first candidate and the claim lands on **interface 0, the keyboard**. Classification then falls through to `GENERIC_HID_GAMEPAD`, whose descriptor parse fails (keyboard input items sit on usage pages 0x07/0x08) and whose fallback decoder gates only on `len >= 7`, so an 8-byte boot keyboard report would decode "successfully", pinning the sticks to the rail and firing keycode bytes as buttons.

Boot-protocol HID interfaces now sort below everything else. The rule is keyed on `bInterfaceSubClass`/`bInterfaceProtocol`, not on Valve's vendor id, so any composite pad benefits. They are deprioritised, not disqualified, so a device offering nothing else is still claimable. Rank constants renumbered accordingly; relative order of XInput, GIP, HID and vendor-fallback is unchanged.

### 4. Build config (unrelated, bundled here)

`org.gradle.tooling.parallel=true` lets the IDE build project models concurrently during sync. It overrides `org.gradle.parallel` in that context only, so task execution is unaffected. No relation to the rest of the PR, carried here rather than spending a separate round trip on a three-line properties change.

## What the user sees

- The pad appears by name (`Valve Steam Controller`, or `(dongle)`) in the guided USB setup flow, which lists raw USB devices rather than registry gamepads.
- Picking **Direct** claims it, and sticks, triggers, buttons, dpad, the right pad as a right stick, and motion stream to the bound destination.
- While claimed, it stops acting as a mouse and keyboard on the phone.
- Switching back to **Standard**, unplugging, or any claim failure restores stand-alone mode.
- No new screens. One new notification string (the claim-hold body, translated in all six locales) arrived with the follow-up commits below. For other controllers the only behaviour change is the foreground service also counting their held Direct claims.

Capability surface, all derived from the existing native model queries rather than new plumbing:

| Feature | State | Path |
|---|---|---|
| Motion | Available | `parserHasImu` → `modelHasImu` → `PathCapabilities.motion` |
| Rumble | Not available | `parserHasRumble` false, nothing advertised |
| Touchpad | Sourced from the phone overlay | `parserHasTouchpad` false → `TouchpadRouting` → `TouchpadSource.PHONE` |
| Auto-claim | Never | in `kImported`, so `isVerifiedFastLane` is false |

## Changed surface

| File | What |
|---|---|
| `app/src/main/cpp/usb_parsers.h` | `Parser::STEAM_CONTROLLER`, `InitKind::STEAM_QUIET`, `SteamConfig`, held-stick state, `runTeardown` declaration |
| `app/src/main/cpp/usb_parsers.cpp` | `decodeSteamController`, `buildSteamConfigPacket`, `sendFeatureReport`, `runTeardown`, two `kImported` rows, capability predicates |
| `app/src/main/cpp/usb_host.cpp` | `runTeardown` on all three exit paths; `runInit` gains the interface number |
| `.../source/usb/UsbGamepadManager.kt` | boot-interface deprioritisation in `gameInterfaceRank` |
| `app/src/test/cpp/usb_parsers_test.cpp` | 20 native tests |
| `.../source/usb/UsbGamepadManagerTest.kt` | 2 interface-selection tests |
| `THIRD_PARTY.md` | SDL `hidapi/steam` and `hid-steam` attribution |
| `CHANGELOG.md` | entry under `[Unreleased] / Added` |
| `docs/usb-direct-mode-followups.md` | item 8: status, unverified list, known limitations, acceptance criteria |
| `gradle.properties` | the Tooling API parallel flag |

**Not touched:** no wire-protocol change (nothing in `wire_encoders`, no `protocolVersion` bump, not `[wire-coordinated]`), no UI layouts, no satellite or host-side work. This is a client-only change and needs no fleet coordination. (The follow-up commits add one notification string per locale and one DI edge, `StreamingServiceController`/`StreamingService` → `UsbGamepadManager`; the graph stays acyclic and Hilt compiles it.)

## Scope: what is deliberately not here

- **Rumble.** The pad has no motors, only trackpad voice coils driven by `ID_TRIGGER_HAPTIC_PULSE` pulse trains; the simple rumble command is Steam Deck firmware only and `hid-steam` gates force feedback on the Deck quirk.
- **The grip buttons**, which have no XUSB equivalent.
- **Streaming either trackpad over `MSG_TOUCHPAD`**, which would double-actuate against the right stick.
- **Bluetooth.** The pad speaks Valve's own BLE protocol, not HID over GATT, so it never reaches the framework as a gamepad.

## Not verified on hardware

I have no Steam Controller. Protocol facts come from SDL's `hidapi/steam` headers and `hid-steam`, attributed in `THIRD_PARTY.md`. IMU axis signs, right-pad feel, and dongle behaviour are unverified and written up in `docs/usb-direct-mode-followups.md` item 8, along with two known limitations:

- The dongle enumerates four pad interfaces, one per paired controller, and the rank tiebreak only ever reaches the first. A pad on another slot fails `probeDecodable` and falls back to routed, which is safe but reads as "Direct failed".
- The interface pick assumes the emulated keyboard and mouse declare the HID boot subclass. `hid-steam` deliberately does not rely on that, distinguishing the real pad by its report descriptor instead. If the assumption is wrong the config packets stall and the claim falls back to routed after roughly a second.

One residual risk that cannot be closed from inside the process: a controller left paired to the dongle stays powered when the dongle is pulled, so an app kill between attach and teardown could leave it mute as a desktop mouse until it sleeps or the Steam button is held. A wired pad self-heals because unplugging powers it down. The follow-up service hold (`a3b7957`) shrinks the exposure, since a claimed pad no longer rides in an unprotected cached process, but nothing can send a restore at kill time.

## Review follow-ups

A scenario audit of what happens to the flipped device-side settings across releases, disconnects, backgrounding, and process death turned up four gaps; `b92dfe4` and `a3b7957` close them.

- **Every clean release falsely reported failure.** The restored pad settles as a keyboard and mouse, which `PhysicalGamepadRegistry` rightly refuses to track as a gamepad, so `FrameworkUp` never fired and the FSM's wait timed out into RestoreStuck ("Standard isn't responding") on every single switch back, with NeedsReplug on the stolen-interface claim-failure path. `UsbController.frameworkExpected` (fed from `modelExpectsFrameworkGamepad` in the native model table) now settles both paths on Standard immediately for models with no framework gamepad identity.
- **A pad dropping off the dongle latched its last input.** `ID_CONTROLLER_WIRELESS` events were rejected by the decoder, so a pad powering off mid-session kept its last decoded state on the wire, plausibly the held Steam button of the power-off gesture, popping overlays host-side. And a pad powering back on rebooted into stand-alone defaults with no re-init, streaming without motion while its lizard keyboard leaked into the phone. `checkWirelessEvent` now classifies the events; the poll loop publishes neutral state on disconnect and re-runs the attach init on connect, mirroring `hid-steam`'s reconnect handling.
- **Physical unplug leaked the native device context.** The unplug path emitted `RemoveSynthetic` without ever calling the native detach, stranding the exited poller thread, its dup'd fd, and dispatch state in `g_devices`, for every Direct family, not just this one. The `RemoveSynthetic` effect now detaches first; the call is idempotent after a `Release`.
- **Backgrounding left a claimed pad unprotected.** The connectedDevice foreground service stopped on process ON_STOP while the USB claim survived, so a background kill (the one exit with no restore hook) was the likeliest way to strand a quiet-mode pad. The service and its controller now count held Direct claims alongside streaming slots, run in the background while any remain, and exit when the last goes; the notification's Stop action releases held claims (restore included) and its body says what is held when nothing is streaming.

## Tests and verification

- **26 native tests** covering classification and init resolution, both config sequences and their bounds, buffer-overrun refusal, every button mapping, trigger scaling and saturation, all three left-axis sharing modes, right-pad rotation and recentring, IMU axis order and scale, the silent-IMU guard, rejection of short, wrong-version and wireless-event packets, wireless connect/disconnect classification (and its malformed and wrong-parser rejections), and the framework-identity table.
- **JVM tests**: interface selection (the controller interface wins over a boot keyboard and mouse; a boot-only device is still claimable); FSM coverage of the no-framework-identity release and stolen-claim-failure settles, the never-starts-the-stuck-timer guarantee, the opt-straight-back-into-Direct journey, and totality over both `frameworkExpected` values; manager-level release flows for both identities, the double-detach the unplug path relies on, and `releaseAllDirect`; service-controller coverage of claim-alone start, background hold with claims, background stop without, and the foreground re-assert.

Every protocol constant was cross-checked against current upstream (SDL `main`, Linux `master`): the 19 button masks, byte offsets for buttons, triggers, axes and IMU, trigger expansion and full scale, pad rotation direction, IMU axis order and both scale factors against this project's wire convention, message and setting ids, trackpad and gyro mode values, and the SET_REPORT framing.

Local gates green: clang-format (22.1.4, matching the CI pin), play-metadata lint, ktlint, detekt, Android lint, JVM unit tests, **318 native tests**, assembleDebug, and the JNI library build. Instrumented suite runs in CI.

