### PR TITLE
feat: lightbar background wash on the virtual pad

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadConstants.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadConstants.kt
@@ -117,8 +117,11 @@ internal object GamepadConstants {
 
     const val TRACKPAD_CLICK_PULSE_MS = 70L
 
-    // Host-driven feedback rendering (lightbar ring, player-LED row, trigger-effect accents).
+    // Host-driven feedback rendering (lightbar ring + background wash, player-LED row,
+    // trigger-effect accents).
     const val LIGHTBAR_STROKE_DP = 3f
+
+    const val LIGHTBAR_BG_BLEND_FRACTION = 0.25f
 
     const val PLAYER_LED_COUNT = 5
 

--- a/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadSkin.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadSkin.kt
@@ -12,11 +12,13 @@ import com.tinkernorth.dish.core.net.moonlight.MoonlightEmulatedType
 // (stick/d-pad placement) splits the PlayStation family from the rest; the glyphs
 // split every skin: Xbox360 carries Back/Start where Xbox carries View/Menu, and
 // DualSense carries Create/Options where PlayStation carries the DS4 Share/Options.
-enum class GamepadSkin {
+enum class GamepadSkin(
+    val hasLightbar: Boolean = false,
+) {
     Xbox,
     Xbox360,
-    PlayStation,
-    DualSense,
+    PlayStation(hasLightbar = true),
+    DualSense(hasLightbar = true),
     Switch,
     ;
 

--- a/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadTouchView.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/common/GamepadTouchView.kt
@@ -24,6 +24,7 @@ import com.tinkernorth.dish.ui.common.GamepadConstants.ABXY_BTN_DRAW_SIZE_FACTOR
 import com.tinkernorth.dish.ui.common.GamepadConstants.ABXY_BTN_SPACING_FACTOR
 import com.tinkernorth.dish.ui.common.GamepadConstants.CENTER_BTN_DRAW_SIZE_FACTOR
 import com.tinkernorth.dish.ui.common.GamepadConstants.HOME_DRAW_SIZE_FACTOR
+import com.tinkernorth.dish.ui.common.GamepadConstants.LIGHTBAR_BG_BLEND_FRACTION
 import com.tinkernorth.dish.ui.common.GamepadConstants.LIGHTBAR_STROKE_DP
 import com.tinkernorth.dish.ui.common.GamepadConstants.PILL_CORNER_RADIUS_FRACTION
 import com.tinkernorth.dish.ui.common.GamepadConstants.PILL_ICON_SIZE_FRACTION
@@ -176,9 +177,11 @@ class GamepadTouchView
                 invalidate()
             }
 
+        private val surfaceColor = ContextCompat.getColor(context, R.color.colorSurface)
+
         private val paintBg =
             Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                color = ContextCompat.getColor(context, R.color.colorSurface)
+                color = surfaceColor
             }
         private val paintStickBg =
             Paint(Paint.ANTI_ALIAS_FLAG).apply {
@@ -477,6 +480,11 @@ class GamepadTouchView
 
         override fun onDraw(canvas: Canvas) {
             super.onDraw(canvas)
+            paintBg.color =
+                lightbarColor
+                    ?.takeIf { skin.hasLightbar }
+                    ?.let { ColorUtils.blendARGB(surfaceColor, it, LIGHTBAR_BG_BLEND_FRACTION) }
+                    ?: surfaceColor
             canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), paintBg)
             val l = layout ?: return
             val s = recognizer.state

--- a/app/src/test/java/com/tinkernorth/dish/ui/common/GamepadSkinTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/common/GamepadSkinTest.kt
@@ -48,6 +48,14 @@ class GamepadSkinTest {
     }
 
     @Test
+    fun `only the PlayStation-family skins carry a lightbar`() {
+        assertEquals(
+            setOf(GamepadSkin.PlayStation, GamepadSkin.DualSense),
+            GamepadSkin.entries.filter { it.hasLightbar }.toSet(),
+        )
+    }
+
+    @Test
     fun `every skin name round-trips through the intent extra`() {
         GamepadSkin.entries.forEach { skin ->
             assertEquals(skin, GamepadSkin.fromName(skin.name))

--- a/docs/rumble.md
+++ b/docs/rumble.md
@@ -111,11 +111,12 @@ only for those slots. The same plumbing carries the protocol-2 additions
 replayed verbatim) and `MSG_PLAYER_LEDS` (0x0011, DualSense bar / Switch
 Pro player lights), gated on the `triggerEffects` / `playerLeds`
 descriptor caps. Moonlight `RGB_LED` events land on the same lightbar
-writer. The virtual pad is a sink too: its skin renders the lightbar,
-player LEDs and an active adaptive-trigger effect
-(`VirtualPadFeedbackStore`), and Moonlight trigger rumble folds into the
-phone vibrator through the rumble path so the delivery toggle and stop
-rules keep applying.
+writer. The virtual pad is a sink too: its skin renders the lightbar (an edge
+glow on the trackpad plus a background wash across the pad, on the
+lightbar-bearing PlayStation-family skins), player LEDs and an active
+adaptive-trigger effect (`VirtualPadFeedbackStore`), and Moonlight
+trigger rumble folds into the phone vibrator through the rumble path so
+the delivery toggle and stop rules keep applying.
 
 ## USB-direct rumble output reports
 


### PR DESCRIPTION
Host lightbar colours (satellite `MSG_LIGHTBAR`, Moonlight `RGB_LED`) only rendered on the virtual pad as a thin ring around the trackpad zone, so they were invisible whenever that zone was hidden. The pad background now washes toward the host colour on the skins whose real hardware carries a lightbar.

- `GamepadSkin`: `hasLightbar` flag, true for PlayStation and DualSense
- `GamepadTouchView`: background blends 25% toward the lightbar colour when one is set and the skin supports it; plain surface otherwise, so the default look is unchanged and a stale stored colour never tints a non-lightbar skin after a rebind
- `GamepadConstants`: `LIGHTBAR_BG_BLEND_FRACTION`
- `docs/rumble.md`: FR-4 note now mentions the wash

Tests: `GamepadSkinTest` pins which skins carry a lightbar; compile + ktlint/detekt green locally.
