### PR TITLE
fix(release): unblock the 1.1.0 release (Play 10100 notes + cosign 2.6.5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -431,8 +431,8 @@ jobs:
       - name: Install cosign (upstream binary)
         shell: bash
         env:
-          COSIGN_VERSION: "2.4.1"
-          COSIGN_SHA256: "8b24b946dd5809c6bd93de08033bcf6bc0ed7d336b7785787c080f574b89249b" # cosign-linux-amd64 v2.4.1
+          COSIGN_VERSION: "2.6.5"
+          COSIGN_SHA256: "c3b4f5410e608af03a5eb0aaac84a4313d8da131248e08ff1759ac70c79d1644" # cosign-linux-amd64 v2.6.5
         run: |
           set -euo pipefail
           curl -fsSL -o /tmp/cosign \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ computer. Those lines say "update Satellite too".
 
 ---
 
-## [Unreleased]
+## [1.1.0] - 2026-08-17
 
 ### Fixed
 
@@ -62,5 +62,5 @@ The first public release.
 
 Earlier test builds (0.0.x) are only documented in the git history.
 
-[Unreleased]: https://github.com/TinkerNorth/dish-android/compare/1.0.1...HEAD
+[1.1.0]: https://github.com/TinkerNorth/dish-android/releases/tag/1.1.0
 [1.0.1]: https://github.com/TinkerNorth/dish-android/releases/tag/1.0.1

--- a/play/metadata/android/de-DE/changelogs/10100.txt
+++ b/play/metadata/android/de-DE/changelogs/10100.txt
@@ -1,5 +1,5 @@
-Steam-Controller-Unterstützung und ein Fix für kabelgebundene PDP-Switch-Controller.
+Steam Controller und Amazon Luna unterstützt, plus Fix für PDP-Switch-Pads mit Kabel.
 
 • Steam Controller läuft im Direktmodus über USB, per Kabel oder Dongle (Opt-in): Sticks, Trigger, Tasten, Motion und das rechte Trackpad als rechter Stick.
-• Solange Dish ihn nutzt, wirkt er nicht mehr als Maus am Handy und wird danach unverändert zurückgegeben.
+• Amazon Luna Controller voll unterstützt über USB: alle Tasten, beide Sticks, beide Trigger und Rumble.
 • PDP-Switch-Pads (Faceoff, Fight Pad Pro, Rock Candy) repariert: Jede Taste tut jetzt, was draufsteht, auch A, und ZL/ZR wirken als Trigger.

--- a/play/metadata/android/en-US/changelogs/10100.txt
+++ b/play/metadata/android/en-US/changelogs/10100.txt
@@ -1,5 +1,5 @@
-Steam Controller support, plus a fix for PDP wired Switch controllers.
+Steam Controller and Amazon Luna support, plus a fix for PDP wired Switch pads.
 
 • Steam Controller works in Direct mode over USB, wired or via the dongle (opt-in): sticks, triggers, buttons, motion, and the right trackpad as a right stick.
-• While Dish uses it, it stops doubling as a mouse for the phone, and is handed back exactly as it was.
+• Amazon Luna Controller fully supported over USB: every button, both sticks, both triggers, and rumble.
 • Fixed PDP wired Switch pads (Faceoff, Fight Pad Pro, Rock Candy): every button now does what it says, including A, and ZL/ZR work as the triggers.

--- a/play/metadata/android/es-ES/changelogs/10100.txt
+++ b/play/metadata/android/es-ES/changelogs/10100.txt
@@ -1,5 +1,5 @@
-Compatibilidad con el Steam Controller y arreglo para mandos PDP de Switch con cable.
+Steam Controller y Amazon Luna, más un arreglo para mandos PDP de Switch con cable.
 
 • Steam Controller funciona en Modo directo por USB, con cable o dongle (opcional): sticks, gatillos, botones, motion y el trackpad derecho como stick derecho.
-• Mientras Dish lo usa, deja de actuar como ratón del teléfono, y se devuelve tal como estaba.
+• Amazon Luna totalmente compatible por USB: todos los botones, ambos sticks, gatillos y vibración.
 • Arreglados los mandos PDP de Switch (Faceoff, Fight Pad Pro, Rock Candy): cada botón hace lo que indica, incluido A, y ZL/ZR funcionan como gatillos.

--- a/play/metadata/android/fr-FR/changelogs/10100.txt
+++ b/play/metadata/android/fr-FR/changelogs/10100.txt
@@ -1,5 +1,5 @@
-Steam Controller pris en charge, plus un correctif pour les manettes PDP Switch filaires.
+Steam Controller et Amazon Luna, plus un correctif pour les manettes PDP Switch filaires.
 
 • Steam Controller en Mode direct par USB, filaire ou dongle (optionnel) : sticks, gâchettes, boutons, mouvement et pavé droit comme stick droit.
-• Pendant que Dish l'utilise, il cesse de faire souris sur le téléphone, puis est rendu tel quel.
+• Manette Amazon Luna prise en charge en USB : tous les boutons, deux sticks, gâchettes et vibrations.
 • Manettes PDP Switch corrigées (Faceoff, Fight Pad Pro, Rock Candy) : chaque bouton fait ce qu'il indique, A compris, et ZL/ZR servent de gâchettes.

--- a/play/metadata/android/pt-BR/changelogs/10100.txt
+++ b/play/metadata/android/pt-BR/changelogs/10100.txt
@@ -1,5 +1,5 @@
-Suporte ao Steam Controller, e correção para controles PDP de Switch com fio.
+Suporte ao Steam Controller e ao Amazon Luna, e correção para controles PDP de Switch com fio.
 
 • Steam Controller no Modo direto por USB, com fio ou dongle (opcional): sticks, gatilhos, botões, movimento e o trackpad direito como stick direito.
-• Enquanto o Dish o usa, ele deixa de agir como mouse do celular, e é devolvido exatamente como estava.
+• Controle Amazon Luna com suporte total por USB: todos os botões, os dois sticks, gatilhos e vibração.
 • Controles PDP de Switch corrigidos (Faceoff, Fight Pad Pro, Rock Candy): cada botão faz o que diz, inclusive o A, e ZL/ZR funcionam como gatilhos.


### PR DESCRIPTION
The 1.1.0 tag run failed in two independent jobs ([run 32032681945](https://github.com/TinkerNorth/dish-android/actions/runs/32032681945)).

## Play metadata gate

`Upload AAB to Google Play` failed the pre-upload lint: every locale was missing `changelogs/10100.txt`. The notes had been staged as `10002.txt` for a 1.0.2 that never shipped, then the release went out as 1.1.0 (versionCode 10100).

- Renamed `10002.txt` to `10100.txt` in all 5 locales.
- Reworked the notes to also cover the Amazon Luna support (#153) that landed in this range; the header and bullets now match the release scope (Steam Controller, Luna, PDP wired Switch fix) while staying under Play's 500-char cap.
- Dated the CHANGELOG `[Unreleased]` section as 1.1.0.

Validated locally: `EXPECTED_VERSION_CODE=10100 python scripts/check_play_metadata.py` reports 0 errors (the 512x512 icon warnings are the known open store item).

## Harden job: cosign keyless signing

`cosign sign-blob` died with `fetching ambient OIDC credentials: invalid character 'u' looking for beginning of value`: the pinned cosign 2.4.1 (Nov 2024) failed to parse a non-JSON response from the Actions OIDC token endpoint. The same job passed on July 25, so this broke on the service side, not in the workflow.

- Bumped the pinned cosign to 2.6.5, the current release of the maintained v2 line (Aug 6, 2026, includes the GHSA-fx35-mq7g-6g98 fix). The `sign-blob --output-signature/--output-certificate` CLI used here is unchanged in v2; v3 was deliberately avoided because it changes sign-blob's output format.
- `COSIGN_SHA256` verified by downloading `cosign-linux-amd64` and matching it against the upstream `cosign_checksums.txt`.

## Re-releasing after merge

The 1.1.0 tag still points at the broken snapshot (`d3006c0`). After merging:

```
git fetch origin
git tag -f 1.1.0 origin/main
git push origin 1.1.0 --force
```

The tag push reruns the release workflow with these fixes in the tagged tree.

One remaining risk outside this PR: if the Play app record has never had a build uploaded manually, the upload step can still fail; the Play API cannot create the first build of an app (see the note in release.yml).