### PR TITLE
Capture and upload fresh store screenshots on every release

### DIFF
--- a/.github/workflows/play-listing.yml
+++ b/.github/workflows/play-listing.yml
@@ -1,10 +1,15 @@
 name: Play Listing Sync
 
-# Pushes the committed store listing (per-locale text, screenshots,
-# feature graphics, icon) to the Play Console from play/metadata.
-# Binary releases ride release.yml's publish-play job instead; this
-# workflow only syncs listing content, so listing edits do not require
-# cutting a release.
+# Pushes the committed store listing (per-locale text, feature graphics,
+# icon and, on request, screenshots) to the Play Console from
+# play/metadata. Binary releases ride release.yml's publish-play job
+# instead; this workflow only syncs listing content, so listing edits do
+# not require cutting a release.
+#
+# Screenshots default to off here: every release captures a fresh set from
+# the build it ships and uploads that, so the committed PNGs are a reviewed
+# baseline that may trail the store. Turn upload_images on only to push a
+# deliberately refreshed set (or a new feature graphic or icon).
 #
 # Requires the PLAY_SERVICE_ACCOUNT_JSON secret (raw JSON key). The app
 # record and its first build must already exist in the Play Console.
@@ -20,9 +25,9 @@ on:
         type: boolean
         default: true
       upload_images:
-        description: "Also upload screenshots, feature graphics, and the icon"
+        description: "Also upload screenshots, feature graphics, and the icon (releases upload fresh screenshots on their own)"
         type: boolean
-        default: true
+        default: false
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,17 +38,23 @@ on:
 #                                 Firebase. When unset, the build still
 #                                 succeeds but ships without crash reporting.
 #   PLAY_SERVICE_ACCOUNT_JSON     Google Play service-account key (raw
-#                                 JSON). When set, the signed AAB rolls
-#                                 out to the Play production track with
-#                                 per-locale release notes and the full
-#                                 store listing (text, screenshots,
-#                                 graphics) synced from play/metadata.
+#                                 JSON). When set, the `screenshots` job
+#                                 captures a fresh store screenshot set
+#                                 from the tagged build on CI emulators
+#                                 (store-screenshots.yml, one leg per form
+#                                 factor), and publish-play rolls the
+#                                 signed AAB out to the Play production
+#                                 track with per-locale release notes and
+#                                 the full store listing: text and graphics
+#                                 from play/metadata, screenshots from that
+#                                 capture. The committed screenshots are
+#                                 the reviewed baseline, never what ships.
 #                                 workflow_dispatch can pick another
 #                                 track or a draft status. When unset,
-#                                 the publish-play job no-ops. The app
-#                                 record and its FIRST build must be
-#                                 created manually in the Play Console
-#                                 before the API can publish.
+#                                 both jobs are skipped. The app record
+#                                 and its FIRST build must be created
+#                                 manually in the Play Console before the
+#                                 API can publish.
 #
 # Pin map (verify with `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`):
 #   actions/checkout                @ v7.0.1  → 3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -279,9 +285,71 @@ jobs:
           name: android
           path: dist/
 
