### PR TITLE
fix: claim a silent verified pad instead of failing the Direct probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ four repos share a version number.
 - Phantom held inputs (a button, the d-pad, or an off-center stick or
   trigger) no longer linger on the virtual pad after binding a controller,
   before the first real movement.
+- Claiming USB Direct no longer fails on a verified controller that is
+  sitting untouched. Event-driven pads such as the Amazon Luna Controller
+  send no reports at rest, so the switch used to succeed only while a
+  stick or button was moving.
 
 ### Changed: control-plane rewrite (protocol 1) `[wire-coordinated]`
 

--- a/app/src/main/cpp/usb_host.cpp
+++ b/app/src/main/cpp/usb_host.cpp
@@ -290,10 +290,12 @@ constexpr int kProbeMaxReads = 16;
 constexpr unsigned kProbeReadTimeoutMs = 80;
 constexpr int kProbeMaxTimeouts = 4;
 
-bool probeDecodable(int fd, uint8_t epIn, uint16_t epInMaxPacket, usbparsers::Parser parser) {
+usbparsers::ProbeOutcome probeEndpoint(int fd, uint8_t epIn, uint16_t epInMaxPacket,
+                                       usbparsers::Parser parser) {
     std::vector<uint8_t> buf(epInMaxPacket == 0 ? 64 : epInMaxPacket);
     gamepad::DeviceState scratch{};
     usbparsers::ParserState probeSticks;
+    bool sawTraffic = false;
     int consecutiveTimeouts = 0;
     for (int i = 0; i < kProbeMaxReads; i++) {
         struct usbdevfs_bulktransfer xfer = {};
@@ -307,12 +309,17 @@ bool probeDecodable(int fd, uint8_t epIn, uint16_t epInMaxPacket, usbparsers::Pa
             continue;
         }
         consecutiveTimeouts = 0;
+        sawTraffic = true;
+        if (usbparsers::checkWirelessEvent(parser, buf.data(), (size_t)n) !=
+            usbparsers::WirelessEvent::NONE) {
+            return usbparsers::ProbeOutcome::DECODED;
+        }
         memset(&scratch, 0, sizeof(scratch));
         if (usbparsers::decodeReport(parser, buf.data(), (size_t)n, scratch, &probeSticks)) {
-            return true;
+            return usbparsers::ProbeOutcome::DECODED;
         }
     }
-    return false;
+    return sawTraffic ? usbparsers::ProbeOutcome::UNDECODED : usbparsers::ProbeOutcome::SILENT;
 }
 
 // Best-effort: a failed transfer or unparseable descriptor leaves the layout invalid, so the
@@ -390,13 +397,18 @@ AttachResult attachDevice(int fd, uint16_t vid, uint16_t pid, int interfaceNumbe
         return out;
     }
 
-    if (!probeDecodable(fd, epIn, epInMaxPacket, parser)) {
-        LOGI("attach %04X:%04X (%s): no parseable reports, releasing to framework", vid, pid,
-             modelName.c_str());
+    usbparsers::ProbeOutcome probed = probeEndpoint(fd, epIn, epInMaxPacket, parser);
+    if (!usbparsers::probePermitsClaim(probed, usbparsers::isVerifiedFastLane(vid, pid))) {
+        LOGI("attach %04X:%04X (%s): %s, releasing to framework", vid, pid, modelName.c_str(),
+             probed == usbparsers::ProbeOutcome::SILENT ? "no reports" : "reports did not decode");
         usbparsers::runTeardown(fd, interfaceNumber, parser);
         releaseAndReattach(fd, interfaceNumber);
         ::close(fd);
         return out;
+    }
+    if (probed == usbparsers::ProbeOutcome::SILENT) {
+        LOGI("attach %04X:%04X (%s): silent at rest, claiming verified model", vid, pid,
+             modelName.c_str());
     }
 
     auto ctx = std::make_shared<DeviceCtx>();

--- a/app/src/main/cpp/usb_parsers.cpp
+++ b/app/src/main/cpp/usb_parsers.cpp
@@ -406,6 +406,18 @@ bool modelExpectsFrameworkGamepad(uint16_t vid, uint16_t pid) {
     return k == nullptr || k->parser != Parser::STEAM_CONTROLLER;
 }
 
+bool probePermitsClaim(ProbeOutcome outcome, bool verifiedFastLane) {
+    switch (outcome) {
+    case ProbeOutcome::DECODED:
+        return true;
+    case ProbeOutcome::SILENT:
+        return verifiedFastLane;
+    case ProbeOutcome::UNDECODED:
+        return false;
+    }
+    return false;
+}
+
 constexpr uint8_t kIfClassVendor = 0xFF;
 constexpr uint8_t kXInputSubclass = 0x5D;
 constexpr uint8_t kXInputProtocol = 0x01;

--- a/app/src/main/cpp/usb_parsers.h
+++ b/app/src/main/cpp/usb_parsers.h
@@ -114,6 +114,14 @@ Classification classifyDevice(uint16_t vid, uint16_t pid, uint8_t ifClass, uint8
 
 bool isVerifiedFastLane(uint16_t vid, uint16_t pid);
 
+enum class ProbeOutcome : uint8_t {
+    DECODED = 0,
+    SILENT = 1,
+    UNDECODED = 2,
+};
+
+bool probePermitsClaim(ProbeOutcome outcome, bool verifiedFastLane);
+
 // Whether releasing this model back to Standard produces a framework gamepad InputDevice. False
 // for the Steam Controller, whose stand-alone identity is a keyboard and mouse: a release that
 // waited for a framework gamepad would always time out into a false "restore stuck".

--- a/app/src/test/cpp/usb_parsers_test.cpp
+++ b/app/src/test/cpp/usb_parsers_test.cpp
@@ -38,6 +38,8 @@ using usbparsers::parserHasImu;
 using usbparsers::parserHasRumble;
 using usbparsers::parserHasTouchpad;
 using usbparsers::ParserState;
+using usbparsers::ProbeOutcome;
+using usbparsers::probePermitsClaim;
 using usbparsers::PsImuCalib;
 using usbparsers::SteamConfig;
 using usbparsers::WirelessEvent;
@@ -308,6 +310,21 @@ TEST(KnownDevices, ImportedPs4StickRoutesToDualShock4) {
 TEST(KnownDevices, UnknownModelIsNeitherRecognizedNorFastLane) {
     EXPECT_EQ(nullptr, usbparsers::lookupKnown(0x0000, 0x0000));
     EXPECT_FALSE(usbparsers::isVerifiedFastLane(0x0000, 0x0000));
+}
+
+TEST(ProbeRule, DecodedReportClaimsAtAnyTrustLevel) {
+    EXPECT_TRUE(probePermitsClaim(ProbeOutcome::DECODED, true));
+    EXPECT_TRUE(probePermitsClaim(ProbeOutcome::DECODED, false));
+}
+
+TEST(ProbeRule, SilenceClaimsOnlyVerifiedModels) {
+    EXPECT_TRUE(probePermitsClaim(ProbeOutcome::SILENT, true));
+    EXPECT_FALSE(probePermitsClaim(ProbeOutcome::SILENT, false));
+}
+
+TEST(ProbeRule, UndecodedTrafficNeverClaims) {
+    EXPECT_FALSE(probePermitsClaim(ProbeOutcome::UNDECODED, true));
+    EXPECT_FALSE(probePermitsClaim(ProbeOutcome::UNDECODED, false));
 }
 
 TEST(Decode, SwitchProAveragesImuSubframes) {


### PR DESCRIPTION
## Description

The USB Direct attach probe treated ~320ms of endpoint silence as proof the chosen parser was wrong and released the device back to the framework. That assumption held for every current verified table entry because wired XInput-class pads stream reports at rest. The Amazon Luna Controller (wired USB, `1949:041A`, #153) is event-driven: it sends nothing until a button, stick, or trigger changes, so switching an idle Luna to Direct failed unless the user happened to be moving a stick during the probe window, and putting the model on the verified fast lane would make the plug-in auto-claim fail the same way.

`probeEndpoint` (was `probeDecodable`) now distinguishes three outcomes, and `probePermitsClaim` in `usb_parsers` decides per trust level:

- A decoded report, or a recognized wireless link event, claims at any trust level.
- Traffic that never decodes releases at any trust level: bytes in the wrong shape are positive evidence of a wrong parser.
- Pure silence claims only a model in the hardware-verified `kKnown` table. Imported and descriptor-sniffed models still require a decoded report, because for them the probe is the only verification.

This mirrors what the reference stacks do with this device class: the Linux xpad driver (5.13+) and SDL both classify the Luna by ID alone and are event-driven end to end, with no idle-traffic requirement. Neither has a wake or init packet we could send instead; none exists for this protocol family.

The steady-state poll loop is already silence-tolerant (interrupt URBs stay pending until data arrives; only ENODEV exits), so a claimed idle pad is healthy. Behavior for every currently verified model is unchanged, since they all stream at rest.

Prepares for #153, which puts the Luna on the verified fast lane.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Unit tests
- [ ] Instrumented tests
- [ ] Manual testing on device/emulator

Native host suite 321/321 passing, including three new `ProbeRule` cases covering the outcome/trust truth table. `:app:externalNativeBuildDebug` compiles clean on both ABIs. clang-format 22.1.4 clean on all touched files.

Hardware verification on an actual Luna is requested in #153 from @MichaelWilsonSNC, who has the device: idle plug-in auto-claim, idle Standard-to-Direct toggle, and toggle while active.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Any non-obvious code explains why, not what (no new comments; rationale is in this PR and the commit message)
- [x] I have made corresponding changes to documentation (`CHANGELOG.md`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
