### PR TITLE
Date the 2.1.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ computer. Those lines say "update Satellite too".
 
 ---
 
-## [2.1.0] - Unreleased
+## [2.1.0] - 2026-09-07
 
 ### Added
 


### PR DESCRIPTION
Stamps today's date on the 2.1.0 section ahead of the tag, the same way #186 did for 2.0.0. No other changes.