### PR TITLE
feat: input-path-honest capabilities (Direct/Standard/Bluetooth)

### DIFF
--- a/app/src/main/java/com/tinkernorth/dish/composer/CapabilityComposer.kt
+++ b/app/src/main/java/com/tinkernorth/dish/composer/CapabilityComposer.kt
@@ -29,6 +29,13 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import javax.inject.Inject
 import javax.inject.Singleton
 
+data class InputFunctions(
+    val known: Boolean,
+    val rumble: Boolean,
+    val gyro: Boolean,
+    val touchpad: Boolean,
+)
+
 @Suppress("UNCHECKED_CAST", "LongParameterList")
 private inline fun <T1, T2, T3, T4, T5, T6, T7, R> combine7(
     f1: Flow<T1>,
@@ -168,9 +175,10 @@ class CapabilityComposer
             candidateType: Int,
             candidateHostKind: ConnectionKind,
             candidateHostId: String?,
+            candidateDirect: Boolean? = null,
         ): SlotCapabilities =
             CapabilityResolver.resolve(
-                controller = liveControllerLayer(slotId),
+                controller = candidateControllerLayer(slotId, candidateDirect),
                 transport = TransportProfiles.forKind(candidateHostKind),
                 type = typeCapabilitiesFor(candidateType, candidateHostId, candidateHostKind),
                 host = candidateHostLayer(candidateHostKind, candidateHostId),
@@ -230,50 +238,85 @@ class CapabilityComposer
             return CapabilitySet(out)
         }
 
