### PR TITLE
Stop the test package's own process crashing under ActivityScenario

### DIFF
--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application>
+        <!-- OkHttp 5 registers an App Startup initializer in its manifest, and
+             okhttp-tls (the fake satellite's TLS, androidTest only) merges it
+             into this test APK. The startup runtime itself is not packaged
+             here: the build strips every class the app already ships. Inside
+             the instrumented app process that is harmless, since only the
+             app's own startup provider runs there. It is fatal in the test
+             package's OWN process, which ActivityScenario starts to host its
+             EmptyActivity on every launch: the provider cannot be loaded, the
+             process dies, and Android's "keeps stopping" dialog was being
+             captured into the store screenshots. Nothing in the tests needs
+             the initializer (OkHttp works without it), so it is removed. -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            tools:node="remove" />
+    </application>
+
+</manifest>

--- a/scripts/ci_capture_screenshots.sh
+++ b/scripts/ci_capture_screenshots.sh
@@ -20,11 +20,23 @@ for LOC in ${CAPTURE_LOCALES}; do
   adb shell cmd locale set-app-locales com.tinkernorth.dish --locales "$LOC"
   adb shell am force-stop com.tinkernorth.dish
   adb shell run-as com.tinkernorth.dish rm -rf files/screengrab || true
+  # The crash log buffer is separate from main and small, so it cannot wrap
+  # over a long locale; cleared here so only this locale's crashes count.
+  adb logcat -c -b crash
   adb shell am instrument -w -e testLocale "$LOC" \
     -e class com.tinkernorth.dish.screenshots.DishScreenshots \
     com.tinkernorth.dish.test/androidx.test.runner.AndroidJUnitRunner | tee /tmp/instrument.log
   # am instrument exits 0 even on test failures; gate on the runner summary.
   grep -q "OK (" /tmp/instrument.log
+  # A crash in ANY process of the app or the test package puts Android's
+  # "keeps stopping" dialog over the next capture, while the runner still
+  # reports OK because the instrumented process itself survived. Those
+  # screenshots must never leave this job.
+  if adb logcat -d -b crash | grep -q "FATAL EXCEPTION"; then
+    adb logcat -d -b crash | head -60
+    echo "::error::A process crashed during the ${LOC} capture; its dialog would be in the screenshots. See the crash log above."
+    exit 1
+  fi
   adb exec-out run-as com.tinkernorth.dish tar cf - -C files screengrab > captures/grab.tar
   tar xf captures/grab.tar -C captures
   rm captures/grab.tar


### PR DESCRIPTION
Every store screenshot captured since July 8 carried Android's **"com.tinkernorth.dish.test keeps stopping"** dialog (see the artifacts of any Store Screenshots run since then, including the 2.0.0 tag-time self-test). The instrumentation reported `OK (8 tests)` throughout, so nothing noticed.

**Cause.** OkHttp 5 registers an App Startup initializer in its manifest, and `okhttp-tls` (androidTest only, added with the integration suite that same evening) merges it into the test APK's manifest, while the build strips `androidx.startup` from the test APK because the app already ships it. Inside the instrumented app process that is harmless: only the app's own startup provider runs there. `ActivityScenario`, however, launches its `EmptyActivity` from the test package, which starts the test package's **own** process; that process installs the merged provider, cannot load the class, and dies on every launch:

```
FATAL EXCEPTION: main  Process: com.tinkernorth.dish.test
java.lang.RuntimeException: Unable to get provider androidx.startup.InitializationProvider
Caused by: java.lang.ClassNotFoundException: Didn't find class "androidx.startup.InitializationProvider"
```

**Fix.** `app/src/androidTest/AndroidManifest.xml` removes that provider from the test APK; nothing in the tests needs the initializer and OkHttp works without it. `scripts/ci_capture_screenshots.sh` now clears the crash log buffer per locale and fails the locale when it shows any `FATAL EXCEPTION`, so a dialog can never again ride into the store while the runner says OK.

**Verified locally** on the Dish_Phone emulator (API 36): before the fix the harness run showed four `FATAL EXCEPTION` entries and the dialog in shots 02 through 09; after it, zero crashes and all eight captures clean. The integration tests in CI exercise the same `ActivityScenario` path.