### PR TITLE
Stage the changelog as 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ computer. Those lines say "update Satellite too".
 
 ---
 
-## Unreleased
+## [2.0.0] - Unreleased
+
+Everything below ships as 2.0.0, the release where the whole Dish and
+Satellite family moves to one shared version number. The headline since
+1.1.4: your controller gains a microphone, a speaker and a working mute
+light, and Dish can now stream from Moonlight hosts (Sunshine, Apollo,
+Wolf) as well as Satellite.
 
 ### Added
 

--- a/app/src/test/java/com/tinkernorth/dish/source/audio/MicEngineTest.kt
+++ b/app/src/test/java/com/tinkernorth/dish/source/audio/MicEngineTest.kt
@@ -65,8 +65,11 @@ class MicEngineTest {
         ): MicCaptureSession? {
             lastFrameSamples.set(frameSamples)
             if (refuse.get()) return null
-            opens.incrementAndGet()
+            // Endpoint first, count second: the tests await on the count and then read the
+            // endpoint list, so the increment is the publication barrier. The other order let
+            // an await release between the two writes and read one endpoint too few.
             openedEndpoints += preferredDeviceId
+            opens.incrementAndGet()
             return Session(frameSamples, preferredDeviceId)
         }
 


### PR DESCRIPTION
Stages the changelog for the 2.0.0 release: the Unreleased section gains the 2.0.0 heading and a short framing paragraph (the family aligns on one version number). Content otherwise unchanged; no version numbers move here, releasing stays a separate act.