### PR TITLE
feat: Switch-layout button remap for PDP wired Switch pads (Standard quirk + Direct button order)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,188 +1,66 @@
 # Changelog
 
-All notable changes to the Dish Android client are documented in this
-file. The format is loosely based on
-[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
-project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
-once it reaches `1.0.0`.
+What's new in each version of Dish, in plain language. Newest first.
 
-Cross-repo coordination: changes to the wire protocol or pairing flow
-that require matching updates in `satellite`, `dish-linux`, or `dish-mac`
-are marked `[wire-coordinated]`. Releases tagged in lockstep across the
-four repos share a version number.
+Some updates need the matching version of the free Satellite app on your
+computer. Those lines say "update Satellite too".
 
 ---
 
 ## [Unreleased]
 
-### Added
-
-- Guided Dish Setup flow that takes a first-run user from nothing to a
-  bound controller: pick an input (USB, a Bluetooth controller, or the
-  on-screen pad), set it up, choose a destination (a satellite over Wi-Fi
-  or a Bluetooth host), then configure the controller type and bind. This
-  replaces the old welcome carousel and setup wizard.
-- Bluetooth host pairing: the phone can present itself as a Bluetooth HID
-  gamepad to a paired PC, console, or set-top box. The add flow covers the
-  controller-type pick, the discoverability prompt, and a live
-  wait-for-host countdown.
-- Wider wired-controller support: a curated SDL controller-ID import plus
-  native USB and HID decoding, including a generic HID descriptor parser,
-  DualShock 4 and DualSense motion, Switch Pro motion, and Xbox 360
-  wireless rumble. Imported models are recognized but flagged unverified.
-- Amazon Luna Controller (wired USB) recognized on the verified fast lane:
-  its wired mode is a byte-identical Xbox 360/XInput report, confirmed on
-  hardware for every button, both triggers, both sticks, and rumble.
-- Steam Controller over USB Direct (wired and dongle): sticks, triggers,
-  buttons, motion, and the right trackpad as a right stick. While claimed
-  it no longer doubles as a mouse and keyboard for the phone, and it is
-  put back the way it was when released. Switching it back to Standard
-  settles instantly instead of ending in a false "restore failed" banner,
-  a pad that drops off the dongle no longer leaves its last input held,
-  and one that reconnects is set up again automatically. Unverified on
-  hardware, so it stays opt-in and is never auto-claimed.
-- The streaming notification now also keeps Dish alive while a USB
-  controller is held in Direct mode, so a backgrounded app can always
-  hand the pad back properly, and its Stop action releases those
-  controllers too.
-- Tri-zone controller cards: a read-only report card (connection,
-  destination, emulated type, functions) plus a dedicated Configure
-  bindings screen. Binding changes are staged and applied explicitly
-  instead of committing live.
-- Diagnostics screen, reachable from Settings: live telemetry for every
-  connected controller and host, an input inspector (sticks, buttons,
-  motion, touch) with stick drift/range/circularity health and a rumble
-  tester, a wire-truth panel showing what is actually sent on the wire,
-  network stats with a one-way latency sparkline, a flight recorder,
-  and an opt-in hot-path latency benchmark.
-- Physical trackpads stream natively in USB Direct mode: a DualShock 4
-  or DualSense trackpad drives the satellite touchpad directly, and the
-  phone touchpad overlay is offered only for inputs without a trackpad.
-
-### Changed (user-facing)
-
-- The Connections screen scans for satellites automatically when it opens,
-  and re-homes a remembered satellite whose box moved to a new IP or port,
-  so it reconnects without a manual rescan.
-
 ### Fixed
 
-- Phantom held inputs (a button, the d-pad, or an off-center stick or
-  trigger) no longer linger on the virtual pad after binding a controller,
-  before the first real movement.
-- Claiming USB Direct no longer fails on a verified controller that is
-  sitting untouched. Event-driven pads such as the Amazon Luna Controller
-  send no reports at rest, so the switch used to succeed only while a
-  stick or button was moving.
-
-### Changed: control-plane rewrite (protocol 1) `[wire-coordinated]`
-
-Clean-break rewrite of the satellite control plane against
-`satellite/docs/contract.md` (Android mapping: `docs/contract.md`,
-replacing the former `docs/wire-format.md`).
-
-- Connecting is ONE declarative call: `PUT /api/connections` carries
-  identity, an `hmacProof` of the pairing key, and the full controller
-  topology; the response is the applied state. Re-PUT converges;
-  `connectionId` is stable, the token rotates. Single-slot changes (type,
-  motion caps, touchpad routing) ride per-controller PUT/DELETE routes:
-  no token rotation for a toggle.
-- UDP no longer mutates topology: the controller ADD/REMOVE/TYPE/CAPS
-  opcodes, the ACK-retry choreography, the registration mutex, and the
-  compat type re-send are gone from the JNI layer, which is now socket +
-  crypto + streams only. The enriched heartbeat ack (epoch + active
-  bitmap) drives a self-healing reconcile; the authenticated session-close
-  notify (0x000F) lands as an immediate, reasoned disconnect.
-- Per-session UDP keys: `HKDF-SHA256(pairingKey, sessionSalt, token)` with
-  a direction byte in the nonce (the pairing key never touches UDP).
-  Interop vectors are pinned on both ends.
-- A coded 401 (`NOT_PAIRED` / `BAD_PROOF`) is terminal: the key is
-  dropped, the row reads "needs pairing", and retries stop. Silent
-  reconnects use bounded exponential backoff (1 s to 60 s) instead of a
-  fixed 1.5 s loop.
-- Binding commits the user's chosen type WITH the bind. The
-  default-then-correct Xbox phase is gone end to end (USB-direct claims
-  adopt the remembered type too). `bind` refuses slot ids the registry no
-  longer knows (the zombie-slot guard) and the apply flow re-resolves the
-  slot id after a USB path switch.
-- The binding "Apply" overlay shows one spinner per real async action: the
-  USB-direct switch (which can wait on the system permission prompt) and
-  the single satellite round-trip.
-- The "Emulate" picker renders from the satellite's localized
-  `GET /api/catalog` (ETag-cached); unknown controller types render from
-  server-provided strings instead of being impossible to select.
-- Identity is machineId-only: legacy `satellite:<ip>:<udpPort>` keys, the
-  ghost-row reconciliation, and the single-slot legacy key migration are
-  deleted. Forgetting a satellite now also self-unpairs on it
-  (`DELETE /api/pair`), closing any live session server-side.
-- The per-connection touchpad-mode REST endpoint is gone; routing rides
-  each controller descriptor (client-owned, single writer).
-- JNI `openSocket` refuses non-IPv4 literals instead of silently streaming
-  to 0.0.0.0 when discovery resolves an IPv6 address.
+- PDP wired Switch controllers (Faceoff, Faceoff Deluxe, Faceoff
+  Deluxe+ Audio, Wired Fight Pad Pro, Rock Candy) now work the way the
+  pad is labeled. Before this fix, A did nothing, the right bumper and
+  Home were dead, and most other buttons landed on the wrong action.
+  Now every button does what it says, ZL and ZR act as the triggers,
+  and Home is the guide button, in both Standard and Direct mode.
+- Switching a controller to Direct mode no longer fails while the pad
+  sits untouched. Pads that stay silent until you press something
+  (like the Amazon Luna Controller) used to switch over only if you
+  were moving a stick at the same time.
 
 ### Added
 
-- Firebase Crashlytics integration for crash + ANR reporting.
-  Crashlytics is the only Firebase SDK on the classpath; Firebase
-  Analytics is deliberately NOT included (see the comment in
-  `app/build.gradle.kts` for the rationale). The `google-services` and
-  `firebase-crashlytics` Gradle plugins remain conditional on
-  `app/google-services.json` so local builds without a Firebase project
-  still compile and run (Crashlytics no-ops at runtime via a
-  `FirebaseApp.getApps` check).
-- In-app crash-reporting opt-out: `SettingsActivity` reachable from
-  the gear icon on the main screen → *Share crash reports*. Backed by
-  `CrashReportingStore` (separate `user_preferences.xml`
-  SharedPreferences, included in cloud backup) and
-  `CrashReportingController` (process-lifecycle observer that bridges
-  the store to `FirebaseCrashlytics.setCrashlyticsCollectionEnabled`).
-- `PRIVACY.md` describing data collection, processors, and user choices.
-- `network_security_config.xml` denying cleartext traffic explicitly
-  (the previous `usesCleartextTraffic` removal was implicit).
-- `app/src/androidTest/` smoke test that launches `MainActivity` and
-  asserts the process survives `onResume`.
-- `StrictMode` thread + VM policy in debug builds, gated on
-  `FLAG_DEBUGGABLE`.
-- Mapping file (`mapping.txt`) is now shipped with every signed release,
-  cosign-signed alongside the APK/AAB, so external de-obfuscation of
-  prod stack traces is possible without Firebase access.
-
-### Removed
-
-- `firebase-analytics` dependency. Pulling it in would have
-  auto-collected events (`first_open`, `session_start`, `screen_view`,
-  `app_remove`, ...) and caused the manifest merger to inject
-  `com.google.android.gms.permission.AD_ID` into the production APK,
-  contradicting the policy's zero-analytics / no-advertising-ID
-  posture. With Analytics out, the only Firebase product running is
-  Crashlytics, and the merged manifest no longer declares `AD_ID`.
-
-### Changed
-
-- Overlay resends are edge-burst + keepalive: real input stays event-driven;
-  a state change is re-sent 3 scheduler ticks in a row (50 ms apart) to heal
-  a lost edge frame, then the stream idles at a 1 Hz keepalive, replacing
-  the previous constant 250 Hz re-send of the last state.
-- `versionCode` and `versionName` are now derived from CI environment
-  variables (`DISH_VERSION_CODE` / `DISH_VERSION_NAME`), with a
-  `git describe` fallback for local dev. The hardcoded `1` / `"0.0.0"`
-  defaults remain only when neither signal is present.
-- `release.yml` stages `mapping.txt` into `dist/` alongside the AAB and
-  APK so it gets the same SHA256SUMS + cosign signature treatment.
-
-### Notes
-
-This is the first tracked release, so it covers the public 1.0.0 feature
-set plus the build, release, and observability work that a downstream
-consumer of the binary cares about. Earlier development history is in
-`git log`.
+- Steam Controller support over USB, wired or through its dongle
+  (opt-in). Sticks, triggers, buttons, motion, and the right trackpad
+  as a right stick. While Dish is using it, it stops doubling as a
+  mouse and keyboard for the phone, and it is handed back exactly as
+  it was. If it drops off the dongle, no input stays stuck, and it
+  sets itself up again when it reconnects.
+- The Amazon Luna Controller is fully supported over USB, verified on
+  real hardware: every button, both sticks, both triggers, and rumble.
 
 ---
 
-## [1.0.0] - TBD
+## [1.0.1] - 2026-07-25
 
-Initial public release. Tag will be created when the Play Store internal
-testing track is opened.
+The first public release.
 
-[Unreleased]: https://github.com/TinkerNorth/dish-android/compare/1.0.0...HEAD
-[1.0.0]: https://github.com/TinkerNorth/dish-android/releases/tag/1.0.0
+- Turn a controller or your phone into a wireless gamepad for a PC,
+  console, or set-top box.
+- Two ways to connect: Wi-Fi with the free Satellite app, or Bluetooth
+  with no extra software.
+- Play with the on-screen pad, a USB controller, or a Bluetooth
+  controller.
+- Wide controller support, including Xbox, PlayStation, Switch Pro,
+  and many third-party pads. Wired pads can run in Direct mode, where
+  Dish reads them directly so extras like motion, the touchpad, and
+  rumble work.
+- Pick what the game should see: Xbox, DualShock 4, DualSense, or
+  Switch Pro.
+- Guided setup walks you through your first connection, and remembered
+  setups reconnect on their own.
+- Motion aim, touchpad, and rumble on the Wi-Fi path.
+- Diagnostics screen to check sticks, buttons, motion, rumble, and
+  connection quality.
+- No ads and no analytics. Optional crash reporting, and you can turn
+  it off in Settings.
+- Free and open source (LGPL-3.0).
+
+Earlier test builds (0.0.x) are only documented in the git history.
+
+[Unreleased]: https://github.com/TinkerNorth/dish-android/compare/1.0.1...HEAD
+[1.0.1]: https://github.com/TinkerNorth/dish-android/releases/tag/1.0.1

--- a/app/src/main/cpp/gamepad_input.cpp
+++ b/app/src/main/cpp/gamepad_input.cpp
@@ -79,6 +79,49 @@ uint16_t keycodeToXusb(int32_t kc) {
     }
 }
 