-        private fun deviceControllerLayer(device: PhysicalGamepadRegistry.Device): CapabilitySet {
+        private fun deviceControllerLayer(
+            device: PhysicalGamepadRegistry.Device,
+            direct: Boolean = device.isUsbSynthetic,
+        ): CapabilitySet {
             // The pad supplies the gamepad axes. Touch comes from the pad's OWN trackpad where
             // the path can read it (USB Direct); the phone screen substitutes only for a pad
             // that has no trackpad at all. Rumble needs the pad's OWN motor: routing never
             // falls back to the phone for a physical controller, so a motorless pad has no
             // rumble.
+            val vid = device.vendorId
+            val pid = device.productId
             val out = mutableSetOf(Feature.GAMEPAD, Feature.ANALOG_TRIGGERS, Feature.BATTERY)
-            if (deviceTouchpadSource(device) != TouchpadSource.NONE) {
+            if (deviceTouchpadSource(device, direct) != TouchpadSource.NONE) {
                 out += Feature.TOUCHPAD
                 out += Feature.MOUSE
             }
-            if (deviceMotionAvailable(device)) out += Feature.MOTION
-            if (deviceRumbleAvailable(device)) out += Feature.RUMBLE
-            // LED / trigger surfaces exist only on the raw Direct path: the framework
-            // exposes no controller LED or trigger-motor API for its pads.
-            if (device.isUsbSynthetic) {
-                if (native.modelHasLightbar(device.vendorId, device.productId)) {
-                    out += Feature.LIGHTBAR
-                }
-                if (native.modelHasTriggerEffects(device.vendorId, device.productId)) {
-                    out += Feature.TRIGGER_EFFECTS
-                }
-                if (native.modelHasPlayerLeds(device.vendorId, device.productId)) {
-                    out += Feature.PLAYER_LEDS
-                }
-                if (native.modelHasTriggerRumble(device.vendorId, device.productId)) {
-                    out += Feature.TRIGGER_RUMBLE
-                }
+            if (direct) {
+                // A Direct pad has no framework InputDevice to probe; everything, including the
+                // LED / trigger surfaces the framework can never reach, comes from the native tables.
+                if (native.modelHasImu(vid, pid)) out += Feature.MOTION
+                if (native.modelHasRumble(vid, pid)) out += Feature.RUMBLE
+                if (native.modelHasLightbar(vid, pid)) out += Feature.LIGHTBAR
+                if (native.modelHasTriggerEffects(vid, pid)) out += Feature.TRIGGER_EFFECTS
+                if (native.modelHasPlayerLeds(vid, pid)) out += Feature.PLAYER_LEDS
+                if (native.modelHasTriggerRumble(vid, pid)) out += Feature.TRIGGER_RUMBLE
+            } else {
+                val framework = frameworkFactsFor(device)
+                if (framework?.hasGyro == true) out += Feature.MOTION
+                if (framework?.hasRumble == true) out += Feature.RUMBLE
             }
             return CapabilitySet(out)
         }
 
-        // A Direct synthetic has no framework InputDevice to probe, so its feedback comes from the native parser instead.
-        private fun deviceMotionAvailable(device: PhysicalGamepadRegistry.Device): Boolean =
-            if (device.isUsbSynthetic) native.modelHasImu(device.vendorId, device.productId) else device.hasGyro
+        private fun frameworkFactsFor(device: PhysicalGamepadRegistry.Device): PhysicalGamepadRegistry.FrameworkCaps? =
+            if (device.isUsbSynthetic) {
+                registry.frameworkCapsFor(device.vendorId, device.productId)
+            } else {
+                PhysicalGamepadRegistry.FrameworkCaps(hasGyro = device.hasGyro, hasRumble = device.hasRumble)
+            }
 
-        private fun deviceRumbleAvailable(device: PhysicalGamepadRegistry.Device): Boolean =
-            if (device.isUsbSynthetic) native.modelHasRumble(device.vendorId, device.productId) else device.hasRumble
+        fun inputFunctionsFor(
+            slotId: String,
+            direct: Boolean?,
+        ): InputFunctions {
+            if (slotId == VIRTUAL_SLOT_ID) {
+                return InputFunctions(known = true, rumble = false, gyro = phoneHasGyro, touchpad = true)
+            }
+            val device =
+                slotId.toIntOrNull()?.let { registry.devices.value[it] }
+                    ?: return InputFunctions(known = true, rumble = false, gyro = false, touchpad = false)
+            val vid = device.vendorId
+            val pid = device.productId
+            val onDirect = direct ?: device.isUsbSynthetic
+            if (onDirect) {
+                val known = native.isKnownFastLaneModel(vid, pid)
+                return InputFunctions(
+                    known = known,
+                    rumble = known && native.modelHasRumble(vid, pid),
+                    gyro = known && native.modelHasImu(vid, pid),
+                    touchpad = known && native.modelHasTouchpad(vid, pid),
+                )
+            }
+            val framework = frameworkFactsFor(device)
+            return InputFunctions(
+                known = framework != null,
+                rumble = framework?.hasRumble == true,
+                gyro = framework?.hasGyro == true,
+                touchpad = false,
+            )
+        }
 
-        private fun deviceTouchpadSource(device: PhysicalGamepadRegistry.Device): TouchpadSource =
+        private fun deviceTouchpadSource(
+            device: PhysicalGamepadRegistry.Device,
+            direct: Boolean = device.isUsbSynthetic,
+        ): TouchpadSource =
             TouchpadRouting.sourceFor(
                 isVirtual = false,
                 padHasTouchpad = native.modelHasTouchpad(device.vendorId, device.productId),
-                padCaptured = device.isUsbSynthetic,
+                padCaptured = direct,
             )
 
         /** Who produces touch for [slotId] right now: the pad, the phone screen, or nobody. */
@@ -288,6 +331,15 @@ class CapabilityComposer
             if (slotId == VIRTUAL_SLOT_ID) return virtualControllerLayer()
             val device = slotId.toIntOrNull()?.let { registry.devices.value[it] } ?: return CapabilitySet.EMPTY
             return deviceControllerLayer(device)
+        }
+
+        private fun candidateControllerLayer(
+            slotId: String,
+            direct: Boolean?,
+        ): CapabilitySet {
+            if (direct == null || slotId == VIRTUAL_SLOT_ID) return liveControllerLayer(slotId)
+            val device = slotId.toIntOrNull()?.let { registry.devices.value[it] } ?: return CapabilitySet.EMPTY
+            return deviceControllerLayer(device, direct)
         }
 
         // Unbound slots get a permissive transport so candidate/report queries see inherent availability.

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsActivity.kt
@@ -143,10 +143,11 @@ class ConfigureBindingsActivity : BaseGamepadHostActivity() {
         s.tvInputName.text = " · ${snapshot.name}"
 
         val (linkLabel, linkIcon) =
-            when (snapshot.link) {
-                BindingLink.USB -> getString(R.string.binding_link_usb) to R.drawable.ic_usb
-                BindingLink.BLUETOOTH -> getString(R.string.binding_link_bluetooth) to R.drawable.ic_bluetooth
-                BindingLink.ONSCREEN -> getString(R.string.binding_link_onscreen) to R.drawable.ic_gamepad_virtual
+            when {
+                snapshot.link == BindingLink.BLUETOOTH -> getString(R.string.binding_link_bluetooth) to R.drawable.ic_bluetooth
+                snapshot.link == BindingLink.ONSCREEN -> getString(R.string.binding_link_onscreen) to R.drawable.ic_gamepad_virtual
+                state.draft?.directOn == true -> getString(R.string.binding_mode_direct) to R.drawable.ic_bolt
+                else -> getString(R.string.binding_mode_standard) to R.drawable.ic_cable
             }
         s.ivConnIcon.setImageResource(linkIcon)
         s.tvConnText.text = linkLabel
@@ -169,19 +170,34 @@ class ConfigureBindingsActivity : BaseGamepadHostActivity() {
 
         val fc = s.functionsContainer
         fc.removeAllViews()
-        if (snapshot.hasRumble) {
+        val funcs = state.inputFuncs
+        if (!funcs.known) {
+            listOf(
+                R.string.binding_func_rumble to R.drawable.ic_rumble,
+                R.string.binding_func_gyro to R.drawable.ic_motion,
+                R.string.binding_func_touchpad to R.drawable.ic_touchpad,
+            ).forEach { (label, icon) ->
+                fc.addView(fc.inflateBindingPill(unknownFuncLabel(label), icon, PillTone.OFF))
+            }
+            return
+        }
+        if (funcs.rumble) {
             fc.addView(
                 fc.inflateBindingPill(getString(R.string.binding_func_rumble), R.drawable.ic_rumble, PillTone.CAP),
             )
         }
-        if (snapshot.hasGyro) fc.addView(fc.inflateBindingPill(getString(R.string.binding_func_gyro), R.drawable.ic_motion, PillTone.CAP))
-        if (snapshot.hasTouchpad) {
+        if (funcs.gyro) fc.addView(fc.inflateBindingPill(getString(R.string.binding_func_gyro), R.drawable.ic_motion, PillTone.CAP))
+        if (funcs.touchpad) {
             fc.addView(
                 fc.inflateBindingPill(getString(R.string.binding_func_touchpad), R.drawable.ic_touchpad, PillTone.CAP),
             )
         }
         if (fc.isEmpty()) fc.addView(noneValue(fc))
     }
+
+    private fun unknownFuncLabel(
+        @StringRes label: Int,
+    ): String = getString(R.string.binding_func_value, getString(label), getString(R.string.binding_state_unknown))
 
     private fun bindDestinationSection(
         state: ConfigUiState,
@@ -489,7 +505,10 @@ class ConfigureBindingsActivity : BaseGamepadHostActivity() {
                     getString(R.string.ml_type_auto_resolved, getString(moonlightTypeLabelRes(candidate)))
             }
             card.capabilityContainer.bindCapabilityRows(
-                capabilityRows(viewModel.capabilityForCandidate(snapshot.slotId, candidate, host.kind, host.id)),
+                capabilityRows(
+                    viewModel.capabilityForCandidate(snapshot.slotId, candidate, host.kind, host.id),
+                    inputUnknown = state.inputUnknown,
+                ),
             )
             card.typeCard.setOnClickListener {
                 viewModel.setType(option.id)

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ConfigureBindingsViewModel.kt
@@ -15,6 +15,7 @@ import com.tinkernorth.dish.composer.CapabilityComposer
 import com.tinkernorth.dish.composer.ConnectionCoordinator
 import com.tinkernorth.dish.composer.ConnectionKind
 import com.tinkernorth.dish.composer.ConnectionSummary
+import com.tinkernorth.dish.composer.InputFunctions
 import com.tinkernorth.dish.composer.LinkState
 import com.tinkernorth.dish.composer.LinkTiers
 import com.tinkernorth.dish.core.jni.PhysicalInputNative
@@ -88,9 +89,6 @@ data class BindingSnapshot(
     val link: BindingLink,
     val directCapable: Boolean,
     val directVerified: Boolean,
-    val hasRumble: Boolean,
-    val hasGyro: Boolean,
-    val hasTouchpad: Boolean,
     val bound: Boolean,
     val directPollHz: Int,
     // Used to re-resolve the slot after a USB path switch replaces the
@@ -149,6 +147,7 @@ data class ConfigUiState(
     val controllerPresent: Boolean = true,
     val dismissedUnsteadyHostIds: Set<String> = emptySet(),
     val capabilities: SlotCapabilities = SlotCapabilities.NONE,
+    val inputFuncs: InputFunctions = InputFunctions(known = true, rumble = false, gyro = false, touchpad = false),
     // Set only when a satellite catalog fetch failed with nothing cached, so Loading (fetch in
     // flight) and Error (fetch failed) are distinguishable — neither is derivable from the draft alone.
     val typeFetchFailed: Boolean = false,
@@ -216,6 +215,11 @@ data class ConfigUiState(
     val isBluetoothHost: Boolean get() = selectedHost?.kind == ConnectionKind.BLUETOOTH
 
     val isMoonlightHost: Boolean get() = selectedHost?.kind == ConnectionKind.MOONLIGHT
+
+    // The USB path the draft would apply (null off USB), so previews track the toggle, not the current path.
+    val candidateDirect: Boolean? get() = if (snapshot?.link == BindingLink.USB) draft?.directOn == true else null
+
+    val inputUnknown: Boolean get() = !inputFuncs.known
 }
 
 data class ApplyStep(
@@ -365,6 +369,7 @@ class ConfigureBindingsViewModel
                     candidateType = MoonlightEmulatedType.XBOX,
                     candidateHostKind = ConnectionKind.MOONLIGHT,
                     candidateHostId = _ui.value.draft?.hostId,
+                    candidateDirect = _ui.value.candidateDirect,
                 )
             return MoonlightEmulatedType.resolve(picked, caps.inputOk(Feature.MOTION))
         }
@@ -542,7 +547,14 @@ class ConfigureBindingsViewModel
             candidateType: Int,
             candidateHostKind: ConnectionKind,
             candidateHostId: String?,
-        ): SlotCapabilities = capabilityComposer.capabilityForCandidate(slotId, candidateType, candidateHostKind, candidateHostId)
+        ): SlotCapabilities =
+            capabilityComposer.capabilityForCandidate(
+                slotId = slotId,
+                candidateType = candidateType,
+                candidateHostKind = candidateHostKind,
+                candidateHostId = candidateHostId,
+                candidateDirect = _ui.value.candidateDirect,
+            )
 
         // Re-resolves the path capabilities from the current draft/host so the gates stay in sync.
         // userEnabled is forced full inside the composer, so these are the inherent "available" layers.
@@ -558,9 +570,10 @@ class ConfigureBindingsViewModel
                         candidateType = if (kind == ConnectionKind.MOONLIGHT) moonlightResolvedType(it) else it,
                         candidateHostKind = kind,
                         candidateHostId = d.hostId,
+                        candidateDirect = candidateDirect,
                     )
                 } ?: SlotCapabilities.NONE
-            return copy(capabilities = caps)
+            return copy(capabilities = caps, inputFuncs = capabilityComposer.inputFunctionsFor(slotId, candidateDirect))
         }
 
         // The label for a controller type from the live catalog, falling back to the
@@ -877,9 +890,6 @@ class ConfigureBindingsViewModel
                     link = BindingLink.ONSCREEN,
                     directCapable = false,
                     directVerified = false,
-                    hasRumble = false,
-                    hasGyro = capabilityComposer.capabilityFor(slotId).inputOk(Feature.MOTION),
-                    hasTouchpad = true,
                     bound = bound,
                     directPollHz = 0,
                 )
@@ -888,16 +898,12 @@ class ConfigureBindingsViewModel
             val isUsb = device?.transport != Transport.Bluetooth
             val vid = device?.vendorId ?: 0
             val pid = device?.productId ?: 0
-            val caps = capabilityComposer.capabilityFor(slotId)
             return BindingSnapshot(
                 slotId = slotId,
                 name = device?.name ?: "",
                 link = if (isUsb) BindingLink.USB else BindingLink.BLUETOOTH,
                 directCapable = isUsb,
                 directVerified = native.isKnownFastLaneModel(vid, pid),
-                hasRumble = caps.inputOk(Feature.RUMBLE),
-                hasGyro = caps.inputOk(Feature.MOTION),
-                hasTouchpad = native.modelHasTouchpad(vid, pid),
                 bound = bound,
                 directPollHz = device?.pollRateHz ?: 0,
                 vendorId = vid,

--- a/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/main/ControllerAdapter.kt
@@ -266,7 +266,7 @@ class ControllerAdapter(
             bound: ConnectionSummary,
         ) {
             connectionRow.root.visibility = View.VISIBLE
-            connectionPills.bind(connectionSpecs(row, bound.kind))
+            connectionPills.bind(connectionSpecs(row))
 
             destinationRow.root.visibility = View.VISIBLE
             showDestination(bound.label)
@@ -287,9 +287,8 @@ class ControllerAdapter(
         }
 
         private fun bindUnbound(row: Row) {
-            // Unbound shows the connection without a mode chip; Direct/Standard is only chosen at bind time.
             connectionRow.root.visibility = View.VISIBLE
-            connectionPills.bind(connectionSpecs(row, kind = null))
+            connectionPills.bind(connectionSpecs(row))
             destinationRow.root.visibility = View.VISIBLE
             showDestination(null)
             compatRow.root.visibility = View.GONE
@@ -308,10 +307,7 @@ class ControllerAdapter(
             }
         }
 
-        private fun connectionSpecs(
-            row: Row,
-            kind: ConnectionKind?,
-        ): List<PillSpec> {
+        private fun connectionSpecs(row: Row): List<PillSpec> {
             val card = row.pathCard
             val virtual = row.slot.inputType == SlotInputType.VIRTUAL
             val isUsb = !virtual && card?.transport == Transport.Usb
@@ -323,8 +319,7 @@ class ControllerAdapter(
                     else -> R.string.binding_link_usb to R.drawable.ic_usb
                 }
             val specs = mutableListOf(PillSpec(ctx.getString(label), icon, PillTone.FACT))
-            // The Direct/Standard mode chip only applies once a USB controller is on a known path.
-            if (isUsb && kind != null) specs.add(usbModeSpec(card))
+            if (isUsb && card != null) specs.add(usbModeSpec(card))
             if (isBt && card?.wiredSwitchAvailable == true) {
                 specs.add(PillSpec(ctx.getString(R.string.binding_usb_available), R.drawable.ic_usb, PillTone.WARN))
             }
@@ -373,6 +368,7 @@ class ControllerAdapter(
             row: Row,
             bound: ConnectionSummary,
         ): List<PillSpec> {
+            if (inputFunctionsUnknown(row.pathCard)) return unknownFunctionSpecs(row)
             val specs = mutableListOf<PillSpec>()
             val card = row.pathCard
             val rumblePresent =
@@ -403,6 +399,27 @@ class ControllerAdapter(
             specs.addAll(feedbackFuncFacts(row.motionCap).map(::feedbackFactPill))
             return specs
         }
+
+        private fun unknownFunctionSpecs(row: Row): List<PillSpec> {
+            val specs =
+                mutableListOf(
+                    unknownFuncPill(R.string.binding_func_rumble, R.drawable.ic_rumble),
+                    unknownFuncPill(R.string.binding_func_gyro, R.drawable.ic_motion),
+                    unknownFuncPill(R.string.binding_func_touchpad, R.drawable.ic_touchpad),
+                )
+            if (row.pointer?.mouseOpenable == true) specs.add(pointerFactPill(PointerPillFact.MOUSE_READY))
+            return specs
+        }
+
+        private fun unknownFuncPill(
+            @StringRes label: Int,
+            @DrawableRes icon: Int,
+        ): PillSpec =
+            PillSpec(
+                ctx.getString(R.string.binding_func_value, ctx.getString(label), ctx.getString(R.string.binding_state_unknown)),
+                icon,
+                PillTone.OFF,
+            )
 
         private fun feedbackFactPill(fact: FeedbackPillFact): PillSpec =
             when (fact) {
@@ -713,6 +730,10 @@ internal enum class CardActionKind { GAMEPAD, TOUCHPAD, MOUSE, SWITCH_DIRECT, SE
 // facts stay testable: the pad surface reports its declared routing (or the Direct nudge
 // that unlocks it), and the mouse rides as an on-demand chip wherever its surface can open.
 internal enum class PointerPillFact { PAD_NEEDS_DIRECT, PAD_ON, PAD_OFF, MOUSE_READY }
+
+// Direct on an unrecognized model reads a guessed layout, so what the pad supports is not known.
+internal fun inputFunctionsUnknown(card: PathCard?): Boolean =
+    card != null && card.currentMode == InputPathMode.Direct && card.risk == PathRisk.GuessedLayout
 
 internal fun pointerFuncFacts(row: ControllerAdapter.Row): List<PointerPillFact> =
     buildList {

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/CapabilityRows.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/CapabilityRows.kt
@@ -26,23 +26,29 @@ data class SetupCapabilityRow(
     val inputOk: Boolean,
     val destinationOk: Boolean,
     val typeOk: Boolean,
+    val inputUnknown: Boolean = false,
 ) {
     val available: Boolean get() = inputOk && destinationOk && typeOk
+
+    val unknown: Boolean get() = inputUnknown && destinationOk && typeOk
 }
 
 // The three classic rows always render (their off-state is informative); the
 // feedback/battery rows appended in protocol 2 render only when SOME layer can
 // carry them, so a plain Xbox-over-Bluetooth card stays three rows instead of
 // eight rows of crosses.
-fun capabilityRows(caps: SlotCapabilities): List<SetupCapabilityRow> {
+fun capabilityRows(
+    caps: SlotCapabilities,
+    inputUnknown: Boolean = false,
+): List<SetupCapabilityRow> {
     val rows =
         mutableListOf(
-            rowFor(SetupCapabilityKind.RUMBLE, Feature.RUMBLE, caps),
-            rowFor(SetupCapabilityKind.MOTION, Feature.MOTION, caps),
-            rowFor(SetupCapabilityKind.TOUCHPAD, Feature.TOUCHPAD, caps),
+            rowFor(SetupCapabilityKind.RUMBLE, Feature.RUMBLE, caps, inputUnknown),
+            rowFor(SetupCapabilityKind.MOTION, Feature.MOTION, caps, inputUnknown),
+            rowFor(SetupCapabilityKind.TOUCHPAD, Feature.TOUCHPAD, caps, inputUnknown),
         )
     for ((kind, feature) in EXTENDED_ROWS) {
-        val row = rowFor(kind, feature, caps)
+        val row = rowFor(kind, feature, caps, inputUnknown)
         if (row.inputOk || row.destinationOk || row.typeOk) rows += row
     }
     return rows
@@ -61,10 +67,12 @@ private fun rowFor(
     kind: SetupCapabilityKind,
     feature: Feature,
     caps: SlotCapabilities,
+    inputUnknown: Boolean,
 ): SetupCapabilityRow =
     SetupCapabilityRow(
         kind = kind,
         inputOk = caps.inputOk(feature),
         destinationOk = caps.destinationOk(feature),
         typeOk = caps.typeOk(feature),
+        inputUnknown = inputUnknown,
     )

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupBluetoothHostActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupBluetoothHostActivity.kt
@@ -168,11 +168,12 @@ class SetupBluetoothHostActivity : BaseGamepadHostActivity() {
     // A Bluetooth host is never a Satellite, so its transport carries only the gamepad:
     // motion/touchpad/rumble resolve off for both types via the capability layers.
     private fun renderTypeTables() {
+        val inputUnknown = viewModel.inputUnknown()
         binding.cardXbox.capabilityContainer.bindCapabilityRows(
-            capabilityRows(viewModel.capabilityForType(CONTROLLER_TYPE_XBOX)),
+            capabilityRows(viewModel.capabilityForType(CONTROLLER_TYPE_XBOX), inputUnknown),
         )
         binding.cardPlaystation.capabilityContainer.bindCapabilityRows(
-            capabilityRows(viewModel.capabilityForType(CONTROLLER_TYPE_PLAYSTATION)),
+            capabilityRows(viewModel.capabilityForType(CONTROLLER_TYPE_PLAYSTATION), inputUnknown),
         )
     }
 

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupBluetoothHostViewModel.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupBluetoothHostViewModel.kt
@@ -136,6 +136,8 @@ class SetupBluetoothHostViewModel
                 candidateHostId = null,
             )
 
+        fun inputUnknown(): Boolean = !capabilityComposer.inputFunctionsFor(slotId, direct = null).known
+
         // Refresh the grant snapshot on every foreground; the OS never broadcasts
         // a revoke, and a grant landed in the Activity launcher needs reflecting.
         fun refresh() = permission.refresh()

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupCapabilityView.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupCapabilityView.kt
@@ -18,9 +18,15 @@ fun LinearLayout.bindCapabilityRows(rows: List<SetupCapabilityRow>) {
     rows.forEach { row ->
         val rowBinding = SetupCapabilityRowBinding.inflate(inflater, this, false)
         rowBinding.capName.setText(capabilityNameRes(row.kind))
-        rowBinding.capStatus.setText(if (row.available) R.string.setup_cap_available else R.string.setup_cap_off)
+        val statusRes =
+            when {
+                row.available -> R.string.setup_cap_available
+                row.unknown -> R.string.setup_cap_unknown
+                else -> R.string.setup_cap_off
+            }
+        rowBinding.capStatus.setText(statusRes)
         rowBinding.capStatus.setTextColor(context.getColor(if (row.available) R.color.colorSuccess else R.color.colorMuted))
-        applyCheck(rowBinding.icInput, row.inputOk)
+        if (row.inputUnknown) applyUnknown(rowBinding.icInput) else applyCheck(rowBinding.icInput, row.inputOk)
         applyCheck(rowBinding.icDestination, row.destinationOk)
         applyCheck(rowBinding.icType, row.typeOk)
         addView(rowBinding.root)
@@ -45,4 +51,9 @@ private fun applyCheck(
 ) {
     view.setImageResource(if (ok) R.drawable.ic_check_circle else R.drawable.ic_cancel)
     view.imageTintList = ColorStateList.valueOf(view.context.getColor(if (ok) R.color.colorSuccess else R.color.colorMuted))
+}
+
+private fun applyUnknown(view: ImageView) {
+    view.setImageResource(R.drawable.ic_help)
+    view.imageTintList = ColorStateList.valueOf(view.context.getColor(R.color.colorMuted))
 }

--- a/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConfigureActivity.kt
+++ b/app/src/main/java/com/tinkernorth/dish/ui/setup/SetupConfigureActivity.kt
@@ -206,6 +206,7 @@ class SetupConfigureActivity : BaseGamepadHostActivity() {
                     candidateHostKind = state.selectedHost?.kind ?: ConnectionKind.SATELLITE,
                     candidateHostId = state.draft?.hostId,
                 ),
+                inputUnknown = state.inputUnknown,
             ),
         )
     }
@@ -242,6 +243,7 @@ class SetupConfigureActivity : BaseGamepadHostActivity() {
                     candidateHostKind = ConnectionKind.MOONLIGHT,
                     candidateHostId = state.draft?.hostId,
                 ),
+                inputUnknown = state.inputUnknown,
             ),
         )
     }
@@ -414,6 +416,7 @@ class SetupConfigureActivity : BaseGamepadHostActivity() {
                         add(gamepad)
                         if (model.motionOn) add(motion)
                         if (model.batteryOn) add(battery)
+                        if (state.inputUnknown) add(ReviewFlow(R.drawable.ic_help, R.string.setup_cap_unknown))
                     },
                 gets = gets,
             )

--- a/app/src/main/res/values-bs/strings_setup.xml
+++ b/app/src/main/res/values-bs/strings_setup.xml
@@ -108,8 +108,9 @@
     <string name="setup_cap_trigger_rumble">Vibracija okidača</string>
     <string name="setup_cap_trigger_effects">Adaptivni okidači</string>
     <string name="setup_cap_player_leds">LED igrača</string>
-    <string name="setup_cap_available">Dostupno</string>
+    <string name="setup_cap_available">Podržano</string>
     <string name="setup_cap_off">Isključeno</string>
+    <string name="setup_cap_unknown">Nepoznato</string>
     <string name="setup_cap_input">Unos</string>
     <string name="setup_cap_destination">Odredište</string>
     <string name="setup_cap_type">Tip</string>

--- a/app/src/main/res/values-de/strings_setup.xml
+++ b/app/src/main/res/values-de/strings_setup.xml
@@ -116,8 +116,9 @@
     <string name="setup_cap_trigger_rumble">Trigger-Vibration</string>
     <string name="setup_cap_trigger_effects">Adaptive Trigger</string>
     <string name="setup_cap_player_leds">Spieler-LEDs</string>
-    <string name="setup_cap_available">Verfügbar</string>
+    <string name="setup_cap_available">Unterstützt</string>
     <string name="setup_cap_off">Aus</string>
+    <string name="setup_cap_unknown">Unbekannt</string>
     <string name="setup_cap_input">Eingabe</string>
     <string name="setup_cap_destination">Ziel</string>
     <string name="setup_cap_type">Typ</string>

--- a/app/src/main/res/values-es/strings_setup.xml
+++ b/app/src/main/res/values-es/strings_setup.xml
@@ -108,8 +108,9 @@
     <string name="setup_cap_trigger_rumble">Vibración de gatillos</string>
     <string name="setup_cap_trigger_effects">Gatillos adaptativos</string>
     <string name="setup_cap_player_leds">LED de jugador</string>
-    <string name="setup_cap_available">Disponible</string>
+    <string name="setup_cap_available">Compatible</string>
     <string name="setup_cap_off">Apagado</string>
+    <string name="setup_cap_unknown">Desconocido</string>
     <string name="setup_cap_input">Entrada</string>
     <string name="setup_cap_destination">Destino</string>
     <string name="setup_cap_type">Tipo</string>

--- a/app/src/main/res/values-fr/strings_setup.xml
+++ b/app/src/main/res/values-fr/strings_setup.xml
@@ -115,8 +115,9 @@
     <string name="setup_cap_trigger_rumble">Vibration des gâchettes</string>
     <string name="setup_cap_trigger_effects">Gâchettes adaptatives</string>
     <string name="setup_cap_player_leds">LED joueur</string>
-    <string name="setup_cap_available">Disponible</string>
+    <string name="setup_cap_available">Pris en charge</string>
     <string name="setup_cap_off">Désactivé</string>
+    <string name="setup_cap_unknown">Inconnu</string>
     <string name="setup_cap_input">Entrée</string>
     <string name="setup_cap_destination">Destination</string>
     <string name="setup_cap_type">Type</string>

--- a/app/src/main/res/values-pt-rBR/strings_setup.xml
+++ b/app/src/main/res/values-pt-rBR/strings_setup.xml
@@ -108,8 +108,9 @@
     <string name="setup_cap_trigger_rumble">Vibração dos gatilhos</string>
     <string name="setup_cap_trigger_effects">Gatilhos adaptáveis</string>
     <string name="setup_cap_player_leds">LEDs de jogador</string>
-    <string name="setup_cap_available">Disponível</string>
+    <string name="setup_cap_available">Suportado</string>
     <string name="setup_cap_off">Desligado</string>
+    <string name="setup_cap_unknown">Desconhecido</string>
     <string name="setup_cap_input">Entrada</string>
     <string name="setup_cap_destination">Destino</string>
     <string name="setup_cap_type">Tipo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -622,6 +622,7 @@
     <string name="binding_func_gyro">Gyro</string>
     <string name="binding_state_on">On</string>
     <string name="binding_state_off">Off</string>
+    <string name="binding_state_unknown" translatable="false">?</string>
     <string name="binding_func_value">%1$s · %2$s</string>
 
     <string name="binding_rate_hz">%1$d Hz</string>

--- a/app/src/main/res/values/strings_setup.xml
+++ b/app/src/main/res/values/strings_setup.xml
@@ -116,8 +116,9 @@
     <string name="setup_cap_trigger_rumble">Trigger rumble</string>
     <string name="setup_cap_trigger_effects">Adaptive triggers</string>
     <string name="setup_cap_player_leds">Player LEDs</string>
-    <string name="setup_cap_available">Available</string>
+    <string name="setup_cap_available">Supported</string>
     <string name="setup_cap_off">Off</string>
+    <string name="setup_cap_unknown">Unknown</string>
     <string name="setup_cap_input">Input</string>
     <string name="setup_cap_destination">Destination</string>
     <string name="setup_cap_type">Type</string>

--- a/app/src/test/java/com/tinkernorth/dish/composer/CapabilityComposerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/CapabilityComposerTest.kt
@@ -86,10 +86,16 @@ class CapabilityComposerTest {
         modelHasPlayerLeds: Boolean = false,
         modelHasTriggerEffects: Boolean = false,
         modelHasTriggerRumble: Boolean = false,
+        knownFastLane: Boolean = false,
+        frameworkCaps: PhysicalGamepadRegistry.FrameworkCaps? = null,
         satTypes: MutableStateFlow<Map<Pair<String, String>, Int>> = MutableStateFlow(emptyMap()),
     ): CapabilityComposer {
         val availability: PhoneMotionAvailability = mockk { every { hasGyro } returns phoneAvailable }
-        val registry: PhysicalGamepadRegistry = mockk { every { this@mockk.devices } returns devices }
+        val registry: PhysicalGamepadRegistry =
+            mockk {
+                every { this@mockk.devices } returns devices
+                every { frameworkCapsFor(any(), any()) } returns frameworkCaps
+            }
         val hub: ConnectionCoordinator =
             mockk {
                 every { this@mockk.bindings } returns bindings
@@ -105,6 +111,7 @@ class CapabilityComposerTest {
                 every { modelHasPlayerLeds(any(), any()) } returns modelHasPlayerLeds
                 every { modelHasTriggerEffects(any(), any()) } returns modelHasTriggerEffects
                 every { modelHasTriggerRumble(any(), any()) } returns modelHasTriggerRumble
+                every { isKnownFastLaneModel(any(), any()) } returns knownFastLane
             }
         val motionStore: MotionEnabledStore = mockk { every { state } returns motionEnabled }
         val rumbleStore: RumbleEnabledStore = mockk { every { state } returns rumbleEnabled }
@@ -405,6 +412,154 @@ class CapabilityComposerTest {
                     candidateHostId = "sat-A",
                 )
             assertFalse(caps.isAvailable(Feature.RUMBLE))
+        }
+
+    @Test
+    fun `candidateDirect previews the Direct layer for a pad still routed Standard`() =
+        composerTest {
+            val devices =
+                MutableStateFlow(mapOf(7 to device(7, vendorId = 0x054C, productId = 0x09CC, hasRumble = false, hasGyro = false)))
+            val composer =
+                composerFor(
+                    phoneAvailable = false,
+                    devices = devices,
+                    bindings = MutableStateFlow(emptyMap()),
+                    connections = MutableStateFlow(emptyList()),
+                    scope = backgroundScope,
+                    modelHasImu = true,
+                    modelHasRumble = true,
+                    knownFastLane = true,
+                )
+            composer.probe(this)
+            testScheduler.runCurrent()
+
+            val direct =
+                composer.capabilityForCandidate(
+                    slotId = "7",
+                    candidateType = CONTROLLER_TYPE_PLAYSTATION,
+                    candidateHostKind = ConnectionKind.SATELLITE,
+                    candidateHostId = "sat-A",
+                    candidateDirect = true,
+                )
+            assertTrue(Feature.MOTION in direct.controller)
+            assertTrue(Feature.RUMBLE in direct.controller)
+
+            val standard =
+                composer.capabilityForCandidate(
+                    slotId = "7",
+                    candidateType = CONTROLLER_TYPE_PLAYSTATION,
+                    candidateHostKind = ConnectionKind.SATELLITE,
+                    candidateHostId = "sat-A",
+                    candidateDirect = false,
+                )
+            assertFalse(Feature.MOTION in standard.controller)
+            assertFalse(Feature.RUMBLE in standard.controller)
+        }
+
+    @Test
+    fun `candidateDirect false on a claimed pad reads the last framework sighting`() =
+        composerTest {
+            val devices =
+                MutableStateFlow(mapOf(-1000 to device(-1000, vendorId = 0x054C, productId = 0x09CC, isUsbSynthetic = true)))
+            val composer =
+                composerFor(
+                    phoneAvailable = false,
+                    devices = devices,
+                    bindings = MutableStateFlow(emptyMap()),
+                    connections = MutableStateFlow(emptyList()),
+                    scope = backgroundScope,
+                    modelHasImu = true,
+                    modelHasRumble = true,
+                    frameworkCaps = PhysicalGamepadRegistry.FrameworkCaps(hasGyro = true, hasRumble = false),
+                )
+            composer.probe(this)
+            testScheduler.runCurrent()
+
+            val standard =
+                composer.capabilityForCandidate(
+                    slotId = "-1000",
+                    candidateType = CONTROLLER_TYPE_PLAYSTATION,
+                    candidateHostKind = ConnectionKind.SATELLITE,
+                    candidateHostId = "sat-A",
+                    candidateDirect = false,
+                )
+            assertTrue(Feature.MOTION in standard.controller)
+            assertFalse(Feature.RUMBLE in standard.controller)
+        }
+
+    @Test
+    fun `inputFunctionsFor marks Direct on an unrecognized model unknown`() =
+        composerTest {
+            val devices = MutableStateFlow(mapOf(7 to device(7, vendorId = 0x0E6F, productId = 0x0180)))
+            val composer =
+                composerFor(
+                    phoneAvailable = false,
+                    devices = devices,
+                    bindings = MutableStateFlow(emptyMap()),
+                    connections = MutableStateFlow(emptyList()),
+                    scope = backgroundScope,
+                    knownFastLane = false,
+                )
+            composer.probe(this)
+            testScheduler.runCurrent()
+
+            val funcs = composer.inputFunctionsFor("7", direct = true)
+            assertFalse(funcs.known)
+            assertFalse(funcs.rumble)
+            assertFalse(funcs.gyro)
+            assertFalse(funcs.touchpad)
+        }
+
+    @Test
+    fun `inputFunctionsFor reads the framework probe on Standard and the tables on Direct`() =
+        composerTest {
+            val devices =
+                MutableStateFlow(mapOf(7 to device(7, vendorId = 0x054C, productId = 0x09CC, hasRumble = true, hasGyro = false)))
+            val composer =
+                composerFor(
+                    phoneAvailable = false,
+                    devices = devices,
+                    bindings = MutableStateFlow(emptyMap()),
+                    connections = MutableStateFlow(emptyList()),
+                    scope = backgroundScope,
+                    modelHasImu = true,
+                    modelHasRumble = true,
+                    modelHasTouchpad = true,
+                    knownFastLane = true,
+                )
+            composer.probe(this)
+            testScheduler.runCurrent()
+
+            val standard = composer.inputFunctionsFor("7", direct = false)
+            assertTrue(standard.known)
+            assertTrue(standard.rumble)
+            assertFalse(standard.gyro)
+            assertFalse(standard.touchpad)
+
+            val direct = composer.inputFunctionsFor("7", direct = true)
+            assertTrue(direct.known)
+            assertTrue(direct.gyro)
+            assertTrue(direct.touchpad)
+        }
+
+    @Test
+    fun `inputFunctionsFor is unknown for a claimed pad never seen routed`() =
+        composerTest {
+            val devices =
+                MutableStateFlow(mapOf(-1000 to device(-1000, vendorId = 0x054C, productId = 0x09CC, isUsbSynthetic = true)))
+            val composer =
+                composerFor(
+                    phoneAvailable = false,
+                    devices = devices,
+                    bindings = MutableStateFlow(emptyMap()),
+                    connections = MutableStateFlow(emptyList()),
+                    scope = backgroundScope,
+                    frameworkCaps = null,
+                )
+            composer.probe(this)
+            testScheduler.runCurrent()
+
+            assertFalse(composer.inputFunctionsFor("-1000", direct = false).known)
         }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/composer/MoonlightSessionControllerTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/composer/MoonlightSessionControllerTest.kt
@@ -97,7 +97,7 @@ class MoonlightSessionControllerTest {
         every { hub.bindings } returns bindings
         every { hub.connections } returns connections
         every { hub.satTypes } returns satTypes
-        every { capabilities.capabilityForCandidate(any(), any(), any(), any()) } returns padCaps
+        every { capabilities.capabilityForCandidate(any(), any(), any(), any(), any()) } returns padCaps
     }
 
     @After
@@ -154,7 +154,7 @@ class MoonlightSessionControllerTest {
     @Test
     fun `Auto becomes PlayStation when the bound input reports motion`() =
         runTest(dispatcher) {
-            every { capabilities.capabilityForCandidate(any(), any(), any(), any()) } returns motionCaps
+            every { capabilities.capabilityForCandidate(any(), any(), any(), any(), any()) } returns motionCaps
             connections.value = listOf(summary("moonlight:pc"))
             bindings.value = mapOf("1" to "moonlight:pc")
             val desired = slot<Map<String, List<MoonlightPadRequest>>>()

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/CardActionsTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/CardActionsTest.kt
@@ -13,8 +13,10 @@ import com.tinkernorth.dish.hotpath.input.Transport
 import com.tinkernorth.dish.repository.TouchpadModeValue
 import com.tinkernorth.dish.source.usb.PathChoice
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class CardActionsTest {
@@ -254,6 +256,15 @@ class CardActionsTest {
     @Test
     fun `a slot with neither surface reports no pointer pills`() {
         assertEquals(emptyList<PointerPillFact>(), pointerFuncFacts(row(slot(SlotInputType.PHYSICAL))))
+    }
+
+    @Test
+    fun `input functions are unknown only for Direct on an unrecognized model`() {
+        assertFalse(inputFunctionsUnknown(null))
+        assertFalse(inputFunctionsUnknown(pathCard()))
+        val direct = pathCard().copy(currentMode = InputPathMode.Direct, risk = PathRisk.GuessedLayout)
+        assertTrue(inputFunctionsUnknown(direct))
+        assertFalse(inputFunctionsUnknown(direct.copy(risk = PathRisk.None)))
     }
 
     @Test

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/ConfigureBindingsDefaultTypeTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/ConfigureBindingsDefaultTypeTest.kt
@@ -8,6 +8,7 @@ import com.tinkernorth.dish.composer.CapabilityComposer
 import com.tinkernorth.dish.composer.ConnectionCoordinator
 import com.tinkernorth.dish.composer.ConnectionKind
 import com.tinkernorth.dish.composer.ConnectionSummary
+import com.tinkernorth.dish.composer.InputFunctions
 import com.tinkernorth.dish.composer.LinkState
 import com.tinkernorth.dish.core.jni.PhysicalInputNative
 import com.tinkernorth.dish.core.model.CatalogDto
@@ -112,7 +113,9 @@ class ConfigureBindingsDefaultTypeTest {
         every { gamepadRegistry.devices } returns devicesFlow
         every { usbGamepadManager.controllers } returns MutableStateFlow(emptyMap())
         every { capabilityComposer.capabilityFor(any()) } returns SlotCapabilities.NONE
-        every { capabilityComposer.capabilityForCandidate(any(), any(), any(), any()) } returns SlotCapabilities.NONE
+        every { capabilityComposer.capabilityForCandidate(any(), any(), any(), any(), any()) } returns SlotCapabilities.NONE
+        every { capabilityComposer.inputFunctionsFor(any(), any()) } returns
+            InputFunctions(known = true, rumble = false, gyro = false, touchpad = false)
 
         val conn = mockk<SatelliteConnection>(relaxed = true)
         every { conn.server } returns MutableStateFlow(server)

--- a/app/src/test/java/com/tinkernorth/dish/ui/main/ConfigureBindingsMoonlightActionsTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/main/ConfigureBindingsMoonlightActionsTest.kt
@@ -8,6 +8,7 @@ import com.tinkernorth.dish.composer.CapabilityComposer
 import com.tinkernorth.dish.composer.ConnectionCoordinator
 import com.tinkernorth.dish.composer.ConnectionKind
 import com.tinkernorth.dish.composer.ConnectionSummary
+import com.tinkernorth.dish.composer.InputFunctions
 import com.tinkernorth.dish.composer.LinkState
 import com.tinkernorth.dish.core.jni.PhysicalInputNative
 import com.tinkernorth.dish.core.model.SlotCapabilities
@@ -101,7 +102,9 @@ class ConfigureBindingsMoonlightActionsTest {
 
         val capabilities = mockk<CapabilityComposer>(relaxed = true)
         every { capabilities.capabilityFor(any()) } returns SlotCapabilities.NONE
-        every { capabilities.capabilityForCandidate(any(), any(), any(), any()) } returns SlotCapabilities.NONE
+        every { capabilities.capabilityForCandidate(any(), any(), any(), any(), any()) } returns SlotCapabilities.NONE
+        every { capabilities.inputFunctionsFor(any(), any()) } returns
+            InputFunctions(known = true, rumble = false, gyro = false, touchpad = false)
         val registry = mockk<PhysicalGamepadRegistry>(relaxed = true)
         every { registry.devices } returns MutableStateFlow(emptyMap())
         val usb = mockk<UsbGamepadManager>(relaxed = true)

--- a/app/src/test/java/com/tinkernorth/dish/ui/setup/CapabilityRowsTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/setup/CapabilityRowsTest.kt
@@ -127,4 +127,30 @@ class CapabilityRowsTest {
         assertFalse(motion.available)
         assertEquals(motion.inputOk && motion.destinationOk && motion.typeOk, motion.available)
     }
+
+    @Test
+    fun `inputUnknown rides every row and reads unknown only where the rest of the path carries`() {
+        val everything = CapabilitySet(Feature.entries.toSet())
+        val caps =
+            SlotCapabilities(
+                controller = CapabilitySet.EMPTY,
+                transport = everything,
+                type = CapabilitySet.of(Feature.RUMBLE, Feature.MOTION),
+                host = everything,
+                userEnabled = CapabilitySet.EMPTY,
+                runtimeDown = CapabilitySet.EMPTY,
+            )
+        val rows = capabilityRows(caps, inputUnknown = true).associateBy { it.kind }
+
+        val rumble = rows.getValue(SetupCapabilityKind.RUMBLE)
+        assertTrue(rumble.inputUnknown)
+        assertTrue(rumble.unknown)
+        assertFalse(rumble.available)
+
+        val touchpad = rows.getValue(SetupCapabilityKind.TOUCHPAD)
+        assertTrue(touchpad.inputUnknown)
+        assertFalse(touchpad.unknown)
+
+        assertTrue(capabilityRows(caps).none { it.inputUnknown })
+    }
 }

--- a/app/src/test/java/com/tinkernorth/dish/ui/setup/SetupBluetoothHostViewModelTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/ui/setup/SetupBluetoothHostViewModelTest.kt
@@ -60,7 +60,7 @@ class SetupBluetoothHostViewModelTest {
         every { store.rememberedBtFlow } returns remembered
         every { motion.hasGyro } returns true
         every { hub.bind(any(), any(), any()) } returns true
-        every { capabilityComposer.capabilityForCandidate(any(), any(), any(), any()) } returns SlotCapabilities.NONE
+        every { capabilityComposer.capabilityForCandidate(any(), any(), any(), any(), any()) } returns SlotCapabilities.NONE
         vm = SetupBluetoothHostViewModel(registry, permission, store, hub, capabilityComposer, motion)
     }
 


### PR DESCRIPTION
The configure screen, controller cards, and setup flow described the input controller from its current path, so previews lied when the draft toggled Direct/Standard, and Direct on an unrecognized model claimed "no rumble/gyro/touchpad" when the truth is we don't know. This is about the controller connected to the phone, not the host side.  - `CapabilityComposer.capabilityForCandidate` takes a `candidateDirect` path so drafts preview the layer they would apply (Direct reads the native model tables, Standard the framework probe / last routed sighting); new `inputFunctionsFor` reports the pad's own functions per path plus whether that answer is known - Configure bindings input section: the connection pill now reads Direct / Standard / Bluetooth (tracking the toggle), and the function pills follow the chosen path, showing `Rumble · ?` / `Gyro · ?` / `Touchpad · ?` when Direct is unverified - Capability tables (configure type picker, setup type cards, BT-host pick-type): the Input column shows a `?` and the row status reads "Unknown" when the input is unknown but the rest of the path carries; "Available" copy renamed to "Supported" in all locales - Controller cards: the Direct/Standard chip now also shows on unbound USB cards, and the function row switches to `?` pills for Direct on an unrecognized model - Setup review: the controller node carries an "Unknown" chip in that state  Tests: composer coverage for candidate-path layers and `inputFunctionsFor`, capability-row unknown flags, and the card unknown gate; ktlint/detekt and unit-test compile pass locally, full suite on CI.  