### PR TITLE
Publish the APK under the stable name dish.apk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,6 +249,11 @@ jobs:
 
           apk=$(find app/build/outputs/apk/github/release -name '*.apk' | head -1)
           [ -n "$apk" ] && cp "$apk" "dist/dish-${tag}${suffix}.apk"
+          # Stable-name copy: releases/latest/download/dish.apk is a permanent
+          # link to the newest sideload build. dish-website links it, so the
+          # name is a public API; it never carries the version or the
+          # -unsigned suffix (tagged builds hard-fail without the keystore).
+          [ -n "$apk" ] && cp "$apk" dist/dish.apk
           aab=$(find app/build/outputs/bundle/playRelease -name '*.aab' | head -1)
           [ -n "$aab" ] && cp "$aab" "dist/dish-${tag}${suffix}.aab"
           # R8 mapping files for de-obfuscating prod stack traces. Crashlytics
@@ -516,8 +521,9 @@ jobs:
       base64-subjects: ${{ needs.harden.outputs.hashes }}
       provenance-name: dish-android.intoto.jsonl
       upload-assets: false
-      # Required while private: signing posts the repo name to the public Rekor log.
-      private-repository: true
+      # The repo is public now; the flag only mattered while it was private
+      # (signing posts the repo name to the public Rekor log).
+      private-repository: false
 
   publish:
     name: Publish to GitHub Releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ computer. Those lines say "update Satellite too".
 
 ---
 
+## [1.1.4] - 2026-08-24
+
+### Changed
+
+- The APK on GitHub Releases is now also published under the stable name
+  `dish.apk`, so
+  `github.com/TinkerNorth/dish-android/releases/latest/download/dish.apk`
+  always delivers the newest release. dish.tinkernorth.com links it, which
+  makes the name a public API: do not rename or drop it. Nothing changes
+  inside the app.
+
 ## [1.1.3] - 2026-08-18
 
 ### Changed
@@ -97,5 +108,6 @@ The first public release.
 
 Earlier test builds (0.0.x) are only documented in the git history.
 
+[1.1.4]: https://github.com/TinkerNorth/dish-android/releases/tag/1.1.4
 [1.1.1]: https://github.com/TinkerNorth/dish-android/releases/tag/1.1.1
 [1.0.1]: https://github.com/TinkerNorth/dish-android/releases/tag/1.0.1

--- a/play/metadata/android/de-DE/changelogs/10104.txt
+++ b/play/metadata/android/de-DE/changelogs/10104.txt
@@ -1,0 +1,4 @@
+Wartungsversion. In der App selbst ändert sich nichts.
+
+• Die außerhalb von Google Play erhältliche Version von Dish hat jetzt einen dauerhaften Download-Link, der immer die neueste Version liefert.
+• Keine neuen Berechtigungen, keine neuen Abhängigkeiten, und Satellite muss nicht aktualisiert werden.

--- a/play/metadata/android/en-US/changelogs/10104.txt
+++ b/play/metadata/android/en-US/changelogs/10104.txt
@@ -1,0 +1,4 @@
+Maintenance release. Nothing changes inside the app.
+
+• The version of Dish downloaded outside Google Play now has a permanent download link that always delivers the newest release.
+• No new permissions, no new dependencies, and Satellite does not need updating.

--- a/play/metadata/android/es-ES/changelogs/10104.txt
+++ b/play/metadata/android/es-ES/changelogs/10104.txt
@@ -1,0 +1,4 @@
+Versión de mantenimiento. Nada cambia dentro de la aplicación.
+
+• La versión de Dish que se descarga fuera de Google Play ahora tiene un enlace de descarga permanente que siempre entrega la versión más reciente.
+• Sin permisos nuevos, sin dependencias nuevas, y no hace falta actualizar Satellite.

--- a/play/metadata/android/fr-FR/changelogs/10104.txt
+++ b/play/metadata/android/fr-FR/changelogs/10104.txt
@@ -1,0 +1,4 @@
+Version de maintenance. Rien ne change dans l'application.
+
+• La version de Dish téléchargée en dehors de Google Play dispose désormais d'un lien de téléchargement permanent qui fournit toujours la version la plus récente.
+• Aucune nouvelle permission, aucune nouvelle dépendance, et Satellite n'a pas besoin d'être mis à jour.

--- a/play/metadata/android/pt-BR/changelogs/10104.txt
+++ b/play/metadata/android/pt-BR/changelogs/10104.txt
@@ -1,0 +1,4 @@
+Versão de manutenção. Nada muda dentro do aplicativo.
+
+• A versão do Dish baixada fora do Google Play agora tem um link de download permanente que sempre entrega a versão mais recente.
+• Sem novas permissões, sem novas dependências, e o Satellite não precisa ser atualizado.


### PR DESCRIPTION
## What

The release Stage step now uploads the github-flavor APK twice: the versioned `dish-<tag>.apk` (unchanged) plus a stable **`dish.apk`**, so

`https://github.com/TinkerNorth/dish-android/releases/latest/download/dish.apk`

always delivers the newest release. This lets dish-website offer a direct APK download that never goes stale, matching the contract dish-windows (`dish-setup.exe`) and now satellite/dish-linux ship. The alias is staged before the harden job, so SHA256SUMS, cosign signatures, and SLSA provenance cover it. It never carries the `-unsigned` suffix — tagged builds hard-fail without the keystore, so a published `dish.apk` is always signed.

Once the website links it, the name is a public API (CHANGELOG says so): renaming it breaks the download link in the field.

## Also

- `private-repository: false` on the SLSA generator call — the repo has been public since the distribution work, and the flag only acknowledged the Rekor name leak while private.
- CHANGELOG entry for 1.1.4 and Play changelogs `10104.txt` in all five locales, so the `check_play_metadata` gate passes when 1.1.4 is tagged.