+  play-inputs:
+    name: Play publish inputs
+    needs: [gates]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      enabled: ${{ steps.gate.outputs.enabled }}
+      locales: ${{ steps.locales.outputs.locales }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      # Secrets cannot be read from a job-level `if`, so the capture job keys
+      # off this output instead: no credentials, no half hour of emulator
+      # time for screenshots nothing would upload.
+      - name: Gate on Play credentials
+        id: gate
+        env:
+          PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${PLAY_SERVICE_ACCOUNT_JSON:-}" ]; then
+            echo "::notice::PLAY_SERVICE_ACCOUNT_JSON not set. Skipping the screenshot capture and the Play upload."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # The listing locales are the directories under play/metadata/android,
+      # exactly the set fastlane supply publishes. play/metadata/unsupported
+      # (Bosnian) is captured by the manual workflow for the repo's own
+      # record but has no Play listing to land in, so it stays out here.
+      - name: List Play listing locales
+        id: locales
+        shell: bash
+        run: |
+          set -euo pipefail
+          locales=$(find play/metadata/android -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | LC_ALL=C sort | tr '\n' ' ')
+          locales="${locales% }"
+          [ -n "$locales" ] || { echo "::error::play/metadata/android has no locale directories."; exit 1; }
+          echo "locales=$locales" >> "$GITHUB_OUTPUT"
+          echo "Play listing locales: $locales"
+
+  screenshots:
+    name: Capture store screenshots
+    needs: [play-inputs]
+    if: ${{ needs.play-inputs.outputs.enabled == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/store-screenshots.yml
+    with:
+      locales: ${{ needs.play-inputs.outputs.locales }}
+      ref: ${{ inputs.tag || github.ref }}
+
   publish-play:
     name: Upload AAB to Google Play
-    needs: [release]
+    needs: [release, screenshots]
+    # Fresh screenshots are part of the upload, so a failed capture fails the
+    # publish instead of quietly shipping the committed baseline; `gh run
+    # rerun --failed` re-runs the capture and this job. A skipped capture
+    # (no Play credentials) skips this job the same way.
+    if: ${{ !cancelled() && needs.release.result == 'success' && needs.screenshots.result == 'success' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -314,6 +382,42 @@ jobs:
         with:
           name: android
           path: dist
+
+      - name: Download fresh screenshots
+        if: ${{ steps.gate.outputs.enabled == 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: screenshots-*
+          merge-multiple: true
+          path: fresh
+
+      # The three capture artifacts share the play/metadata layout. Each
+      # form-factor directory is replaced whole, so a screen dropped from the
+      # harness cannot linger as a stale committed PNG, and every listing
+      # locale must have every form factor: a partial set is a failed
+      # capture, not something to paper over with the committed images.
+      - name: Replace committed screenshots with the fresh capture
+        if: ${{ steps.gate.outputs.enabled == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          replaced=0
+          for locdir in play/metadata/android/*/; do
+            loc=$(basename "$locdir")
+            for form in phoneScreenshots sevenInchScreenshots tenInchScreenshots; do
+              src="fresh/play/metadata/android/${loc}/images/${form}"
+              if ! compgen -G "${src}/*.png" > /dev/null; then
+                echo "::error::No ${form} captures for ${loc} in the screenshots artifacts."
+                exit 1
+              fi
+              dest="${locdir}images/${form}"
+              rm -rf "$dest"
+              mkdir -p "$dest"
+              cp "${src}"/*.png "$dest/"
+              replaced=$((replaced + $(find "$dest" -name '*.png' | wc -l)))
+            done
+          done
+          echo "Replaced the committed screenshot set with ${replaced} fresh captures."
 
       - name: Locate signed AAB and mapping
         if: ${{ steps.gate.outputs.enabled == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ on:
 #                                 captures a fresh store screenshot set
 #                                 from the tagged build on CI emulators
 #                                 (store-screenshots.yml, one leg per form
-#                                 factor), and publish-play rolls the
+#                                 factor and locale), and publish-play rolls the
 #                                 signed AAB out to the Play production
 #                                 track with per-locale release notes and
 #                                 the full store listing: text and graphics
@@ -391,7 +391,8 @@ jobs:
           merge-multiple: true
           path: fresh
 
-      # The three capture artifacts share the play/metadata layout. Each
+      # The capture artifacts (one per form factor and locale) share the
+      # play/metadata layout and merge into one tree on download. Each
       # form-factor directory is replaced whole, so a screen dropped from the
       # harness cannot linger as a stale committed PNG, and every listing
       # locale must have every form factor: a partial set is a failed

--- a/.github/workflows/store-screenshots.yml
+++ b/.github/workflows/store-screenshots.yml
@@ -4,7 +4,10 @@ name: Store Screenshots
 # DishScreenshots instrumented harness: one matrix leg per store form
 # factor, each looping the six listing locales, cropped to Play's
 # dimensions and uploaded as artifacts laid out for play/metadata.
-# Dispatch-only: captures are reviewed by a human before committing.
+# Runs two ways: dispatched by hand to refresh the committed set (a human
+# reviews the captures before they land in play/metadata), and called from
+# release.yml on every tag, so the Play upload carries screenshots of the
+# build it ships rather than the committed baseline.
 #
 # Pin map (verify with `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`):
 #   actions/checkout                     @ v7.0.1  → 3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -21,6 +24,18 @@ on:
         description: "Space-separated locale tags to capture"
         required: false
         default: "en-US bs de-DE es-ES fr-FR pt-BR"
+  workflow_call:
+    inputs:
+      locales:
+        description: "Space-separated locale tags to capture"
+        type: string
+        required: false
+        default: "en-US bs de-DE es-ES fr-FR pt-BR"
+      ref:
+        description: "Git ref to capture from (empty: the calling run's ref)"
+        type: string
+        required: false
+        default: ""
   # Self-test: editing this workflow re-runs it for en-US only, and a
   # branch push registers it so workflow_dispatch works pre-merge.
   push:
@@ -54,6 +69,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
@@ -92,7 +109,7 @@ jobs:
         env:
           CAPTURE_SIZE: ${{ matrix.size }}
           CAPTURE_DENSITY: ${{ matrix.density }}
-          CAPTURE_LOCALES: ${{ github.event_name == 'workflow_dispatch' && inputs.locales || 'en-US' }}
+          CAPTURE_LOCALES: ${{ inputs.locales || 'en-US' }}
         with:
           api-level: 35
           target: google_apis

--- a/.github/workflows/store-screenshots.yml
+++ b/.github/workflows/store-screenshots.yml
@@ -2,8 +2,9 @@ name: Store Screenshots
 
 # Re-captures the Play screenshot set on CI emulators using the
 # DishScreenshots instrumented harness: one matrix leg per store form
-# factor, each looping the six listing locales, cropped to Play's
-# dimensions and uploaded as artifacts laid out for play/metadata.
+# factor and locale, cropped to Play's dimensions and uploaded as
+# artifacts laid out for play/metadata (download them together with
+# `gh run download <run> -p 'screenshots-*'` and they merge into one tree).
 # Runs two ways: dispatched by hand to refresh the committed set (a human
 # reviews the captures before they land in play/metadata), and called from
 # release.yml on every tag, so the Play upload carries screenshots of the
@@ -46,13 +47,43 @@ permissions:
   contents: read
 
 jobs:
+  # One capture leg per form factor AND locale. A locale takes the harness
+  # about 13 minutes on a CI emulator, so a single leg looping all six ran
+  # past the 60-minute job limit and was cancelled mid-locale; fanning out
+  # keeps every leg well inside it and brings a full set down to one leg's
+  # wall time. The locale list arrives as a string (workflow inputs cannot
+  # be arrays), so this job turns it into the JSON the matrix needs.
+  plan:
+    name: Plan locales
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      locales: ${{ steps.plan.outputs.locales }}
+    steps:
+      - name: Locales to JSON
+        id: plan
+        env:
+          LOCALES: ${{ inputs.locales || 'en-US' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          json=$(printf '%s\n' $LOCALES | sed 's/.*/"&"/' | paste -sd, -)
+          [ -n "$json" ] || { echo "::error::No locales to capture."; exit 1; }
+          echo "locales=[${json}]" >> "$GITHUB_OUTPUT"
+          echo "Capturing: [${json}]"
+
   capture:
-    name: Capture (${{ matrix.form }})
+    name: Capture (${{ matrix.form }}, ${{ matrix.locale }})
+    needs: [plan]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
+        locale: ${{ fromJSON(needs.plan.outputs.locales) }}
+        form: [phone, sevenInch, tenInch]
+        # Keyed by form, so each entry only attaches its sizes to the
+        # locale × form combinations rather than adding a leg of its own.
         include:
           - form: phone
             size: 1080x2424
@@ -109,7 +140,7 @@ jobs:
         env:
           CAPTURE_SIZE: ${{ matrix.size }}
           CAPTURE_DENSITY: ${{ matrix.density }}
-          CAPTURE_LOCALES: ${{ inputs.locales || 'en-US' }}
+          CAPTURE_LOCALES: ${{ matrix.locale }}
         with:
           api-level: 35
           target: google_apis
@@ -137,6 +168,6 @@ jobs:
       - name: Upload screenshots
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: screenshots-${{ matrix.form }}
+          name: screenshots-${{ matrix.form }}-${{ matrix.locale }}
           path: stage/
           retention-days: 14

--- a/play/SCREENSHOT-STRATEGY.md
+++ b/play/SCREENSHOT-STRATEGY.md
@@ -2,7 +2,7 @@
 
 This file describes how every PNG currently sitting in `metadata/android/<locale>/images/` was produced, what data it depicts, and how to recreate the set. It is the source of truth for the screenshot pipeline so the captures stay reproducible across model edits, emulator changes, and future locale additions.
 
-> Status: the screenshots currently committed were captured before the guided Setup flow and the dashboard card rework, so some show screens that no longer exist (the old welcome and setup-wizard screens). They are stale and must be re-captured before submission. The pipeline below is still the procedure to use, and the screen catalogue has been updated to the current screens.
+> Status: every tagged release captures a fresh set from the build it ships and uploads that to Play (`release.yml`: the `screenshots` job calls `store-screenshots.yml`, and `publish-play` swaps the captures in before `fastlane supply`). The PNGs committed here are the reviewed baseline, not what the store shows: refresh them with the Store Screenshots workflow whenever the screens change, so reviewers, the manual listing sync and this document stay honest.
 
 ## Output layout
 


### PR DESCRIPTION
The release workflow uploaded whatever screenshot PNGs were committed under `play/metadata`, and nothing regenerated them: the store has shown July captures through 1.1.x and 2.0.0. With this change every tag captures its own set from the build it ships and uploads that.

**release.yml**
- `play-inputs`: reads the Play credential (a job-level `if` cannot see secrets) and lists the listing locales from `play/metadata/android` (the Bosnian set under `play/metadata/unsupported` has no Play listing, so it stays out).
- `screenshots`: calls `store-screenshots.yml`, now reusable, for those locales at the tagged ref. Runs in parallel with the build.
- `publish-play`: needs the build and the capture, downloads the three form-factor artifacts, replaces each committed screenshot directory whole, and fails when any locale lacks any form factor. A broken capture fails the Play upload rather than quietly shipping the baseline; `gh run rerun --failed` re-runs the capture and the upload. Without Play credentials both jobs are skipped, as `publish-play` already was.
- The GitHub release path (`harden`, `provenance`, `publish`) is untouched and does not wait for emulators.

**store-screenshots.yml** keeps its manual and self-test triggers and adds `workflow_call` with `locales` and `ref` inputs.

**play-listing.yml** now defaults `upload_images` to off: pushing the committed set would replace the store's fresh captures with the older baseline. Turn it on deliberately for a refreshed set, a new feature graphic, or a new icon.

**play/SCREENSHOT-STRATEGY.md** describes the committed PNGs as the reviewed baseline rather than what the store shows.

Verification: all three workflows parse; the branch push runs the workflow's own en-US self-test, which exercises the reusable file. The new release jobs run for real on the next tag, since a release cannot be dry-run against an existing version code.