### PR TITLE
feat: rank connection kinds with controller-style tier cues

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/composer/LinkTiers.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/LinkTiers.kt
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.composer
+
+// Ranked best-first: satellite links are the fastest and most stable path, a Moonlight
+// host's control stream is next, and the Bluetooth HID gamepad is the last resort.
+enum class LinkTier { FASTEST, FAST, BASIC }
+
+object LinkTiers {
+    fun forKind(kind: ConnectionKind): LinkTier =
+        when (kind) {
+            ConnectionKind.SATELLITE -> LinkTier.FASTEST
+            ConnectionKind.MOONLIGHT -> LinkTier.FAST
+            ConnectionKind.BLUETOOTH -> LinkTier.BASIC
+        }
+
+    fun <T> byTier(kind: (T) -> ConnectionKind): Comparator<T> = compareBy { forKind(kind(it)) }
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/common/LinkTierBadges.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/LinkTierBadges.kt
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.common
+
+import android.content.Context
+import android.widget.TextView
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import com.tinkernorth.dish.R
+import com.tinkernorth.dish.composer.ConnectionKind
+import com.tinkernorth.dish.composer.LinkTier
+import com.tinkernorth.dish.composer.LinkTiers
+import com.tinkernorth.dish.ui.main.PillSpec
+import com.tinkernorth.dish.ui.main.PillTone
+
+@StringRes
+fun tierLabelRes(tier: LinkTier): Int =
+    when (tier) {
+        LinkTier.FASTEST -> R.string.link_tier_fastest
+        LinkTier.FAST -> R.string.link_tier_fast
+        LinkTier.BASIC -> R.string.link_tier_basic
+    }
+
+@DrawableRes
+fun tierIconRes(tier: LinkTier): Int =
+    when (tier) {
+        LinkTier.FASTEST -> R.drawable.ic_bolt
+        LinkTier.FAST -> R.drawable.ic_wifi
+        LinkTier.BASIC -> R.drawable.ic_bluetooth
+    }
+
+internal fun tierTone(tier: LinkTier): PillTone =
+    when (tier) {
+        LinkTier.FASTEST -> PillTone.ON
+        LinkTier.FAST -> PillTone.FACT
+        LinkTier.BASIC -> PillTone.CAP
+    }
+
+internal fun Context.tierPillSpec(tier: LinkTier): PillSpec = PillSpec(getString(tierLabelRes(tier)), tierIconRes(tier), tierTone(tier))
+
+internal fun Context.tierPillSpec(kind: ConnectionKind): PillSpec = tierPillSpec(LinkTiers.forKind(kind))
+
+internal fun TextView.paintTierBadge(tier: LinkTier) {
+    val tone = tierTone(tier)
+    setText(tierLabelRes(tier))
+    setBackgroundResource(tone.background)
+    setTextColor(context.getColor(tone.foreground))
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/common/PillFlowLayout.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/PillFlowLayout.kt
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.common
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.view.ViewGroup
+import com.tinkernorth.dish.R
+
+internal data class FlowLine(
+    val firstChild: Int,
+    val childCount: Int,
+    val width: Int,
+    val height: Int,
+)
+
+// Greedy line breaking: a child starts a new line when it no longer fits beside the
+// previous ones. A child wider than the row still gets its own full line.
+internal fun buildFlowLines(
+    sizes: List<Pair<Int, Int>>,
+    maxWidth: Int,
+    gap: Int,
+): List<FlowLine> {
+    val lines = mutableListOf<FlowLine>()
+    var first = 0
+    var count = 0
+    var width = 0
+    var height = 0
+    sizes.forEachIndexed { i, (w, h) ->
+        if (count > 0 && width + gap + w > maxWidth) {
+            lines.add(FlowLine(first, count, width, height))
+            first = i
+            count = 0
+            width = 0
+            height = 0
+        }
+        width += (if (count > 0) gap else 0) + w
+        height = maxOf(height, h)
+        count++
+    }
+    if (count > 0) lines.add(FlowLine(first, count, width, height))
+    return lines
+}
+
+// Pill row that wraps onto new lines instead of squeezing its last chip. Lines are
+// end-aligned to match the right-hugging chip rows it replaces.
+class PillFlowLayout
+    @JvmOverloads
+    constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+    ) : ViewGroup(context, attrs) {
+        private val gap = resources.getDimensionPixelSize(R.dimen.binding_pill_gap)
+        private var lines: List<FlowLine> = emptyList()
+
+        private fun visibleChildren(): List<View> =
+            (0 until childCount)
+                .map { getChildAt(it) }
+                .filter { it.visibility != GONE }
+
+        override fun onMeasure(
+            widthMeasureSpec: Int,
+            heightMeasureSpec: Int,
+        ) {
+            val maxWidth = (MeasureSpec.getSize(widthMeasureSpec) - paddingLeft - paddingRight).coerceAtLeast(0)
+            val childWidthSpec = MeasureSpec.makeMeasureSpec(maxWidth, MeasureSpec.AT_MOST)
+            val childHeightSpec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)
+            val children = visibleChildren()
+            children.forEach { it.measure(childWidthSpec, childHeightSpec) }
+            lines = buildFlowLines(children.map { it.measuredWidth to it.measuredHeight }, maxWidth, gap)
+            val contentWidth = lines.maxOfOrNull { it.width } ?: 0
+            val contentHeight = lines.sumOf { it.height } + gap * (lines.size - 1).coerceAtLeast(0)
+            setMeasuredDimension(
+                resolveSize(contentWidth + paddingLeft + paddingRight, widthMeasureSpec),
+                resolveSize(contentHeight + paddingTop + paddingBottom, heightMeasureSpec),
+            )
+        }
+
+        override fun onLayout(
+            changed: Boolean,
+            l: Int,
+            t: Int,
+            r: Int,
+            b: Int,
+        ) {
+            val children = visibleChildren()
+            var y = paddingTop
+            lines.forEach { line ->
+                var x = (r - l) - paddingRight - line.width
+                for (i in line.firstChild until line.firstChild + line.childCount) {
+                    val child = children[i]
+                    child.layout(x, y, x + child.measuredWidth, y + child.measuredHeight)
+                    x += child.measuredWidth + gap
+                }
+                y += line.height + gap
+            }
+        }
+    }

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
@@ -64,6 +64,7 @@ import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.StaticViewAdapter
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
+import com.tinkernorth.dish.ui.common.setLoading
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import com.tinkernorth.dish.ui.donate.attachDonatePill
 import dagger.hilt.android.AndroidEntryPoint
@@ -291,8 +292,11 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.ui.collect { state ->
                     render(state)
-                    satelliteHeader.setLoading(state.scanning, getString(R.string.action_scanning))
-                    moonlightHeader.setLoading(state.moonlightScanning, getString(R.string.action_scanning))
+                    binding.btnScanAll.setLoading(
+                        state.scanning || state.moonlightScanning,
+                        getString(R.string.action_scanning),
+                        getString(R.string.action_scan),
+                    )
                     // Success path emits no ConnectionEvent, so observe state directly to dismiss PIN dialog.
                     dismissPinDialogIfPaired(state)
                 }
@@ -429,15 +433,14 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
     }
 
     private fun setupList() {
+        binding.btnScanAll.setOnClickListener { ensureLocalNetworkThenDiscover(userInitiated = true) }
         satelliteHeader =
             SectionHeaderAdapter(
                 R.drawable.ic_satellite,
                 R.string.section_satellites,
-                R.string.action_scan,
-                secondaryActionLabel = R.string.action_add,
+                R.string.action_add,
                 tier = LinkTiers.forKind(ConnectionKind.SATELLITE),
-                onSecondaryAction = ::showAddSatelliteDialog,
-            ) { ensureLocalNetworkThenDiscover(userInitiated = true) }
+            ) { showAddSatelliteDialog() }
         bluetoothHeader =
             SectionHeaderAdapter(
                 R.drawable.ic_bluetooth,
@@ -449,11 +452,9 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
             SectionHeaderAdapter(
                 R.drawable.ic_pc_monitor,
                 R.string.section_moonlight_hosts,
-                R.string.action_scan,
-                secondaryActionLabel = R.string.action_add,
+                R.string.action_add,
                 tier = LinkTiers.forKind(ConnectionKind.MOONLIGHT),
-                onSecondaryAction = ::showAddMoonlightDialog,
-            ) { ensureLocalNetworkThenDiscover(userInitiated = true) }
+            ) { showAddMoonlightDialog() }
         satelliteList = SatelliteListAdapter(satelliteRowListener)
         bluetoothList = BluetoothListAdapter(bluetoothRowListener)
         moonlightList = MoonlightListAdapter(moonlightRowListener)

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/ConnectionsActivity.kt
@@ -32,8 +32,10 @@ import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.composer.ConnectionCoordinator
+import com.tinkernorth.dish.composer.ConnectionKind
 import com.tinkernorth.dish.composer.ConnectionSummary
 import com.tinkernorth.dish.composer.LinkState
+import com.tinkernorth.dish.composer.LinkTiers
 import com.tinkernorth.dish.core.input.BluetoothGamepad
 import com.tinkernorth.dish.core.model.DiscoveredServer
 import com.tinkernorth.dish.core.model.DiscoverySource
@@ -433,6 +435,7 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
                 R.string.section_satellites,
                 R.string.action_scan,
                 secondaryActionLabel = R.string.action_add,
+                tier = LinkTiers.forKind(ConnectionKind.SATELLITE),
                 onSecondaryAction = ::showAddSatelliteDialog,
             ) { ensureLocalNetworkThenDiscover(userInitiated = true) }
         bluetoothHeader =
@@ -440,6 +443,7 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
                 R.drawable.ic_bluetooth,
                 R.string.section_bluetooth_hosts,
                 R.string.action_add,