+// Switch-order HID pads (usage row Y B A X L R ZL ZR Minus Plus L3 R3 Home Capture) arrive from
+// Generic.kl as BUTTON_A..BUTTON_THUMBL; remap by position to match decodeSwitchProUsb.
+uint16_t switchLayoutKeycodeToXusb(int32_t kc) {
+    switch (kc) {
+    case KC_BUTTON_A:
+        return XUSB_X;
+    case KC_BUTTON_B:
+        return XUSB_A;
+    case KC_BUTTON_C:
+        return XUSB_B;
+    case KC_BUTTON_X:
+        return XUSB_Y;
+    case KC_BUTTON_Y:
+        return XUSB_LB;
+    case KC_BUTTON_Z:
+        return XUSB_RB;
+    case KC_BUTTON_L2:
+        return XUSB_BACK;
+    case KC_BUTTON_R2:
+        return XUSB_START;
+    case KC_BUTTON_SELECT:
+        return XUSB_THUMB_L;
+    case KC_BUTTON_START:
+        return XUSB_THUMB_R;
+    case KC_BUTTON_MODE:
+        return XUSB_GUIDE;
+    case KC_DPAD_UP:
+        return XUSB_DPAD_UP;
+    case KC_DPAD_DOWN:
+        return XUSB_DPAD_DOWN;
+    case KC_DPAD_LEFT:
+        return XUSB_DPAD_LEFT;
+    case KC_DPAD_RIGHT:
+        return XUSB_DPAD_RIGHT;
+    default:
+        return 0;
+    }
+}
+
+bool switchLayoutConsumesKey(int32_t kc) {
+    return kc == KC_BUTTON_L1 || kc == KC_BUTTON_R1 || switchLayoutKeycodeToXusb(kc) != 0;
+}
+
 uint16_t applyButtonQuirk(uint16_t bit, uint8_t quirk) {
     if (quirk & QUIRK_SWAP_AB) {
         if (bit == XUSB_A) return XUSB_B;
@@ -92,6 +135,26 @@ uint16_t applyButtonQuirk(uint16_t bit, uint8_t quirk) {
 }
 
 bool applyKey(DeviceState& s, int32_t kc, bool down) {
+    if (s.quirk & QUIRK_SWITCH_LAYOUT) {
+        if (kc == KC_BUTTON_L1) {
+            s.ltFromKey = down;
+            s.bLT = down ? 255 : 0;
+            return true;
+        }
+        if (kc == KC_BUTTON_R1) {
+            s.rtFromKey = down;
+            s.bRT = down ? 255 : 0;
+            return true;
+        }
+        uint16_t bit = switchLayoutKeycodeToXusb(kc);
+        if (bit == 0) return false;
+        if (down) {
+            s.wButtons = static_cast<uint16_t>(s.wButtons | bit);
+        } else {
+            s.wButtons = static_cast<uint16_t>(s.wButtons & ~bit);
+        }
+        return true;
+    }
     if (kc == KC_BUTTON_L2 || kc == KC_BUTTON_7) {
         s.ltFromKey = down;
         s.bLT = down ? 255 : 0;

--- a/app/src/main/cpp/gamepad_input.h
+++ b/app/src/main/cpp/gamepad_input.h
@@ -31,8 +31,10 @@ constexpr int32_t KC_DPAD_LEFT = 21;
 constexpr int32_t KC_DPAD_RIGHT = 22;
 constexpr int32_t KC_BUTTON_A = 96;
 constexpr int32_t KC_BUTTON_B = 97;
+constexpr int32_t KC_BUTTON_C = 98;
 constexpr int32_t KC_BUTTON_X = 99;
 constexpr int32_t KC_BUTTON_Y = 100;
+constexpr int32_t KC_BUTTON_Z = 101;
 constexpr int32_t KC_BUTTON_L1 = 102;
 constexpr int32_t KC_BUTTON_R1 = 103;
 constexpr int32_t KC_BUTTON_L2 = 104;
@@ -41,6 +43,7 @@ constexpr int32_t KC_BUTTON_THUMBL = 106;
 constexpr int32_t KC_BUTTON_THUMBR = 107;
 constexpr int32_t KC_BUTTON_START = 108;
 constexpr int32_t KC_BUTTON_SELECT = 109;
+constexpr int32_t KC_BUTTON_MODE = 110;
 
 constexpr int32_t KC_BUTTON_1 = 188;
 constexpr int32_t KC_BUTTON_2 = 189;
@@ -62,6 +65,7 @@ constexpr int32_t KC_BUTTON_16 = 203;
 // Per-device framework-path button quirks (Nintendo and friends sit A/B and X/Y opposite to Xbox).
 constexpr uint8_t QUIRK_SWAP_AB = 0x01;
 constexpr uint8_t QUIRK_SWAP_XY = 0x02;
+constexpr uint8_t QUIRK_SWITCH_LAYOUT = 0x04;
 
 struct DeviceState {
     uint16_t wButtons = 0;
@@ -143,6 +147,10 @@ uint8_t scaleTrigger(float v, float max);
 float deadzone(float v, float flat);
 
 uint16_t keycodeToXusb(int32_t androidKeycode);
+
+uint16_t switchLayoutKeycodeToXusb(int32_t androidKeycode);
+
+bool switchLayoutConsumesKey(int32_t androidKeycode);
 
 uint16_t applyButtonQuirk(uint16_t xusbBit, uint8_t quirk);
 

--- a/app/src/main/cpp/satellite_jni.cpp
+++ b/app/src/main/cpp/satellite_jni.cpp
@@ -384,14 +384,18 @@ static bool gamepadKeyFilter(const GameActivityKeyEvent* ev) {
                   (source & AINPUT_SOURCE_JOYSTICK) == AINPUT_SOURCE_JOYSTICK;
     if (!isGame) return false;
     int32_t kc = ev->keyCode;
-    bool isMappedKey =
-        (kc == AKEYCODE_BUTTON_L2 || kc == AKEYCODE_BUTTON_R2) || gamepad::keycodeToXusb(kc) != 0;
+    int32_t deviceId = ev->deviceId;
+    std::lock_guard<std::mutex> lock(g_devicesMtx);
+    auto it = g_devices.find(deviceId);
+    uint8_t quirk = it != g_devices.end() ? it->second.quirk : 0;
+    bool isMappedKey = (quirk & gamepad::QUIRK_SWITCH_LAYOUT)
+                           ? gamepad::switchLayoutConsumesKey(kc)
+                           : (kc == AKEYCODE_BUTTON_L2 || kc == AKEYCODE_BUTTON_R2) ||
+                                 gamepad::keycodeToXusb(kc) != 0;
     if (!isMappedKey) return false;
 
     int32_t action = ev->action;
     if (action == AKEY_EVENT_ACTION_DOWN || action == AKEY_EVENT_ACTION_UP) {
-        int32_t deviceId = ev->deviceId;
-        std::lock_guard<std::mutex> lock(g_devicesMtx);
         g_frameworkEventCounts[deviceId]++;
         auto& state = g_devices[deviceId];
         if (gamepad::applyKey(state, kc, action == AKEY_EVENT_ACTION_DOWN)) {
@@ -994,12 +998,16 @@ JNIEXPORT jboolean JNICALL
 Java_com_tinkernorth_dish_core_jni_SatelliteNative_processGamepadKeyEvent(
     JNIEnv*, jobject, jint deviceId, jint /*source*/, jint action, jint keyCode) {
     // Source bits are unreliable; gate on the mapped-keycode check instead.
-    bool isMappedKey = (keyCode == AKEYCODE_BUTTON_L2 || keyCode == AKEYCODE_BUTTON_R2 ||
-                        keyCode == AKEYCODE_BUTTON_7 || keyCode == AKEYCODE_BUTTON_8) ||
-                       gamepad::keycodeToXusb(keyCode) != 0;
+    std::lock_guard<std::mutex> lock(g_devicesMtx);
+    auto it = g_devices.find(deviceId);
+    uint8_t quirk = it != g_devices.end() ? it->second.quirk : 0;
+    bool isMappedKey = (quirk & gamepad::QUIRK_SWITCH_LAYOUT)
+                           ? gamepad::switchLayoutConsumesKey(keyCode)
+                           : (keyCode == AKEYCODE_BUTTON_L2 || keyCode == AKEYCODE_BUTTON_R2 ||
+                              keyCode == AKEYCODE_BUTTON_7 || keyCode == AKEYCODE_BUTTON_8) ||
+                                 gamepad::keycodeToXusb(keyCode) != 0;
     if (!isMappedKey) return JNI_FALSE;
     if (action != AKEY_EVENT_ACTION_DOWN && action != AKEY_EVENT_ACTION_UP) return JNI_FALSE;
-    std::lock_guard<std::mutex> lock(g_devicesMtx);
     g_frameworkEventCounts[deviceId]++;
     auto& state = g_devices[deviceId];
     if (gamepad::applyKey(state, keyCode, action == AKEY_EVENT_ACTION_DOWN)) {

--- a/app/src/main/cpp/usb_hid_descriptor.cpp
+++ b/app/src/main/cpp/usb_hid_descriptor.cpp
@@ -89,6 +89,39 @@ uint16_t buttonBit(uint8_t idx) {
     }
 }
 
+// Switch-order HID pads declare buttons in usage row Y B A X L R ZL ZR Minus Plus L3 R3 Home
+// Capture; remap by position to match decodeSwitchProUsb. ZL/ZR (indices 6/7) fold into the
+// triggers in decodeFromLayout instead of mapping here.
+uint16_t switchOrderButtonBit(uint8_t idx) {
+    using namespace gamepad;
+    switch (idx) {
+    case 0:
+        return XUSB_X;
+    case 1:
+        return XUSB_A;
+    case 2:
+        return XUSB_B;
+    case 3:
+        return XUSB_Y;
+    case 4:
+        return XUSB_LB;
+    case 5:
+        return XUSB_RB;
+    case 8:
+        return XUSB_BACK;
+    case 9:
+        return XUSB_START;
+    case 10:
+        return XUSB_THUMB_L;
+    case 11:
+        return XUSB_THUMB_R;
+    case 12:
+        return XUSB_GUIDE;
+    default:
+        return 0;
+    }
+}
+
 uint16_t dpadBitsForDir(int dir) {
     using namespace gamepad;
     switch (dir) {
@@ -314,9 +347,25 @@ bool decodeFromLayout(const uint8_t* buf, size_t len, DeviceState& s, const HidL
         int range = (int)L.hatLogicalMax - (int)L.hatLogicalMin;
         if (dir >= 0 && dir <= range && dir <= 7) b = (uint16_t)(b | dpadBitsForDir(dir));
     }
-    for (uint8_t i = 0; i < L.buttonCount; i++) {
-        if (extractBits(d, dlen, (uint32_t)L.buttonBitOffset + i, 1)) {
-            b = (uint16_t)(b | buttonBit(i));
+    if (L.switchOrderButtons) {
+        bool zl = false, zr = false;
+        for (uint8_t i = 0; i < L.buttonCount; i++) {
+            if (!extractBits(d, dlen, (uint32_t)L.buttonBitOffset + i, 1)) continue;
+            if (i == 6) {
+                zl = true;
+            } else if (i == 7) {
+                zr = true;
+            } else {
+                b = (uint16_t)(b | switchOrderButtonBit(i));
+            }
+        }
+        s.bLT = zl ? 255 : 0;
+        s.bRT = zr ? 255 : 0;
+    } else {
+        for (uint8_t i = 0; i < L.buttonCount; i++) {
+            if (extractBits(d, dlen, (uint32_t)L.buttonBitOffset + i, 1)) {
+                b = (uint16_t)(b | buttonBit(i));
+            }
         }
     }
     s.wButtons = b;

--- a/app/src/main/cpp/usb_hid_descriptor.h
+++ b/app/src/main/cpp/usb_hid_descriptor.h
@@ -31,6 +31,9 @@ struct HidLayout {
     int32_t hatLogicalMax = 0;
     uint16_t buttonBitOffset = 0;
     uint8_t buttonCount = 0;
+    // Set by the attach path from the model catalog, after parseReportDescriptor resets the
+    // struct; never derived from the descriptor itself.
+    bool switchOrderButtons = false;
 };
 
 // Parses a HID report descriptor into the gamepad field map. Pure and defensive: returns false and

--- a/app/src/main/cpp/usb_host.cpp
+++ b/app/src/main/cpp/usb_host.cpp
@@ -426,6 +426,8 @@ AttachResult attachDevice(int fd, uint16_t vid, uint16_t pid, int interfaceNumbe
     ctx->parserName = usbparsers::parserName(parser);
     if (parser == usbparsers::Parser::GENERIC_HID_GAMEPAD) {
         fetchHidLayout(fd, interfaceNumber, ctx->stickRange.hidLayout);
+        ctx->stickRange.hidLayout.switchOrderButtons =
+            classification.order == usbparsers::ButtonOrder::SWITCH;
     } else if (parser == usbparsers::Parser::DUALSHOCK4) {
         fetchPsCalibration(fd, interfaceNumber, 0x02, ctx->stickRange.psImu);
     } else if (parser == usbparsers::Parser::DUALSENSE) {

--- a/app/src/main/cpp/usb_parsers.cpp
+++ b/app/src/main/cpp/usb_parsers.cpp
@@ -379,6 +379,17 @@ static const KnownDevice kImported[] = {
     {0x3285, 0x0D18, "Nacon Revolution 5 Pro (PS5 dongle)", Parser::DUALSENSE, InitKind::NONE},
     {0x3285, 0x0D19, "Nacon Revolution 5 Pro (PS5 wired)", Parser::DUALSENSE, InitKind::NONE},
 
+    {0x0E6F, 0x0180, "PDP Faceoff Wired Pro Controller (Switch)", Parser::GENERIC_HID_GAMEPAD,
+     InitKind::NONE, ButtonOrder::SWITCH},
+    {0x0E6F, 0x0181, "PDP Faceoff Deluxe Wired Pro Controller (Switch)",
+     Parser::GENERIC_HID_GAMEPAD, InitKind::NONE, ButtonOrder::SWITCH},
+    {0x0E6F, 0x0184, "PDP Faceoff Deluxe+ Audio Controller (Switch)", Parser::GENERIC_HID_GAMEPAD,
+     InitKind::NONE, ButtonOrder::SWITCH},
+    {0x0E6F, 0x0185, "PDP Wired Fight Pad Pro (Switch)", Parser::GENERIC_HID_GAMEPAD,
+     InitKind::NONE, ButtonOrder::SWITCH},
+    {0x0E6F, 0x0187, "PDP Rock Candy Wired Controller (Switch)", Parser::GENERIC_HID_GAMEPAD,
+     InitKind::NONE, ButtonOrder::SWITCH},
+
     {0x28DE, 0x1102, "Valve Steam Controller", Parser::STEAM_CONTROLLER, InitKind::STEAM_QUIET},
     {0x28DE, 0x1142, "Valve Steam Controller (dongle)", Parser::STEAM_CONTROLLER,
      InitKind::STEAM_QUIET},
@@ -428,7 +439,7 @@ constexpr uint8_t kGipProtocol = 0xD0;
 Classification classifyDevice(uint16_t vid, uint16_t pid, uint8_t ifClass, uint8_t ifSubclass,
                               uint8_t ifProtocol) {
     const KnownDevice* known = lookupKnown(vid, pid);
-    if (known != nullptr) { return {known->parser, known->init, known->name}; }
+    if (known != nullptr) { return {known->parser, known->init, known->name, known->order}; }
     // Wired XInput streams unsolicited; GIP needs the power-on packet first.
     if (ifClass == kIfClassVendor && ifSubclass == kXInputSubclass &&
         ifProtocol == kXInputProtocol) {

--- a/app/src/main/cpp/usb_parsers.h
+++ b/app/src/main/cpp/usb_parsers.h
@@ -52,18 +52,25 @@ enum class WirelessEvent : uint8_t {
     DISCONNECT = 2,
 };
 
+enum class ButtonOrder : uint8_t {
+    WESTERN = 0,
+    SWITCH = 1,
+};
+
 struct KnownDevice {
     uint16_t vid;
     uint16_t pid;
     const char* name;
     Parser parser;
     InitKind init;
+    ButtonOrder order = ButtonOrder::WESTERN;
 };
 
 struct Classification {
     Parser parser = Parser::NONE;
     InitKind init = InitKind::NONE;
     const char* name = nullptr;
+    ButtonOrder order = ButtonOrder::WESTERN;
 };
 
 // Per-device, expand-only auto-range for sticks that report raw ADC values. We don't read the

--- a/app/src/main/java/com/tinkernorth/dish/core/input/GamepadQuirks.kt
+++ b/app/src/main/java/com/tinkernorth/dish/core/input/GamepadQuirks.kt
@@ -6,11 +6,23 @@ package com.tinkernorth.dish.core.input
 internal const val QUIRK_NONE = 0
 internal const val QUIRK_SWAP_AB = 0x01
 internal const val QUIRK_SWAP_XY = 0x02
+internal const val QUIRK_SWITCH_LAYOUT = 0x04
 
 private const val VENDOR_NINTENDO = 0x057E
+private const val VENDOR_PDP = 0x0E6F
+
+// PDP's wired Switch pads (SDL's SwitchInputOnlyController set): plain HID devices whose buttons
+// arrive in the Switch usage order, so Generic.kl shifts the whole row. 0x0186 is excluded on
+// purpose: it speaks the Switch Pro protocol and its USB port is charge-only.
+private val PDP_SWITCH_LAYOUT_PRODUCTS = setOf(0x0180, 0x0181, 0x0184, 0x0185, 0x0187)
 
 // Nintendo's A/B and X/Y sit opposite Xbox; remap by position, like SDL/Steam/Moonlight.
-internal fun resolveGamepadQuirk(vendorId: Int): Int {
-    if (vendorId != VENDOR_NINTENDO) return QUIRK_NONE
-    return QUIRK_SWAP_AB or QUIRK_SWAP_XY
-}
+internal fun resolveGamepadQuirk(
+    vendorId: Int,
+    productId: Int,
+): Int =
+    when {
+        vendorId == VENDOR_NINTENDO -> QUIRK_SWAP_AB or QUIRK_SWAP_XY
+        vendorId == VENDOR_PDP && productId in PDP_SWITCH_LAYOUT_PRODUCTS -> QUIRK_SWITCH_LAYOUT
+        else -> QUIRK_NONE
+    }

--- a/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistry.kt
+++ b/app/src/main/java/com/tinkernorth/dish/hotpath/input/PhysicalGamepadRegistry.kt
@@ -497,7 +497,8 @@ class PhysicalGamepadRegistry
                 dev.getMotionRange(MotionEvent.AXIS_RZ, src)?.flat ?: 0f,
             )
             val vid = runCatching { dev.vendorId }.getOrDefault(0)
-            native.setDeviceQuirk(dev.id, resolveGamepadQuirk(vid))
+            val pid = runCatching { dev.productId }.getOrDefault(0)
+            native.setDeviceQuirk(dev.id, resolveGamepadQuirk(vid, pid))
             logDeviceCapabilities(dev)
         }
 

--- a/app/src/test/cpp/gamepad_input_test.cpp
+++ b/app/src/test/cpp/gamepad_input_test.cpp
@@ -683,3 +683,179 @@ TEST(DeviceStateJson, TooSmallBufferReturnsZero) {
     char buf[16];
     EXPECT_EQ(0u, formatDeviceStateJson(s, buf, sizeof(buf)));
 }
+
+// ── Switch-layout quirk: Generic.kl hands Switch-order HID buttons over shifted by one row ──
+
+TEST(KeycodeToXusb, SwitchOrderKeycodesAreNotInBaseMap) {
+    // Physical A / R / Home on a Switch-order pad arrive as BUTTON_C / BUTTON_Z / BUTTON_MODE;
+    // the base map drops them (the PDP Faceoff "A does not register" symptom).
+    EXPECT_EQ(0, keycodeToXusb(KC_BUTTON_C));
+    EXPECT_EQ(0, keycodeToXusb(KC_BUTTON_Z));
+    EXPECT_EQ(0, keycodeToXusb(KC_BUTTON_MODE));
+}
+
+TEST(ApplyKey, BaseQuirkIgnoresSwitchOrderKeycodes) {
+    DeviceState s;
+    s.wButtons = XUSB_A;
+    EXPECT_FALSE(applyKey(s, KC_BUTTON_C, true));
+    EXPECT_FALSE(applyKey(s, KC_BUTTON_Z, true));
+    EXPECT_FALSE(applyKey(s, KC_BUTTON_MODE, true));
+    EXPECT_EQ(XUSB_A, s.wButtons);
+}
+
+TEST(SwitchLayout, QuirkBitMatchesTheKotlinContract) { EXPECT_EQ(0x04, QUIRK_SWITCH_LAYOUT); }
+
+TEST(SwitchLayout, FaceRowRemapsByPosition) {
+    EXPECT_EQ(XUSB_X, switchLayoutKeycodeToXusb(KC_BUTTON_A));
+    EXPECT_EQ(XUSB_A, switchLayoutKeycodeToXusb(KC_BUTTON_B));
+    EXPECT_EQ(XUSB_B, switchLayoutKeycodeToXusb(KC_BUTTON_C));
+    EXPECT_EQ(XUSB_Y, switchLayoutKeycodeToXusb(KC_BUTTON_X));
+}
+
+TEST(SwitchLayout, PhysicalBumpersComeFromButtonYAndZ) {
+    EXPECT_EQ(XUSB_LB, switchLayoutKeycodeToXusb(KC_BUTTON_Y));
+    EXPECT_EQ(XUSB_RB, switchLayoutKeycodeToXusb(KC_BUTTON_Z));
+}
+
+TEST(SwitchLayout, MinusPlusBecomeBackStart) {
+    EXPECT_EQ(XUSB_BACK, switchLayoutKeycodeToXusb(KC_BUTTON_L2));
+    EXPECT_EQ(XUSB_START, switchLayoutKeycodeToXusb(KC_BUTTON_R2));
+}
+
+TEST(SwitchLayout, StickClicksComeFromSelectAndStart) {
+    EXPECT_EQ(XUSB_THUMB_L, switchLayoutKeycodeToXusb(KC_BUTTON_SELECT));
+    EXPECT_EQ(XUSB_THUMB_R, switchLayoutKeycodeToXusb(KC_BUTTON_START));
+}
+
+TEST(SwitchLayout, HomeBecomesGuide) {
+    EXPECT_EQ(XUSB_GUIDE, switchLayoutKeycodeToXusb(KC_BUTTON_MODE));
+}
+
+TEST(SwitchLayout, DpadPassesThrough) {
+    EXPECT_EQ(XUSB_DPAD_UP, switchLayoutKeycodeToXusb(KC_DPAD_UP));
+    EXPECT_EQ(XUSB_DPAD_DOWN, switchLayoutKeycodeToXusb(KC_DPAD_DOWN));
+    EXPECT_EQ(XUSB_DPAD_LEFT, switchLayoutKeycodeToXusb(KC_DPAD_LEFT));
+    EXPECT_EQ(XUSB_DPAD_RIGHT, switchLayoutKeycodeToXusb(KC_DPAD_RIGHT));
+}
+
+TEST(SwitchLayout, ZlZrTakeTheTriggerPathNotTheButtonMap) {
+    EXPECT_EQ(0, switchLayoutKeycodeToXusb(KC_BUTTON_L1));
+    EXPECT_EQ(0, switchLayoutKeycodeToXusb(KC_BUTTON_R1));
+}
+
+TEST(SwitchLayout, CaptureAndForeignKeycodesAreUnmapped) {
+    EXPECT_EQ(0, switchLayoutKeycodeToXusb(KC_BUTTON_THUMBL));
+    EXPECT_EQ(0, switchLayoutKeycodeToXusb(KC_BUTTON_THUMBR));
+    EXPECT_EQ(0, switchLayoutKeycodeToXusb(KC_BUTTON_1));
+    EXPECT_EQ(0, switchLayoutKeycodeToXusb(0));
+}
+
+TEST(SwitchLayoutConsumesKey, CoversEveryMappedPadKeycode) {
+    const int32_t mapped[] = {
+        KC_BUTTON_A,    KC_BUTTON_B,  KC_BUTTON_C,  KC_BUTTON_X,  KC_BUTTON_Y,      KC_BUTTON_Z,
+        KC_BUTTON_L1,   KC_BUTTON_R1, KC_BUTTON_L2, KC_BUTTON_R2, KC_BUTTON_SELECT, KC_BUTTON_START,
+        KC_BUTTON_MODE, KC_DPAD_UP,   KC_DPAD_DOWN, KC_DPAD_LEFT, KC_DPAD_RIGHT};
+    for (int32_t kc : mapped) EXPECT_TRUE(switchLayoutConsumesKey(kc)) << kc;
+}
+
+TEST(SwitchLayoutConsumesKey, CaptureAndForeignKeycodesFallThrough) {
+    EXPECT_FALSE(switchLayoutConsumesKey(KC_BUTTON_THUMBL));
+    EXPECT_FALSE(switchLayoutConsumesKey(KC_BUTTON_1));
+    EXPECT_FALSE(switchLayoutConsumesKey(62));
+    EXPECT_FALSE(switchLayoutConsumesKey(0));
+}
+
+TEST(ApplyKey, SwitchLayoutZlDrivesLeftTrigger) {
+    DeviceState s;
+    s.quirk = QUIRK_SWITCH_LAYOUT;
+    EXPECT_TRUE(applyKey(s, KC_BUTTON_L1, true));
+    EXPECT_EQ(255, s.bLT);
+    EXPECT_TRUE(s.ltFromKey);
+    EXPECT_EQ(0, s.wButtons);
+    EXPECT_TRUE(applyKey(s, KC_BUTTON_L1, false));
+    EXPECT_EQ(0, s.bLT);
+    EXPECT_FALSE(s.ltFromKey);
+}
+
+TEST(ApplyKey, SwitchLayoutZrDrivesRightTrigger) {
+    DeviceState s;
+    s.quirk = QUIRK_SWITCH_LAYOUT;
+    EXPECT_TRUE(applyKey(s, KC_BUTTON_R1, true));
+    EXPECT_EQ(255, s.bRT);
+    EXPECT_TRUE(s.rtFromKey);
+    EXPECT_EQ(0, s.wButtons);
+}
+
+TEST(ApplyKey, SwitchLayoutPhysicalAReachesTheWire) {
+    // The bug this quirk exists for: physical A arrives as BUTTON_C and must not be dropped.
+    DeviceState s;
+    s.quirk = QUIRK_SWITCH_LAYOUT;
+    EXPECT_TRUE(applyKey(s, KC_BUTTON_C, true));
+    EXPECT_EQ(XUSB_B, s.wButtons);
+    EXPECT_TRUE(applyKey(s, KC_BUTTON_C, false));
+    EXPECT_EQ(0, s.wButtons);
+}
+
+TEST(ApplyKey, SwitchLayoutMinusPlusAreButtonsNotTriggers) {
+    DeviceState s;
+    s.quirk = QUIRK_SWITCH_LAYOUT;
+    applyKey(s, KC_BUTTON_L2, true);
+    applyKey(s, KC_BUTTON_R2, true);
+    EXPECT_TRUE(s.wButtons & XUSB_BACK);
+    EXPECT_TRUE(s.wButtons & XUSB_START);
+    EXPECT_EQ(0, s.bLT);
+    EXPECT_EQ(0, s.bRT);
+    EXPECT_FALSE(s.ltFromKey);
+    EXPECT_FALSE(s.rtFromKey);
+}
+
+TEST(ApplyKey, SwitchLayoutCaptureIsIgnored) {
+    DeviceState s;
+    s.quirk = QUIRK_SWITCH_LAYOUT;
+    s.wButtons = XUSB_A;
+    EXPECT_FALSE(applyKey(s, KC_BUTTON_THUMBL, true));
+    EXPECT_EQ(XUSB_A, s.wButtons);
+}
+
+TEST(ApplyKey, SwitchLayoutWinsOverStraySwapBits) {
+    DeviceState s;
+    s.quirk = (uint8_t)(QUIRK_SWITCH_LAYOUT | QUIRK_SWAP_AB | QUIRK_SWAP_XY);
+    applyKey(s, KC_BUTTON_C, true);
+    EXPECT_EQ(XUSB_B, s.wButtons);
+}
+
+TEST(ApplyKey, SwitchLayoutFullPadHoldsEveryMappedControl) {
+    DeviceState s;
+    s.quirk = QUIRK_SWITCH_LAYOUT;
+    const int32_t row[] = {KC_BUTTON_A,   KC_BUTTON_B,  KC_BUTTON_C,      KC_BUTTON_X,
+                           KC_BUTTON_Y,   KC_BUTTON_Z,  KC_BUTTON_L1,     KC_BUTTON_R1,
+                           KC_BUTTON_L2,  KC_BUTTON_R2, KC_BUTTON_SELECT, KC_BUTTON_START,
+                           KC_BUTTON_MODE};
+    for (int32_t kc : row) applyKey(s, kc, true);
+    const uint16_t expected =
+        static_cast<uint16_t>(XUSB_A | XUSB_B | XUSB_X | XUSB_Y | XUSB_LB | XUSB_RB | XUSB_BACK |
+                              XUSB_START | XUSB_THUMB_L | XUSB_THUMB_R | XUSB_GUIDE);
+    EXPECT_EQ(expected, s.wButtons);
+    EXPECT_EQ(255, s.bLT);
+    EXPECT_EQ(255, s.bRT);
+}
+
+TEST(ApplyAxes, SwitchLayoutHeldZlSurvivesZeroAxisSamples) {
+    DeviceState s;
+    s.quirk = QUIRK_SWITCH_LAYOUT;
+    applyKey(s, KC_BUTTON_L1, true);
+    applyAxes(s, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f);
+    EXPECT_EQ(255, s.bLT);
+    applyKey(s, KC_BUTTON_L1, false);
+    applyAxes(s, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f);
+    EXPECT_EQ(0, s.bLT);
+}
+
+TEST(ApplyKey, BaseBehaviorUnchangedWithoutTheSwitchQuirk) {
+    DeviceState s;
+    applyKey(s, KC_BUTTON_A, true);
+    EXPECT_EQ(XUSB_A, s.wButtons);
+    applyKey(s, KC_BUTTON_L1, true);
+    EXPECT_TRUE(s.wButtons & XUSB_LB);
+    EXPECT_EQ(0, s.bLT);
+}

--- a/app/src/test/cpp/usb_hid_descriptor_test.cpp
+++ b/app/src/test/cpp/usb_hid_descriptor_test.cpp
@@ -10,7 +10,18 @@
 using gamepad::DeviceState;
 using gamepad::XUSB_A;
 using gamepad::XUSB_B;
+using gamepad::XUSB_BACK;
+using gamepad::XUSB_DPAD_DOWN;
+using gamepad::XUSB_DPAD_MASK;
 using gamepad::XUSB_DPAD_RIGHT;
+using gamepad::XUSB_GUIDE;
+using gamepad::XUSB_LB;
+using gamepad::XUSB_RB;
+using gamepad::XUSB_START;
+using gamepad::XUSB_THUMB_L;
+using gamepad::XUSB_THUMB_R;
+using gamepad::XUSB_X;
+using gamepad::XUSB_Y;
 using usbhid::decodeFromLayout;
 using usbhid::HidLayout;
 using usbhid::parseReportDescriptor;
@@ -216,4 +227,195 @@ TEST(HidDescriptor, NarrowHatRejectsOutOfRangeNull) {
     DeviceState s2;
     ASSERT_TRUE(decodeFromLayout(nullDir.data(), nullDir.size(), s2, L));
     EXPECT_EQ(0, s2.wButtons & gamepad::XUSB_DPAD_MASK);
+}
+
+namespace {
+
+// PDP Faceoff Wired Pro (0e6f:0180) report shape: 14 buttons in Switch usage order
+// (Y B A X L R ZL ZR Minus Plus L3 R3 Home Capture) + 2-bit pad, 4-bit hat + 4-bit pad, then
+// X/Y/Z/Rz bytes. 56-bit / 7-byte input report, no report id.
+const uint8_t kSwitchOrderDescriptor[] = {
+    0x05, 0x01,       // Usage Page (Generic Desktop)
+    0x09, 0x05,       // Usage (Game Pad)
+    0xA1, 0x01,       // Collection (Application)
+    0x15, 0x00,       //   Logical Minimum (0)
+    0x25, 0x01,       //   Logical Maximum (1)
+    0x75, 0x01,       //   Report Size (1)
+    0x95, 0x0E,       //   Report Count (14)
+    0x05, 0x09,       //   Usage Page (Button)
+    0x19, 0x01,       //   Usage Minimum (1)
+    0x29, 0x0E,       //   Usage Maximum (14)
+    0x81, 0x02,       //   Input (Data,Var,Abs)
+    0x95, 0x02,       //   Report Count (2)
+    0x81, 0x01,       //   Input (Const)
+    0x05, 0x01,       //   Usage Page (Generic Desktop)
+    0x25, 0x07,       //   Logical Maximum (7)
+    0x75, 0x04,       //   Report Size (4)
+    0x95, 0x01,       //   Report Count (1)
+    0x09, 0x39,       //   Usage (Hat switch)
+    0x81, 0x42,       //   Input (Data,Var,Abs,Null)
+    0x95, 0x01,       //   Report Count (1)
+    0x81, 0x01,       //   Input (Const)
+    0x26, 0xFF, 0x00, //   Logical Maximum (255)
+    0x09, 0x30,       //   Usage (X)
+    0x09, 0x31,       //   Usage (Y)
+    0x09, 0x32,       //   Usage (Z)
+    0x09, 0x35,       //   Usage (Rz)
+    0x75, 0x08,       //   Report Size (8)
+    0x95, 0x04,       //   Report Count (4)
+    0x81, 0x02,       //   Input (Data,Var,Abs)
+    0xC0,             // End Collection
+};
+
+std::vector<uint8_t> switchReport(uint8_t btnLo, uint8_t btnHi, uint8_t hat = 0x08,
+                                  uint8_t x = 0x7F, uint8_t y = 0x7F, uint8_t z = 0x7F,
+                                  uint8_t rz = 0x7F) {
+    return {btnLo, btnHi, hat, x, y, z, rz};
+}
+
+HidLayout switchLayout(bool switchOrder) {
+    HidLayout L;
+    EXPECT_TRUE(parseReportDescriptor(kSwitchOrderDescriptor, sizeof(kSwitchOrderDescriptor), L));
+    L.switchOrderButtons = switchOrder;
+    return L;
+}
+
+} // namespace
+
+TEST(SwitchOrderHid, ParsesTheFaceoffReportShape) {
+    HidLayout L;
+    ASSERT_TRUE(parseReportDescriptor(kSwitchOrderDescriptor, sizeof(kSwitchOrderDescriptor), L));
+    EXPECT_EQ(0, L.reportId);
+    EXPECT_EQ(0, L.buttonBitOffset);
+    EXPECT_EQ(14, L.buttonCount);
+    EXPECT_TRUE(L.hasHat);
+    EXPECT_EQ(16, L.hatBitOffset);
+    EXPECT_EQ(4, L.hatBitSize);
+    EXPECT_EQ(24, L.lx.bitOffset);
+    EXPECT_EQ(32, L.ly.bitOffset);
+    EXPECT_EQ(40, L.rx.bitOffset); // Z
+    EXPECT_EQ(48, L.ry.bitOffset); // Rz
+    EXPECT_FALSE(L.lt.present);
+    EXPECT_FALSE(L.rt.present);
+}
+
+TEST(SwitchOrderHid, ParseResetsTheOrderFlagSoAttachMustSetItAfter) {
+    HidLayout L;
+    L.switchOrderButtons = true;
+    ASSERT_TRUE(parseReportDescriptor(kSwitchOrderDescriptor, sizeof(kSwitchOrderDescriptor), L));
+    EXPECT_FALSE(L.switchOrderButtons);
+}
+
+TEST(SwitchOrderHid, WesternDecodeScramblesTheFaceoffPad) {
+    // Pre-quirk behavior pin: without the catalog flag, physical A (bit 2) lands on X, ZL lands
+    // on Back with no trigger, and R3/Home/Capture vanish.
+    HidLayout L = switchLayout(false);
+
+    DeviceState a;
+    auto physicalA = switchReport(0x04, 0x00);
+    ASSERT_TRUE(decodeFromLayout(physicalA.data(), physicalA.size(), a, L));
+    EXPECT_EQ(XUSB_X, a.wButtons);
+
+    DeviceState zl;
+    auto zlReport = switchReport(0x40, 0x00);
+    ASSERT_TRUE(decodeFromLayout(zlReport.data(), zlReport.size(), zl, L));
+    EXPECT_EQ(XUSB_BACK, zl.wButtons);
+    EXPECT_EQ(0, zl.bLT);
+
+    DeviceState upper;
+    auto upperReport = switchReport(0x00, 0x38);
+    ASSERT_TRUE(decodeFromLayout(upperReport.data(), upperReport.size(), upper, L));
+    EXPECT_EQ(0, upper.wButtons);
+}
+
+TEST(SwitchOrderHid, FaceButtonsRemapByPosition) {
+    HidLayout L = switchLayout(true);
+    struct Case {
+        uint8_t bit;
+        uint16_t expected;
+    };
+    const Case cases[] = {
+        {0x01, XUSB_X}, // Y (west)
+        {0x02, XUSB_A}, // B (south)
+        {0x04, XUSB_B}, // A (east)
+        {0x08, XUSB_Y}, // X (north)
+    };
+    for (const Case& c : cases) {
+        DeviceState s;
+        auto r = switchReport(c.bit, 0x00);
+        ASSERT_TRUE(decodeFromLayout(r.data(), r.size(), s, L));
+        EXPECT_EQ(c.expected, s.wButtons) << (int)c.bit;
+    }
+}
+
+TEST(SwitchOrderHid, BumpersMapAndZlZrDriveTriggers) {
+    HidLayout L = switchLayout(true);
+
+    DeviceState bumpers;
+    auto lr = switchReport(0x30, 0x00);
+    ASSERT_TRUE(decodeFromLayout(lr.data(), lr.size(), bumpers, L));
+    EXPECT_EQ(static_cast<uint16_t>(XUSB_LB | XUSB_RB), bumpers.wButtons);
+    EXPECT_EQ(0, bumpers.bLT);
+    EXPECT_EQ(0, bumpers.bRT);
+
+    DeviceState triggers;
+    auto zlzr = switchReport(0xC0, 0x00);
+    ASSERT_TRUE(decodeFromLayout(zlzr.data(), zlzr.size(), triggers, L));
+    EXPECT_EQ(0, triggers.wButtons);
+    EXPECT_EQ(255, triggers.bLT);
+    EXPECT_EQ(255, triggers.bRT);
+
+    auto released = switchReport(0x00, 0x00);
+    ASSERT_TRUE(decodeFromLayout(released.data(), released.size(), triggers, L));
+    EXPECT_EQ(0, triggers.bLT);
+    EXPECT_EQ(0, triggers.bRT);
+}
+
+TEST(SwitchOrderHid, UpperRowMapsMinusPlusSticksAndHome) {
+    HidLayout L = switchLayout(true);
+    struct Case {
+        uint8_t bit;
+        uint16_t expected;
+    };
+    const Case cases[] = {
+        {0x01, XUSB_BACK},    // Minus
+        {0x02, XUSB_START},   // Plus
+        {0x04, XUSB_THUMB_L}, // L3
+        {0x08, XUSB_THUMB_R}, // R3
+        {0x10, XUSB_GUIDE},   // Home
+        {0x20, 0},            // Capture: no XUSB equivalent
+    };
+    for (const Case& c : cases) {
+        DeviceState s;
+        auto r = switchReport(0x00, c.bit);
+        ASSERT_TRUE(decodeFromLayout(r.data(), r.size(), s, L));
+        EXPECT_EQ(c.expected, s.wButtons) << (int)c.bit;
+    }
+}
+
+TEST(SwitchOrderHid, HatAndSticksAreUntouchedByTheRemap) {
+    HidLayout L = switchLayout(true);
+
+    DeviceState east;
+    auto r = switchReport(0x00, 0x00, 0x02, 0xFF);
+    ASSERT_TRUE(decodeFromLayout(r.data(), r.size(), east, L));
+    EXPECT_TRUE(east.wButtons & XUSB_DPAD_RIGHT);
+    EXPECT_GT(east.sLX, 30000);
+
+    DeviceState neutral;
+    auto n = switchReport(0x00, 0x00);
+    ASSERT_TRUE(decodeFromLayout(n.data(), n.size(), neutral, L));
+    EXPECT_EQ(0, neutral.wButtons & XUSB_DPAD_MASK);
+    EXPECT_EQ(0, neutral.sLX);
+}
+
+TEST(SwitchOrderHid, CombinedReportDecodesAllFields) {
+    HidLayout L = switchLayout(true);
+    DeviceState s;
+    auto r = switchReport(0x44, 0x02, 0x04, 0xFF);
+    ASSERT_TRUE(decodeFromLayout(r.data(), r.size(), s, L));
+    EXPECT_EQ(static_cast<uint16_t>(XUSB_B | XUSB_START | XUSB_DPAD_DOWN), s.wButtons);
+    EXPECT_EQ(255, s.bLT);
+    EXPECT_EQ(0, s.bRT);
+    EXPECT_GT(s.sLX, 30000);
 }

--- a/app/src/test/cpp/usb_parsers_test.cpp
+++ b/app/src/test/cpp/usb_parsers_test.cpp
@@ -26,6 +26,7 @@ using gamepad::XUSB_Y;
 using usbparsers::buildGipInitPacket;
 using usbparsers::buildRumbleReport;
 using usbparsers::buildSteamConfigPacket;
+using usbparsers::ButtonOrder;
 using usbparsers::checkWirelessEvent;
 using usbparsers::decodeReport;
 using usbparsers::InitKind;
@@ -727,6 +728,77 @@ TEST(ClassifyDevice, HidInterfaceClassifiesAsGenericHid) {
 TEST(ClassifyDevice, UnknownVendorInterfaceFallsBackToGeneric) {
     auto c = usbparsers::classifyDevice(0x1234, 0x5678, 0xFF, 0x99, 0x99);
     EXPECT_EQ(c.parser, Parser::GENERIC_HID_GAMEPAD);
+}
+
+TEST(ClassifyDevice, PdpFaceoffIsGenericHidWithSwitchOrder) {
+    auto c = usbparsers::classifyDevice(0x0E6F, 0x0180, 0x03, 0x00, 0x00);
+    EXPECT_EQ(c.parser, Parser::GENERIC_HID_GAMEPAD);
+    EXPECT_EQ(c.init, InitKind::NONE);
+    EXPECT_EQ(c.order, ButtonOrder::SWITCH);
+    EXPECT_STREQ("PDP Faceoff Wired Pro Controller (Switch)", c.name);
+}
+
+TEST(ClassifyDevice, EveryPdpWiredSwitchPadCarriesSwitchOrder) {
+    const uint16_t pids[] = {0x0180, 0x0181, 0x0184, 0x0185, 0x0187};
+    for (uint16_t pid : pids) {
+        auto c = usbparsers::classifyDevice(0x0E6F, pid, 0x03, 0x00, 0x00);
+        EXPECT_EQ(c.parser, Parser::GENERIC_HID_GAMEPAD) << pid;
+        EXPECT_EQ(c.order, ButtonOrder::SWITCH) << pid;
+        EXPECT_NE(c.name, nullptr) << pid;
+    }
+}
+
+TEST(ClassifyDevice, PdpAfterglowWirelessIsNotSwitchOrder) {
+    // 0e6f:0186 speaks the Switch Pro protocol and its USB port is charge-only (SDL's
+    // controller list); it must not be remapped like the wired Switch-order pads.
+    auto c = usbparsers::classifyDevice(0x0E6F, 0x0186, 0x03, 0x00, 0x00);
+    EXPECT_EQ(c.parser, Parser::GENERIC_HID_GAMEPAD);
+    EXPECT_EQ(c.order, ButtonOrder::WESTERN);
+}
+
+TEST(ClassifyDevice, PdpXboxPadsKeepWesternOrder) {
+    auto x360 = usbparsers::classifyDevice(0x0E6F, 0x0501, 0x00, 0x00, 0x00);
+    EXPECT_EQ(x360.parser, Parser::XINPUT_360);
+    EXPECT_EQ(x360.order, ButtonOrder::WESTERN);
+
+    auto gip = usbparsers::classifyDevice(0x0E6F, 0x013B, 0x00, 0x00, 0x00);
+    EXPECT_EQ(gip.parser, Parser::XBOX_ONE_GIP);
+    EXPECT_EQ(gip.order, ButtonOrder::WESTERN);
+}
+
+TEST(ClassifyDevice, TableAndDescriptorFallbacksAreWesternOrder) {
+    EXPECT_EQ(usbparsers::classifyDevice(0x045E, 0x028E, 0x00, 0x00, 0x00).order,
+              ButtonOrder::WESTERN);
+    EXPECT_EQ(usbparsers::classifyDevice(0x1234, 0x5678, 0x03, 0x00, 0x00).order,
+              ButtonOrder::WESTERN);
+    EXPECT_EQ(usbparsers::classifyDevice(0x1234, 0x5678, 0xFF, 0x5D, 0x01).order,
+              ButtonOrder::WESTERN);
+}
+
+TEST(ClassifyDevice, PdpSwitchPadsAreNotVerifiedFastLane) {
+    EXPECT_FALSE(isVerifiedFastLane(0x0E6F, 0x0180));
+    EXPECT_FALSE(isVerifiedFastLane(0x0E6F, 0x0185));
+}
+
+TEST(GenericHidDecode, SwitchOrderLayoutFlowsThroughDecodeReport) {
+    const uint8_t desc[] = {0x05, 0x01, 0x09, 0x05, 0xA1, 0x01, 0x15, 0x00, 0x25,
+                            0x01, 0x75, 0x01, 0x95, 0x0E, 0x05, 0x09, 0x19, 0x01,
+                            0x29, 0x0E, 0x81, 0x02, 0x95, 0x02, 0x81, 0x01, 0xC0};
+    ParserState st;
+    ASSERT_TRUE(usbhid::parseReportDescriptor(desc, sizeof(desc), st.hidLayout));
+    st.hidLayout.switchOrderButtons = true;
+
+    std::vector<uint8_t> physicalA = {0x04, 0x00};
+    DeviceState s;
+    ASSERT_TRUE(
+        decodeReport(Parser::GENERIC_HID_GAMEPAD, physicalA.data(), physicalA.size(), s, &st));
+    EXPECT_EQ(XUSB_B, s.wButtons);
+
+    std::vector<uint8_t> zl = {0x40, 0x00};
+    DeviceState s2;
+    ASSERT_TRUE(decodeReport(Parser::GENERIC_HID_GAMEPAD, zl.data(), zl.size(), s2, &st));
+    EXPECT_EQ(0, s2.wButtons);
+    EXPECT_EQ(255, s2.bLT);
 }
 
 namespace {

--- a/app/src/test/java/com/tinkernorth/dish/core/input/GamepadQuirksTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/core/input/GamepadQuirksTest.kt
@@ -9,23 +9,58 @@ import org.junit.Test
 class GamepadQuirksTest {
     @Test
     fun `nintendo controllers swap both face-button pairs`() {
-        val q = resolveGamepadQuirk(0x057E)
+        val q = resolveGamepadQuirk(0x057E, 0x2009)
         assertTrue(q and QUIRK_SWAP_AB != 0)
         assertTrue(q and QUIRK_SWAP_XY != 0)
     }
 
     @Test
+    fun `nintendo swap applies regardless of product id`() {
+        assertEquals(resolveGamepadQuirk(0x057E, 0x2009), resolveGamepadQuirk(0x057E, 0x0000))
+        assertEquals(resolveGamepadQuirk(0x057E, 0x2009), resolveGamepadQuirk(0x057E, 0x0180))
+    }
+
+    @Test
     fun `xbox controllers get no quirk`() {
-        assertEquals(QUIRK_NONE, resolveGamepadQuirk(0x045E))
+        assertEquals(QUIRK_NONE, resolveGamepadQuirk(0x045E, 0x028E))
     }
 
     @Test
     fun `sony controllers get no quirk`() {
-        assertEquals(QUIRK_NONE, resolveGamepadQuirk(0x054C))
+        assertEquals(QUIRK_NONE, resolveGamepadQuirk(0x054C, 0x09CC))
     }
 
     @Test
     fun `unknown vendor gets no quirk`() {
-        assertEquals(QUIRK_NONE, resolveGamepadQuirk(0x0000))
+        assertEquals(QUIRK_NONE, resolveGamepadQuirk(0x0000, 0x0000))
+    }
+
+    @Test
+    fun `pdp wired switch pads get the switch layout quirk`() {
+        for (pid in listOf(0x0180, 0x0181, 0x0184, 0x0185, 0x0187)) {
+            assertEquals(QUIRK_SWITCH_LAYOUT, resolveGamepadQuirk(0x0E6F, pid))
+        }
+    }
+
+    @Test
+    fun `pdp afterglow wireless is not switch layout`() {
+        assertEquals(QUIRK_NONE, resolveGamepadQuirk(0x0E6F, 0x0186))
+    }
+
+    @Test
+    fun `pdp xbox pads get no quirk`() {
+        assertEquals(QUIRK_NONE, resolveGamepadQuirk(0x0E6F, 0x0501))
+        assertEquals(QUIRK_NONE, resolveGamepadQuirk(0x0E6F, 0x013B))
+        assertEquals(QUIRK_NONE, resolveGamepadQuirk(0x0E6F, 0x0201))
+    }
+
+    @Test
+    fun `switch layout quirk bit matches the native contract`() {
+        assertEquals(0x04, QUIRK_SWITCH_LAYOUT)
+    }
+
+    @Test
+    fun `switch layout does not overlap the swap bits`() {
+        assertEquals(0, QUIRK_SWITCH_LAYOUT and (QUIRK_SWAP_AB or QUIRK_SWAP_XY))
     }
 }

--- a/play/metadata/android/de-DE/changelogs/10002.txt
+++ b/play/metadata/android/de-DE/changelogs/10002.txt
@@ -1,6 +1,5 @@
-Steam-Controller-Unterstützung.
+Steam-Controller-Unterstützung und ein Fix für kabelgebundene PDP-Switch-Controller.
 
-• Läuft im Direktmodus über USB, per Kabel oder Dongle (Opt-in).
-• Sticks, Trigger, Tasten, Motion und das rechte Trackpad als rechter Stick.
-• Solange Dish ihn nutzt, wirkt er nicht mehr als Maus und Tastatur am Handy und wird danach unverändert zurückgegeben.
-• Fällt ein Pad vom Dongle, bleibt keine Eingabe mehr hängen; beim Wiederverbinden richtet es sich automatisch neu ein.
+• Steam Controller läuft im Direktmodus über USB, per Kabel oder Dongle (Opt-in): Sticks, Trigger, Tasten, Motion und das rechte Trackpad als rechter Stick.
+• Solange Dish ihn nutzt, wirkt er nicht mehr als Maus am Handy und wird danach unverändert zurückgegeben.
+• PDP-Switch-Pads (Faceoff, Fight Pad Pro, Rock Candy) repariert: Jede Taste tut jetzt, was draufsteht, auch A, und ZL/ZR wirken als Trigger.

--- a/play/metadata/android/en-US/changelogs/10002.txt
+++ b/play/metadata/android/en-US/changelogs/10002.txt
@@ -1,6 +1,5 @@
-Steam Controller support.
+Steam Controller support, plus a fix for PDP wired Switch controllers.
 
-• Works in Direct mode over USB, wired or through the dongle (opt-in).
-• Sticks, triggers, buttons, motion, and the right trackpad as a right stick.
-• While Dish uses it, it stops doubling as a mouse and keyboard for the phone, and is handed back exactly as it was.
-• A pad that drops off the dongle no longer holds its last input, and it sets up again automatically when it reconnects.
+• Steam Controller works in Direct mode over USB, wired or via the dongle (opt-in): sticks, triggers, buttons, motion, and the right trackpad as a right stick.
+• While Dish uses it, it stops doubling as a mouse for the phone, and is handed back exactly as it was.
+• Fixed PDP wired Switch pads (Faceoff, Fight Pad Pro, Rock Candy): every button now does what it says, including A, and ZL/ZR work as the triggers.

--- a/play/metadata/android/es-ES/changelogs/10002.txt
+++ b/play/metadata/android/es-ES/changelogs/10002.txt
@@ -1,6 +1,5 @@
-Compatibilidad con el Steam Controller.
+Compatibilidad con el Steam Controller y arreglo para mandos PDP de Switch con cable.
 
-• Funciona en Modo directo por USB, con cable o mediante el dongle (opcional).
-• Sticks, gatillos, botones, motion y el trackpad derecho como stick derecho.
-• Mientras Dish lo usa, deja de actuar como ratón y teclado del teléfono, y se devuelve tal como estaba.
-• Si un mando se desconecta del dongle ya no deja su última entrada retenida, y al reconectarse se configura de nuevo automáticamente.
+• Steam Controller funciona en Modo directo por USB, con cable o dongle (opcional): sticks, gatillos, botones, motion y el trackpad derecho como stick derecho.
+• Mientras Dish lo usa, deja de actuar como ratón del teléfono, y se devuelve tal como estaba.
+• Arreglados los mandos PDP de Switch (Faceoff, Fight Pad Pro, Rock Candy): cada botón hace lo que indica, incluido A, y ZL/ZR funcionan como gatillos.

--- a/play/metadata/android/fr-FR/changelogs/10002.txt
+++ b/play/metadata/android/fr-FR/changelogs/10002.txt
@@ -1,6 +1,5 @@
-Prise en charge du Steam Controller.
+Steam Controller pris en charge, plus un correctif pour les manettes PDP Switch filaires.
 
-• Fonctionne en Mode direct par USB, en filaire ou via le dongle (optionnel).
-• Sticks, gâchettes, boutons, capteurs de mouvement et pavé tactile droit comme stick droit.
-• Pendant que Dish l'utilise, la manette cesse de faire souris et clavier sur le téléphone, puis est rendue telle quelle.
-• Une manette qui décroche du dongle ne garde plus sa dernière entrée, et se reconfigure automatiquement à la reconnexion.
+• Steam Controller en Mode direct par USB, filaire ou dongle (optionnel) : sticks, gâchettes, boutons, mouvement et pavé droit comme stick droit.
+• Pendant que Dish l'utilise, il cesse de faire souris sur le téléphone, puis est rendu tel quel.
+• Manettes PDP Switch corrigées (Faceoff, Fight Pad Pro, Rock Candy) : chaque bouton fait ce qu'il indique, A compris, et ZL/ZR servent de gâchettes.

--- a/play/metadata/android/pt-BR/changelogs/10002.txt
+++ b/play/metadata/android/pt-BR/changelogs/10002.txt
@@ -1,6 +1,5 @@
-Suporte ao Steam Controller.
+Suporte ao Steam Controller, e correção para controles PDP de Switch com fio.
 
-• Funciona no Modo direto por USB, com fio ou pelo dongle (opcional).
-• Sticks, gatilhos, botões, sensores de movimento e o trackpad direito como stick direito.
-• Enquanto o Dish o usa, ele deixa de agir como mouse e teclado do celular, e é devolvido exatamente como estava.
-• Um controle que cai do dongle não mantém mais a última entrada, e é configurado de novo automaticamente ao reconectar.
+• Steam Controller no Modo direto por USB, com fio ou dongle (opcional): sticks, gatilhos, botões, movimento e o trackpad direito como stick direito.
+• Enquanto o Dish o usa, ele deixa de agir como mouse do celular, e é devolvido exatamente como estava.
+• Controles PDP de Switch corrigidos (Faceoff, Fight Pad Pro, Rock Candy): cada botão faz o que diz, inclusive o A, e ZL/ZR funcionam como gatilhos.


### PR DESCRIPTION
## Problem

A PDP Faceoff Wired Pro Controller for Nintendo Switch (USB `0e6f:0180`, hardware in hand) streams with its A button dead in Standard mode. Tracing the pad (live USB descriptor read plus the Android input chain) showed the whole button row is shifted; A is just the loudest casualty.

These pads declare 14 buttons in the Switch usage order: Y B A X L R ZL ZR Minus Plus L3 R3 Home Capture.

**Standard:** the kernel maps button usages sequentially from `BTN_SOUTH`, and `Generic.kl` turns that into `BUTTON_A..BUTTON_THUMBL`. Physical A therefore arrives as `KEYCODE_BUTTON_C` and physical R as `KEYCODE_BUTTON_Z`; `keycodeToXusb()` had no case for either, so both key gates dropped the events. Everything else landed one label off: Y acted as A, L as Y, ZL/ZR as bumpers, Minus/Plus as full-press triggers, stick clicks as Back/Start, Capture as L3, and Home vanished.

**Direct:** the pad classifies as `GENERIC_HID_GAMEPAD` and its descriptor parses fine, but `buttonBit()` assumes the western A B X Y order, which scrambles the pad differently (A acted as X, ZL/ZR as Back/Start, R3/Home/Capture dropped). So Direct was not a workaround either.

## Fix

One Switch-order layout applied on both paths, positional to match `decodeSwitchProUsb`: south to A, east to B, west to X, north to Y, L/R to the bumpers, ZL/ZR to the triggers, Minus/Plus to Back/Start, L3/R3 to the stick clicks, Home to Guide. Capture stays unmapped because XUSB has no equivalent bit.

**Standard path**
- New `QUIRK_SWITCH_LAYOUT` bit (0x04) in `gamepad_input.h` and `GamepadQuirks.kt`; `resolveGamepadQuirk()` now takes VID and PID and the registry pushes both.
- `applyKey()` branches on the quirk into `switchLayoutKeycodeToXusb()`; ZL/ZR (arriving as `BUTTON_L1/R1`) drive the triggers through the existing `ltFromKey`/`rtFromKey` latch so a zero axis sample cannot clear a held trigger.
- Both key gates (`gamepadKeyFilter` and `processGamepadKeyEvent`) now look the device quirk up under `g_devicesMtx` before deciding whether a keycode is consumable, so `BUTTON_C`/`BUTTON_Z`/`BUTTON_MODE` are consumed only for Switch-layout devices. Non-quirked devices keep the exact previous gate behavior, including the pre-IME gate not special-casing `BUTTON_7/8`.

**Direct path**
- `KnownDevice` and `Classification` carry a `ButtonOrder` (default `WESTERN`).
- The attach path stamps `HidLayout.switchOrderButtons` after `fetchHidLayout` (the parse resets the struct, pinned by a test).
- `decodeFromLayout()` uses `switchOrderButtonBit()` when flagged, with button indices 6/7 folding into `bLT`/`bRT`.

## Model catalog

Five PDP models join `kImported` with `Parser::GENERIC_HID_GAMEPAD` and `ButtonOrder::SWITCH`: 0180 Faceoff Wired Pro, 0181 Faceoff Deluxe, 0184 Faceoff Deluxe+ Audio, 0185 Wired Fight Pad Pro, 0187 Rock Candy. They get card names and stay off the verified fast lane, so nothing auto-claims into Direct.

`0e6f:0186` (Afterglow Wireless) is excluded on purpose: SDL classifies it as a Switch Pro protocol controller whose USB port is charge-only, so the wired Switch-order remap would be wrong for it. Source: [SDL controller_list.h](https://raw.githubusercontent.com/libsdl-org/SDL/refs/heads/main/src/joystick/controller_list.h).

The model set intentionally lives in two places (Kotlin quirk table for the framework path, `kImported` for the direct path); each side pins its five PIDs in tests, and the exclusion of 0186 is tested on both sides too.

## Tests

Current-state pins (documenting the bug and the assumptions the fix rests on):
- `keycodeToXusb` drops `BUTTON_C`/`BUTTON_Z`/`BUTTON_MODE`; `applyKey` without the quirk ignores them.
- A byte-accurate Faceoff descriptor fixture parses to the expected field map (buttons at bit 0, count 14, hat at bit 16, X/Y/Z/Rz bytes), and western decode of that shape reproduces the scramble (A lands on X, ZL on Back, upper row vanishes).
- Classification fallbacks and PDP's Xbox pads stay `WESTERN`; PDP Switch pads are not verified fast lane.

New behavior:
- Full truth tables for `switchLayoutKeycodeToXusb` and `switchOrderButtonBit` (face row, bumpers, Minus/Plus, stick clicks, Home, dpad, Capture unmapped).
- Trigger latching: ZL/ZR set and clear `bLT`/`bRT` on both paths, survive zero axis samples while held, and Minus/Plus do not touch the triggers.
- Gate predicate coverage (`switchLayoutConsumesKey`), quirk-bit cross-language pin (0x04 asserted in both gtest and JUnit), stray swap bits do not double-remap.
- End-to-end `decodeReport` with a Switch-order layout through `ParserState`.
- Kotlin: the five PIDs resolve to `QUIRK_SWITCH_LAYOUT`, 0186 and PDP Xbox PIDs resolve to none, Nintendo vendor behavior unchanged.

## Verification

- Native host tests: 288/288 pass (`:app:nativeTest`).
- `:app:ktlintCheck`, `:app:detekt`, `GamepadQuirksTest` green; full unit-test source set compiles.
- clang-format 22.1.4 (CI pin) clean over `app/src/main/cpp`.
- `:app:externalNativeBuildDebug` green on arm64-v8a and x86_64.
- Hardware: the 0180 unit is on hand. Draft until the on-device pass is done: Standard (A/B/X/Y positional, ZL/ZR as triggers, Minus/Plus as Back/Start, Home as Guide) and Direct (same table through the descriptor path), plus a regression check on an Xbox pad and a Switch Pro.

## Notes for review

- Positional mapping (not label) was chosen to match the repo's existing Nintendo convention (`resolveGamepadQuirk` comment, `decodeSwitchProUsb`). If label mapping is preferred for these pads, it is a two-table change.
- The key gates now take `g_devicesMtx` slightly earlier (to read the quirk) and hold it across the same work as before; no new lock ordering.
- Capture is consumed nowhere and mapped nowhere; if the wire ever grows a Share bit it slots into both tables.
