### PR TITLE
chore(release): key the Play notes to 1.1.2 (10102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ computer. Those lines say "update Satellite too".
 
 ---
 
-## [Unreleased]
+## [1.1.2] - 2026-08-18
 
 ### Fixed
 

--- a/play/metadata/android/de-DE/changelogs/10102.txt
+++ b/play/metadata/android/de-DE/changelogs/10102.txt
@@ -1,0 +1,4 @@
+Zwei Fixes: die Xbox/Guide-Taste an Kabel-Pads und ein klarer Weg zu USB, wenn ein Bluetooth-Pad eingesteckt wird.
+
+• Die Xbox/Guide-Taste funktioniert jetzt an XInput-USB-Controllern (Xbox 360 und Klone, Amazon Luna).
+• Wird ein schon per Bluetooth verbundener Controller eingesteckt, bleibt das Kabel nicht mehr wirkungslos: Die Karte zeigt „USB verfügbar“ mit der Taste „Kabel verwenden“. Dish wechselt nie von selbst, Laden beim Spielen über Bluetooth geht wie bisher.

--- a/play/metadata/android/en-US/changelogs/10102.txt
+++ b/play/metadata/android/en-US/changelogs/10102.txt
@@ -1,0 +1,4 @@
+Two fixes: the Xbox/Guide button on wired pads, and a clear path to USB when a Bluetooth pad gets plugged in.
+
+• The Xbox/Guide button now works on XInput-style wired USB controllers (Xbox 360 and its clones, Amazon Luna).
+• Plugging in a controller that is already on Bluetooth no longer leaves the cable doing nothing: its card shows "USB available" with a "Use wired" button. Dish never switches on its own, so you can keep playing on Bluetooth while charging.

--- a/play/metadata/android/es-ES/changelogs/10102.txt
+++ b/play/metadata/android/es-ES/changelogs/10102.txt
@@ -1,0 +1,4 @@
+Dos arreglos: el botón Xbox/Guía en mandos con cable y un camino claro al USB cuando enchufas un mando Bluetooth.
+
+• El botón Xbox/Guía ya funciona en mandos USB tipo XInput (Xbox 360 y clones, Amazon Luna).
+• Enchufar un mando que ya está por Bluetooth ya no deja el cable sin hacer nada: su tarjeta muestra "USB disponible" con un botón "Usar cable". Dish nunca cambia por su cuenta, así que puedes seguir jugando por Bluetooth mientras carga.

--- a/play/metadata/android/fr-FR/changelogs/10102.txt
+++ b/play/metadata/android/fr-FR/changelogs/10102.txt
@@ -1,0 +1,4 @@
+Deux correctifs : le bouton Xbox/Guide des manettes filaires, et un passage clair à l'USB quand une manette Bluetooth est branchée.
+
+• Le bouton Xbox/Guide fonctionne désormais sur les manettes USB de type XInput (Xbox 360 et clones, Amazon Luna).
+• Brancher une manette déjà en Bluetooth ne laisse plus le câble inactif : sa carte affiche « USB disponible » avec un bouton « Utiliser le câble ». Dish ne bascule jamais seul, on peut donc rester en Bluetooth pendant la charge.

--- a/play/metadata/android/pt-BR/changelogs/10102.txt
+++ b/play/metadata/android/pt-BR/changelogs/10102.txt
@@ -1,0 +1,4 @@
+Duas correções: o botão Xbox/Guia em controles com fio e um caminho claro para o USB quando um controle Bluetooth é conectado ao cabo.
+
+• O botão Xbox/Guia agora funciona em controles USB tipo XInput (Xbox 360 e clones, Amazon Luna).
+• Conectar o cabo a um controle que já está no Bluetooth não deixa mais o cabo sem efeito: o cartão dele mostra "USB disponível" com o botão "Usar cabo". O Dish nunca troca sozinho, então dá para seguir no Bluetooth enquanto carrega.


### PR DESCRIPTION
1.1.1 shipped 2026-08-17. Main has picked up two user-facing fixes since: the Guide button on XInput wired pads (#162) and the "Use wired" card action when a Bluetooth pad's cable is plugged in (#163). This keys the release docs to 1.1.2 so the tag can ship them; tag 1.1.2 derives versionCode 10102.

- CHANGELOG.md: retitle Unreleased to 1.1.2, dated 2026-08-18
- changelogs/10102.txt in all 5 locales, quoting each locale's actual UI strings for the card badge and button

Validated locally: `EXPECTED_VERSION_CODE=10102 python scripts/check_play_metadata.py` reports 0 errors (only the known 512x512 icon warnings).

## Releasing after merge

```
git fetch origin
git tag 1.1.2 origin/main
git push origin 1.1.2
```