+                tier = LinkTiers.forKind(ConnectionKind.BLUETOOTH),
             ) { requestBtPermissions(continueToAdd = true) }
         moonlightHeader =
             SectionHeaderAdapter(
@@ -447,6 +451,7 @@ class ConnectionsActivity : BaseGamepadHostActivity() {
                 R.string.section_moonlight_hosts,
                 R.string.action_scan,
                 secondaryActionLabel = R.string.action_add,
+                tier = LinkTiers.forKind(ConnectionKind.MOONLIGHT),
                 onSecondaryAction = ::showAddMoonlightDialog,
             ) { ensureLocalNetworkThenDiscover(userInitiated = true) }
         satelliteList = SatelliteListAdapter(satelliteRowListener)

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/MoonlightListAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/MoonlightListAdapter.kt
@@ -6,6 +6,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.annotation.ColorRes
+import androidx.annotation.StringRes
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -18,6 +20,7 @@ import com.tinkernorth.dish.databinding.RowConnectionBinding
 import com.tinkernorth.dish.source.connection.moonlight.MoonlightTrustState
 import com.tinkernorth.dish.ui.common.setLoading
 import com.tinkernorth.dish.ui.main.chipTextRes
+import com.tinkernorth.dish.ui.main.holdsPairing
 
 /** Rows for the Moonlight-hosts section, the sibling of [SatelliteRow]. */
 sealed interface MoonlightRow {
@@ -95,23 +98,18 @@ class MoonlightListAdapter(
             }
         }
 
-        // Pairing is remembered trust, not a live link, so the chip says which of the
-        // three trust words applies and never lights up as though the host were online.
-        // The session lives in the binding; all this screen offers is the way out of one.
+        // Pairing is remembered trust, not a live link, so the chip carries the trust word
+        // and never lights up as though the host were online. The session lives in the
+        // binding; all this screen offers is the way out of one.
         private fun bindKnown(row: MoonlightRow.Known) {
             val c = row.summary
             b.paintConnection(c.label, detailFor(row), ctx.getString(row.trust.chipTextRes()), ConnectionKind.MOONLIGHT, c.live)
+            b.tvRowStatus.setTextColor(ctx.getColor(moonlightTrustColorRes(row.trust)))
             if (row.controllerCount > 0) {
                 b.btnRowAction.setLoading(false, "", ctx.getString(R.string.ml_action_quit_session))
                 b.btnRowAction.setOnClickListener { listener.onQuitSession(c.id) }
             } else {
-                val label =
-                    if (row.trust == MoonlightTrustState.PAIRED) {
-                        ctx.getString(R.string.ml_action_pair_again)
-                    } else {
-                        ctx.getString(R.string.ml_action_pair)
-                    }
-                b.btnRowAction.setLoading(false, "", label)
+                b.btnRowAction.setLoading(false, "", ctx.getString(moonlightPairActionRes(row.trust)))
                 b.btnRowAction.setOnClickListener { listener.onPairKnown(c) }
             }
             b.btnRowSecondary.visibility = View.VISIBLE
@@ -139,6 +137,7 @@ class MoonlightListAdapter(
                 ConnectionKind.MOONLIGHT,
                 LinkState.Found,
             )
+            b.tvRowStatus.setTextColor(ctx.getColor(R.color.colorMuted))
             b.btnRowAction.setLoading(false, "", ctx.getString(R.string.ml_action_pair))
             b.btnRowAction.setOnClickListener { listener.onPairDiscovered(h) }
             b.btnRowSecondary.visibility = View.GONE
@@ -200,8 +199,17 @@ fun moonlightRows(
     }
 }
 
-// "Paired" is the word that wants proof, so it is reserved for a session that is up or a host
-// that authorised a call this visit. A host the user only added or bound to is remembered at most.
+@StringRes
+internal fun moonlightPairActionRes(trust: MoonlightTrustState): Int =
+    if (trust.holdsPairing()) R.string.action_repair_short else R.string.ml_action_pair
+
+@ColorRes
+internal fun moonlightTrustColorRes(trust: MoonlightTrustState): Int =
+    if (trust.holdsPairing()) R.color.colorSuccess else R.color.colorMuted
+
+// PAIRED is proven this visit (live session or an authorised mutual-TLS call); REMEMBERED
+// holds a stored record without fresh proof. Both wear the "Paired" chip; the split still
+// decides nothing user-visible here beyond being available to callers that probe.
 internal fun moonlightTrustFor(
     summary: ConnectionSummary,
     paired: Boolean,

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/SectionHeaderAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/SectionHeaderAdapter.kt
@@ -10,14 +10,18 @@ import androidx.annotation.StringRes
 import androidx.core.view.updateLayoutParams
 import androidx.recyclerview.widget.RecyclerView
 import com.tinkernorth.dish.R
+import com.tinkernorth.dish.composer.LinkTier
 import com.tinkernorth.dish.databinding.SectionHeaderBinding
 import com.tinkernorth.dish.ui.common.setLoading
+import com.tinkernorth.dish.ui.common.tierPillSpec
+import com.tinkernorth.dish.ui.main.bindPill
 
 class SectionHeaderAdapter(
     @DrawableRes private val icon: Int,
     @StringRes private val label: Int,
     @StringRes private val actionLabel: Int,
     @StringRes private val secondaryActionLabel: Int? = null,
+    private val tier: LinkTier? = null,
     private val onSecondaryAction: (() -> Unit)? = null,
     private val onAction: () -> Unit,
 ) : RecyclerView.Adapter<SectionHeaderAdapter.VH>() {
@@ -57,6 +61,13 @@ class SectionHeaderAdapter(
         b.iconSection.visibility = View.VISIBLE
         b.iconSection.setImageResource(icon)
         b.labelSection.setText(label)
+        val tier = tier
+        if (tier != null) {
+            b.pillSectionTier.bindPill(b.root.context.tierPillSpec(tier))
+            b.pillSectionTier.root.visibility = View.VISIBLE
+        } else {
+            b.pillSectionTier.root.visibility = View.GONE
+        }
         b.btnSectionAction.visibility = View.VISIBLE
         b.btnSectionAction.setLoading(loading, loadingText, b.root.context.getString(actionLabel))
         b.btnSectionAction.setOnClickListener { onAction() }

--- a/app/src/main/java/com/tinkernorth/dish/ui/connections/SectionHeaderAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/connections/SectionHeaderAdapter.kt
@@ -12,7 +12,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.composer.LinkTier
 import com.tinkernorth.dish.databinding.SectionHeaderBinding
-import com.tinkernorth.dish.ui.common.setLoading
 import com.tinkernorth.dish.ui.common.tierPillSpec
 import com.tinkernorth.dish.ui.main.bindPill
 
@@ -20,24 +19,9 @@ class SectionHeaderAdapter(
     @DrawableRes private val icon: Int,
     @StringRes private val label: Int,
     @StringRes private val actionLabel: Int,
-    @StringRes private val secondaryActionLabel: Int? = null,
     private val tier: LinkTier? = null,
-    private val onSecondaryAction: (() -> Unit)? = null,
     private val onAction: () -> Unit,
 ) : RecyclerView.Adapter<SectionHeaderAdapter.VH>() {
-    private var loading = false
-    private var loadingText = ""
-
-    fun setLoading(
-        loading: Boolean,
-        loadingText: String,
-    ) {
-        if (this.loading == loading && this.loadingText == loadingText) return
-        this.loading = loading
-        this.loadingText = loadingText
-        notifyItemChanged(0)
-    }
-
     class VH(
         val binding: SectionHeaderBinding,
     ) : RecyclerView.ViewHolder(binding.root)
@@ -69,16 +53,8 @@ class SectionHeaderAdapter(
             b.pillSectionTier.root.visibility = View.GONE
         }
         b.btnSectionAction.visibility = View.VISIBLE
-        b.btnSectionAction.setLoading(loading, loadingText, b.root.context.getString(actionLabel))
+        b.btnSectionAction.setText(actionLabel)
         b.btnSectionAction.setOnClickListener { onAction() }
-        val secondary = secondaryActionLabel
-        if (secondary != null && onSecondaryAction != null) {
-            b.btnSectionSecondary.visibility = View.VISIBLE
-            b.btnSectionSecondary.setText(secondary)
-            b.btnSectionSecondary.setOnClickListener { onSecondaryAction() }
-        } else {
-            b.btnSectionSecondary.visibility = View.GONE
-        }
     }
 
     override fun getItemCount(): Int = 1

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/BaseInputOverlayActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/BaseInputOverlayActivity.kt
@@ -2,6 +2,7 @@
 
 package com.tinkernorth.dish.ui.main
 
+import android.content.res.ColorStateList
 import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
@@ -22,17 +23,21 @@ import com.tinkernorth.dish.R
 import com.tinkernorth.dish.composer.ConnectionCoordinator
 import com.tinkernorth.dish.composer.ConnectionSummary
 import com.tinkernorth.dish.core.model.DishNotification
+import com.tinkernorth.dish.databinding.OverlayLinkGuardBinding
 import com.tinkernorth.dish.source.connection.ConnectionEvent
 import com.tinkernorth.dish.source.connection.SatelliteConnectionManager
 import com.tinkernorth.dish.source.inputrate.InputRateStore
+import com.tinkernorth.dish.source.system.NetworkStateObserver
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.FoldAwareSession
 import com.tinkernorth.dish.ui.common.Posture
 import com.tinkernorth.dish.ui.common.ResendPacer
 import com.tinkernorth.dish.ui.common.hingeInsetsFor
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.android.asCoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOf
@@ -48,6 +53,8 @@ abstract class BaseInputOverlayActivity : BaseGamepadHostActivity() {
     @Inject lateinit var satellite: SatelliteConnectionManager
 
     @Inject lateinit var inputRateStore: InputRateStore
+
+    @Inject lateinit var networkState: NetworkStateObserver
 
     protected var connectionId: String = ""
 
@@ -69,6 +76,12 @@ abstract class BaseInputOverlayActivity : BaseGamepadHostActivity() {
     protected open fun onConnectionSummaryChanged(summary: ConnectionSummary?) = Unit
 
     protected open fun onConnectionEvent(event: ConnectionEvent) = Unit
+
+    // The slot this overlay drives; the link guard watches its binding and its controller.
+    protected open val guardSlotId: String get() = VIRTUAL_SLOT_ID
+
+    // Physical-controller presence behind the slot; null for slots with no controller.
+    protected open fun slotDeviceStates(): Flow<SlotDeviceState?> = flowOf(null)
 
     protected fun installBaseScaffolding() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
@@ -119,6 +132,131 @@ abstract class BaseInputOverlayActivity : BaseGamepadHostActivity() {
                 runResendLoop()
             }
         }
+
+        installLinkGuard()
+    }
+
+    private var guardCloseJob: Job? = null
+
+    private fun installLinkGuard() {
+        val guardRoot = rootView().findViewById<View>(R.id.linkGuard) ?: return
+        val guard = OverlayLinkGuardBinding.bind(guardRoot)
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                combine(
+                    hub.connections.map { conns -> conns.firstOrNull { it.id == connectionId } },
+                    hub.bindings.map { it[guardSlotId] },
+                    slotDeviceStates(),
+                    networkState.state,
+                ) { summary, bound, device, network ->
+                    overlayGuardFor(summary, bound, connectionId, device, network)
+                }.distinctUntilChanged().collectLatest { ui ->
+                    // A link blip settles before the scrim appears; recovery paints instantly.
+                    if (ui.kind == GuardKind.RECONNECTING || ui.kind == GuardKind.HOST_LOST) {
+                        delay(LINK_GUARD_GRACE_MS)
+                    }
+                    renderLinkGuard(guard, ui)
+                }
+            }
+        }
+    }
+
+    private fun renderLinkGuard(
+        g: OverlayLinkGuardBinding,
+        ui: OverlayGuardUi,
+    ) {
+        if (!ui.autoClose) {
+            guardCloseJob?.cancel()
+            guardCloseJob = null
+        }
+        g.root.visibility = if (ui.kind == GuardKind.NONE) View.GONE else View.VISIBLE
+        if (ui.kind == GuardKind.NONE) return
+        paintGuardHeader(g, ui)
+        paintGuardActions(g, ui)
+        g.pbGuardSpinner.visibility = if (ui.kind == GuardKind.RECONNECTING) View.VISIBLE else View.GONE
+        val graceSec = ui.countdownSec
+        if (graceSec != null) {
+            g.guardCountdownRow.visibility = View.VISIBLE
+            g.tvGuardCountdown.text = graceSec.toString()
+        } else if (!ui.autoClose) {
+            g.guardCountdownRow.visibility = View.GONE
+        }
+        if (ui.autoClose && guardCloseJob == null) {
+            guardCloseJob =
+                lifecycleScope.launch {
+                    var left = GUARD_AUTO_CLOSE_SEC
+                    g.guardCountdownRow.visibility = View.VISIBLE
+                    while (left > 0) {
+                        g.tvGuardCountdown.text = left.toString()
+                        delay(1000L)
+                        left--
+                    }
+                    finish()
+                }
+        }
+    }
+
+    private fun paintGuardHeader(
+        g: OverlayLinkGuardBinding,
+        ui: OverlayGuardUi,
+    ) {
+        val (icon, color) =
+            when (ui.kind) {
+                GuardKind.HOST_LOST, GuardKind.GONE -> R.drawable.ic_error to R.color.colorError
+                GuardKind.RECONNECTING -> R.drawable.ic_refresh to R.color.colorPrimary
+                GuardKind.UNBOUND -> R.drawable.ic_link_off to R.color.colorWarning
+                else -> R.drawable.ic_gamepad to R.color.colorWarning
+            }
+        g.ivGuardIcon.setImageResource(icon)
+        g.ivGuardIcon.imageTintList = ColorStateList.valueOf(getColor(color))
+        g.tvGuardTitle.setText(guardTitleRes(ui.kind))
+        g.tvGuardDetail.text = guardDetailText(ui)
+    }
+
+    private fun guardTitleRes(kind: GuardKind): Int =
+        when (kind) {
+            GuardKind.HOST_LOST -> R.string.binding_edge_host_lost_title
+            GuardKind.RECONNECTING -> R.string.chip_status_connecting
+            GuardKind.UNPLUGGED, GuardKind.DEPARTED -> R.string.binding_edge_input_lost_title
+            GuardKind.UNBOUND -> R.string.overlay_guard_unbound_title
+            else -> R.string.overlay_guard_gone_title
+        }
+
+    private fun guardDetailText(ui: OverlayGuardUi): String =
+        when (ui.kind) {
+            GuardKind.HOST_LOST, GuardKind.RECONNECTING ->
+                when (ui.detail) {
+                    GuardDetail.WIFI_DOWN -> getString(R.string.overlay_guard_wifi_detail)
+                    GuardDetail.BLUETOOTH_HOST -> getString(R.string.overlay_guard_bt_detail)
+                    GuardDetail.MOONLIGHT_SESSION -> getString(R.string.overlay_guard_ml_detail)
+                    GuardDetail.GENERIC -> getString(R.string.binding_edge_host_lost_detail, ui.hostLabel)
+                }
+            GuardKind.UNPLUGGED -> getString(R.string.overlay_guard_replug_detail)
+            GuardKind.DEPARTED -> getString(R.string.overlay_guard_departed_detail)
+            GuardKind.UNBOUND -> getString(R.string.overlay_guard_unbound_detail, ui.hostLabel)
+            else -> getString(R.string.overlay_guard_gone_detail)
+        }
+
+    private fun paintGuardActions(
+        g: OverlayLinkGuardBinding,
+        ui: OverlayGuardUi,
+    ) {
+        if (ui.showReconnect) {
+            g.btnGuardPrimary.visibility = View.VISIBLE
+            g.btnGuardPrimary.setIconResource(R.drawable.ic_refresh)
+            g.btnGuardPrimary.setText(R.string.binding_edge_action_reconnect)
+            g.btnGuardPrimary.setOnClickListener { hub.autoReconnectAll() }
+        } else if (ui.autoClose) {
+            g.btnGuardPrimary.visibility = View.VISIBLE
+            g.btnGuardPrimary.setIconResource(R.drawable.ic_link_off)
+            g.btnGuardPrimary.setText(R.string.action_close)
+            g.btnGuardPrimary.setOnClickListener { finish() }
+        } else {
+            g.btnGuardPrimary.visibility = View.GONE
+        }
+        g.btnGuardSecondary.visibility = if (ui.autoClose) View.GONE else View.VISIBLE
+        g.btnGuardSecondary.setText(R.string.action_close)
+        g.btnGuardSecondary.setOnClickListener { finish() }
     }
 
     private suspend fun runResendLoop() {
@@ -285,5 +423,8 @@ abstract class BaseInputOverlayActivity : BaseGamepadHostActivity() {
         const val RESEND_INTERVAL_NS_DEFAULT = RESEND_INTERVAL_MS_DEFAULT * 1_000_000L
 
         const val MAX_BACKLOG_FACTOR = 5L
+
+        const val LINK_GUARD_GRACE_MS = 1500L
+        const val GUARD_AUTO_CLOSE_SEC = 8
     }
 }

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsActivity.kt
@@ -34,6 +34,7 @@ import com.tinkernorth.dish.ui.common.DishNavigator
 import com.tinkernorth.dish.ui.common.applyDishActivityTransitions
 import com.tinkernorth.dish.ui.common.applyDishSystemBars
 import com.tinkernorth.dish.ui.common.moonlightTypeLabelRes
+import com.tinkernorth.dish.ui.common.tierPillSpec
 import com.tinkernorth.dish.ui.donate.wireDonateButton
 import com.tinkernorth.dish.ui.setup.ReviewFlow
 import com.tinkernorth.dish.ui.setup.bindCapabilityRows
@@ -429,6 +430,8 @@ class ConfigureBindingsActivity : BaseGamepadHostActivity() {
             card.reviewKind.setText(R.string.binding_label_destination)
             card.reviewName.text = host.label
             card.reviewSublabel.text = destinationSublabel(host)
+            card.reviewTierPill.bindPill(tierPillSpec(host.kind))
+            card.reviewTierPill.root.visibility = View.VISIBLE
             bindReviewFlows(card.reviewSendsRow, card.reviewSendsChips, destinationSends(caps))
             bindReviewFlows(card.reviewGetsRow, card.reviewGetsChips, destinationGets(caps))
             card.reviewCard.isClickable = true

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsViewModel.kt
@@ -16,6 +16,7 @@ import com.tinkernorth.dish.composer.ConnectionCoordinator
 import com.tinkernorth.dish.composer.ConnectionKind
 import com.tinkernorth.dish.composer.ConnectionSummary
 import com.tinkernorth.dish.composer.LinkState
+import com.tinkernorth.dish.composer.LinkTiers
 import com.tinkernorth.dish.core.jni.PhysicalInputNative
 import com.tinkernorth.dish.core.model.CatalogTypeDto
 import com.tinkernorth.dish.core.model.Feature
@@ -69,6 +70,8 @@ data class BindingHost(
     val label: String,
     val kind: ConnectionKind,
 )
+
+internal fun List<BindingHost>.orderedForPicker(): List<BindingHost> = sortedWith(LinkTiers.byTier(BindingHost::kind))
 
 data class BindingSnapshot(
     val slotId: String,
@@ -885,6 +888,7 @@ class ConfigureBindingsViewModel
         private fun buildHosts(): List<BindingHost> =
             connectionsVisibleInPicker(hub.connections.value, loadedSlotId?.let { hub.bindings.value[it] })
                 .map { BindingHost(it.id, it.label, it.kind) }
+                .orderedForPicker()
 
         private fun buildSeedDraft(slotId: String): BindingDraft {
             val hostId = hub.bindings.value[slotId]

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/GamepadOverlayActivity.kt
@@ -19,7 +19,6 @@ import com.tinkernorth.dish.R
 import com.tinkernorth.dish.composer.CapabilityComposer
 import com.tinkernorth.dish.composer.ConnectionKind
 import com.tinkernorth.dish.composer.ConnectionSummary
-import com.tinkernorth.dish.composer.LinkState
 import com.tinkernorth.dish.core.input.hidToXusb
 import com.tinkernorth.dish.core.model.Feature
 import com.tinkernorth.dish.core.model.SlotCapabilities
@@ -125,7 +124,7 @@ class GamepadOverlayActivity :
         val state = lastReportedState ?: return
         val summary = hub.summary(connectionId) ?: return
         if (summary.kind != ConnectionKind.SATELLITE) return
-        if (summary.live != LinkState.Connected) return
+        if (!summary.live.isLiveLink()) return
         // The live state object mutates on the UI thread: copy() is the
         // stable comparison base (a torn read just costs one extra burst).
         val changed = state != lastResentSnapshot
@@ -183,7 +182,7 @@ class GamepadOverlayActivity :
             capability.inputOk(Feature.MOTION) &&
                 capability.userWants(Feature.MOTION) &&
                 summary?.kind == ConnectionKind.SATELLITE &&
-                summary.live == LinkState.Connected
+                summary.live.isLiveLink()
         if (effective && !motionSource.isStreaming) {
             motionSource.start { sample, deltaUs ->
                 inputRateStore.recordMotionSample(VIRTUAL_SLOT_ID)
@@ -294,7 +293,7 @@ class GamepadOverlayActivity :
         // moment it flips to Connected.
         lastReportedState = state
         val summary = hub.summary(connectionId) ?: return
-        if (summary.live != LinkState.Connected) return
+        if (!summary.live.isLiveLink()) return
         when (summary.kind) {
             ConnectionKind.BLUETOOTH -> {
                 val report =

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/MoonlightSessionUi.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/MoonlightSessionUi.kt
@@ -388,7 +388,7 @@ val MoonlightSessionUi.blocksApply: Boolean
 fun MoonlightAction.labelRes(): Int =
     when (this) {
         MoonlightAction.PAIR -> R.string.ml_action_pair
-        MoonlightAction.PAIR_AGAIN -> R.string.ml_action_pair_again
+        MoonlightAction.PAIR_AGAIN -> R.string.action_repair_short
         MoonlightAction.NEW_CODE -> R.string.ml_action_new_code
         MoonlightAction.CANCEL -> R.string.ml_action_cancel
         MoonlightAction.TRY_AGAIN -> R.string.ml_action_try_again
@@ -415,15 +415,15 @@ fun MoonlightTone.colorRes(): Int =
         MoonlightTone.SUCCESS -> R.color.colorSuccess
     }
 
-// Seven states, three words. Anything outstanding or unanswered reads as remembered,
-// because a stored record with no fresh answer is precisely what we hold. "Paired" wants
-// proof, which is either a session that is up or a mutual-TLS call that went through, and
-// whatever has neither a record nor proof reads as not paired.
+// Seven states, two words. Holding a pairing record reads as paired, whether or not
+// this visit has re-proven it; only a state with no usable record reads as not paired.
 @StringRes
 fun MoonlightTrustState.chipTextRes(): Int =
     when (this) {
-        MoonlightTrustState.PAIRED -> R.string.ml_trust_paired
-        MoonlightTrustState.REMEMBERED, MoonlightTrustState.CHECKING -> R.string.ml_trust_remembered
-        MoonlightTrustState.UNREACHABLE -> R.string.ml_trust_remembered
+        MoonlightTrustState.PAIRED, MoonlightTrustState.REMEMBERED,
+        MoonlightTrustState.CHECKING, MoonlightTrustState.UNREACHABLE,
+        -> R.string.ml_trust_paired
         MoonlightTrustState.NOT_PAIRED, MoonlightTrustState.TRUST_LOST, MoonlightTrustState.REPLACED -> R.string.ml_trust_not_paired
     }
+
+fun MoonlightTrustState.holdsPairing(): Boolean = chipTextRes() == R.string.ml_trust_paired

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/OverlayLinkGuard.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/OverlayLinkGuard.kt
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.main
+
+import com.tinkernorth.dish.composer.ConnectionKind
+import com.tinkernorth.dish.composer.ConnectionSummary
+import com.tinkernorth.dish.composer.LinkState
+import com.tinkernorth.dish.source.system.NetworkState
+
+internal enum class GuardKind { NONE, UNPLUGGED, RECONNECTING, HOST_LOST, DEPARTED, UNBOUND, GONE }
+
+internal enum class GuardDetail { GENERIC, WIFI_DOWN, BLUETOOTH_HOST, MOONLIGHT_SESSION }
+
+// Presence of the physical controller behind an overlay's slot; null for slots with no
+// controller (the on-screen pad's virtual slot).
+data class SlotDeviceState(
+    val present: Boolean,
+    val disconnectingSecLeft: Int? = null,
+    val transitioning: Boolean = false,
+    val needsReplug: Boolean = false,
+)
+
+internal data class OverlayGuardUi(
+    val kind: GuardKind,
+    val hostLabel: String = "",
+    val countdownSec: Int? = null,
+    val showReconnect: Boolean = false,
+    val detail: GuardDetail = GuardDetail.GENERIC,
+    // Terminal states: nothing on this screen can recover them, so it closes itself.
+    val autoClose: Boolean = false,
+)
+
+// The overlay keeps sending only while the link routes; everything else must surface.
+// Priority: a dead connection outranks a dead controller outranks a dead link, because
+// each earlier state makes the later checks meaningless. A device mid path-switch is
+// left alone: the twin swap resolves by itself and the sweep covers the failure case.
+internal fun overlayGuardFor(
+    summary: ConnectionSummary?,
+    boundConnectionId: String?,
+    connectionId: String,
+    device: SlotDeviceState?,
+    network: NetworkState,
+): OverlayGuardUi {
+    summary ?: return OverlayGuardUi(GuardKind.GONE, autoClose = true)
+    val deviceGuard = deviceGuardFor(device, summary.label)
+    return when {
+        deviceGuard != null -> deviceGuard
+        boundConnectionId != connectionId -> OverlayGuardUi(GuardKind.UNBOUND, hostLabel = summary.label, autoClose = true)
+        summary.live.isLiveLink() -> OverlayGuardUi(GuardKind.NONE)
+        else -> linkGuardFor(summary, network)
+    }
+}
+
+private fun deviceGuardFor(
+    device: SlotDeviceState?,
+    label: String,
+): OverlayGuardUi? {
+    if (device == null || device.transitioning) return null
+    return when {
+        !device.present -> OverlayGuardUi(GuardKind.DEPARTED, hostLabel = label, autoClose = true)
+        device.needsReplug -> OverlayGuardUi(GuardKind.UNPLUGGED, hostLabel = label)
+        device.disconnectingSecLeft != null ->
+            OverlayGuardUi(GuardKind.UNPLUGGED, hostLabel = label, countdownSec = device.disconnectingSecLeft)
+        else -> null
+    }
+}
+
+private fun linkGuardFor(
+    summary: ConnectionSummary,
+    network: NetworkState,
+): OverlayGuardUi {
+    val detail =
+        when {
+            summary.kind == ConnectionKind.BLUETOOTH -> GuardDetail.BLUETOOTH_HOST
+            network != NetworkState.WIFI -> GuardDetail.WIFI_DOWN
+            summary.kind == ConnectionKind.MOONLIGHT -> GuardDetail.MOONLIGHT_SESSION
+            else -> GuardDetail.GENERIC
+        }
+    return if (summary.live == LinkState.Connecting) {
+        OverlayGuardUi(GuardKind.RECONNECTING, hostLabel = summary.label, detail = detail)
+    } else {
+        OverlayGuardUi(
+            GuardKind.HOST_LOST,
+            hostLabel = summary.label,
+            showReconnect = summary.kind == ConnectionKind.SATELLITE,
+            detail = detail,
+        )
+    }
+}

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/TouchpadOverlayActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/TouchpadOverlayActivity.kt
@@ -9,7 +9,6 @@ import android.view.View
 import com.tinkernorth.dish.R
 import com.tinkernorth.dish.composer.ConnectionKind
 import com.tinkernorth.dish.composer.ConnectionSummary
-import com.tinkernorth.dish.composer.LinkState
 import com.tinkernorth.dish.databinding.ActivityTouchpadOverlayBinding
 import com.tinkernorth.dish.ui.common.TouchpadPadCoordinator
 import com.tinkernorth.dish.ui.common.TouchpadSurfaceView
@@ -17,6 +16,9 @@ import com.tinkernorth.dish.ui.common.paintConnectionMenuItem
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import com.tinkernorth.dish.ui.common.showConnectionDialog
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 
 @AndroidEntryPoint
 class TouchpadOverlayActivity : BaseInputOverlayActivity() {
@@ -36,6 +38,21 @@ class TouchpadOverlayActivity : BaseInputOverlayActivity() {
 
     override val resendIntervalNs: Long = BaseInputOverlayActivity.RESEND_INTERVAL_NS_DEFAULT
 
+    override val guardSlotId: String get() = slotId
+
+    override fun slotDeviceStates(): Flow<SlotDeviceState?> {
+        val deviceId = slotId.toIntOrNull() ?: return flowOf(null)
+        return gamepadRegistry.devices.map { devices ->
+            val device = devices[deviceId] ?: return@map SlotDeviceState(present = false)
+            SlotDeviceState(
+                present = true,
+                disconnectingSecLeft = device.disconnectingTimeLeftSec,
+                transitioning = device.transitioning,
+                needsReplug = device.needsReplug,
+            )
+        }
+    }
+
     // Resend-thread-only (single-threaded Handler dispatcher).
     private var lastResentSnapshot: TouchpadSurfaceView.TouchpadState? = null
 
@@ -43,8 +60,8 @@ class TouchpadOverlayActivity : BaseInputOverlayActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityTouchpadOverlayBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        installBaseScaffolding()
         slotId = intent.getStringExtra(EXTRA_SLOT_ID) ?: VIRTUAL_SLOT_ID
+        installBaseScaffolding()
 
         setupDishToolbar(binding.overlayToolbar)
         binding.overlayToolbar.setTitle(R.string.overlay_title_touchpad)
@@ -86,7 +103,7 @@ class TouchpadOverlayActivity : BaseInputOverlayActivity() {
                     inputRateStore.recordScreenSample()
                     lastReportedState = state
                     val summary = hub.summary(connectionId) ?: return
-                    if (summary.live != LinkState.Connected) return
+                    if (!summary.live.isLiveLink()) return
                     if (summary.kind != ConnectionKind.SATELLITE) return
                     sendSatelliteTouchpadReport(state)
                 }
@@ -109,7 +126,7 @@ class TouchpadOverlayActivity : BaseInputOverlayActivity() {
         val state = lastReportedState ?: return
         val summary = hub.summary(connectionId) ?: return
         if (summary.kind != ConnectionKind.SATELLITE) return
-        if (summary.live != LinkState.Connected) return
+        if (!summary.live.isLiveLink()) return
         // The live state object mutates on the UI thread: copy() is the
         // stable comparison base (a torn read just costs one extra burst).
         val changed = state != lastResentSnapshot

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/ReviewFlow.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/ReviewFlow.kt
@@ -4,7 +4,7 @@ package com.tinkernorth.dish.ui.setup
 
 import android.content.res.ColorStateList
 import android.view.View
-import android.widget.LinearLayout
+import android.view.ViewGroup
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
@@ -23,7 +23,7 @@ data class ReviewFlow(
 // Fills a sends/gets chip row, hiding the whole row when there is nothing to show.
 fun AppCompatActivity.bindReviewFlows(
     row: View,
-    chips: LinearLayout,
+    chips: ViewGroup,
     flows: List<ReviewFlow>,
 ) {
     row.isVisible = flows.isNotEmpty()

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConnectionActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConnectionActivity.kt
@@ -15,7 +15,10 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.tinkernorth.dish.R
+import com.tinkernorth.dish.composer.ConnectionKind
 import com.tinkernorth.dish.composer.LinkState
+import com.tinkernorth.dish.composer.LinkTier
+import com.tinkernorth.dish.composer.LinkTiers
 import com.tinkernorth.dish.core.model.DiscoveredServer
 import com.tinkernorth.dish.databinding.ActivitySetupConnectionBinding
 import com.tinkernorth.dish.databinding.SetupChoiceRowBinding
@@ -25,6 +28,7 @@ import com.tinkernorth.dish.source.store.OnboardingPreferenceStore
 import com.tinkernorth.dish.source.system.LocalNetworkAccess
 import com.tinkernorth.dish.ui.common.BaseGamepadHostActivity
 import com.tinkernorth.dish.ui.common.DishNavigator
+import com.tinkernorth.dish.ui.common.paintTierBadge
 import com.tinkernorth.dish.ui.common.setupDishToolbar
 import com.tinkernorth.dish.ui.connections.PairPinDialog
 import com.tinkernorth.dish.ui.main.chipTextRes
@@ -83,21 +87,21 @@ class SetupConnectionActivity : BaseGamepadHostActivity() {
             R.drawable.ic_satellite,
             R.string.setup_conn_satellite_title,
             R.string.setup_conn_satellite_body,
-            R.string.setup_conn_satellite_badge,
+            LinkTiers.forKind(ConnectionKind.SATELLITE),
         ) { withLocalNetwork { viewModel.chooseSatellite() } }
         bindChoice(
             binding.cardMoonlight,
             R.drawable.ic_pc_monitor,
             R.string.ml_dest_section,
             R.string.setup_conn_moonlight_body,
-            badge = null,
+            LinkTiers.forKind(ConnectionKind.MOONLIGHT),
         ) { withLocalNetwork { viewModel.chooseMoonlight() } }
         bindChoice(
             binding.cardBluetoothHost,
             R.drawable.ic_bluetooth,
             R.string.setup_conn_bt_host_title,
             R.string.setup_conn_bt_host_body,
-            badge = null,
+            LinkTiers.forKind(ConnectionKind.BLUETOOTH),
         ) { nav.toSetupBluetoothHost(inputType, slotId) }
 
         binding.btnBack.setOnClickListener { handleBack() }
@@ -282,18 +286,14 @@ class SetupConnectionActivity : BaseGamepadHostActivity() {
         @DrawableRes icon: Int,
         @StringRes title: Int,
         @StringRes body: Int,
-        @StringRes badge: Int?,
+        tier: LinkTier,
         onClick: () -> Unit,
     ) {
         row.choiceIcon.setImageResource(icon)
         row.choiceTitle.setText(title)
         row.choiceBody.setText(body)
-        if (badge == null) {
-            row.choiceBadge.visibility = View.GONE
-        } else {
-            row.choiceBadge.visibility = View.VISIBLE
-            row.choiceBadge.setText(badge)
-        }
+        row.choiceBadge.visibility = View.VISIBLE
+        row.choiceBadge.paintTierBadge(tier)
         row.choiceCard.setOnClickListener { onClick() }
     }
 

--- a/app/src/main/res/layout-land/activity_connections.xml
+++ b/app/src/main/res/layout-land/activity_connections.xml
@@ -24,11 +24,38 @@
 
         <LinearLayout
             android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingHorizontal="@dimen/spacing_5xl"
+            android:paddingTop="@dimen/spacing_3xl">
+
+            <TextView
+                android:id="@+id/tvScanHint"
+                style="@style/TextAppearance.Dish.BodySmall"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginEnd="@dimen/spacing_md"
+                android:textColor="@color/colorOnSurfaceVariant"
+                android:text="@string/scan_all_hint" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnScanAll"
+                style="@style/Widget.Dish.Button.Outlined"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/action_scan" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
             android:orientation="horizontal"
             android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingVertical="@dimen/spacing_3xl">
+            android:paddingTop="@dimen/spacing_lg"
+            android:paddingBottom="@dimen/spacing_3xl">
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rvSatellites"

--- a/app/src/main/res/layout-sw600dp/activity_connections.xml
+++ b/app/src/main/res/layout-sw600dp/activity_connections.xml
@@ -17,11 +17,38 @@
 
         <LinearLayout
             android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingHorizontal="@dimen/spacing_5xl"
+            android:paddingTop="@dimen/spacing_3xl">
+
+            <TextView
+                android:id="@+id/tvScanHint"
+                style="@style/TextAppearance.Dish.BodySmall"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginEnd="@dimen/spacing_md"
+                android:textColor="@color/colorOnSurfaceVariant"
+                android:text="@string/scan_all_hint" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnScanAll"
+                style="@style/Widget.Dish.Button.Outlined"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/action_scan" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
             android:orientation="horizontal"
             android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingVertical="@dimen/spacing_3xl">
+            android:paddingTop="@dimen/spacing_lg"
+            android:paddingBottom="@dimen/spacing_3xl">
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rvSatellites"

--- a/app/src/main/res/layout/activity_connections.xml
+++ b/app/src/main/res/layout/activity_connections.xml
@@ -27,6 +27,34 @@
                 android:layout_gravity="end" />
         </com.google.android.material.appbar.MaterialToolbar>
 
+        <!-- Pinned page action: one scan covers satellites and Moonlight hosts,
+             so the button lives here instead of repeating per section. -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingHorizontal="@dimen/spacing_5xl"
+            android:paddingTop="@dimen/spacing_3xl">
+
+            <TextView
+                android:id="@+id/tvScanHint"
+                style="@style/TextAppearance.Dish.BodySmall"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginEnd="@dimen/spacing_md"
+                android:textColor="@color/colorOnSurfaceVariant"
+                android:text="@string/scan_all_hint" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnScanAll"
+                style="@style/Widget.Dish.Button.Outlined"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/action_scan" />
+        </LinearLayout>
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rvConnections"
             android:layout_width="match_parent"
@@ -34,7 +62,7 @@
             android:layout_weight="1"
             android:clipToPadding="false"
             android:paddingHorizontal="@dimen/spacing_5xl"
-            android:paddingTop="@dimen/spacing_3xl"
+            android:paddingTop="@dimen/spacing_lg"
             android:paddingBottom="@dimen/low_power_chip_scroll_clearance" />
     </LinearLayout>
 

--- a/app/src/main/res/layout/activity_gamepad_overlay.xml
+++ b/app/src/main/res/layout/activity_gamepad_overlay.xml
@@ -47,6 +47,12 @@
                 android:paddingHorizontal="@dimen/spacing_2xl"
                 android:paddingTop="@dimen/spacing_lg"
                 android:paddingBottom="@dimen/spacing_2xl" />
+
+            <include
+                android:id="@+id/linkGuard"
+                layout="@layout/overlay_link_guard"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
         </FrameLayout>
     </LinearLayout>
 

--- a/app/src/main/res/layout/activity_touchpad_overlay.xml
+++ b/app/src/main/res/layout/activity_touchpad_overlay.xml
@@ -72,6 +72,12 @@
                     android:layout_weight="1"
                     android:layout_marginStart="@dimen/spacing_md" />
             </LinearLayout>
+
+            <include
+                android:id="@+id/linkGuard"
+                layout="@layout/overlay_link_guard"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
         </FrameLayout>
     </LinearLayout>
 

--- a/app/src/main/res/layout/overlay_link_guard.xml
+++ b/app/src/main/res/layout/overlay_link_guard.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Link-guard scrim for the input overlays (gamepad + touchpad). Same visual
+     language as item_controller's edge overlay: scrim, state icon, title,
+     optional countdown, detail, primary/secondary actions. Sits over the
+     input surface so dead input can't be mashed into the void. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/colorOverlayScrim"
+    android:clickable="true"
+    android:focusable="true"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:padding="@dimen/binding_edge_padding"
+    android:visibility="gone">
+
+    <ImageView
+        android:id="@+id/ivGuardIcon"
+        android:layout_width="@dimen/binding_edge_icon_size"
+        android:layout_height="@dimen/binding_edge_icon_size"
+        android:importantForAccessibility="no" />
+
+    <TextView
+        android:id="@+id/tvGuardTitle"
+        style="@style/TextAppearance.Dish.Title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/binding_edge_gap"
+        android:gravity="center" />
+
+    <LinearLayout
+        android:id="@+id/guardCountdownRow"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/binding_edge_gap"
+        android:gravity="center"
+        android:orientation="horizontal"
+        android:visibility="gone">
+
+        <TextView
+            android:id="@+id/tvGuardCountdown"
+            style="@style/TextAppearance.Dish.Display"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/colorWarning" />
+
+        <TextView
+            style="@style/TextAppearance.Dish.Body.Mono"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/spacing_xs"
+            android:text="@string/binding_edge_seconds"
+            android:textColor="@color/colorOnSurfaceVariant" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/tvGuardDetail"
+        style="@style/TextAppearance.Dish.BodySmall"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/binding_edge_gap"
+        android:gravity="center"
+        android:maxWidth="@dimen/guard_detail_max_width"
+        android:textColor="@color/colorOnSurfaceVariant" />
+
+    <ProgressBar
+        android:id="@+id/pbGuardSpinner"
+        android:layout_width="@dimen/binding_edge_spinner_size"
+        android:layout_height="@dimen/binding_edge_spinner_size"
+        android:layout_marginTop="@dimen/binding_edge_actions_gap"
+        android:indeterminate="true"
+        android:indeterminateTint="@color/colorPrimary"
+        android:visibility="gone" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnGuardPrimary"
+        style="@style/Widget.Dish.Button.Tonal"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/binding_edge_actions_gap"
+        android:visibility="gone"
+        app:iconGravity="textStart" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnGuardSecondary"
+        style="@style/Widget.Dish.Button.Text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone" />
+</LinearLayout>

--- a/app/src/main/res/layout/section_header.xml
+++ b/app/src/main/res/layout/section_header.xml
@@ -54,10 +54,24 @@
     <TextView
         android:id="@+id/labelSection"
         style="@style/TextAppearance.Dish.Label.Accent"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
         tools:text="SECTION" />
+
+    <!-- Optional link-tier pill next to the label (Connections section headers).
+         Defaults to `gone`; SectionHeaderAdapter binds it when a tier is given. -->
+    <include
+        android:id="@+id/pillSectionTier"
+        layout="@layout/binding_pill"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/spacing_sm"
+        android:visibility="gone" />
+
+    <Space
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btnSectionSecondary"

--- a/app/src/main/res/layout/setup_review_card.xml
+++ b/app/src/main/res/layout/setup_review_card.xml
@@ -60,6 +60,14 @@
                     android:textColor="@color/colorOnSurfaceVariant"
                     tools:text="USB / Direct" />
             </LinearLayout>
+
+            <include
+                android:id="@+id/reviewTierPill"
+                layout="@layout/binding_pill"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/spacing_md"
+                android:visibility="gone" />
         </LinearLayout>
 
         <LinearLayout

--- a/app/src/main/res/layout/setup_review_card.xml
+++ b/app/src/main/res/layout/setup_review_card.xml
@@ -93,16 +93,12 @@
                 android:layout_marginStart="@dimen/spacing_xs"
                 android:text="@string/setup_cfg_review_sends" />
 
-            <LinearLayout
+            <com.tinkernorth.dish.ui.common.PillFlowLayout
                 android:id="@+id/reviewSendsChips"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:layout_marginStart="@dimen/spacing_md"
-                android:divider="@drawable/binding_pill_gap"
-                android:gravity="center_vertical|end"
-                android:orientation="horizontal"
-                android:showDividers="middle" />
+                android:layout_marginStart="@dimen/spacing_md" />
         </LinearLayout>
 
         <LinearLayout
@@ -128,16 +124,12 @@
                 android:layout_marginStart="@dimen/spacing_xs"
                 android:text="@string/setup_cfg_review_gets" />
 
-            <LinearLayout
+            <com.tinkernorth.dish.ui.common.PillFlowLayout
                 android:id="@+id/reviewGetsChips"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:layout_marginStart="@dimen/spacing_md"
-                android:divider="@drawable/binding_pill_gap"
-                android:gravity="center_vertical|end"
-                android:orientation="horizontal"
-                android:showDividers="middle" />
+                android:layout_marginStart="@dimen/spacing_md" />
         </LinearLayout>
     </LinearLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -124,6 +124,15 @@
     <string name="overlay_title_touchpad">Dodirna ploča</string>
     <string name="overlay_rate_touch">Dodir %1$s</string>
     <string name="overlay_rate_motion">Pokret %1$s</string>
+    <string name="overlay_guard_wifi_detail">Wi-Fi je isključen ili na drugoj mreži. Vratite se na mrežu hosta.</string>
+    <string name="overlay_guard_bt_detail">Ponovo se povežite iz Bluetooth podešavanja hosta.</string>
+    <string name="overlay_guard_ml_detail">Moonlight sesija je završena. Ponovo povežite kontroler da pokrenete novu.</string>
+    <string name="overlay_guard_replug_detail">Ponovo priključite kontroler da nastavite koristiti ovaj ekran.</string>
+    <string name="overlay_guard_departed_detail">Kontroler se nije vratio. Ovaj ekran će se zatvoriti.</string>
+    <string name="overlay_guard_unbound_title">Kontroler odvezan</string>
+    <string name="overlay_guard_unbound_detail">Ovaj slot više nije povezan sa %1$s. Ovaj ekran će se zatvoriti.</string>
+    <string name="overlay_guard_gone_title">Veza uklonjena</string>
+    <string name="overlay_guard_gone_detail">Veza je zaboravljena. Ovaj ekran će se zatvoriti.</string>
     <string name="touchpad_pad_click_label">Klik + Pomak</string>
     <string name="touchpad_pad_move_label">Pomak</string>
     <string name="touchpad_pad_click_hint">Povucite za klik i pomak</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -27,6 +27,7 @@
     <string name="action_scan">Skeniraj</string>
     <string name="action_scanning">Skeniranje…</string>
     <string name="action_add">Dodaj</string>
+    <string name="scan_all_hint">Jedno skeniranje pronalazi satelite i Moonlight hostove</string>
     <string name="bt_hosts_empty">Nema zapamćenih hostova. Dodirnite Dodaj da registrujete novi</string>
 
     <!-- row_connection.xml + dinamičke oznake redova u ConnectionsActivity. -->
@@ -161,7 +162,6 @@
     <string name="ml_session_live_title">Strimuje na %1$s</string>
     <string name="ml_session_live_body">%1$s · kontroler %2$d od 4</string>
     <string name="ml_trust_paired">Upareno</string>
-    <string name="ml_trust_remembered">Zapamćeno</string>
     <string name="ml_trust_not_paired">Nije upareno</string>
     <string name="ml_host_in_use">Koristi ga %1$s</string>
     <plurals name="ml_host_in_use_count">
@@ -203,7 +203,6 @@
     <string name="ml_ended_title">%1$s je završio sesiju</string>
     <string name="ml_ended_body">Aplikacija je zatvorena na hostu. Pokrenite novu sesiju da nastavite koristiti ovaj kontroler.</string>
     <string name="ml_action_pair">Upari sada</string>
-    <string name="ml_action_pair_again">Upari ponovo</string>
     <string name="ml_action_new_code">Novi kod</string>
     <string name="ml_action_cancel">Otkaži</string>
     <string name="ml_action_try_again">Pokušaj ponovo</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -105,6 +105,10 @@
     <string name="chip_status_online">Na vezi</string>
     <string name="chip_status_unstable">Nestabilan</string>
 
+    <string name="link_tier_fastest">Najbrži</string>
+    <string name="link_tier_fast">Brz</string>
+    <string name="link_tier_basic">Osnovni</string>
+
     <!-- Sloj kontrolera (activity_gamepad_overlay.xml + GamepadOverlayActivity). -->
     <string name="overlay_status_unknown">Nepoznata veza</string>
     <string name="overlay_status_not_connected">Nije povezan</string>

--- a/app/src/main/res/values-bs/strings_setup.xml
+++ b/app/src/main/res/values-bs/strings_setup.xml
@@ -59,7 +59,6 @@
     <string name="setup_conn_path_subtitle">Odaberite kako ovaj telefon razgovara s vašim PC-om.</string>
     <string name="setup_conn_satellite_title">Satellite preko Wi-Fi-ja</string>
     <string name="setup_conn_satellite_body">Najmanja latencija, sve funkcije. Treba besplatnu PC aplikaciju.</string>
-    <string name="setup_conn_satellite_badge">Najbolje</string>
     <string name="setup_conn_moonlight_body">Strimujte na PC s Sunshine, Apollo ili Wolf. Dish priključuje kontroler u sesiju.</string>
     <string name="setup_conn_bt_host_title">Bluetooth host</string>
     <string name="setup_conn_bt_host_body">Telefon se uparuje s PC-om kao pad. Bez PC aplikacije.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -123,6 +123,15 @@
     <string name="overlay_title_touchpad">Touchpad</string>
     <string name="overlay_rate_touch">Touch %1$s</string>
     <string name="overlay_rate_motion">Bewegung %1$s</string>
+    <string name="overlay_guard_wifi_detail">WLAN ist aus oder in einem anderen Netzwerk. Verbinde dich wieder mit dem Netzwerk des Hosts.</string>
+    <string name="overlay_guard_bt_detail">Stelle die Verbindung über die Bluetooth-Einstellungen des Hosts wieder her.</string>
+    <string name="overlay_guard_ml_detail">Die Moonlight-Sitzung wurde beendet. Verknüpfe den Controller erneut, um eine neue zu starten.</string>
+    <string name="overlay_guard_replug_detail">Stecke den Controller wieder ein, um diesen Bildschirm weiter zu nutzen.</string>
+    <string name="overlay_guard_departed_detail">Der Controller kam nicht zurück. Dieser Bildschirm wird geschlossen.</string>
+    <string name="overlay_guard_unbound_title">Verknüpfung aufgehoben</string>
+    <string name="overlay_guard_unbound_detail">Dieser Slot ist nicht mehr mit %1$s verknüpft. Dieser Bildschirm wird geschlossen.</string>
+    <string name="overlay_guard_gone_title">Verbindung entfernt</string>
+    <string name="overlay_guard_gone_detail">Die Verbindung wurde entfernt. Dieser Bildschirm wird geschlossen.</string>
     <string name="touchpad_pad_click_label">Klicken + Bewegen</string>
     <string name="touchpad_pad_move_label">Bewegen</string>
     <string name="touchpad_pad_click_hint">Ziehen zum Klicken und Bewegen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -26,6 +26,7 @@
     <string name="action_scan">Suchen</string>
     <string name="action_scanning">Suche läuft…</string>
     <string name="action_add">Hinzufügen</string>
+    <string name="scan_all_hint">Ein Suchlauf findet Satelliten und Moonlight-Hosts</string>
     <string name="bt_hosts_empty">Keine gemerkten Hosts. Auf Hinzufügen tippen, um einen neuen zu registrieren</string>
 
     <!-- row_connection.xml + dynamische Zeilenbeschriftungen in ConnectionsActivity. -->
@@ -161,7 +162,6 @@
     <string name="ml_session_live_title">Streamt an %1$s</string>
     <string name="ml_session_live_body">%1$s · Controller %2$d von 4</string>
     <string name="ml_trust_paired">Gekoppelt</string>
-    <string name="ml_trust_remembered">Gemerkt</string>
     <string name="ml_trust_not_paired">Nicht gekoppelt</string>
     <string name="ml_host_in_use">Genutzt von %1$s</string>
     <plurals name="ml_host_in_use_count">
@@ -202,7 +202,6 @@
     <string name="ml_ended_title">%1$s hat die Sitzung beendet</string>
     <string name="ml_ended_body">Die App wurde auf dem Host geschlossen. Starte eine neue Sitzung, um diesen Controller weiter zu nutzen.</string>
     <string name="ml_action_pair">Jetzt koppeln</string>
-    <string name="ml_action_pair_again">Erneut koppeln</string>
     <string name="ml_action_new_code">Neuer Code</string>
     <string name="ml_action_cancel">Abbrechen</string>
     <string name="ml_action_try_again">Erneut versuchen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -104,6 +104,10 @@
     <string name="chip_status_online">Online</string>
     <string name="chip_status_unstable">Instabil</string>
 
+    <string name="link_tier_fastest">Am schnellsten</string>
+    <string name="link_tier_fast">Schnell</string>
+    <string name="link_tier_basic">Einfach</string>
+
     <!-- Controller-Overlay (activity_gamepad_overlay.xml + GamepadOverlayActivity). -->
     <string name="overlay_status_unknown">Unbekannte Verbindung</string>
     <string name="overlay_status_not_connected">Nicht verbunden</string>

--- a/app/src/main/res/values-de/strings_setup.xml
+++ b/app/src/main/res/values-de/strings_setup.xml
@@ -65,7 +65,6 @@
     <string name="setup_conn_path_subtitle">Wähle, wie dieses Handy mit deinem PC spricht.</string>
     <string name="setup_conn_satellite_title">Satellite über WLAN</string>
     <string name="setup_conn_satellite_body">Geringste Latenz, voller Funktionsumfang. Braucht die kostenlose PC-App.</string>
-    <string name="setup_conn_satellite_badge">Am besten</string>
     <string name="setup_conn_moonlight_body">Stream an einen PC mit Sunshine, Apollo oder Wolf. Dish schließt einen Controller an die Sitzung an.</string>
     <string name="setup_conn_bt_host_title">Bluetooth-Host</string>
     <string name="setup_conn_bt_host_body">Das Handy koppelt sich als Pad mit dem PC. Keine PC-App.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -28,6 +28,7 @@
     <string name="action_scan">Buscar</string>
     <string name="action_scanning">Buscando…</string>
     <string name="action_add">Añadir</string>
+    <string name="scan_all_hint">Una búsqueda encuentra satélites y hosts Moonlight</string>
     <string name="bt_hosts_empty">No hay hosts recordados. Toca Añadir para registrar uno nuevo</string>
 
     <!-- row_connection.xml + etiquetas dinámicas de fila en ConnectionsActivity. -->
@@ -163,7 +164,6 @@
     <string name="ml_session_live_title">Transmitiendo a %1$s</string>
     <string name="ml_session_live_body">%1$s · mando %2$d de 4</string>
     <string name="ml_trust_paired">Emparejado</string>
-    <string name="ml_trust_remembered">Recordado</string>
     <string name="ml_trust_not_paired">Sin emparejar</string>
     <string name="ml_host_in_use">En uso por %1$s</string>
     <plurals name="ml_host_in_use_count">
@@ -205,7 +205,6 @@
     <string name="ml_ended_title">%1$s terminó la sesión</string>
     <string name="ml_ended_body">La app se cerró en el host. Inicia una sesión nueva para seguir usando este mando.</string>
     <string name="ml_action_pair">Emparejar ahora</string>
-    <string name="ml_action_pair_again">Emparejar de nuevo</string>
     <string name="ml_action_new_code">Código nuevo</string>
     <string name="ml_action_cancel">Cancelar</string>
     <string name="ml_action_try_again">Intentar de nuevo</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -125,6 +125,15 @@
     <string name="overlay_title_touchpad">Panel táctil</string>
     <string name="overlay_rate_touch">Táctil %1$s</string>
     <string name="overlay_rate_motion">Movimiento %1$s</string>
+    <string name="overlay_guard_wifi_detail">El Wi-Fi está apagado o en otra red. Vuelve a la red del host.</string>
+    <string name="overlay_guard_bt_detail">Reconecta desde los ajustes de Bluetooth del host.</string>
+    <string name="overlay_guard_ml_detail">La sesión de Moonlight terminó. Vincula el mando de nuevo para iniciar otra.</string>
+    <string name="overlay_guard_replug_detail">Vuelve a conectar el mando para seguir usando esta pantalla.</string>
+    <string name="overlay_guard_departed_detail">El mando no volvió. Esta pantalla se cerrará.</string>
+    <string name="overlay_guard_unbound_title">Mando desvinculado</string>
+    <string name="overlay_guard_unbound_detail">Esta ranura ya no está vinculada a %1$s. Esta pantalla se cerrará.</string>
+    <string name="overlay_guard_gone_title">Conexión eliminada</string>
+    <string name="overlay_guard_gone_detail">La conexión fue olvidada. Esta pantalla se cerrará.</string>
     <string name="touchpad_pad_click_label">Clic + Mover</string>
     <string name="touchpad_pad_move_label">Mover</string>
     <string name="touchpad_pad_click_hint">Arrastra para hacer clic y mover</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -106,6 +106,10 @@
     <string name="chip_status_online">En línea</string>
     <string name="chip_status_unstable">Inestable</string>
 
+    <string name="link_tier_fastest">Más rápida</string>
+    <string name="link_tier_fast">Rápida</string>
+    <string name="link_tier_basic">Básica</string>
+
     <!-- Capa de superposición del mando (activity_gamepad_overlay.xml + GamepadOverlayActivity). -->
     <string name="overlay_status_unknown">Conexión desconocida</string>
     <string name="overlay_status_not_connected">Sin conexión</string>

--- a/app/src/main/res/values-es/strings_setup.xml
+++ b/app/src/main/res/values-es/strings_setup.xml
@@ -59,7 +59,6 @@
     <string name="setup_conn_path_subtitle">Elige cómo habla este teléfono con tu PC.</string>
     <string name="setup_conn_satellite_title">Satellite por Wi-Fi</string>
     <string name="setup_conn_satellite_body">La menor latencia, todas las funciones. Necesita la app gratuita para PC.</string>
-    <string name="setup_conn_satellite_badge">La mejor</string>
     <string name="setup_conn_moonlight_body">Transmite a un PC con Sunshine, Apollo o Wolf. Dish conecta un mando a la sesión.</string>
     <string name="setup_conn_bt_host_title">Host Bluetooth</string>
     <string name="setup_conn_bt_host_body">El teléfono se empareja con el PC como un mando. Sin app para PC.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -124,6 +124,15 @@
     <string name="overlay_title_touchpad">Pavé tactile</string>
     <string name="overlay_rate_touch">Tactile %1$s</string>
     <string name="overlay_rate_motion">Mouvement %1$s</string>
+    <string name="overlay_guard_wifi_detail">Le Wi-Fi est désactivé ou sur un autre réseau. Rejoignez le réseau de l\'hôte.</string>
+    <string name="overlay_guard_bt_detail">Reconnectez depuis les réglages Bluetooth de l\'hôte.</string>
+    <string name="overlay_guard_ml_detail">La session Moonlight est terminée. Associez à nouveau la manette pour en démarrer une nouvelle.</string>
+    <string name="overlay_guard_replug_detail">Rebranchez la manette pour continuer à utiliser cet écran.</string>
+    <string name="overlay_guard_departed_detail">La manette n\'est pas revenue. Cet écran va se fermer.</string>
+    <string name="overlay_guard_unbound_title">Manette dissociée</string>
+    <string name="overlay_guard_unbound_detail">Cet emplacement n\'est plus associé à %1$s. Cet écran va se fermer.</string>
+    <string name="overlay_guard_gone_title">Connexion supprimée</string>
+    <string name="overlay_guard_gone_detail">La connexion a été oubliée. Cet écran va se fermer.</string>
     <string name="touchpad_pad_click_label">Clic + Déplacer</string>
     <string name="touchpad_pad_move_label">Déplacer</string>
     <string name="touchpad_pad_click_hint">Glissez pour cliquer et déplacer</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -105,6 +105,10 @@
     <string name="chip_status_online">En ligne</string>
     <string name="chip_status_unstable">Instable</string>
 
+    <string name="link_tier_fastest">La plus rapide</string>
+    <string name="link_tier_fast">Rapide</string>
+    <string name="link_tier_basic">Basique</string>
+
     <!-- Superposition manette (activity_gamepad_overlay.xml + GamepadOverlayActivity). -->
     <string name="overlay_status_unknown">Connexion inconnue</string>
     <string name="overlay_status_not_connected">Non connectée</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -27,6 +27,7 @@
     <string name="action_scan">Scanner</string>
     <string name="action_scanning">Recherche…</string>
     <string name="action_add">Ajouter</string>
+    <string name="scan_all_hint">Un scan trouve les satellites et les hôtes Moonlight</string>
     <string name="bt_hosts_empty">Aucun hôte mémorisé : touchez Ajouter pour en enregistrer un</string>
 
     <!-- row_connection.xml + libellés dynamiques des lignes dans ConnectionsActivity. -->
@@ -162,7 +163,6 @@
     <string name="ml_session_live_title">Diffusion vers %1$s</string>
     <string name="ml_session_live_body">%1$s · manette %2$d sur 4</string>
     <string name="ml_trust_paired">Appairé</string>
-    <string name="ml_trust_remembered">Mémorisé</string>
     <string name="ml_trust_not_paired">Non appairé</string>
     <string name="ml_host_in_use">Utilisé par %1$s</string>
     <plurals name="ml_host_in_use_count">
@@ -204,7 +204,6 @@
     <string name="ml_ended_title">%1$s a mis fin à la session</string>
     <string name="ml_ended_body">L\'appli s\'est fermée sur l\'hôte. Lancez une nouvelle session pour continuer à utiliser cette manette.</string>
     <string name="ml_action_pair">Appairer maintenant</string>
-    <string name="ml_action_pair_again">Appairer à nouveau</string>
     <string name="ml_action_new_code">Nouveau code</string>
     <string name="ml_action_cancel">Annuler</string>
     <string name="ml_action_try_again">Réessayer</string>

--- a/app/src/main/res/values-fr/strings_setup.xml
+++ b/app/src/main/res/values-fr/strings_setup.xml
@@ -64,7 +64,6 @@
     <string name="setup_conn_path_subtitle">Choisissez comment ce téléphone communique avec votre PC.</string>
     <string name="setup_conn_satellite_title">Satellite par Wi-Fi</string>
     <string name="setup_conn_satellite_body">Latence minimale, toutes les fonctionnalités. Nécessite l\'app PC gratuite.</string>
-    <string name="setup_conn_satellite_badge">Meilleur</string>
     <string name="setup_conn_moonlight_body">Diffusez vers un PC avec Sunshine, Apollo ou Wolf. Dish branche une manette dans la session.</string>
     <string name="setup_conn_bt_host_title">Hôte Bluetooth</string>
     <string name="setup_conn_bt_host_body">Le téléphone s\'appaire au PC comme une manette. Sans app PC.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -106,6 +106,10 @@
     <string name="chip_status_online">On-line</string>
     <string name="chip_status_unstable">Instável</string>
 
+    <string name="link_tier_fastest">Mais rápida</string>
+    <string name="link_tier_fast">Rápida</string>
+    <string name="link_tier_basic">Básica</string>
+
     <!-- Superposição do controle (activity_gamepad_overlay.xml + GamepadOverlayActivity). -->
     <string name="overlay_status_unknown">Conexão desconhecida</string>
     <string name="overlay_status_not_connected">Não conectado</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -125,6 +125,15 @@
     <string name="overlay_title_touchpad">Touchpad</string>
     <string name="overlay_rate_touch">Toque %1$s</string>
     <string name="overlay_rate_motion">Movimento %1$s</string>
+    <string name="overlay_guard_wifi_detail">O Wi-Fi está desligado ou em outra rede. Volte para a rede do host.</string>
+    <string name="overlay_guard_bt_detail">Reconecte pelas configurações Bluetooth do host.</string>
+    <string name="overlay_guard_ml_detail">A sessão Moonlight terminou. Vincule o controle de novo para iniciar outra.</string>
+    <string name="overlay_guard_replug_detail">Conecte o controle de novo para continuar usando esta tela.</string>
+    <string name="overlay_guard_departed_detail">O controle não voltou. Esta tela vai fechar.</string>
+    <string name="overlay_guard_unbound_title">Controle desvinculado</string>
+    <string name="overlay_guard_unbound_detail">Este slot não está mais vinculado a %1$s. Esta tela vai fechar.</string>
+    <string name="overlay_guard_gone_title">Conexão removida</string>
+    <string name="overlay_guard_gone_detail">A conexão foi esquecida. Esta tela vai fechar.</string>
     <string name="touchpad_pad_click_label">Clique + Mover</string>
     <string name="touchpad_pad_move_label">Mover</string>
     <string name="touchpad_pad_click_hint">Arraste para clicar e mover</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -28,6 +28,7 @@
     <string name="action_scan">Buscar</string>
     <string name="action_scanning">Buscando…</string>
     <string name="action_add">Adicionar</string>
+    <string name="scan_all_hint">Uma busca encontra satélites e hosts Moonlight</string>
     <string name="bt_hosts_empty">Nenhum host lembrado. Toque em Adicionar para registrar um novo</string>
 
     <!-- row_connection.xml + rótulos dinâmicos de linha no ConnectionsActivity. -->
@@ -163,7 +164,6 @@
     <string name="ml_session_live_title">Transmitindo para %1$s</string>
     <string name="ml_session_live_body">%1$s · controle %2$d de 4</string>
     <string name="ml_trust_paired">Pareado</string>
-    <string name="ml_trust_remembered">Lembrado</string>
     <string name="ml_trust_not_paired">Não pareado</string>
     <string name="ml_host_in_use">Em uso por %1$s</string>
     <plurals name="ml_host_in_use_count">
@@ -205,7 +205,6 @@
     <string name="ml_ended_title">%1$s encerrou a sessão</string>
     <string name="ml_ended_body">O app foi fechado no host. Inicie uma nova sessão para continuar usando este controle.</string>
     <string name="ml_action_pair">Parear agora</string>
-    <string name="ml_action_pair_again">Parear de novo</string>
     <string name="ml_action_new_code">Novo código</string>
     <string name="ml_action_cancel">Cancelar</string>
     <string name="ml_action_try_again">Tentar de novo</string>

--- a/app/src/main/res/values-pt-rBR/strings_setup.xml
+++ b/app/src/main/res/values-pt-rBR/strings_setup.xml
@@ -59,7 +59,6 @@
     <string name="setup_conn_path_subtitle">Escolha como este celular fala com o seu PC.</string>
     <string name="setup_conn_satellite_title">Satellite por Wi-Fi</string>
     <string name="setup_conn_satellite_body">Menor latência, recursos completos. Precisa do app gratuito para PC.</string>
-    <string name="setup_conn_satellite_badge">Melhor</string>
     <string name="setup_conn_moonlight_body">Transmita para um PC com Sunshine, Apollo ou Wolf. O Dish conecta um controle na sessão.</string>
     <string name="setup_conn_bt_host_title">Host Bluetooth</string>
     <string name="setup_conn_bt_host_body">O celular pareia com o PC como um controle. Sem app no PC.</string>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -193,6 +193,7 @@
     <dimen name="binding_edge_gap">@dimen/size_9</dimen>
     <dimen name="binding_edge_actions_gap">@dimen/size_8</dimen>
     <dimen name="binding_edge_spinner_size">@dimen/size_28</dimen>
+    <dimen name="guard_detail_max_width">@dimen/size_280</dimen>
 
     <dimen name="low_power_chip_scroll_clearance">@dimen/size_80</dimen>
     <dimen name="low_power_dim_body_max_width">@dimen/size_280</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="action_scan">Scan</string>
     <string name="action_scanning">Scanning…</string>
     <string name="action_add">Add</string>
+    <string name="scan_all_hint">One scan finds satellites and Moonlight hosts</string>
     <string name="bt_hosts_empty">No remembered hosts. Tap Add to register a new one</string>
 
     <!-- row_connection.xml + ConnectionsActivity dynamic row labels. -->
@@ -205,7 +206,6 @@
     <string name="ml_session_live_body">%1$s · controller %2$d of 4</string>
 
     <string name="ml_trust_paired">Paired</string>
-    <string name="ml_trust_remembered">Remembered</string>
     <string name="ml_trust_not_paired">Not paired</string>
     <string name="ml_host_in_use">In use by %1$s</string>
     <plurals name="ml_host_in_use_count">
@@ -249,7 +249,6 @@
     <string name="ml_ended_body">The app closed on the host. Start a new session to keep using this controller.</string>
 
     <string name="ml_action_pair">Pair now</string>
-    <string name="ml_action_pair_again">Pair again</string>
     <string name="ml_action_new_code">New code</string>
     <string name="ml_action_cancel">Cancel</string>
     <string name="ml_action_try_again">Try again</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,6 +131,11 @@
     <string name="chip_status_online">Online</string>
     <string name="chip_status_unstable">Unsteady</string>
 
+    <!-- LinkTier vocabulary: the speed/stability ladder of the connection kinds. -->
+    <string name="link_tier_fastest">Fastest</string>
+    <string name="link_tier_fast">Fast</string>
+    <string name="link_tier_basic">Basic</string>
+
     <!-- Overlay screens (gamepad + touchpad): toolbar action icons + their info-dialog content. -->
     <string name="overlay_status_unknown">Unknown connection</string>
     <string name="overlay_status_not_connected">Not connected</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -154,6 +154,15 @@
     <string name="overlay_title_touchpad">Touchpad</string>
     <string name="overlay_rate_touch">Touch %1$s</string>
     <string name="overlay_rate_motion">Motion %1$s</string>
+    <string name="overlay_guard_wifi_detail">Wi-Fi is off or on a different network. Rejoin the host\'s network.</string>
+    <string name="overlay_guard_bt_detail">Reconnect from the host\'s Bluetooth settings.</string>
+    <string name="overlay_guard_ml_detail">The Moonlight session ended. Bind the controller again to start a new one.</string>
+    <string name="overlay_guard_replug_detail">Plug the controller back in to keep using this screen.</string>
+    <string name="overlay_guard_departed_detail">The controller didn\'t come back. This screen will close.</string>
+    <string name="overlay_guard_unbound_title">Controller unbound</string>
+    <string name="overlay_guard_unbound_detail">This slot is no longer bound to %1$s. This screen will close.</string>
+    <string name="overlay_guard_gone_title">Connection removed</string>
+    <string name="overlay_guard_gone_detail">The connection was forgotten. This screen will close.</string>
 
     <!-- Labels for the two side-by-side trackpads in the touchpad overlay.
          The "click" pad routes touches as click+position (drag, text

--- a/app/src/main/res/values/strings_setup.xml
+++ b/app/src/main/res/values/strings_setup.xml
@@ -65,7 +65,6 @@
     <string name="setup_conn_path_subtitle">Pick how this phone talks to your PC.</string>
     <string name="setup_conn_satellite_title">Satellite over Wi-Fi</string>
     <string name="setup_conn_satellite_body">Lowest latency, full features. Needs the free PC app.</string>
-    <string name="setup_conn_satellite_badge">Best</string>
     <string name="setup_conn_moonlight_body">Stream to a PC running Sunshine, Apollo or Wolf. Dish plugs a controller into the session.</string>
     <string name="setup_conn_bt_host_title">Bluetooth host</string>
     <string name="setup_conn_bt_host_body">Phone pairs to the PC as a pad. No PC app.</string>

--- a/app/src/test/java/com/tinkernorth/dish/composer/LinkTiersTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/LinkTiersTest.kt
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.composer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LinkTiersTest {
+    @Test
+    fun `satellite is the fastest tier`() {
+        assertEquals(LinkTier.FASTEST, LinkTiers.forKind(ConnectionKind.SATELLITE))
+    }
+
+    @Test
+    fun `moonlight host is the fast tier`() {
+        assertEquals(LinkTier.FAST, LinkTiers.forKind(ConnectionKind.MOONLIGHT))
+    }
+
+    @Test
+    fun `bluetooth is the basic tier`() {
+        assertEquals(LinkTier.BASIC, LinkTiers.forKind(ConnectionKind.BLUETOOTH))
+    }
+
+    @Test
+    fun `every kind resolves to a tier`() {
+        for (kind in ConnectionKind.entries) LinkTiers.forKind(kind)
+    }
+
+    @Test
+    fun `tiers are declared best-first`() {
+        assertTrue(LinkTier.FASTEST.ordinal < LinkTier.FAST.ordinal)
+        assertTrue(LinkTier.FAST.ordinal < LinkTier.BASIC.ordinal)
+    }
+
+    @Test
+    fun `each tier is claimed by exactly one kind`() {
+        val tiers = ConnectionKind.entries.map { LinkTiers.forKind(it) }
+        assertEquals(LinkTier.entries.toSet(), tiers.toSet())
+        assertEquals(tiers.size, tiers.toSet().size)
+    }
+
+    @Test
+    fun `comparator orders satellite before moonlight before bluetooth`() {
+        val sorted =
+            listOf(
+                ConnectionKind.BLUETOOTH,
+                ConnectionKind.MOONLIGHT,
+                ConnectionKind.SATELLITE,
+            ).sortedWith(LinkTiers.byTier { it })
+
+        assertEquals(
+            listOf(ConnectionKind.SATELLITE, ConnectionKind.MOONLIGHT, ConnectionKind.BLUETOOTH),
+            sorted,
+        )
+    }
+
+    @Test
+    fun `comparator treats same-kind entries as equal`() {
+        val cmp = LinkTiers.byTier<ConnectionKind> { it }
+        for (kind in ConnectionKind.entries) {
+            assertEquals(0, cmp.compare(kind, kind))
+        }
+    }
+
+    @Test
+    fun `comparator is consistent with the tier declaration order`() {
+        val cmp = LinkTiers.byTier<ConnectionKind> { it }
+        assertTrue(cmp.compare(ConnectionKind.SATELLITE, ConnectionKind.MOONLIGHT) < 0)
+        assertTrue(cmp.compare(ConnectionKind.MOONLIGHT, ConnectionKind.BLUETOOTH) < 0)
+        assertTrue(cmp.compare(ConnectionKind.SATELLITE, ConnectionKind.BLUETOOTH) < 0)
+        assertTrue(cmp.compare(ConnectionKind.BLUETOOTH, ConnectionKind.SATELLITE) > 0)
+    }
+
+    @Test
+    fun `comparator extracts the kind through the selector`() {
+        data class Row(
+            val name: String,
+            val kind: ConnectionKind,
+        )
+
+        val sorted =
+            listOf(
+                Row("bt", ConnectionKind.BLUETOOTH),
+                Row("sat", ConnectionKind.SATELLITE),
+                Row("ml", ConnectionKind.MOONLIGHT),
+            ).sortedWith(LinkTiers.byTier(Row::kind))
+
+        assertEquals(listOf("sat", "ml", "bt"), sorted.map { it.name })
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/ui/common/LinkTierBadgesTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/common/LinkTierBadgesTest.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.common
+
+import com.tinkernorth.dish.R
+import com.tinkernorth.dish.composer.LinkTier
+import com.tinkernorth.dish.ui.main.PillTone
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LinkTierBadgesTest {
+    @Test
+    fun `fastest tier reads Fastest`() {
+        assertEquals(R.string.link_tier_fastest, tierLabelRes(LinkTier.FASTEST))
+    }
+
+    @Test
+    fun `fast tier reads Fast`() {
+        assertEquals(R.string.link_tier_fast, tierLabelRes(LinkTier.FAST))
+    }
+
+    @Test
+    fun `basic tier reads Basic`() {
+        assertEquals(R.string.link_tier_basic, tierLabelRes(LinkTier.BASIC))
+    }
+
+    @Test
+    fun `fastest tier wears the bolt, same glyph as the Direct path pill`() {
+        assertEquals(R.drawable.ic_bolt, tierIconRes(LinkTier.FASTEST))
+    }
+
+    @Test
+    fun `fast tier wears the wifi glyph`() {
+        assertEquals(R.drawable.ic_wifi, tierIconRes(LinkTier.FAST))
+    }
+
+    @Test
+    fun `basic tier wears the bluetooth glyph`() {
+        assertEquals(R.drawable.ic_bluetooth, tierIconRes(LinkTier.BASIC))
+    }
+
+    @Test
+    fun `fastest tier lights up in the ON tone, same tone as the Direct path pill`() {
+        assertEquals(PillTone.ON, tierTone(LinkTier.FASTEST))
+    }
+
+    @Test
+    fun `fast tier renders as a plain fact`() {
+        assertEquals(PillTone.FACT, tierTone(LinkTier.FAST))
+    }
+
+    @Test
+    fun `basic tier renders in the muted cap tone, same tone as the Standard path pill`() {
+        assertEquals(PillTone.CAP, tierTone(LinkTier.BASIC))
+    }
+
+    @Test
+    fun `every tier resolves to a non-zero label, icon, and tone`() {
+        for (tier in LinkTier.entries) {
+            assertTrue("missing label for $tier", tierLabelRes(tier) != 0)
+            assertTrue("missing icon for $tier", tierIconRes(tier) != 0)
+            tierTone(tier)
+        }
+    }
+
+    @Test
+    fun `each tier has a distinct label, icon, and tone`() {
+        assertEquals(LinkTier.entries.size, LinkTier.entries.mapTo(mutableSetOf()) { tierLabelRes(it) }.size)
+        assertEquals(LinkTier.entries.size, LinkTier.entries.mapTo(mutableSetOf()) { tierIconRes(it) }.size)
+        assertEquals(LinkTier.entries.size, LinkTier.entries.mapTo(mutableSetOf()) { tierTone(it) }.size)
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/ui/common/PillFlowLayoutTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/common/PillFlowLayoutTest.kt
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.common
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PillFlowLayoutTest {
+    private val gap = 8
+
+    @Test
+    fun `no children means no lines`() {
+        assertEquals(emptyList<FlowLine>(), buildFlowLines(emptyList(), 100, gap))
+    }
+
+    @Test
+    fun `a single child fills one line`() {
+        val lines = buildFlowLines(listOf(40 to 20), 100, gap)
+        assertEquals(listOf(FlowLine(firstChild = 0, childCount = 1, width = 40, height = 20)), lines)
+    }
+
+    @Test
+    fun `children that fit stay on one line with gaps between them`() {
+        val lines = buildFlowLines(listOf(30 to 20, 30 to 20), 100, gap)
+        assertEquals(listOf(FlowLine(firstChild = 0, childCount = 2, width = 68, height = 20)), lines)
+    }
+
+    @Test
+    fun `an exact fit does not wrap`() {
+        val lines = buildFlowLines(listOf(46 to 20, 46 to 20), 100, gap)
+        assertEquals(1, lines.size)
+        assertEquals(100, lines[0].width)
+    }
+
+    @Test
+    fun `one pixel too wide wraps the last child to a new line`() {
+        val lines = buildFlowLines(listOf(47 to 20, 46 to 20), 100, gap)
+        assertEquals(2, lines.size)
+        assertEquals(FlowLine(firstChild = 0, childCount = 1, width = 47, height = 20), lines[0])
+        assertEquals(FlowLine(firstChild = 1, childCount = 1, width = 46, height = 20), lines[1])
+    }
+
+    @Test
+    fun `the leading child never pays a gap`() {
+        val lines = buildFlowLines(listOf(100 to 20), 100, gap)
+        assertEquals(1, lines.size)
+        assertEquals(100, lines[0].width)
+    }
+
+    @Test
+    fun `a child wider than the row still gets its own full line`() {
+        val lines = buildFlowLines(listOf(30 to 20, 500 to 20, 30 to 20), 100, gap)
+        assertEquals(3, lines.size)
+        assertEquals(FlowLine(firstChild = 1, childCount = 1, width = 500, height = 20), lines[1])
+    }
+
+    @Test
+    fun `line height is the tallest child on that line`() {
+        val lines = buildFlowLines(listOf(30 to 10, 30 to 24, 90 to 16), 100, gap)
+        assertEquals(2, lines.size)
+        assertEquals(24, lines[0].height)
+        assertEquals(16, lines[1].height)
+    }
+
+    @Test
+    fun `wrapping keeps every child exactly once and in order`() {
+        val sizes = List(9) { 35 to 20 }
+        val lines = buildFlowLines(sizes, 100, gap)
+        assertEquals(sizes.size, lines.sumOf { it.childCount })
+        var next = 0
+        lines.forEach { line ->
+            assertEquals(next, line.firstChild)
+            next += line.childCount
+        }
+        assertEquals(sizes.size, next)
+    }
+
+    @Test
+    fun `every line respects the max width unless a single child forces it`() {
+        val sizes = listOf(60 to 20, 50 to 20, 40 to 20, 70 to 20, 20 to 20)
+        val lines = buildFlowLines(sizes, 120, gap)
+        lines.forEach { line ->
+            assertTrue(line.width <= 120 || line.childCount == 1)
+        }
+    }
+
+    @Test
+    fun `zero available width puts each child on its own line`() {
+        val lines = buildFlowLines(listOf(10 to 5, 10 to 5, 10 to 5), 0, gap)
+        assertEquals(3, lines.size)
+        lines.forEach { assertEquals(1, it.childCount) }
+    }
+
+    @Test
+    fun `four destination-sized chips wrap into two lines on a narrow dialog`() {
+        val chip = 96 to 28
+        val lines = buildFlowLines(listOf(chip, chip, chip, chip), 220, gap)
+        assertEquals(2, lines.size)
+        assertEquals(2, lines[0].childCount)
+        assertEquals(2, lines[1].childCount)
+        assertEquals(200, lines[0].width)
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/ui/connections/MoonlightRowsTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/connections/MoonlightRowsTest.kt
@@ -67,12 +67,12 @@ class MoonlightRowsTest {
         assertEquals(MoonlightTrustState.PAIRED, moonlightTrustFor(idle, paired = false, verified = true))
     }
 
-    // Three words and no fourth. The hosts screen never probes, so every state the
+    // Two words and no third. The hosts screen never probes, so every state the
     // rest of the app can be in still has to land on one of these, and none of them
     // may read as a liveness light.
     @Test
-    fun `every row a scan can produce says exactly one of the three trust words`() {
-        val words = setOf(R.string.ml_trust_paired, R.string.ml_trust_remembered, R.string.ml_trust_not_paired)
+    fun `every row a scan can produce says exactly one of the two trust words`() {
+        val words = setOf(R.string.ml_trust_paired, R.string.ml_trust_not_paired)
         val states = mutableSetOf<MoonlightTrustState>()
         for (live in LinkState.entries) {
             for (paired in listOf(false, true)) {

--- a/app/src/test/java/com/tinkernorth/dish/ui/connections/MoonlightTrustPresentationTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/connections/MoonlightTrustPresentationTest.kt
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.connections
+
+import com.tinkernorth.dish.R
+import com.tinkernorth.dish.source.connection.moonlight.MoonlightTrustState
+import com.tinkernorth.dish.ui.main.holdsPairing
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MoonlightTrustPresentationTest {
+    @Test
+    fun `a host holding a pairing offers Re-pair, the same word as a stale satellite`() {
+        assertEquals(R.string.action_repair_short, moonlightPairActionRes(MoonlightTrustState.PAIRED))
+        assertEquals(R.string.action_repair_short, moonlightPairActionRes(MoonlightTrustState.REMEMBERED))
+        assertEquals(R.string.action_repair_short, moonlightPairActionRes(MoonlightTrustState.CHECKING))
+        assertEquals(R.string.action_repair_short, moonlightPairActionRes(MoonlightTrustState.UNREACHABLE))
+    }
+
+    @Test
+    fun `a host with no usable pairing offers Pair now`() {
+        assertEquals(R.string.ml_action_pair, moonlightPairActionRes(MoonlightTrustState.NOT_PAIRED))
+        assertEquals(R.string.ml_action_pair, moonlightPairActionRes(MoonlightTrustState.TRUST_LOST))
+        assertEquals(R.string.ml_action_pair, moonlightPairActionRes(MoonlightTrustState.REPLACED))
+    }
+
+    @Test
+    fun `paired status renders in the success color, unpaired stays muted`() {
+        for (state in MoonlightTrustState.entries) {
+            val expected = if (state.holdsPairing()) R.color.colorSuccess else R.color.colorMuted
+            assertEquals(state.name, expected, moonlightTrustColorRes(state))
+        }
+    }
+
+    @Test
+    fun `action and color always agree on whether a pairing is held`() {
+        for (state in MoonlightTrustState.entries) {
+            val repair = moonlightPairActionRes(state) == R.string.action_repair_short
+            val success = moonlightTrustColorRes(state) == R.color.colorSuccess
+            assertEquals(state.name, repair, success)
+        }
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/BindingHostOrderTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/BindingHostOrderTest.kt
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.main
+
+import com.tinkernorth.dish.composer.ConnectionKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class BindingHostOrderTest {
+    private fun host(
+        id: String,
+        kind: ConnectionKind,
+    ) = BindingHost(id = id, label = id, kind = kind)
+
+    @Test
+    fun `satellites come before moonlight hosts before bluetooth`() {
+        val ordered =
+            listOf(
+                host("bt:1", ConnectionKind.BLUETOOTH),
+                host("ml:1", ConnectionKind.MOONLIGHT),
+                host("s:1", ConnectionKind.SATELLITE),
+            ).orderedForPicker()
+
+        assertEquals(listOf("s:1", "ml:1", "bt:1"), ordered.map { it.id })
+    }
+
+    @Test
+    fun `hosts of the same kind keep their incoming order`() {
+        val ordered =
+            listOf(
+                host("s:b", ConnectionKind.SATELLITE),
+                host("s:a", ConnectionKind.SATELLITE),
+                host("ml:b", ConnectionKind.MOONLIGHT),
+                host("ml:a", ConnectionKind.MOONLIGHT),
+                host("bt:b", ConnectionKind.BLUETOOTH),
+                host("bt:a", ConnectionKind.BLUETOOTH),
+            ).orderedForPicker()
+
+        assertEquals(listOf("s:b", "s:a", "ml:b", "ml:a", "bt:b", "bt:a"), ordered.map { it.id })
+    }
+
+    @Test
+    fun `interleaved kinds sort into contiguous tier blocks with stable inner order`() {
+        val ordered =
+            listOf(
+                host("bt:1", ConnectionKind.BLUETOOTH),
+                host("s:1", ConnectionKind.SATELLITE),
+                host("ml:1", ConnectionKind.MOONLIGHT),
+                host("bt:2", ConnectionKind.BLUETOOTH),
+                host("s:2", ConnectionKind.SATELLITE),
+                host("ml:2", ConnectionKind.MOONLIGHT),
+            ).orderedForPicker()
+
+        assertEquals(listOf("s:1", "s:2", "ml:1", "ml:2", "bt:1", "bt:2"), ordered.map { it.id })
+    }
+
+    @Test
+    fun `empty list stays empty`() {
+        assertEquals(emptyList<BindingHost>(), emptyList<BindingHost>().orderedForPicker())
+    }
+
+    @Test
+    fun `single host is untouched`() {
+        val only = host("bt:1", ConnectionKind.BLUETOOTH)
+        val ordered = listOf(only).orderedForPicker()
+        assertEquals(listOf(only), ordered)
+        assertSame(only, ordered[0])
+    }
+
+    @Test
+    fun `ordering is idempotent`() {
+        val input =
+            listOf(
+                host("ml:1", ConnectionKind.MOONLIGHT),
+                host("bt:1", ConnectionKind.BLUETOOTH),
+                host("s:1", ConnectionKind.SATELLITE),
+            )
+        val once = input.orderedForPicker()
+        assertEquals(once, once.orderedForPicker())
+    }
+
+    @Test
+    fun `ordering does not mutate the input list`() {
+        val input =
+            mutableListOf(
+                host("bt:1", ConnectionKind.BLUETOOTH),
+                host("s:1", ConnectionKind.SATELLITE),
+            )
+        val snapshot = input.toList()
+
+        input.orderedForPicker()
+
+        assertEquals(snapshot, input)
+    }
+
+    @Test
+    fun `ordering preserves host identity`() {
+        val sat = host("s:1", ConnectionKind.SATELLITE)
+        val bt = host("bt:1", ConnectionKind.BLUETOOTH)
+
+        val ordered = listOf(bt, sat).orderedForPicker()
+
+        assertSame(sat, ordered[0])
+        assertSame(bt, ordered[1])
+    }
+}

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/MoonlightSessionUiTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/MoonlightSessionUiTest.kt
@@ -289,12 +289,24 @@ class MoonlightSessionUiTest {
     }
 
     @Test
-    fun `the trust chip says one of three words and never lights up`() {
+    fun `the trust chip says one of two words and never lights up`() {
         assertEquals(R.string.ml_trust_paired, MoonlightTrustState.PAIRED.chipTextRes())
-        assertEquals(R.string.ml_trust_remembered, MoonlightTrustState.REMEMBERED.chipTextRes())
-        assertEquals(R.string.ml_trust_remembered, MoonlightTrustState.UNREACHABLE.chipTextRes())
+        assertEquals(R.string.ml_trust_paired, MoonlightTrustState.REMEMBERED.chipTextRes())
+        assertEquals(R.string.ml_trust_paired, MoonlightTrustState.CHECKING.chipTextRes())
+        assertEquals(R.string.ml_trust_paired, MoonlightTrustState.UNREACHABLE.chipTextRes())
         assertEquals(R.string.ml_trust_not_paired, MoonlightTrustState.NOT_PAIRED.chipTextRes())
         assertEquals(R.string.ml_trust_not_paired, MoonlightTrustState.TRUST_LOST.chipTextRes())
         assertEquals(R.string.ml_trust_not_paired, MoonlightTrustState.REPLACED.chipTextRes())
+    }
+
+    @Test
+    fun `holdsPairing tracks the chip word exactly`() {
+        for (state in MoonlightTrustState.entries) {
+            assertEquals(
+                state.name,
+                state.chipTextRes() == R.string.ml_trust_paired,
+                state.holdsPairing(),
+            )
+        }
     }
 }

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/OverlayLinkGuardTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/OverlayLinkGuardTest.kt
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package com.tinkernorth.dish.ui.main
+
+import com.tinkernorth.dish.composer.ConnectionKind
+import com.tinkernorth.dish.composer.ConnectionSummary
+import com.tinkernorth.dish.composer.LinkState
+import com.tinkernorth.dish.source.system.NetworkState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OverlayLinkGuardTest {
+    private fun summary(
+        live: LinkState,
+        kind: ConnectionKind = ConnectionKind.SATELLITE,
+        id: String = "s:1",
+    ) = ConnectionSummary(
+        id = id,
+        kind = kind,
+        label = "Desk PC",
+        detail = "",
+        live = live,
+        boundSlotIds = emptyList(),
+    )
+
+    private fun guard(
+        summary: ConnectionSummary? = summary(LinkState.Connected),
+        boundConnectionId: String? = "s:1",
+        connectionId: String = "s:1",
+        device: SlotDeviceState? = null,
+        network: NetworkState = NetworkState.WIFI,
+    ) = overlayGuardFor(summary, boundConnectionId, connectionId, device, network)
+
+    @Test
+    fun `a connected bound slot shows no guard`() {
+        assertEquals(GuardKind.NONE, guard().kind)
+    }
+
+    @Test
+    fun `an unsteady link keeps routing and shows no guard`() {
+        assertEquals(GuardKind.NONE, guard(summary = summary(LinkState.Unstable)).kind)
+    }
+
+    @Test
+    fun `a virtual slot never reports a controller state`() {
+        for (state in LinkState.entries) {
+            val ui = guard(summary = summary(state), device = null)
+            assertTrue(state.name, ui.kind != GuardKind.UNPLUGGED && ui.kind != GuardKind.DEPARTED)
+        }
+    }
+
+    @Test
+    fun `a forgotten connection is terminal`() {
+        val ui = guard(summary = null)
+        assertEquals(GuardKind.GONE, ui.kind)
+        assertTrue(ui.autoClose)
+    }
+
+    @Test
+    fun `a rebound slot is terminal`() {
+        val ui = guard(boundConnectionId = "s:other")
+        assertEquals(GuardKind.UNBOUND, ui.kind)
+        assertTrue(ui.autoClose)
+    }
+
+    @Test
+    fun `an unbound slot is terminal`() {
+        assertEquals(GuardKind.UNBOUND, guard(boundConnectionId = null).kind)
+    }
+
+    @Test
+    fun `a controller in its disconnect grace warns with the replug countdown`() {
+        val ui = guard(device = SlotDeviceState(present = true, disconnectingSecLeft = 7))
+        assertEquals(GuardKind.UNPLUGGED, ui.kind)
+        assertEquals(7, ui.countdownSec)
+        assertFalse(ui.autoClose)
+    }
+
+    @Test
+    fun `a controller the OS dropped warns without a countdown`() {
+        val ui = guard(device = SlotDeviceState(present = true, needsReplug = true))
+        assertEquals(GuardKind.UNPLUGGED, ui.kind)
+        assertEquals(null, ui.countdownSec)
+    }
+
+    @Test
+    fun `a controller that never came back is terminal`() {
+        val ui = guard(device = SlotDeviceState(present = false))
+        assertEquals(GuardKind.DEPARTED, ui.kind)
+        assertTrue(ui.autoClose)
+    }
+
+    @Test
+    fun `a path-switch transition is left alone`() {
+        val ui = guard(device = SlotDeviceState(present = true, disconnectingSecLeft = 3, transitioning = true))
+        assertEquals(GuardKind.NONE, ui.kind)
+    }
+
+    @Test
+    fun `a connecting link reads as reconnecting`() {
+        assertEquals(GuardKind.RECONNECTING, guard(summary = summary(LinkState.Connecting)).kind)
+    }
+
+    @Test
+    fun `every dead link state reads as host lost`() {
+        for (state in listOf(LinkState.Saved, LinkState.Stale, LinkState.Ready, LinkState.Found)) {
+            assertEquals(state.name, GuardKind.HOST_LOST, guard(summary = summary(state)).kind)
+        }
+    }
+
+    @Test
+    fun `only a lost satellite offers reconnect`() {
+        assertTrue(guard(summary = summary(LinkState.Saved, ConnectionKind.SATELLITE)).showReconnect)
+        assertFalse(guard(summary = summary(LinkState.Saved, ConnectionKind.BLUETOOTH)).showReconnect)
+        assertFalse(guard(summary = summary(LinkState.Saved, ConnectionKind.MOONLIGHT)).showReconnect)
+        assertFalse(guard(summary = summary(LinkState.Connecting, ConnectionKind.SATELLITE)).showReconnect)
+    }
+
+    @Test
+    fun `a lost satellite off wifi points at the network`() {
+        for (network in listOf(NetworkState.NONE, NetworkState.CELLULAR)) {
+            val ui = guard(summary = summary(LinkState.Saved), network = network)
+            assertEquals(network.name, GuardDetail.WIFI_DOWN, ui.detail)
+        }
+    }
+
+    @Test
+    fun `a lost satellite on wifi blames the host`() {
+        val ui = guard(summary = summary(LinkState.Saved), network = NetworkState.WIFI)
+        assertEquals(GuardDetail.GENERIC, ui.detail)
+        assertEquals("Desk PC", ui.hostLabel)
+    }
+
+    @Test
+    fun `a lost bluetooth host points at the host device regardless of wifi`() {
+        for (network in NetworkState.entries) {
+            val ui = guard(summary = summary(LinkState.Saved, ConnectionKind.BLUETOOTH), network = network)
+            assertEquals(network.name, GuardDetail.BLUETOOTH_HOST, ui.detail)
+        }
+    }
+
+    @Test
+    fun `a dead moonlight session on wifi points at the session`() {
+        val ui = guard(summary = summary(LinkState.Saved, ConnectionKind.MOONLIGHT))
+        assertEquals(GuardDetail.MOONLIGHT_SESSION, ui.detail)
+    }
+
+    @Test
+    fun `a dead moonlight session off wifi points at the network first`() {
+        val ui = guard(summary = summary(LinkState.Saved, ConnectionKind.MOONLIGHT), network = NetworkState.NONE)
+        assertEquals(GuardDetail.WIFI_DOWN, ui.detail)
+    }
+
+    @Test
+    fun `a gone connection outranks a gone controller`() {
+        val ui = guard(summary = null, device = SlotDeviceState(present = false))
+        assertEquals(GuardKind.GONE, ui.kind)
+    }
+
+    @Test
+    fun `a gone controller outranks an unbound slot`() {
+        val ui = guard(boundConnectionId = null, device = SlotDeviceState(present = false))
+        assertEquals(GuardKind.DEPARTED, ui.kind)
+    }
+
+    @Test
+    fun `a replug grace outranks a dead link`() {
+        val ui =
+            guard(
+                summary = summary(LinkState.Saved),
+                device = SlotDeviceState(present = true, disconnectingSecLeft = 5),
+            )
+        assertEquals(GuardKind.UNPLUGGED, ui.kind)
+    }
+
+    @Test
+    fun `an unbound slot outranks a dead link`() {
+        val ui = guard(summary = summary(LinkState.Saved), boundConnectionId = null)
+        assertEquals(GuardKind.UNBOUND, ui.kind)
+    }
+
+    @Test
+    fun `a present healthy controller falls through to the link checks`() {
+        val device = SlotDeviceState(present = true)
+        assertEquals(GuardKind.NONE, guard(device = device).kind)
+        assertEquals(GuardKind.HOST_LOST, guard(summary = summary(LinkState.Saved), device = device).kind)
+    }
+
+    @Test
+    fun `terminal states and only terminal states auto-close`() {
+        val terminal = setOf(GuardKind.GONE, GuardKind.UNBOUND, GuardKind.DEPARTED)
+        val samples =
+            listOf(
+                guard(),
+                guard(summary = summary(LinkState.Connecting)),
+                guard(summary = summary(LinkState.Saved)),
+                guard(device = SlotDeviceState(present = true, disconnectingSecLeft = 3)),
+                guard(device = SlotDeviceState(present = true, needsReplug = true)),
+                guard(device = SlotDeviceState(present = false)),
+                guard(boundConnectionId = null),
+                guard(summary = null),
+            )
+        samples.forEach { ui ->
+            assertEquals(ui.kind.name, ui.kind in terminal, ui.autoClose)
+        }
+    }
+}


### PR DESCRIPTION
Satellite connections are the fastest and most stable path, Moonlight hosts come next, and Bluetooth is the last resort. The app never said so outside the setup screen's lone "Best" badge. This gives the ladder the same nomenclature and pill visuals the controller cards already use for Direct/Standard.

- `LinkTier` (`FASTEST`/`FAST`/`BASIC`) in `composer`, keyed off `ConnectionKind`, with a best-first comparator
- `LinkTierBadges` maps a tier to the controller pill language: Fastest = bolt in the ON tone (like Direct), Fast = wifi as a plain fact, Basic = muted cap tone (like Standard)
- Connections screen section headers wear the tier pill next to the section label
- Destination picker sorts hosts best tier first and stamps each host card with its tier pill
- Setup path-choice badges are graded per tier instead of the single "Best" on satellite

Follow-ups, per review:

- Scan covers satellites and Moonlight hosts in one pass, so it moved out of the section headers into a pinned row under the toolbar; headers keep only Add, which also fixes the portrait-width overflow with the tier pill
- A Moonlight host holding a pairing record reads "Paired" (success-colored) instead of "Remembered", and its action says "Re-pair" (same word as a stale satellite)
- Review-card gets/sends pills wrap onto new lines (`PillFlowLayout`) instead of crushing the last chip into multiline text
- Link guard on the gamepad/touchpad overlays: a scrim in the controller-card edge-overlay language covers host lost (Reconnect for satellites), reconnecting (spinner), Wi-Fi off/wrong network, Bluetooth-host and Moonlight-session loss, controller unplug (replug countdown), and terminal states (connection forgotten, slot unbound, controller gone) which auto-close after a countdown; link blips debounce before the scrim shows, and the overlays now keep streaming on an Unsteady link like physical pads do

Tests: `LinkTiersTest`, `LinkTierBadgesTest`, `BindingHostOrderTest`, `MoonlightTrustPresentationTest`, `PillFlowLayoutTest`, and `OverlayLinkGuardTest`; existing suites, ktlint, detekt, and lint all pass locally.