### PR TITLE
fix: decode the Guide button bit in decodeXInput360 (XInput-360 family)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ computer. Those lines say "update Satellite too".
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- The Xbox/Guide button on XInput-style wired USB controllers (Xbox 360
+  and its many licensed clones, plus the Amazon Luna Controller) now
+  works. Before this fix, pressing it did nothing.
+
+---
+
 ## [1.1.1] - 2026-08-17
 
 ### Fixed

--- a/app/src/main/cpp/usb_parsers.cpp
+++ b/app/src/main/cpp/usb_parsers.cpp
@@ -720,6 +720,7 @@ bool decodeXInput360(const uint8_t* buf, size_t len, DeviceState& s) {
     if (buf[2] & 0x80) b |= XUSB_THUMB_R;
     if (buf[3] & 0x01) b |= XUSB_LB;
     if (buf[3] & 0x02) b |= XUSB_RB;
+    if (buf[3] & 0x04) b |= XUSB_GUIDE;
     if (buf[3] & 0x10) b |= XUSB_A;
     if (buf[3] & 0x20) b |= XUSB_B;
     if (buf[3] & 0x40) b |= XUSB_X;

--- a/app/src/test/cpp/usb_parsers_test.cpp
+++ b/app/src/test/cpp/usb_parsers_test.cpp
@@ -418,6 +418,16 @@ TEST(Decode, Xbox360WirelessDecodesLikeWired) {
     EXPECT_EQ(wired.sLX, wireless.sLX);
 }
 
+TEST(Decode, Xbox360WiredGuideButtonSetsGuideBit) {
+    std::vector<uint8_t> r(14, 0);
+    r[0] = 0x00;
+    r[3] = 0x04; // Guide (same bit the Amazon Luna Controller's center button reports)
+    DeviceState s;
+    ParserState p;
+    ASSERT_TRUE(decodeReport(Parser::XINPUT_360, r.data(), r.size(), s, &p));
+    EXPECT_TRUE(s.wButtons & XUSB_GUIDE);
+}
+
 TEST(Rumble, Xbox360WirelessWrapsFrame) {
     uint8_t out[64];
     size_t n = buildRumbleReport(Parser::XINPUT_360_WIRELESS, 0xFF00, 0x8000, 7, out, sizeof(out));


### PR DESCRIPTION
## Description

`decodeXInput360` (the shared decoder for every `Parser::XINPUT_360` /
`XINPUT_360_WIRELESS` device in the `kKnown` table — genuine Xbox 360
controllers and its many licensed clones, plus the Amazon Luna
Controller) never read byte 3 bit `0x04` of the wired report. That bit
is the standard Guide/Xbox button position in the XInput wired
protocol (the same bit Linux's `xpad` driver treats as `BTN_MODE`); the
other bits in that byte (`0x01`/`0x02` bumpers, `0x10..0x80` face
buttons) were already decoded, but `0x04` was dead, so any pad's
center/Guide button silently produced no input at all instead of
`XUSB_GUIDE`.

Found on real hardware: a live raw-report capture from an Amazon Luna
Controller (USB VID:PID `1949:041A`, wired mode, from #153) showed
byte 3 going to exactly `0x04` and nothing else when its center button
was pressed, with A/B/X/Y independently confirmed against their own
existing bits (`0x10`/`0x20`/`0x40`/`0x80`) in the same capture. Fix is
a single added line, decoding that bit the same way every other button
in the function already is, with no change to the report layout or any
other bit.

No wire-protocol changes; nothing to coordinate with `satellite`,
`dish-linux`, or `dish-mac`.

Scope note for review: this is a generic decoder fix, not a Luna-only
special case, so it affects every device riding `XINPUT_360`/
`XINPUT_360_WIRELESS` in `kKnown` (Mad Catz, PDP, Hori, PowerA,
Afterglow, dance pads, fight sticks, etc.). Pads without a physical
Guide button never assert that bit in hardware, so this is a no-op for
them. The only theoretical residual risk is an unlicensed clone that
reused bit `0x04` for some other custom function instead of leaving it
unused; if one exists, worst case is that button now also raises
Guide/Home, not a crash or corrupted input.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Unit tests
- [ ] Instrumented tests
- [x] Manual testing on device/emulator

Added `Decode.Xbox360WiredGuideButtonSetsGuideBit` to
`usb_parsers_test.cpp`, asserting byte 3 `0x04` sets `XUSB_GUIDE`
through `decodeReport(Parser::XINPUT_360, ...)`. Full native host
suite: 241/241 passing (`ctest` across all `app/src/test/cpp` binaries).

Manual testing: real Amazon Luna Controller, wired directly to an
Android phone running dish, Direct mode. Captured raw USB interrupt
reports for A/B/X/Y and the center button before the fix (center
button produced no bit at all in `wButtons`); after the fix, rebuilt
and reinstalled the app and confirmed the center button now reaches
the Guide/Home action end-to-end through a `satellite` host.

## Checklist
- [x] My code follows the project's style guidelines (ktlint/detekt
      untouched — no Kotlin changed; clang-format skipped locally, not
      installed at the pinned 22.1.4 version, but the change is a
      single line matching the exact formatting of every neighboring
      line in the same `if` chain, and CI's own clang-format gate will
      catch it if not)
- [x] I have performed a self-review of my code
- [x] Any non-obvious code explains why, not what (no comment added —
      the fix reads identically to every other bit check in the same
      function, so a comment here would be inconsistent with the rest
      of the file)
- [x] I have made corresponding changes to documentation
      (`CHANGELOG.md`, under `[Unreleased]`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my
      feature works
- [x] New and existing unit tests pass locally with my changes
      (241/241 native host tests, `assembleDebug`)